### PR TITLE
Intercom: user id bug

### DIFF
--- a/__tests__/data/intercom_input.json
+++ b/__tests__/data/intercom_input.json
@@ -666,5 +666,147 @@
         "collectContext": false
       }
     }
+  },
+  {
+    "message": {
+        "anonymousId": "58b21c2d-f8d5-4410-a2d0-b268a26b7e33",
+        "channel": "mobile",
+        "context": {
+            "app": {
+                "build": "1.0",
+                "name": "Test_Example",
+                "namespace": "com.example.testapp",
+                "version": "1.0"
+            },
+            "device": {
+                "id": "58b21c2d-f8d5-4410-a2d0-b268a26b7e33",
+                "manufacturer": "Apple",
+                "model": "iPhone",
+                "name": "iPod touch (7th generation)",
+                "type": "iOS"
+            },
+            "library": {
+                "name": "test-ios-library",
+                "version": "1.0.7"
+            },
+            "locale": "en-US",
+            "network": {
+                "bluetooth": false,
+                "carrier": "unavailable",
+                "cellular": false,
+                "wifi": true
+            },
+            "os": {
+                "name": "iOS",
+                "version": "14.0"
+            },
+            "screen": {
+                "density": 2,
+                "height": 320,
+                "width": 568
+            },
+            "timezone": "Asia/Kolkata",
+            "traits": {
+                "anonymousId": "58b21c2d-f8d5-4410-a2d0-b268a26b7e33",
+                "name": "Test Name",
+                "firstName": "Test",
+                "lastName": "Name",
+                "createdAt": "2020-09-30T19:11:00.337Z",
+                "phone": "9876543210",
+                "key1": "value1"
+            },
+            "userAgent": "unknown"
+        },
+        "event": "Test Event 2",
+        "integrations": {
+            "All": true
+        },
+        "messageId": "1601493060-39010c49-e6e4-4626-a75c-0dbf1925c9e8",
+        "originalTimestamp": "2020-09-30T19:11:00.337Z",
+        "receivedAt": "2020-10-01T00:41:11.369+05:30",
+        "request_ip": "2405:201:8005:9856:7911:25e7:5603:5e18",
+        "sentAt": "2020-09-30T19:11:10.382Z",
+        "timestamp": "2020-10-01T00:41:01.324+05:30",
+        "type": "identify"
+    },
+    "destination": {
+        "Config": {
+            "apiKey": "dG9rOjFkNTY4NDk1X2E3OGFfNDBiM19hYjJkXzAyMDExY2Y3YzJjZjoxOjA=",
+            "appId": "9e9cdea1-78fa-4829-a9b2-5d7f7e96d1a0",
+            "collectContext": false,
+            "sendAnonymousId": true
+        }
+    }
+},
+{
+  "message": {
+      "anonymousId": "58b21c2d-f8d5-4410-a2d0-b268a26b7e33",
+      "channel": "mobile",
+      "context": {
+          "app": {
+              "build": "1.0",
+              "name": "Test_Example",
+              "namespace": "com.example.testapp",
+              "version": "1.0"
+          },
+          "device": {
+              "id": "58b21c2d-f8d5-4410-a2d0-b268a26b7e33",
+              "manufacturer": "Apple",
+              "model": "iPhone",
+              "name": "iPod touch (7th generation)",
+              "type": "iOS"
+          },
+          "library": {
+              "name": "test-ios-library",
+              "version": "1.0.7"
+          },
+          "locale": "en-US",
+          "network": {
+              "bluetooth": false,
+              "carrier": "unavailable",
+              "cellular": false,
+              "wifi": true
+          },
+          "os": {
+              "name": "iOS",
+              "version": "14.0"
+          },
+          "screen": {
+              "density": 2,
+              "height": 320,
+              "width": 568
+          },
+          "timezone": "Asia/Kolkata",
+          "traits": {
+              "anonymousId": "58b21c2d-f8d5-4410-a2d0-b268a26b7e33",
+              "name": "Test Name",
+              "firstName": "Test",
+              "lastName": "Name",
+              "createdAt": "2020-09-30T19:11:00.337Z",
+              "phone": "9876543210",
+              "key1": "value1"
+          },
+          "userAgent": "unknown"
+      },
+      "event": "Test Event 2",
+      "integrations": {
+          "All": true
+      },
+      "messageId": "1601493060-39010c49-e6e4-4626-a75c-0dbf1925c9e8",
+      "originalTimestamp": "2020-09-30T19:11:00.337Z",
+      "receivedAt": "2020-10-01T00:41:11.369+05:30",
+      "request_ip": "2405:201:8005:9856:7911:25e7:5603:5e18",
+      "sentAt": "2020-09-30T19:11:10.382Z",
+      "timestamp": "2020-10-01T00:41:01.324+05:30",
+      "type": "identify"
+  },
+  "destination": {
+      "Config": {
+          "apiKey": "dG9rOjFkNTY4NDk1X2E3OGFfNDBiM19hYjJkXzAyMDExY2Y3YzJjZjoxOjA=",
+          "appId": "9e9cdea1-78fa-4829-a9b2-5d7f7e96d1a0",
+          "collectContext": false,
+          "sendAnonymousId": false
+      }
   }
+}
 ]

