### PR TITLE
added createdDate as a standard field for SFMC

### DIFF
--- a/v0/destinations/salesforce/data/SFIdentifyConfig.json
+++ b/v0/destinations/salesforce/data/SFIdentifyConfig.json
@@ -6,6 +6,7 @@
     "metadata": { "defaultValue": "n/a" }
   },
   { "destKey": "Country", "sourceKeys": ["address.country", "country"] },
+  { "destKey": "CreatedDate", "sourceKeys": ["createdAt", "createddate"] },
   { "destKey": "Description", "sourceKeys": "description" },
   { "destKey": "Email", "sourceKeys": "email" },
   { "destKey": "FirstName", "sourceKeys": "firstName" },

--- a/v0/destinations/salesforce/data/SFIgnoreConfig.json
+++ b/v0/destinations/salesforce/data/SFIgnoreConfig.json
@@ -9,6 +9,7 @@
   "company",
   "country",
   "createdAt",
+  "createddate",
   "description",
   "email",
   "firstName",


### PR DESCRIPTION
## Description of the change

> We added CreatedDate as a standard field so that historical users can be added with a different CreatedDate than the current date. If CreatedDate is not passed then it will default to the timestamp of the event

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
