### PR TITLE
fix(ga): Do not fallback to userId for cid when disableMd5 is true, keep it undefined

### DIFF
--- a/__tests__/data/ga_output.json
+++ b/__tests__/data/ga_output.json
@@ -1863,7 +1863,6 @@
       "ua": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36",
       "ul": "en-US",
       "uid": "12345",
-      "cid": "12345",
       "uip": "0.0.0.0"
     },
     "body": {

--- a/v0/destinations/ga/transform.js
+++ b/v0/destinations/ga/transform.js
@@ -306,7 +306,7 @@ function responseBuilderSimple(
       integrationsClientId ||
       getDestinationExternalID(message, "gaExternalId") ||
       message.anonymousId ||
-      message.userId;
+      undefined;
   } else {
     finalPayload.cid =
       integrationsClientId ||


### PR DESCRIPTION
## disableMd5 option should not default to userId

While #522 is a step in the right direction, it does not solve the problem we have at #462 because it still default to a value. The problem we have is that `cid` always have a value, not what kind of value it is.

The reason we does not want `cid` to default any value because it causes double session in GA. GA will treat these value as opaque so if they see a value in `cid`, they will be grouped as different session.

If anyone wanted to default to a value, they already can use `disableMd5` to `false`, for `true` value, we want it to not default to any values, if not, there is no point for that option in the first place.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

- #462
- #522

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 