--- a/__tests__/data/intercom_input.json
+++ b/__tests__/data/intercom_input.json
@@ -17,7 +17,10 @@
           "name": "iPod touch (7th generation)",
           "type": "iOS"
         },
-        "library": { "name": "test-ios-library", "version": "1.0.7" },
+        "library": {
+          "name": "test-ios-library",
+          "version": "1.0.7"
+        },
         "locale": "en-US",
         "network": {
           "bluetooth": false,
@@ -25,8 +28,15 @@
           "cellular": false,
           "wifi": true
         },
-        "os": { "name": "iOS", "version": "14.0" },
-        "screen": { "density": 2, "height": 320, "width": 568 },
+        "os": {
+          "name": "iOS",
+          "version": "14.0"
+        },
+        "screen": {
+          "density": 2,
+          "height": 320,
+          "width": 568
+        },
         "timezone": "Asia/Kolkata",
         "traits": {
           "anonymousId": "58b21c2d-f8d5-4410-a2d0-b268a26b7e33",
@@ -42,7 +52,9 @@
         "userAgent": "unknown"
       },
       "event": "Test Event 2",
-      "integrations": { "All": true },
+      "integrations": {
+        "All": true
+      },
       "messageId": "1601493060-39010c49-e6e4-4626-a75c-0dbf1925c9e8",
       "originalTimestamp": "2020-09-30T19:11:00.337Z",
       "receivedAt": "2020-10-01T00:41:11.369+05:30",
@@ -77,7 +89,10 @@
           "name": "iPod touch (7th generation)",
           "type": "iOS"
         },
-        "library": { "name": "test-ios-library", "version": "1.0.7" },
+        "library": {
+          "name": "test-ios-library",
+          "version": "1.0.7"
+        },
         "locale": "en-US",
         "network": {
           "bluetooth": false,
@@ -85,8 +100,15 @@
           "cellular": false,
           "wifi": true
         },
-        "os": { "name": "iOS", "version": "14.0" },
-        "screen": { "density": 2, "height": 320, "width": 568 },
+        "os": {
+          "name": "iOS",
+          "version": "14.0"
+        },
+        "screen": {
+          "density": 2,
+          "height": 320,
+          "width": 568
+        },
         "timezone": "Asia/Kolkata",
         "traits": {
           "anonymousId": "58b21c2d-f8d5-4410-a2d0-b268a26b7e33",
@@ -100,7 +122,9 @@
         "userAgent": "unknown"
       },
       "event": "Test Event 2",
-      "integrations": { "All": true },
+      "integrations": {
+        "All": true
+      },
       "messageId": "1601493060-39010c49-e6e4-4626-a75c-0dbf1925c9e8",
       "originalTimestamp": "2020-09-30T19:11:00.337Z",
       "receivedAt": "2020-10-01T00:41:11.369+05:30",
@@ -135,7 +159,10 @@
           "name": "iPod touch (7th generation)",
           "type": "iOS"
         },
-        "library": { "name": "test-ios-library", "version": "1.0.7" },
+        "library": {
+          "name": "test-ios-library",
+          "version": "1.0.7"
+        },
         "locale": "en-US",
         "network": {
           "bluetooth": false,
@@ -143,8 +170,15 @@
           "cellular": false,
           "wifi": true
         },
-        "os": { "name": "iOS", "version": "14.0" },
-        "screen": { "density": 2, "height": 320, "width": 568 },
+        "os": {
+          "name": "iOS",
+          "version": "14.0"
+        },
+        "screen": {
+          "density": 2,
+          "height": 320,
+          "width": 568
+        },
         "timezone": "Asia/Kolkata",
         "traits": {
           "anonymousId": "58b21c2d-f8d5-4410-a2d0-b268a26b7e33",
@@ -157,7 +191,9 @@
         "userAgent": "unknown"
       },
       "event": "Test Event 2",
