### PR TITLE
Api Version for transformer <-> backend compatibility

### DIFF
--- a/versionedRouter.js
+++ b/versionedRouter.js
@@ -6,6 +6,7 @@ const { lstatSync, readdirSync } = require("fs");
 const logger = require("./logger");
 
 const versions = ["v0"];
+const API_VERSION = '1'
 
 const transformerMode = process.env.TRANSFORMER_MODE;
 
@@ -83,7 +84,7 @@ async function handleDest(ctx, destHandler) {
   );
   logger.debug(`[DT] Output events: ${JSON.stringify(respList)}`);
   ctx.body = respList;
-  ctx.set('apiVersion', '1')
+  ctx.set('apiVersion', API_VERSION)
 }
 
 if (startDestTransformer) {

--- a/versionedRouter.js
+++ b/versionedRouter.js
@@ -83,6 +83,7 @@ async function handleDest(ctx, destHandler) {
   );
   logger.debug(`[DT] Output events: ${JSON.stringify(respList)}`);
   ctx.body = respList;
+  ctx.set('apiVersion', '1')
 }
 
 if (startDestTransformer) {


### PR DESCRIPTION
Sending an apiVersion as a response header for destination transformations to check against in rudder-server for compatibility

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rudderlabs/rudder-transformer/176)
<!-- Reviewable:end -->
