### PR TITLE
Add default traits object in identify for Amplitude

### DIFF
--- a/__tests__/data/am_input.json
+++ b/__tests__/data/am_input.json
@@ -1912,5 +1912,28 @@
         ]
       }
     }
+  },
+  {
+    "message": {
+      "type": "identify",
+      "userId": "ubcdfghi0001",
+      "anonymousId": "123456",
+      "session_id": "1598597129",
+      "context": {
+        "library": {
+          "name": "http"
+        }
+      }
+    },
+    "destination": {
+      "Config": {
+        "apiKey": "abcde",
+        "traitsToIncrement": [
+          {
+            "traits": "age"
+          }
+        ]
+      }
+    }
   }
 ]

--- a/__tests__/data/am_output.json
+++ b/__tests__/data/am_output.json
@@ -16,7 +16,7 @@
             "os_name": "Chrome",
             "os_version": "77.0.3865.90",
             "platform": "Web",
-            "device_model": "Mac",
+            "device_model": "Mac OS",
             "device_id": "123456",
             "insert_id": "84e26acc-56a5-4835-8233-591137fca468",
             "app_name": "RudderLabs JavaScript SDK",
@@ -69,7 +69,7 @@
             "os_name": "Chrome",
             "os_version": "77.0.3865.90",
             "platform": "Web",
-            "device_model": "Mac",
+            "device_model": "Mac OS",
             "device_id": "00000000000000000000000000",
             "insert_id": "5e10d13a-bf9a-44bf-b884-43a9e591ea71",
             "app_name": "RudderLabs JavaScript SDK",
@@ -126,7 +126,7 @@
             "os_name": "Chrome",
             "os_version": "77.0.3865.90",
             "platform": "Web",
-            "device_model": "Mac",
+            "device_model": "Mac OS",
             "device_id": "00000000000000000000000000",
             "insert_id": "5e10d13a-bf9a-44bf-b884-43a9e591ea71",
             "app_name": "RudderLabs JavaScript SDK",
@@ -186,7 +186,7 @@
             "os_name": "Chrome",
             "os_version": "77.0.3865.90",
             "platform": "Web",
-            "device_model": "Mac",
+            "device_model": "Mac OS",
             "device_id": "00000000000000000000000000",
             "insert_id": "ec5481b6-a926-4d2e-b293-0b3a77c4d3be",
             "app_name": "RudderLabs JavaScript SDK",
@@ -237,7 +237,7 @@
             "os_name": "Chrome",
             "os_version": "77.0.3865.90",
             "platform": "Web",
-            "device_model": "Mac",
+            "device_model": "Mac OS",
             "device_id": "123456",
             "insert_id": "84e26acc-56a5-4835-8233-591137fca468",
             "app_name": "RudderLabs JavaScript SDK",
@@ -443,7 +443,7 @@
               "os_name": "Chrome",
               "os_version": "85.0.4183.121",
               "platform": "Web",
-              "device_model": "Mac",
+              "device_model": "Mac OS",
               "device_id": "my-anonymous-id-new",
               "app_name": "RudderLabs JavaScript SDK",
               "app_version": "1.1.5",