-      "integrations": { "All": true },
+      "integrations": {
+        "All": true
+      },
       "messageId": "1601493060-39010c49-e6e4-4626-a75c-0dbf1925c9e8",
       "originalTimestamp": "2020-09-30T19:11:00.337Z",
       "receivedAt": "2020-10-01T00:41:11.369+05:30",
@@ -192,7 +228,10 @@
           "name": "iPod touch (7th generation)",
           "type": "iOS"
         },
-        "library": { "name": "test-ios-library", "version": "1.0.7" },
+        "library": {
+          "name": "test-ios-library",
+          "version": "1.0.7"
+        },
         "locale": "en-US",
         "network": {
           "bluetooth": false,
@@ -200,8 +239,15 @@
           "cellular": false,
           "wifi": true
         },
-        "os": { "name": "iOS", "version": "14.0" },
-        "screen": { "density": 2, "height": 320, "width": 568 },
+        "os": {
+          "name": "iOS",
+          "version": "14.0"
+        },
+        "screen": {
+          "density": 2,
+          "height": 320,
+          "width": 568
+        },
         "timezone": "Asia/Kolkata",
         "traits": {
           "anonymousId": "58b21c2d-f8d5-4410-a2d0-b268a26b7e33",
@@ -214,7 +260,9 @@
         "userAgent": "unknown"
       },
       "event": "Test Event 2",
-      "integrations": { "All": true },
+      "integrations": {
+        "All": true
+      },
       "messageId": "1601493060-39010c49-e6e4-4626-a75c-0dbf1925c9e8",
       "originalTimestamp": "2020-09-30T19:11:00.337Z",
       "receivedAt": "2020-10-01T00:41:11.369+05:30",
@@ -249,7 +297,10 @@
           "name": "iPod touch (7th generation)",
           "type": "iOS"
         },
-        "library": { "name": "test-ios-library", "version": "1.0.7" },
+        "library": {
+          "name": "test-ios-library",
+          "version": "1.0.7"
+        },
         "locale": "en-US",
         "network": {
           "bluetooth": false,
@@ -257,8 +308,15 @@
           "cellular": false,
           "wifi": true
         },
-        "os": { "name": "iOS", "version": "14.0" },
-        "screen": { "density": 2, "height": 320, "width": 568 },
+        "os": {
+          "name": "iOS",
+          "version": "14.0"
+        },
+        "screen": {
+          "density": 2,
+          "height": 320,
+          "width": 568
+        },
         "timezone": "Asia/Kolkata",
         "traits": {
           "anonymousId": "58b21c2d-f8d5-4410-a2d0-b268a26b7e33",
@@ -270,7 +328,9 @@
         "userAgent": "unknown"
       },
       "event": "Test Event 2",
-      "integrations": { "All": true },
+      "integrations": {
+        "All": true
+      },
       "messageId": "1601493060-39010c49-e6e4-4626-a75c-0dbf1925c9e8",
       "originalTimestamp": "2020-09-30T19:11:00.337Z",
       "receivedAt": "2020-10-01T00:41:11.369+05:30",
@@ -305,7 +365,10 @@
           "name": "iPod touch (7th generation)",
           "type": "iOS"
         },
-        "library": { "name": "test-ios-library", "version": "1.0.7" },
+        "library": {
+          "name": "test-ios-library",
+          "version": "1.0.7"
+        },
         "locale": "en-US",
         "network": {
           "bluetooth": false,
@@ -313,8 +376,15 @@
           "cellular": false,
           "wifi": true
         },
-        "os": { "name": "iOS", "version": "14.0" },
-        "screen": { "density": 2, "height": 320, "width": 568 },
+        "os": {
+          "name": "iOS",
+          "version": "14.0"
+        },
+        "screen": {
+          "density": 2,
+          "height": 320,
+          "width": 568
+        },
         "timezone": "Asia/Kolkata",
         "traits": {
           "anonymousId": "58b21c2d-f8d5-4410-a2d0-b268a26b7e33",
@@ -333,7 +403,9 @@
         "userAgent": "unknown"
       },
       "event": "Test Event 2",
-      "integrations": { "All": true },
+      "integrations": {
+        "All": true
+      },
       "messageId": "1601493060-39010c49-e6e4-4626-a75c-0dbf1925c9e8",
       "originalTimestamp": "2020-09-30T19:11:00.337Z",
       "receivedAt": "2020-10-01T00:41:11.369+05:30",
