### PR TITLE
Api Version for transformer <-> backend compatibility

### DIFF
--- a/versionedRouter.js
+++ b/versionedRouter.js
@@ -163,6 +163,7 @@ if (startDestTransformer) {
       );
       logger.debug(`[CT] Output events: ${JSON.stringify(transformedEvents)}`);
       ctx.body = transformedEvents;
+      ctx.set('apiVersion', API_VERSION)
     });
   }
 }
@@ -194,6 +195,7 @@ async function handleSource(ctx, sourceHandler) {
   );
   logger.debug(`[ST] Output source events: ${JSON.stringify(respList)}`);
   ctx.body = respList;
+  ctx.set('apiVersion', API_VERSION)
 }
 
 if (startSourceTransformer) {


### PR DESCRIPTION
Sending an apiVersion as a response header for source/custom transformations to check against in rudder-server for compatibility

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rudderlabs/rudder-transformer/177)
<!-- Reviewable:end -->
