### PR TITLE
Remove groupedBy tag.

### DIFF
--- a/versionedRouter.js
+++ b/versionedRouter.js
@@ -183,7 +183,6 @@ if (startDestTransformer) {
                 destEvents.length,
                 {
                   transformationVersionId,
-                  groupedBy: dest,
                   processSessions
                 }
               );


### PR DESCRIPTION
This is crashing our influxdb due to huge number of distinct possible values