@@ -368,7 +440,10 @@
           "name": "iPod touch (7th generation)",
           "type": "iOS"
         },
-        "library": { "name": "test-ios-library", "version": "1.0.7" },
+        "library": {
+          "name": "test-ios-library",
+          "version": "1.0.7"
+        },
         "locale": "en-US",
         "network": {
           "bluetooth": false,
@@ -376,8 +451,15 @@
           "cellular": false,
           "wifi": true
         },
-        "os": { "name": "iOS", "version": "14.0" },
-        "screen": { "density": 2, "height": 320, "width": 568 },
+        "os": {
+          "name": "iOS",
+          "version": "14.0"
+        },
+        "screen": {
+          "density": 2,
+          "height": 320,
+          "width": 568
+        },
         "timezone": "Asia/Kolkata",
         "traits": {
           "anonymousId": "58b21c2d-f8d5-4410-a2d0-b268a26b7e33",
@@ -396,7 +478,9 @@
         "userAgent": "unknown"
       },
       "event": "Test Event 2",
-      "integrations": { "All": true },
+      "integrations": {
+        "All": true
+      },
       "messageId": "1601493060-39010c49-e6e4-4626-a75c-0dbf1925c9e8",
       "originalTimestamp": "2020-09-30T19:11:00.337Z",
       "receivedAt": "2020-10-01T00:41:11.369+05:30",
@@ -431,7 +515,10 @@
           "name": "iPod touch (7th generation)",
           "type": "iOS"
         },
-        "library": { "name": "test-ios-library", "version": "1.0.7" },
+        "library": {
+          "name": "test-ios-library",
+          "version": "1.0.7"
+        },
         "locale": "en-US",
         "network": {
           "bluetooth": false,
@@ -439,8 +526,15 @@
           "cellular": false,
           "wifi": true
         },
-        "os": { "name": "iOS", "version": "14.0" },
-        "screen": { "density": 2, "height": 320, "width": 568 },
+        "os": {
+          "name": "iOS",
+          "version": "14.0"
+        },
+        "screen": {
+          "density": 2,
+          "height": 320,
+          "width": 568
+        },
         "timezone": "Asia/Kolkata",
         "traits": {
           "anonymousId": "58b21c2d-f8d5-4410-a2d0-b268a26b7e33",
@@ -458,7 +552,9 @@
         "userAgent": "unknown"
       },
       "event": "Test Event 2",
-      "integrations": { "All": true },
+      "integrations": {
+        "All": true
+      },
       "messageId": "1601493060-39010c49-e6e4-4626-a75c-0dbf1925c9e8",
       "originalTimestamp": "2020-09-30T19:11:00.337Z",
       "receivedAt": "2020-10-01T00:41:11.369+05:30",
@@ -493,7 +589,10 @@
           "name": "iPod touch (7th generation)",
           "type": "iOS"
         },
-        "library": { "name": "test-ios-library", "version": "1.0.7" },
+        "library": {
+          "name": "test-ios-library",
+          "version": "1.0.7"
+        },
         "locale": "en-US",
         "network": {
           "bluetooth": false,
@@ -501,8 +600,15 @@
           "cellular": false,
           "wifi": true
         },
-        "os": { "name": "iOS", "version": "14.0" },
-        "screen": { "density": 2, "height": 320, "width": 568 },
+        "os": {
+          "name": "iOS",
+          "version": "14.0"
+        },
+        "screen": {
+          "density": 2,
+          "height": 320,
+          "width": 568
+        },
         "timezone": "Asia/Kolkata",
         "traits": {
           "anonymousId": "58b21c2d-f8d5-4410-a2d0-b268a26b7e33",
@@ -533,7 +639,9 @@
         "property6": null
       },
       "event": "Test Event 2",
-      "integrations": { "All": true },
+      "integrations": {
+        "All": true
+      },
       "messageId": "1601493060-39010c49-e6e4-4626-a75c-0dbf1925c9e8",
       "originalTimestamp": "2020-09-30T19:11:00.337Z",
       "receivedAt": "2020-10-01T00:41:11.369+05:30",
@@ -568,7 +676,10 @@
           "name": "iPod touch (7th generation)",
           "type": "iOS"
         },
