### PR TITLE
braze batch identity fix for earlier batches(after split)

### DIFF
--- a/v0/destinations/braze/transform.js
+++ b/v0/destinations/braze/transform.js
@@ -532,7 +532,6 @@ function batch(destEvents) {
       if (!identifyEndpoint) {
         identifyEndpoint = endPoint;
       }
-
       const aliasObjectArr = get(jsonBody, "aliases_to_identify");
       const aliasMaxCount =
         aliasBatch.length + (aliasObjectArr ? aliasObjectArr.length : 0);
@@ -546,7 +545,7 @@ function batch(destEvents) {
           partner: BRAZE_PARTNER_NAME
         };
         if (aliasBatch.length > 0) {
-          responseBodyJson.aliases_to_identify = attributesBatch;
+          responseBodyJson.aliases_to_identify = [...aliasBatch];
         }
         batchResponse.body.JSON = responseBodyJson;
         respList.push(


### PR DESCRIPTION
## Description of the change
Aliases to identity property empty for earlier batches(after batch split)

> Description here
When the identify requests are > 50, then batching actually takes place
Here when 56 identify requests were provided to a batch with all containing user_id identify information
It should've split into 2 batches one containing 50 and other containing remaining 6
But it was observed that only the remaining 6 were seen in the later batch but other 50 were missing.

This PR contains the fix that would enable us to see the missing 50 data.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)

## Related issues
https://www.notion.so/rudderstacks/acorns-BRAZE-9041e5652a604a599566dee82f65b621

> Fix [#1]() 
The fix would enable us to see the missing 50 data

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
