### PR TITLE
Add EXPOSE instruction in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,3 +16,6 @@ COPY --chown=node:node . .
 
 ENTRYPOINT ["/sbin/tini", "--"]
 CMD [ "npm", "start" ]
+
+
+EXPOSE 9090

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,4 @@ ENTRYPOINT ["/sbin/tini", "--"]
 CMD [ "npm", "start" ]
 
 
-EXPOSE 9090
+EXPOSE 9090/tcp


### PR DESCRIPTION
## Overview

This is a minor change that solves a small inconvenience we've faced.

`EXPOSE` is adding metadata to the image, which although not required, can be useful is some cases.

https://docs.docker.com/engine/reference/builder/#expose

## Issue
While using https://github.com/ory/dockertest, we faced the following:

The default way of running containers didn't work:
```go
	resource, err := pool.Run("rudderlabs/rudder-transformer", "latest", []string{".."})
	if err != nil {
		log.Fatalf("Could not start resource: %s", err)
	}
    transformerPort := resource.GetPort("9090/tcp"))

```

That is because by default, `dockertest` does:
```go
docker run  -P rudderlabs/rudder-transformer
```

The command above maps all the exposed ports to random ports on the host. 
Since the image doesn't specify any **exposed** port, which didn't work. 

We had to manually specify the exposed port.

This PR solves this issue.