-        "library": { "name": "test-ios-library", "version": "1.0.7" },
+        "library": {
+          "name": "test-ios-library",
+          "version": "1.0.7"
+        },
         "locale": "en-US",
         "network": {
           "bluetooth": false,
@@ -576,8 +687,15 @@
           "cellular": false,
           "wifi": true
         },
-        "os": { "name": "iOS", "version": "14.0" },
-        "screen": { "density": 2, "height": 320, "width": 568 },
+        "os": {
+          "name": "iOS",
+          "version": "14.0"
+        },
+        "screen": {
+          "density": 2,
+          "height": 320,
+          "width": 568
+        },
         "timezone": "Asia/Kolkata",
         "traits": {
           "anonymousId": "58b21c2d-f8d5-4410-a2d0-b268a26b7e33",
@@ -592,7 +710,9 @@
         "userAgent": "unknown"
       },
       "event": "Test Event 2",
-      "integrations": { "All": true },
+      "integrations": {
+        "All": true
+      },
       "messageId": "1601493060-39010c49-e6e4-4626-a75c-0dbf1925c9e8",
       "originalTimestamp": "2020-09-30T19:11:00.337Z",
       "receivedAt": "2020-10-01T00:41:11.369+05:30",
@@ -627,7 +747,10 @@
           "name": "iPod touch (7th generation)",
           "type": "iOS"
         },
-        "library": { "name": "test-ios-library", "version": "1.0.7" },
+        "library": {
+          "name": "test-ios-library",
+          "version": "1.0.7"
+        },
         "locale": "en-US",
         "network": {
           "bluetooth": false,
@@ -635,8 +758,15 @@
           "cellular": false,
           "wifi": true
         },
-        "os": { "name": "iOS", "version": "14.0" },
-        "screen": { "density": 2, "height": 320, "width": 568 },
+        "os": {
+          "name": "iOS",
+          "version": "14.0"
+        },
+        "screen": {
+          "density": 2,
+          "height": 320,
+          "width": 568
+        },
         "timezone": "Asia/Kolkata",
         "traits": {
           "anonymousId": "58b21c2d-f8d5-4410-a2d0-b268a26b7e33",
@@ -650,7 +780,9 @@
         "userAgent": "unknown"
       },
       "event": "Test Event 2",
-      "integrations": { "All": true },
+      "integrations": {
+        "All": true
+      },
       "messageId": "1601493060-39010c49-e6e4-4626-a75c-0dbf1925c9e8",
       "originalTimestamp": "2020-09-30T19:11:00.337Z",
       "receivedAt": "2020-10-01T00:41:11.369+05:30",
