### PR TITLE
fix(ga): Do not fallback to md5(userId) for cid, keep it undefined

### DIFF
--- a/v0/destinations/ga/transform.js
+++ b/v0/destinations/ga/transform.js
@@ -1,5 +1,4 @@
 const get = require("get-value");
-const md5 = require("md5");
 const { EventType } = require("../../../constants");
 const {
   Event,
@@ -218,7 +217,7 @@ function responseBuilderSimple(
     integrationsClientId ||
     getDestinationExternalID(message, "gaExternalId") ||
     message.anonymousId ||
-    md5(message.userId);
+    undefined;
 
   finalPayload.uip = getParsedIP(message);
 


### PR DESCRIPTION
## Description of the change

Rudderstack GA transformer default empty `cid` to a md5 hash of user ID, this have cause us problem when unifying session. Due to the debug cycle for session unification, our hypothesis cannot be 100% verified but I believe rudderstack should not even fallback to md5 hash of user ID when anonymousId is not availabe.

I understand that GA spec said the if user ID is not available, cid is needed, that for me should be a concern of the implementor, rudderstack shouldn't make such guess as there are use case for not wanting to provide cid to GA.



## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
