### PR TITLE
Remove unused tags from metrics 

### DIFF
--- a/util/stats.js
+++ b/util/stats.js
@@ -3,14 +3,12 @@ const SDC = require("statsd-client");
 const enableStats = process.env.ENABLE_STATS !== "false";
 const statsServerHost = process.env.STATSD_SERVER_HOST || "localhost";
 const statsServerPort = parseInt(process.env.STATSD_SERVER_PORT || "8125", 10);
-// HOSTNAME is automatically set by k8s. No need to add it manually
-const transformerHostName = process.env.HOSTNAME || "local-dev";
 
 const statsdClient = new SDC({
   host: statsServerHost,
   port: statsServerPort,
   prefix: "transformer",
-  tags: { pid: process.pid, transformerHostName }
+  tags: {}
 });
 
 // Sends the diff between current time and start as the stat


### PR DESCRIPTION
## Description of the change

Removes pid and transformerHostName as common tags from all the tags. This is to reduce the memory usage of influx.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