@@ -669,128 +801,57 @@
   },
   {
     "message": {
-        "anonymousId": "58b21c2d-f8d5-4410-a2d0-b268a26b7e33",
-        "channel": "mobile",
-        "context": {
-            "app": {
-                "build": "1.0",
-                "name": "Test_Example",
-                "namespace": "com.example.testapp",
-                "version": "1.0"
-            },
-            "device": {
-                "id": "58b21c2d-f8d5-4410-a2d0-b268a26b7e33",
-                "manufacturer": "Apple",
-                "model": "iPhone",
-                "name": "iPod touch (7th generation)",
-                "type": "iOS"
-            },
-            "library": {
-                "name": "test-ios-library",
-                "version": "1.0.7"
-            },
-            "locale": "en-US",
-            "network": {
-                "bluetooth": false,
-                "carrier": "unavailable",
-                "cellular": false,
-                "wifi": true
-            },
-            "os": {
-                "name": "iOS",
-                "version": "14.0"
-            },
-            "screen": {
-                "density": 2,
-                "height": 320,
-                "width": 568
-            },
-            "timezone": "Asia/Kolkata",
-            "traits": {
-                "anonymousId": "58b21c2d-f8d5-4410-a2d0-b268a26b7e33",
-                "name": "Test Name",
-                "firstName": "Test",
-                "lastName": "Name",
-                "createdAt": "2020-09-30T19:11:00.337Z",
-                "phone": "9876543210",
-                "key1": "value1"
-            },
-            "userAgent": "unknown"
-        },
-        "event": "Test Event 2",
-        "integrations": {
-            "All": true
-        },
-        "messageId": "1601493060-39010c49-e6e4-4626-a75c-0dbf1925c9e8",
-        "originalTimestamp": "2020-09-30T19:11:00.337Z",
-        "receivedAt": "2020-10-01T00:41:11.369+05:30",
-        "request_ip": "2405:201:8005:9856:7911:25e7:5603:5e18",
-        "sentAt": "2020-09-30T19:11:10.382Z",
-        "timestamp": "2020-10-01T00:41:01.324+05:30",
-        "type": "identify"
-    },
-    "destination": {
-        "Config": {
-            "apiKey": "dG9rOjFkNTY4NDk1X2E3OGFfNDBiM19hYjJkXzAyMDExY2Y3YzJjZjoxOjA=",
-            "appId": "9e9cdea1-78fa-4829-a9b2-5d7f7e96d1a0",
-            "collectContext": false,
-            "sendAnonymousId": true
-        }
-    }
-},
-{
-  "message": {
       "anonymousId": "58b21c2d-f8d5-4410-a2d0-b268a26b7e33",
       "channel": "mobile",
       "context": {
-          "app": {
-              "build": "1.0",
-              "name": "Test_Example",
-              "namespace": "com.example.testapp",
-              "version": "1.0"
-          },
-          "device": {
-              "id": "58b21c2d-f8d5-4410-a2d0-b268a26b7e33",
-              "manufacturer": "Apple",
-              "model": "iPhone",
-              "name": "iPod touch (7th generation)",
-              "type": "iOS"
-          },
-          "library": {
-              "name": "test-ios-library",
-              "version": "1.0.7"
-          },
-          "locale": "en-US",
-          "network": {
-              "bluetooth": false,
-              "carrier": "unavailable",
-              "cellular": false,
-              "wifi": true
-          },
-          "os": {
-              "name": "iOS",
-              "version": "14.0"
-          },
-          "screen": {
-              "density": 2,
-              "height": 320,
-              "width": 568
-          },
-          "timezone": "Asia/Kolkata",
-          "traits": {
-              "anonymousId": "58b21c2d-f8d5-4410-a2d0-b268a26b7e33",
-              "name": "Test Name",
-              "firstName": "Test",
-              "lastName": "Name",
-              "createdAt": "2020-09-30T19:11:00.337Z",
-              "phone": "9876543210",
-              "key1": "value1"
-          },
-          "userAgent": "unknown"
+        "app": {
+          "build": "1.0",
+          "name": "Test_Example",
+          "namespace": "com.example.testapp",
+          "version": "1.0"
+        },
+        "device": {
+          "id": "58b21c2d-f8d5-4410-a2d0-b268a26b7e33",
+          "manufacturer": "Apple",
+          "model": "iPhone",
+          "name": "iPod touch (7th generation)",
+          "type": "iOS"
+        },
+        "library": {
+          "name": "test-ios-library",
+          "version": "1.0.7"
+        },
+        "locale": "en-US",
+        "network": {
+          "bluetooth": false,
+          "carrier": "unavailable",
+          "cellular": false,
+          "wifi": true
+        },
+        "os": {
+          "name": "iOS",
+          "version": "14.0"
+        },
+        "screen": {
+          "density": 2,
+          "height": 320,
+          "width": 568
+        },
+        "timezone": "Asia/Kolkata",
+        "traits": {
+          "anonymousId": "58b21c2d-f8d5-4410-a2d0-b268a26b7e33",
+          "name": "Test Name",
+          "firstName": "Test",
+          "lastName": "Name",
+          "createdAt": "2020-09-30T19:11:00.337Z",
+          "phone": "9876543210",
+          "key1": "value1"
+        },
+        "userAgent": "unknown"
       },
       "event": "Test Event 2",
       "integrations": {
-          "All": true
+        "All": true
       },
       "messageId": "1601493060-39010c49-e6e4-4626-a75c-0dbf1925c9e8",
       "originalTimestamp": "2020-09-30T19:11:00.337Z",
@@ -799,14 +860,85 @@
       "sentAt": "2020-09-30T19:11:10.382Z",
       "timestamp": "2020-10-01T00:41:01.324+05:30",
       "type": "identify"
-  },
-  "destination": {
+    },
+    "destination": {
       "Config": {
-          "apiKey": "dG9rOjFkNTY4NDk1X2E3OGFfNDBiM19hYjJkXzAyMDExY2Y3YzJjZjoxOjA=",
-          "appId": "9e9cdea1-78fa-4829-a9b2-5d7f7e96d1a0",
-          "collectContext": false,
-          "sendAnonymousId": false
+        "apiKey": "dG9rOjFkNTY4NDk1X2E3OGFfNDBiM19hYjJkXzAyMDExY2Y3YzJjZjoxOjA=",
+        "appId": "9e9cdea1-78fa-4829-a9b2-5d7f7e96d1a0",
+        "collectContext": false,
+        "sendAnonymousId": true
       }
+    }
+  },
+  {
+    "message": {
+      "anonymousId": "58b21c2d-f8d5-4410-a2d0-b268a26b7e33",
+      "channel": "mobile",
+      "context": {
+        "app": {
+          "build": "1.0",
+          "name": "Test_Example",
+          "namespace": "com.example.testapp",
+          "version": "1.0"
+        },
+        "device": {
+          "id": "58b21c2d-f8d5-4410-a2d0-b268a26b7e33",
+          "manufacturer": "Apple",
+          "model": "iPhone",
+          "name": "iPod touch (7th generation)",
+          "type": "iOS"
+        },
+        "library": {
+          "name": "test-ios-library",
+          "version": "1.0.7"
+        },
+        "locale": "en-US",
+        "network": {
+          "bluetooth": false,
+          "carrier": "unavailable",
+          "cellular": false,
+          "wifi": true
+        },
+        "os": {
+          "name": "iOS",
+          "version": "14.0"
+        },
+        "screen": {
+          "density": 2,
+          "height": 320,
+          "width": 568
+        },
+        "timezone": "Asia/Kolkata",
+        "traits": {
+          "anonymousId": "58b21c2d-f8d5-4410-a2d0-b268a26b7e33",
+          "name": "Test Name",
+          "firstName": "Test",
+          "lastName": "Name",
+          "createdAt": "2020-09-30T19:11:00.337Z",
+          "phone": "9876543210",
+          "key1": "value1"
+        },
+        "userAgent": "unknown"
+      },
+      "event": "Test Event 2",
+      "integrations": {
+        "All": true
+      },
+      "messageId": "1601493060-39010c49-e6e4-4626-a75c-0dbf1925c9e8",
+      "originalTimestamp": "2020-09-30T19:11:00.337Z",
+      "receivedAt": "2020-10-01T00:41:11.369+05:30",
+      "request_ip": "2405:201:8005:9856:7911:25e7:5603:5e18",
+      "sentAt": "2020-09-30T19:11:10.382Z",
+      "timestamp": "2020-10-01T00:41:01.324+05:30",
+      "type": "identify"
+    },
+    "destination": {
+      "Config": {
+        "apiKey": "dG9rOjFkNTY4NDk1X2E3OGFfNDBiM19hYjJkXzAyMDExY2Y3YzJjZjoxOjA=",
+        "appId": "9e9cdea1-78fa-4829-a9b2-5d7f7e96d1a0",
+        "collectContext": false,
+        "sendAnonymousId": false
+      }
+    }
   }
