### PR TITLE
mp-utm-campaign-hotfix: Changed the property for binding campaign nam…

### DIFF
--- a/v0/destinations/mp/data/MPEventPropertiesConfig.json
+++ b/v0/destinations/mp/data/MPEventPropertiesConfig.json
@@ -40,7 +40,7 @@
   },
   {
     "sourceKeys": "context.campaign.name",
-    "destKey": "utm_name"
+    "destKey": "utm_campaign"
   },
   {
     "sourceKeys": "context.campaign.source",

--- a/v0/destinations/mp/transform.js
+++ b/v0/destinations/mp/transform.js
@@ -398,6 +398,10 @@ function process(event) {
   return processSingleMessage(event.message, event.destination);
 }
 
+// Documentation about how Mixpanel handles the utm parameters
+// Ref: https://help.mixpanel.com/hc/en-us/articles/115004613766-Default-Properties-Collected-by-Mixpanel
+// Ref: https://help.mixpanel.com/hc/en-us/articles/115004561786-Track-UTM-Tags
+
 const processRouterDest = async inputs => {
   if (!Array.isArray(inputs) || inputs.length <= 0) {
     const respEvents = getErrorRespEvents(null, 400, "Invalid event array");


### PR DESCRIPTION
Change in the transformation response for Mixpanel

## Description of the change
The property bound after transformation for campaign name was `utm_name`, we have now changed it to `utm_campaign` as required by Mixpanel(Issue: https://github.com/rudderlabs/rudder-transformer/issues/714)

> Description here

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
