### PR TITLE
Fix Mixpanel error when message.context is undefined

### DIFF
--- a/v0/destinations/mp/transform.js
+++ b/v0/destinations/mp/transform.js
@@ -183,7 +183,7 @@ function processIdentifyEvents(message, type, destination) {
   const returnValue = [];
 
   let properties = getTransformedJSON(message, mPIdentifyConfigJson);
-  const { device } = message.context;
+  const { device } = message.context || {};
   if (device && device.token) {
     let payload;
     if (device.type.toLowerCase() === "ios") {


### PR DESCRIPTION
## Description of the change

According to the document, the context is optional, but if we omit context in the request, the following error arises.

```
{
  "error": "Cannot destructure property `device` of 'undefined' or 'null'."
}
```

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues


## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