-}
 ]

--- a/__tests__/data/intercom_output.json
+++ b/__tests__/data/intercom_output.json
@@ -159,7 +159,9 @@
         "companies": [
           {
             "company_id": "company_id",
-            "custom_attributes": { "key1": "value1" },
+            "custom_attributes": {
+              "key1": "value1"
+            },
             "name": "Test Comp",
             "industry": "test industry"
           }
@@ -199,7 +201,9 @@
         "companies": [
           {
             "company_id": "c0277b5c814453e5135f515f943d085a",
-            "custom_attributes": { "key1": "value1" },
+            "custom_attributes": {
+              "key1": "value1"
+            },
             "name": "Test Comp",
             "industry": "test industry"
           }
@@ -277,7 +281,6 @@
     "files": {},
     "userId": "58b21c2d-f8d5-4410-a2d0-b268a26b7e33"
   },
-
   {
     "version": "1",
     "type": "REST",
@@ -314,34 +317,34 @@
     "method": "POST",
     "endpoint": "https://api.intercom.io/users",
     "headers": {
-        "Content-Type": "application/json",
-        "Authorization": "Bearer dG9rOjFkNTY4NDk1X2E3OGFfNDBiM19hYjJkXzAyMDExY2Y3YzJjZjoxOjA=",
-        "Accept": "application/json",
-        "Intercom-Version": "1.4"
+      "Content-Type": "application/json",
+      "Authorization": "Bearer dG9rOjFkNTY4NDk1X2E3OGFfNDBiM19hYjJkXzAyMDExY2Y3YzJjZjoxOjA=",
+      "Accept": "application/json",
+      "Intercom-Version": "1.4"
     },
     "params": {},
     "body": {
-        "JSON": {
-            "phone": "9876543210",
-            "name": "Test Name",
-            "signed_up_at": 1601493060337,
-            "last_seen_user_agent": "unknown",
-            "custom_attributes": {
-                "anonymousId": "58b21c2d-f8d5-4410-a2d0-b268a26b7e33",
-                "key1": "value1"
-            },
-            "user_id": "58b21c2d-f8d5-4410-a2d0-b268a26b7e33",
-            "update_last_request_at": true
+      "JSON": {
+        "phone": "9876543210",
+        "name": "Test Name",
+        "signed_up_at": 1601493060337,
+        "last_seen_user_agent": "unknown",
+        "custom_attributes": {
+          "anonymousId": "58b21c2d-f8d5-4410-a2d0-b268a26b7e33",
+          "key1": "value1"
         },
-        "JSON_ARRAY": {},
-        "XML": {},
-        "FORM": {}
+        "user_id": "58b21c2d-f8d5-4410-a2d0-b268a26b7e33",
+        "update_last_request_at": true
+      },
+      "JSON_ARRAY": {},
+      "XML": {},
+      "FORM": {}
     },
     "files": {},
     "userId": "58b21c2d-f8d5-4410-a2d0-b268a26b7e33"
-},
-{
-  "statusCode": 400,
-  "error": "Email or userId is mandatory"
-}
+  },
+  {
+    "statusCode": 400,
+    "error": "Email or userId is mandatory"
+  }
 ]

