### PR TITLE
fix: Remove event type guard that prevent traits from copying to user props

### DIFF
--- a/v0/destinations/am/transform.js
+++ b/v0/destinations/am/transform.js
@@ -220,8 +220,7 @@ function responseBuilderSimple(
       break;
     default:
       set(rawPayload, "event_properties", message.properties);
-      if (message.type === EventType.TRACK)
-        set(rawPayload, "user_properties", message.context.traits);
+      set(rawPayload, "user_properties", message.context.traits);
 
       rawPayload.event_type = evType;
       rawPayload.user_id = message.userId;


### PR DESCRIPTION
## Description of the change

Events other than `track` might provide traits to Amplitude, e.g. if there's a (utm) campaign, we might populate utm props in traits for `page` view event. This allow us to work around these issue.

Previously, this guard cause the traits to be silently drop without any other option to populate it correctly in transformer.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