@@ -1574,7 +1574,7 @@
           {
             "os_name": "Chrome",
             "os_version": "86.0.4240.198",
-            "device_model": "Mac",
+            "device_model": "Mac OS",
             "platform": "Web",
             "device_id": "2f8b0ba7-d76e-4b91-9577-d1b6ebd68946",
             "app_name": "RudderLabs JavaScript SDK",
@@ -1626,7 +1626,7 @@
           {
             "os_name": "Chrome",
             "os_version": "86.0.4240.198",
-            "device_model": "Mac",
+            "device_model": "Mac OS",
             "platform": "Web",
             "device_id": "2f8b0ba7-d76e-4b91-9577-d1b6ebd68946",
             "app_name": "RudderLabs JavaScript SDK",
@@ -1676,7 +1676,7 @@
           {
             "os_name": "Chrome",
             "os_version": "86.0.4240.198",
-            "device_model": "Mac",
+            "device_model": "Mac OS",
             "platform": "Web",
             "device_id": "2f8b0ba7-d76e-4b91-9577-d1b6ebd68946",
             "app_name": "RudderLabs JavaScript SDK",
@@ -1726,7 +1726,7 @@
           {
             "os_name": "Chrome",
             "os_version": "86.0.4240.198",
-            "device_model": "Mac",
+            "device_model": "Mac OS",
             "platform": "Web",
             "device_id": "2f8b0ba7-d76e-4b91-9577-d1b6ebd68946",
             "app_name": "RudderLabs JavaScript SDK",
@@ -1776,7 +1776,7 @@
           {
             "os_name": "Chrome",
             "os_version": "86.0.4240.198",
-            "device_model": "Mac",
+            "device_model": "Mac OS",
             "platform": "Web",
             "device_id": "2f8b0ba7-d76e-4b91-9577-d1b6ebd68946",
             "app_name": "RudderLabs JavaScript SDK",
@@ -1815,5 +1815,39 @@
     },
     "files": {},
     "userId": "2f8b0ba7-d76e-4b91-9577-d1b6ebd68946"
+  },
+  {
+    "version": "1",
+    "type": "REST",
+    "method": "POST",
+    "endpoint": "https://api.amplitude.com/2/httpapi",
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "params": {},
+    "body": {
+      "JSON": {
+        "api_key": "abcde",
+        "events": [
+          {
+            "device_id": "123456",
+            "user_properties": {
+              "$add": {}
+             },
+            "event_type": "$identify",
+            "session_id": "1598597129",
+            "time": 0,
+            "user_id": "ubcdfghi0001"
+          }
+        ],
+        "options": {
+          "min_id_length": 1
+        }
+      },
+      "XML": {},
+      "FORM": {}
+    },
+    "files": {},
+    "userId": "123456"
   }
 ]

--- a/__tests__/data/am_router_output.json
+++ b/__tests__/data/am_router_output.json
@@ -17,7 +17,7 @@
               {
                 "os_name": "Chrome",
                 "os_version": "77.0.3865.90",
-                "device_model": "Mac",
+                "device_model": "Mac OS",
                 "platform": "Web",
                 "device_id": "123456",
                 "app_name": "RudderLabs JavaScript SDK",
@@ -88,7 +88,7 @@
               {
                 "os_name": "Chrome",
                 "os_version": "77.0.3865.90",
-                "device_model": "Mac",
+                "device_model": "Mac OS",
                 "platform": "Web",
                 "device_id": "00000000000000000000000000",
                 "app_name": "RudderLabs JavaScript SDK",

--- a/v0/destinations/am/transform.js
+++ b/v0/destinations/am/transform.js
@@ -85,15 +85,16 @@ function updateTraitsObject(property, traitsObject, actionKey) {
 
 function prepareTraitsConfig(configPropertyTrait, actionKey, traitsObject) {
   traitsObject[actionKey] = {};
-  configPropertyTrait.forEach(traitsElement => {
-    const property = traitsElement.traits;
-    traitsObject = updateTraitsObject(property, traitsObject, actionKey);
-  });
+  configPropertyTrait
+    .forEach(traitsElement => {
+      const property = traitsElement.traits;
+      traitsObject = updateTraitsObject(property, traitsObject, actionKey);
+    });
   return traitsObject;
 }
 
 function handleTraits(messageTrait, destination) {
-  let traitsObject = JSON.parse(JSON.stringify(messageTrait));
+  let traitsObject = JSON.parse(JSON.stringify(messageTrait)) ?? {};
 
   if (destination.Config.traitsToIncrement) {
     const actionKey = "$add";

--- a/v0/destinations/am/transform.js
+++ b/v0/destinations/am/transform.js
@@ -86,9 +86,9 @@ function updateTraitsObject(property, traitsObject, actionKey) {
 function prepareTraitsConfig(configPropertyTrait, actionKey, traitsObject) {
   traitsObject[actionKey] = {};
   configPropertyTrait.forEach(traitsElement => {
-      const property = traitsElement.traits;
-      traitsObject = updateTraitsObject(property, traitsObject, actionKey);
-    });
+    const property = traitsElement.traits;
+    traitsObject = updateTraitsObject(property, traitsObject, actionKey);
+  });
   return traitsObject;
 }
 

--- a/v0/destinations/am/transform.js
+++ b/v0/destinations/am/transform.js
@@ -85,8 +85,7 @@ function updateTraitsObject(property, traitsObject, actionKey) {
 
 function prepareTraitsConfig(configPropertyTrait, actionKey, traitsObject) {
   traitsObject[actionKey] = {};
-  configPropertyTrait
-    .forEach(traitsElement => {
+  configPropertyTrait.forEach(traitsElement => {
       const property = traitsElement.traits;
       traitsObject = updateTraitsObject(property, traitsObject, actionKey);
     });


### PR DESCRIPTION
## Description of the change

https://rudderstack.slack.com/archives/C01E4PLB135/p1632443620015100

The Amplitude transformer crashes when the [optional](https://docs.rudderstack.com/rudderstack-api/api-specification/rudderstack-spec/identify#identify-fields) 'traits' property is not included in the identify call for a destination that defines `traitsToIncrement`. This PR defaults the traits object to an empty object if it does not already exist on the message.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [ ] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