--- a/__tests__/data/intercom_output.json
+++ b/__tests__/data/intercom_output.json
@@ -307,5 +307,41 @@
   {
     "statusCode": 400,
     "error": "Email or userId is mandatory"
-  }
+  },
+  {
+    "version": "1",
+    "type": "REST",
+    "method": "POST",
+    "endpoint": "https://api.intercom.io/users",
+    "headers": {
+        "Content-Type": "application/json",
+        "Authorization": "Bearer dG9rOjFkNTY4NDk1X2E3OGFfNDBiM19hYjJkXzAyMDExY2Y3YzJjZjoxOjA=",
+        "Accept": "application/json",
+        "Intercom-Version": "1.4"
+    },
+    "params": {},
+    "body": {
+        "JSON": {
+            "phone": "9876543210",
+            "name": "Test Name",
+            "signed_up_at": 1601493060337,
+            "last_seen_user_agent": "unknown",
+            "custom_attributes": {
+                "anonymousId": "58b21c2d-f8d5-4410-a2d0-b268a26b7e33",
+                "key1": "value1"
+            },
+            "user_id": "58b21c2d-f8d5-4410-a2d0-b268a26b7e33",
+            "update_last_request_at": true
+        },
+        "JSON_ARRAY": {},
+        "XML": {},
+        "FORM": {}
+    },
+    "files": {},
+    "userId": "58b21c2d-f8d5-4410-a2d0-b268a26b7e33"
+},
+{
+  "statusCode": 400,
+  "error": "Email or userId is mandatory"
+}
 ]

--- a/v0/destinations/intercom/transform.js
+++ b/v0/destinations/intercom/transform.js
@@ -125,6 +125,7 @@ function processSingleMessage(message, destination) {
     );
   }
   const messageType = message.type.toLowerCase();
+  const { sendAnonymousId } = destination.Config;
   let category;
 
   switch (messageType) {
@@ -143,6 +144,9 @@ function processSingleMessage(message, destination) {
 
   // build the response and return
   const payload = constructPayload(message, MappingConfig[category.name]);
+  if (sendAnonymousId && !payload.user_id && !payload.email) {
+    payload.user_id = message.anonymousId;
+  }
   return validateAndBuildResponse(message, payload, category, destination);
 }
 

--- a/v0/destinations/intercom/transform.js
+++ b/v0/destinations/intercom/transform.js
@@ -144,7 +144,7 @@ function processSingleMessage(message, destination) {
 
   // build the response and return
   const payload = constructPayload(message, MappingConfig[category.name]);
-  if (sendAnonymousId && !payload.user_id && !payload.email) {
+  if (sendAnonymousId && !payload.user_id) {
     payload.user_id = message.anonymousId;
   }
   return validateAndBuildResponse(message, payload, category, destination);


### PR DESCRIPTION
## Description of the change
Now the user has control, whether they want to send anonymousId as secondary userId, which we are planning to use as user_id in the output payload if userId and email are missing from input.

https://www.notion.so/rudderstacks/Intercom-UserId-bug-fix-0243d0386e5e4e8cb7111ce1353bf379
## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
