### PR TITLE
Fixed Device Token not sent to Customer io Immediately

### DIFF
--- a/__tests__/data/customerio_input.json
+++ b/__tests__/data/customerio_input.json
@@ -2108,5 +2108,1411 @@
     "request": {
       "query": {}
     }
+  },
+  {
+    "message": {
+      "anonymousId": "5d727a3e-a72b-4d00-8078-669c1494791d",
+      "channel": "mobile",
+      "context": {
+        "app": {
+          "build": "1",
+          "name": "zx_userid_missing",
+          "namespace": "org.reactjs.native.example.zx-userid-missing",
+          "version": "1.0"
+        },
+        "device": {
+          "attTrackingStatus": 0,
+          "id": "5d727a3e-a72b-4d00-8078-669c1494791d",
+          "manufacturer": "Apple",
+          "model": "iPhone",
+          "name": "iPhone 13",
+          "token": "deviceToken",
+          "type": "iOS"
+        },
+        "library": {
+          "name": "rudder-ios-library",
+          "version": "1.3.1"
+        },
+        "locale": "en-US",
+        "network": {
+          "bluetooth": false,
+          "carrier": "unavailable",
+          "cellular": false,
+          "wifi": true
+        },
+        "os": {
+          "name": "iOS",
+          "version": "15.2"
+        },
+        "screen": {
+          "density": 3,
+          "height": 390,
+          "width": 844
+        },
+        "timezone": "Asia/Kolkata",
+        "traits": {
+          "anonymousId": "5d727a3e-a72b-4d00-8078-669c1494791d",
+          "email": "sofia@gmail.com",
+          "login_status": "Authenticated",
+          "name": "Sofia",
+          "phone_verified": 1,
+          "selected_city": "",
+          "selected_lat": 0,
+          "selected_long": 0,
+          "selected_neighborhood": "",
+          "selected_number": "",
+          "selected_postal_code": "",
+          "selected_state": "",
+          "selected_street": "",
+          "signed_up_for_newsletters": 0,
+          "userId": "e91e0378-63fe-11ec-82ac-0a028ee659c3"
+        }
+      },
+      "event": "Application Opened",
+      "integrations": {
+        "All": true
+      },
+      "messageId": "1641808826-28d23237-f4f0-4f65-baa2-99141e422a8f",
+      "originalTimestamp": "2022-01-10T10:00:26.513Z",
+      "properties": {
+        "from_background": false
+      },
+      "receivedAt": "2022-01-10T20:35:30.556+05:30",
+      "request_ip": "[::1]",
+      "rudderId": "423cdf83-0448-4a99-b14d-36fcc63e6ea0",
+      "sentAt": "2022-01-10T10:00:26.982Z",
+      "timestamp": "2022-01-10T20:35:30.087+05:30",
+      "type": "track",
+      "userId": "e91e0378-63fe-11ec-82ac-0a028ee659c3"
+    },
+    "destination": {
+      "ID": "23Mi76khsFhY7bh9ZyRcvR3pHDt",
+      "Name": "Customer IO Dev",
+      "DestinationDefinition": {
+        "ID": "23MgSlHXsPLsiH7SbW7IzCP32fn",
+        "Name": "CUSTOMERIO",
+        "DisplayName": "Customer IO",
+        "Config": {
+          "destConfig": {
+            "defaultConfig": [
+              "apiKey",
+              "siteID",
+              "datacenterEU",
+              "deviceTokenEventName"
+            ],
+            "web": [
+              "useNativeSDK",
+              "blackListedEvents",
+              "whiteListedEvents"
+            ]
+          },
+          "excludeKeys": [],
+          "includeKeys": [
+            "apiKey",
+            "siteID",
+            "datacenterEU",
+            "blackListedEvents",
+            "whiteListedEvents"
+          ],
+          "saveDestinationResponse": true,
+          "secretKeys": [],
+          "supportedMessageTypes": [
+            "identify",
+            "page",
+            "screen",
+            "track"
+          ],
+          "supportedSourceTypes": [
+            "android",
+            "ios",
+            "web",
+            "unity",
+            "amp",
+            "cloud",
+            "warehouse",
+            "reactnative",
+            "flutter",
+            "cordova"
+          ],
+          "supportsVisualMapper": true,
+          "transformAt": "processor",
+          "transformAtV1": "processor"
+        },
+        "ResponseRules": {}
+      },
+      "Config": {
+        "apiKey": "DESAU SAI",
+        "datacenterEU": false,
+        "deviceTokenEventName": "device_token_registered",
+        "siteID": "DESU SAI"
+      },
+      "Enabled": true,
+      "Transformations": [],
+      "IsProcessorEnabled": true
+    }
+  },
+  {
+    "message": {
+      "anonymousId": "5d727a3e-a72b-4d00-8078-669c1494791d",
+      "channel": "mobile",
+      "context": {
+        "app": {
+          "build": "1",
+          "name": "zx_userid_missing",
+          "namespace": "org.reactjs.native.example.zx-userid-missing",
+          "version": "1.0"
+        },
+        "device": {
+          "attTrackingStatus": 0,
+          "id": "5d727a3e-a72b-4d00-8078-669c1494791d",
+          "manufacturer": "Apple",
+          "model": "iPhone",
+          "name": "iPhone 13",
+          "type": "iOS"
+        },
+        "library": {
+          "name": "rudder-ios-library",
+          "version": "1.3.1"
+        },
+        "locale": "en-US",
+        "network": {
+          "bluetooth": false,
+          "carrier": "unavailable",
+          "cellular": false,
+          "wifi": true
+        },
+        "os": {
+          "name": "iOS",
+          "version": "15.2"
+        },
+        "screen": {
+          "density": 3,
+          "height": 390,
+          "width": 844
+        },
+        "timezone": "Asia/Kolkata",
+        "traits": {
+          "anonymousId": "5d727a3e-a72b-4d00-8078-669c1494791d",
+          "email": "sofia@gmail.com",
+          "login_status": "Authenticated",
+          "name": "Sofia",
+          "phone_verified": 1,
+          "selected_city": "",
+          "selected_lat": 0,
+          "selected_long": 0,
+          "selected_neighborhood": "",
+          "selected_number": "",
+          "selected_postal_code": "",
+          "selected_state": "",
+          "selected_street": "",
+          "signed_up_for_newsletters": 0,
+          "userId": "e91e0378-63fe-11ec-82ac-0a028ee659c3"
+        }
+      },
+      "event": "Application Opened",
+      "integrations": {
+        "All": true
+      },
+      "messageId": "1641808826-28d23237-f4f0-4f65-baa2-99141e422a8f",
+      "originalTimestamp": "2022-01-10T10:00:26.513Z",
+      "properties": {
+        "from_background": false
+      },
+      "receivedAt": "2022-01-10T20:39:04.424+05:30",
+      "request_ip": "[::1]",
+      "rudderId": "423cdf83-0448-4a99-b14d-36fcc63e6ea0",
+      "sentAt": "2022-01-10T10:00:26.982Z",
+      "timestamp": "2022-01-10T20:39:03.955+05:30",
+      "type": "track",
+      "userId": "e91e0378-63fe-11ec-82ac-0a028ee659c3"
+    },
+    "destination": {
+      "ID": "23Mi76khsFhY7bh9ZyRcvR3pHDt",
+      "Name": "Customer IO Dev",
+      "DestinationDefinition": {
+        "ID": "23MgSlHXsPLsiH7SbW7IzCP32fn",
+        "Name": "CUSTOMERIO",
+        "DisplayName": "Customer IO",
+        "Config": {
+          "destConfig": {
+            "defaultConfig": [
+              "apiKey",
+              "siteID",
+              "datacenterEU",
+              "deviceTokenEventName"
+            ],
+            "web": [
+              "useNativeSDK",
+              "blackListedEvents",
+              "whiteListedEvents"
+            ]
+          },
+          "excludeKeys": [],
+          "includeKeys": [
+            "apiKey",
+            "siteID",
+            "datacenterEU",
+            "blackListedEvents",
+            "whiteListedEvents"
+          ],
+          "saveDestinationResponse": true,
+          "secretKeys": [],
+          "supportedMessageTypes": [
+            "identify",
+            "page",
+            "screen",
+            "track"
+          ],
+          "supportedSourceTypes": [
+            "android",
+            "ios",
+            "web",
+            "unity",
+            "amp",
+            "cloud",
+            "warehouse",
+            "reactnative",
+            "flutter",
+            "cordova"
+          ],
+          "supportsVisualMapper": true,
+          "transformAt": "processor",
+          "transformAtV1": "processor"
+        },
+        "ResponseRules": {}
+      },
+      "Config": {
+        "apiKey": "DESAU SAI",
+        "datacenterEU": false,
+        "deviceTokenEventName": "device_token_registered",
+        "siteID": "DESU SAI"
+      },
+      "Enabled": true,
+      "Transformations": [],
+      "IsProcessorEnabled": true
+    }
+  },
+  {
+    "message": {
+      "anonymousId": "5d727a3e-a72b-4d00-8078-669c1494791d",
+      "channel": "mobile",
+      "context": {
+        "app": {
+          "build": "1",
+          "name": "zx_userid_missing",
+          "namespace": "org.reactjs.native.example.zx-userid-missing",
+          "version": "1.0"
+        },
+        "device": {
+          "attTrackingStatus": 0,
+          "id": "5d727a3e-a72b-4d00-8078-669c1494791d",
+          "manufacturer": "Apple",
+          "model": "iPhone",
+          "name": "iPhone 13",
+          "token": "deviceToken",
+          "type": "iOS"
+        },
+        "library": {
+          "name": "rudder-ios-library",
+          "version": "1.3.1"
+        },
+        "locale": "en-US",
+        "network": {
+          "bluetooth": false,
+          "carrier": "unavailable",
+          "cellular": false,
+          "wifi": true
+        },
+        "os": {
+          "name": "iOS",
+          "version": "15.2"
+        },
+        "screen": {
+          "density": 3,
+          "height": 390,
+          "width": 844
+        },
+        "timezone": "Asia/Kolkata",
+        "traits": {
+          "anonymousId": "5d727a3e-a72b-4d00-8078-669c1494791d",
+          "email": "sofia@gmail.com",
+          "login_status": "Authenticated",
+          "name": "Sofia",
+          "phone_verified": 1,
+          "selected_city": "",
+          "selected_lat": 0,
+          "selected_long": 0,
+          "selected_neighborhood": "",
+          "selected_number": "",
+          "selected_postal_code": "",
+          "selected_state": "",
+          "selected_street": "",
+          "signed_up_for_newsletters": 0
+        }
+      },
+      "event": "Application Opened",
+      "integrations": {
+        "All": true
+      },
+      "messageId": "1641808826-28d23237-f4f0-4f65-baa2-99141e422a8f",
+      "originalTimestamp": "2022-01-10T10:00:26.513Z",
+      "properties": {
+        "from_background": false
+      },
+      "receivedAt": "2022-01-10T20:41:30.970+05:30",
+      "request_ip": "[::1]",
+      "rudderId": "423cdf83-0448-4a99-b14d-36fcc63e6ea0",
+      "sentAt": "2022-01-10T10:00:26.982Z",
+      "timestamp": "2022-01-10T20:41:30.501+05:30",
+      "type": "track",
+      "userId": "e91e0378-63fe-11ec-82ac-0a028ee659c3"
+    },
+    "destination": {
+      "ID": "23Mi76khsFhY7bh9ZyRcvR3pHDt",
+      "Name": "Customer IO Dev",
+      "DestinationDefinition": {
+        "ID": "23MgSlHXsPLsiH7SbW7IzCP32fn",
+        "Name": "CUSTOMERIO",
+        "DisplayName": "Customer IO",
+        "Config": {
+          "destConfig": {
+            "defaultConfig": [
+              "apiKey",
+              "siteID",
+              "datacenterEU",
+              "deviceTokenEventName"
+            ],
+            "web": [
+              "useNativeSDK",
+              "blackListedEvents",
+              "whiteListedEvents"
+            ]
+          },
+          "excludeKeys": [],
+          "includeKeys": [
+            "apiKey",
+            "siteID",
+            "datacenterEU",
+            "blackListedEvents",
+            "whiteListedEvents"
+          ],
+          "saveDestinationResponse": true,
+          "secretKeys": [],
+          "supportedMessageTypes": [
+            "identify",
+            "page",
+            "screen",
+            "track"
+          ],
+          "supportedSourceTypes": [
+            "android",
+            "ios",
+            "web",
+            "unity",
+            "amp",
+            "cloud",
+            "warehouse",
+            "reactnative",
+            "flutter",
+            "cordova"
+          ],
+          "supportsVisualMapper": true,
+          "transformAt": "processor",
+          "transformAtV1": "processor"
+        },
+        "ResponseRules": {}
+      },
+      "Config": {
+        "apiKey": "DESAU SAI",
+        "datacenterEU": false,
+        "deviceTokenEventName": "device_token_registered",
+        "siteID": "DESU SAI"
+      },
+      "Enabled": true,
+      "Transformations": [],
+      "IsProcessorEnabled": true
+    }
+  },
+  {
+    "message": {
+      "anonymousId": "5d727a3e-a72b-4d00-8078-669c1494791d",
+      "channel": "mobile",
+      "context": {
+        "app": {
+          "build": "1",
+          "name": "zx_userid_missing",
+          "namespace": "org.reactjs.native.example.zx-userid-missing",
+          "version": "1.0"
+        },
+        "device": {
+          "attTrackingStatus": 0,
+          "id": "5d727a3e-a72b-4d00-8078-669c1494791d",
+          "manufacturer": "Apple",
+          "model": "iPhone",
+          "name": "iPhone 13",
+          "token": "deviceToken",
+          "type": "iOS"
+        },
+        "library": {
+          "name": "rudder-ios-library",
+          "version": "1.3.1"
+        },
+        "locale": "en-US",
+        "network": {
+          "bluetooth": false,
+          "carrier": "unavailable",
+          "cellular": false,
+          "wifi": true
+        },
+        "os": {
+          "name": "iOS",
+          "version": "15.2"
+        },
+        "screen": {
+          "density": 3,
+          "height": 390,
+          "width": 844
+        },
+        "timezone": "Asia/Kolkata",
+        "traits": {
+          "anonymousId": "5d727a3e-a72b-4d00-8078-669c1494791d",
+          "email": "sofia@gmail.com",
+          "login_status": "Authenticated",
+          "name": "Sofia",
+          "phone_verified": 1,
+          "selected_city": "",
+          "selected_lat": 0,
+          "selected_long": 0,
+          "selected_neighborhood": "",
+          "selected_number": "",
+          "selected_postal_code": "",
+          "selected_state": "",
+          "selected_street": "",
+          "signed_up_for_newsletters": 0,
+          "userId": "e91e0378-63fe-11ec-82ac-0a028ee659c3"
+        }
+      },
+      "event": "Application Opened",
+      "integrations": {
+        "All": true
+      },
+      "messageId": "1641808826-28d23237-f4f0-4f65-baa2-99141e422a8f",
+      "originalTimestamp": "2022-01-10T10:00:26.513Z",
+      "properties": {
+        "from_background": false
+      },
+      "receivedAt": "2022-01-10T20:44:52.784+05:30",
+      "request_ip": "[::1]",
+      "rudderId": "0aef312c-0dc0-4a49-b613-4f33fb4e9b46",
+      "sentAt": "2022-01-10T10:00:26.982Z",
+      "timestamp": "2022-01-10T20:44:52.315+05:30",
+      "type": "track"
+    },
+    "destination": {
+      "ID": "23Mi76khsFhY7bh9ZyRcvR3pHDt",
+      "Name": "Customer IO Dev",
+      "DestinationDefinition": {
+        "ID": "23MgSlHXsPLsiH7SbW7IzCP32fn",
+        "Name": "CUSTOMERIO",
+        "DisplayName": "Customer IO",
+        "Config": {
+          "destConfig": {
+            "defaultConfig": [
+              "apiKey",
+              "siteID",
+              "datacenterEU",
+              "deviceTokenEventName"
+            ],
+            "web": [
+              "useNativeSDK",
+              "blackListedEvents",
+              "whiteListedEvents"
+            ]
+          },
+          "excludeKeys": [],
+          "includeKeys": [
+            "apiKey",
+            "siteID",
+            "datacenterEU",
+            "blackListedEvents",
+            "whiteListedEvents"
+          ],
+          "saveDestinationResponse": true,
+          "secretKeys": [],
+          "supportedMessageTypes": [
+            "identify",
+            "page",
+            "screen",
+            "track"
+          ],
+          "supportedSourceTypes": [
+            "android",
+            "ios",
+            "web",
+            "unity",
+            "amp",
+            "cloud",
+            "warehouse",
+            "reactnative",
+            "flutter",
+            "cordova"
+          ],
+          "supportsVisualMapper": true,
+          "transformAt": "processor",
+          "transformAtV1": "processor"
+        },
+        "ResponseRules": {}
+      },
+      "Config": {
+        "apiKey": "DESAU SAI",
+        "datacenterEU": false,
+        "deviceTokenEventName": "device_token_registered",
+        "siteID": "DESU SAI"
+      },
+      "Enabled": true,
+      "Transformations": [],
+      "IsProcessorEnabled": true
+    }
+  },
+  {
+    "message": {
+      "anonymousId": "5d727a3e-a72b-4d00-8078-669c1494791d",
+      "channel": "mobile",
+      "context": {
+        "app": {
+          "build": "1",
+          "name": "zx_userid_missing",
+          "namespace": "org.reactjs.native.example.zx-userid-missing",
+          "version": "1.0"
+        },
+        "device": {
+          "attTrackingStatus": 0,
+          "id": "5d727a3e-a72b-4d00-8078-669c1494791d",
+          "manufacturer": "Apple",
+          "model": "iPhone",
+          "name": "iPhone 13",
+          "token": "deviceToken",
+          "type": "iOS"
+        },
+        "library": {
+          "name": "rudder-ios-library",
+          "version": "1.3.1"
+        },
+        "locale": "en-US",
+        "network": {
+          "bluetooth": false,
+          "carrier": "unavailable",
+          "cellular": false,
+          "wifi": true
+        },
+        "os": {
+          "name": "iOS",
+          "version": "15.2"
+        },
+        "screen": {
+          "density": 3,
+          "height": 390,
+          "width": 844
+        },
+        "timezone": "Asia/Kolkata",
+        "traits": {
+          "anonymousId": "5d727a3e-a72b-4d00-8078-669c1494791d",
+          "email": "sofia@gmail.com",
+          "login_status": "Authenticated",
+          "name": "Sofia",
+          "phone_verified": 1,
+          "selected_city": "",
+          "selected_lat": 0,
+          "selected_long": 0,
+          "selected_neighborhood": "",
+          "selected_number": "",
+          "selected_postal_code": "",
+          "selected_state": "",
+          "selected_street": "",
+          "signed_up_for_newsletters": 0,
+          "userId": "e91e0378-63fe-11ec-82ac-0a028ee659c3"
+        }
+      },
+      "event": "Application Opened",
+      "integrations": {
+        "All": true
+      },
+      "messageId": "1641808826-28d23237-f4f0-4f65-baa2-99141e422a8f",
+      "originalTimestamp": "2022-01-10T10:00:26.513Z",
+      "receivedAt": "2022-01-10T20:47:36.180+05:30",
+      "request_ip": "[::1]",
+      "rudderId": "0aef312c-0dc0-4a49-b613-4f33fb4e9b46",
+      "sentAt": "2022-01-10T10:00:26.982Z",
+      "timestamp": "2022-01-10T20:47:35.711+05:30",
+      "type": "track"
+    },
+    "destination": {
+      "ID": "23Mi76khsFhY7bh9ZyRcvR3pHDt",
+      "Name": "Customer IO Dev",
+      "DestinationDefinition": {
+        "ID": "23MgSlHXsPLsiH7SbW7IzCP32fn",
+        "Name": "CUSTOMERIO",
+        "DisplayName": "Customer IO",
+        "Config": {
+          "destConfig": {
+            "defaultConfig": [
+              "apiKey",
+              "siteID",
+              "datacenterEU",
+              "deviceTokenEventName"
+            ],
+            "web": [
+              "useNativeSDK",
+              "blackListedEvents",
+              "whiteListedEvents"
+            ]
+          },
+          "excludeKeys": [],
+          "includeKeys": [
+            "apiKey",
+            "siteID",
+            "datacenterEU",
+            "blackListedEvents",
+            "whiteListedEvents"
+          ],
+          "saveDestinationResponse": true,
+          "secretKeys": [],
+          "supportedMessageTypes": [
+            "identify",
+            "page",
+            "screen",
+            "track"
+          ],
+          "supportedSourceTypes": [
+            "android",
+            "ios",
+            "web",
+            "unity",
+            "amp",
+            "cloud",
+            "warehouse",
+            "reactnative",
+            "flutter",
+            "cordova"
+          ],
+          "supportsVisualMapper": true,
+          "transformAt": "processor",
+          "transformAtV1": "processor"
+        },
+        "ResponseRules": {}
+      },
+      "Config": {
+        "apiKey": "DESAU SAI",
+        "datacenterEU": false,
+        "deviceTokenEventName": "device_token_registered",
+        "siteID": "DESU SAI"
+      },
+      "Enabled": true,
+      "Transformations": [],
+      "IsProcessorEnabled": true
+    }
+  },
+  {
+    "message": {
+      "anonymousId": "5d727a3e-a72b-4d00-8078-669c1494791d",
+      "channel": "mobile",
+      "context": {
+        "app": {
+          "build": "1",
+          "name": "zx_userid_missing",
+          "namespace": "org.reactjs.native.example.zx-userid-missing",
+          "version": "1.0"
+        },
+        "device": {
+          "attTrackingStatus": 0,
+          "id": "5d727a3e-a72b-4d00-8078-669c1494791d",
+          "manufacturer": "Apple",
+          "model": "iPhone",
+          "name": "iPhone 13",
+          "token": "deviceToken",
+          "type": "iOS"
+        },
+        "library": {
+          "name": "rudder-ios-library",
+          "version": "1.3.1"
+        },
+        "locale": "en-US",
+        "network": {
+          "bluetooth": false,
+          "carrier": "unavailable",
+          "cellular": false,
+          "wifi": true
+        },
+        "os": {
+          "name": "iOS",
+          "version": "15.2"
+        },
+        "screen": {
+          "density": 3,
+          "height": 390,
+          "width": 844
+        },
+        "timezone": "Asia/Kolkata",
+        "traits": {
+          "anonymousId": "5d727a3e-a72b-4d00-8078-669c1494791d",
+          "email": "sofia@gmail.com",
+          "login_status": "Authenticated",
+          "name": "Sofia",
+          "phone_verified": 1,
+          "selected_city": "",
+          "selected_lat": 0,
+          "selected_long": 0,
+          "selected_neighborhood": "",
+          "selected_number": "",
+          "selected_postal_code": "",
+          "selected_state": "",
+          "selected_street": "",
+          "signed_up_for_newsletters": 0,
+          "userId": "e91e0378-63fe-11ec-82ac-0a028ee659c3"
+        }
+      },
+      "event": "device_token_registered",
+      "integrations": {
+        "All": true
+      },
+      "messageId": "1641808826-28d23237-f4f0-4f65-baa2-99141e422a8f",
+      "originalTimestamp": "2022-01-10T10:00:26.513Z",
+      "properties": {
+        "from_background": false
+      },
+      "receivedAt": "2022-01-10T20:49:05.795+05:30",
+      "request_ip": "[::1]",
+      "rudderId": "423cdf83-0448-4a99-b14d-36fcc63e6ea0",
+      "sentAt": "2022-01-10T10:00:26.982Z",
+      "timestamp": "2022-01-10T20:49:05.326+05:30",
+      "type": "track",
+      "userId": "e91e0378-63fe-11ec-82ac-0a028ee659c3"
+    },
+    "destination": {
+      "ID": "23Mi76khsFhY7bh9ZyRcvR3pHDt",
+      "Name": "Customer IO Dev",
+      "DestinationDefinition": {
+        "ID": "23MgSlHXsPLsiH7SbW7IzCP32fn",
+        "Name": "CUSTOMERIO",
+        "DisplayName": "Customer IO",
+        "Config": {
+          "destConfig": {
+            "defaultConfig": [
+              "apiKey",
+              "siteID",
+              "datacenterEU",
+              "deviceTokenEventName"
+            ],
+            "web": [
+              "useNativeSDK",
+              "blackListedEvents",
+              "whiteListedEvents"
+            ]
+          },
+          "excludeKeys": [],
+          "includeKeys": [
+            "apiKey",
+            "siteID",
+            "datacenterEU",
+            "blackListedEvents",
+            "whiteListedEvents"
+          ],
+          "saveDestinationResponse": true,
+          "secretKeys": [],
+          "supportedMessageTypes": [
+            "identify",
+            "page",
+            "screen",
+            "track"
+          ],
+          "supportedSourceTypes": [
+            "android",
+            "ios",
+            "web",
+            "unity",
+            "amp",
+            "cloud",
+            "warehouse",
+            "reactnative",
+            "flutter",
+            "cordova"
+          ],
+          "supportsVisualMapper": true,
+          "transformAt": "processor",
+          "transformAtV1": "processor"
+        },
+        "ResponseRules": {}
+      },
+      "Config": {
+        "apiKey": "DESAU SAI",
+        "datacenterEU": false,
+        "deviceTokenEventName": "device_token_registered",
+        "siteID": "DESU SAI"
+      },
+      "Enabled": true,
+      "Transformations": [],
+      "IsProcessorEnabled": true
+    }
+  },
+  {
+    "message": {
+      "anonymousId": "5d727a3e-a72b-4d00-8078-669c1494791d",
+      "channel": "mobile",
+      "context": {
+        "app": {
+          "build": "1",
+          "name": "zx_userid_missing",
+          "namespace": "org.reactjs.native.example.zx-userid-missing",
+          "version": "1.0"
+        },
+        "device": {
+          "attTrackingStatus": 0,
+          "id": "5d727a3e-a72b-4d00-8078-669c1494791d",
+          "manufacturer": "Apple",
+          "model": "iPhone",
+          "name": "iPhone 13",
+          "type": "iOS"
+        },
+        "library": {
+          "name": "rudder-ios-library",
+          "version": "1.3.1"
+        },
+        "locale": "en-US",
+        "network": {
+          "bluetooth": false,
+          "carrier": "unavailable",
+          "cellular": false,
+          "wifi": true
+        },
+        "os": {
+          "name": "iOS",
+          "version": "15.2"
+        },
+        "screen": {
+          "density": 3,
+          "height": 390,
+          "width": 844
+        },
+        "timezone": "Asia/Kolkata",
+        "traits": {
+          "anonymousId": "5d727a3e-a72b-4d00-8078-669c1494791d",
+          "email": "sofia@gmail.com",
+          "login_status": "Authenticated",
+          "name": "Sofia",
+          "phone_verified": 1,
+          "selected_city": "",
+          "selected_lat": 0,
+          "selected_long": 0,
+          "selected_neighborhood": "",
+          "selected_number": "",
+          "selected_postal_code": "",
+          "selected_state": "",
+          "selected_street": "",
+          "signed_up_for_newsletters": 0,
+          "userId": "e91e0378-63fe-11ec-82ac-0a028ee659c3"
+        }
+      },
+      "event": "device_token_registered",
+      "integrations": {
+        "All": true
+      },
+      "messageId": "1641808826-28d23237-f4f0-4f65-baa2-99141e422a8f",
+      "originalTimestamp": "2022-01-10T10:00:26.513Z",
+      "properties": {
+        "from_background": false
+      },
+      "receivedAt": "2022-01-10T20:50:17.090+05:30",
+      "request_ip": "[::1]",
+      "rudderId": "423cdf83-0448-4a99-b14d-36fcc63e6ea0",
+      "sentAt": "2022-01-10T10:00:26.982Z",
+      "timestamp": "2022-01-10T20:50:16.621+05:30",
+      "type": "track",
+      "userId": "e91e0378-63fe-11ec-82ac-0a028ee659c3"
+    },
+    "destination": {
+      "ID": "23Mi76khsFhY7bh9ZyRcvR3pHDt",
+      "Name": "Customer IO Dev",
+      "DestinationDefinition": {
+        "ID": "23MgSlHXsPLsiH7SbW7IzCP32fn",
+        "Name": "CUSTOMERIO",
+        "DisplayName": "Customer IO",
+        "Config": {
+          "destConfig": {
+            "defaultConfig": [
+              "apiKey",
+              "siteID",
+              "datacenterEU",
+              "deviceTokenEventName"
+            ],
+            "web": [
+              "useNativeSDK",
+              "blackListedEvents",
+              "whiteListedEvents"
+            ]
+          },
+          "excludeKeys": [],
+          "includeKeys": [
+            "apiKey",
+            "siteID",
+            "datacenterEU",
+            "blackListedEvents",
+            "whiteListedEvents"
+          ],
+          "saveDestinationResponse": true,
+          "secretKeys": [],
+          "supportedMessageTypes": [
+            "identify",
+            "page",
+            "screen",
+            "track"
+          ],
+          "supportedSourceTypes": [
+            "android",
+            "ios",
+            "web",
+            "unity",
+            "amp",
+            "cloud",
+            "warehouse",
+            "reactnative",
+            "flutter",
+            "cordova"
+          ],
+          "supportsVisualMapper": true,
+          "transformAt": "processor",
+          "transformAtV1": "processor"
+        },
+        "ResponseRules": {}
+      },
+      "Config": {
+        "apiKey": "DESAU SAI",
+        "datacenterEU": false,
+        "deviceTokenEventName": "device_token_registered",
+        "siteID": "DESU SAI"
+      },
+      "Enabled": true,
+      "Transformations": [],
+      "IsProcessorEnabled": true
+    }
+  },
+  {
+    "message": {
+      "anonymousId": "5d727a3e-a72b-4d00-8078-669c1494791d",
+      "channel": "mobile",
+      "context": {
+        "app": {
+          "build": "1",
+          "name": "zx_userid_missing",
+          "namespace": "org.reactjs.native.example.zx-userid-missing",
+          "version": "1.0"
+        },
+        "device": {
+          "attTrackingStatus": 0,
+          "id": "5d727a3e-a72b-4d00-8078-669c1494791d",
+          "manufacturer": "Apple",
+          "model": "iPhone",
+          "name": "iPhone 13",
+          "token": "deviceToken",
+          "type": "iOS"
+        },
+        "library": {
+          "name": "rudder-ios-library",
+          "version": "1.3.1"
+        },
+        "locale": "en-US",
+        "network": {
+          "bluetooth": false,
+          "carrier": "unavailable",
+          "cellular": false,
+          "wifi": true
+        },
+        "os": {
+          "name": "iOS",
+          "version": "15.2"
+        },
+        "screen": {
+          "density": 3,
+          "height": 390,
+          "width": 844
+        },
+        "timezone": "Asia/Kolkata",
+        "traits": {
+          "anonymousId": "5d727a3e-a72b-4d00-8078-669c1494791d",
+          "email": "sofia@gmail.com",
+          "login_status": "Authenticated",
+          "name": "Sofia",
+          "phone_verified": 1,
+          "selected_city": "",
+          "selected_lat": 0,
+          "selected_long": 0,
+          "selected_neighborhood": "",
+          "selected_number": "",
+          "selected_postal_code": "",
+          "selected_state": "",
+          "selected_street": "",
+          "signed_up_for_newsletters": 0
+        }
+      },
+      "event": "device_token_registered",
+      "integrations": {
+        "All": true
+      },
+      "messageId": "1641808826-28d23237-f4f0-4f65-baa2-99141e422a8f",
+      "originalTimestamp": "2022-01-10T10:00:26.513Z",
+      "properties": {
+        "from_background": false
+      },
+      "receivedAt": "2022-01-10T20:52:19.147+05:30",
+      "request_ip": "[::1]",
+      "rudderId": "423cdf83-0448-4a99-b14d-36fcc63e6ea0",
+      "sentAt": "2022-01-10T10:00:26.982Z",
+      "timestamp": "2022-01-10T20:52:18.678+05:30",
+      "type": "track",
+      "userId": "e91e0378-63fe-11ec-82ac-0a028ee659c3"
+    },
+    "destination": {
+      "ID": "23Mi76khsFhY7bh9ZyRcvR3pHDt",
+      "Name": "Customer IO Dev",
+      "DestinationDefinition": {
+        "ID": "23MgSlHXsPLsiH7SbW7IzCP32fn",
+        "Name": "CUSTOMERIO",
+        "DisplayName": "Customer IO",
+        "Config": {
+          "destConfig": {
+            "defaultConfig": [
+              "apiKey",
+              "siteID",
+              "datacenterEU",
+              "deviceTokenEventName"
+            ],
+            "web": [
+              "useNativeSDK",
+              "blackListedEvents",
+              "whiteListedEvents"
+            ]
+          },
+          "excludeKeys": [],
+          "includeKeys": [
+            "apiKey",
+            "siteID",
+            "datacenterEU",
+            "blackListedEvents",
+            "whiteListedEvents"
+          ],
+          "saveDestinationResponse": true,
+          "secretKeys": [],
+          "supportedMessageTypes": [
+            "identify",
+            "page",
+            "screen",
+            "track"
+          ],
+          "supportedSourceTypes": [
+            "android",
+            "ios",
+            "web",
+            "unity",
+            "amp",
+            "cloud",
+            "warehouse",
+            "reactnative",
+            "flutter",
+            "cordova"
+          ],
+          "supportsVisualMapper": true,
+          "transformAt": "processor",
+          "transformAtV1": "processor"
+        },
+        "ResponseRules": {}
+      },
+      "Config": {
+        "apiKey": "DESAU SAI",
+        "datacenterEU": false,
+        "deviceTokenEventName": "device_token_registered",
+        "siteID": "DESU SAI"
+      },
+      "Enabled": true,
+      "Transformations": [],
+      "IsProcessorEnabled": true
+    }
+  },
+  {
+    "message": {
+      "anonymousId": "5d727a3e-a72b-4d00-8078-669c1494791d",
+      "channel": "mobile",
+      "context": {
+        "app": {
+          "build": "1",
+          "name": "zx_userid_missing",
+          "namespace": "org.reactjs.native.example.zx-userid-missing",
+          "version": "1.0"
+        },
+        "device": {
+          "attTrackingStatus": 0,
+          "id": "5d727a3e-a72b-4d00-8078-669c1494791d",
+          "manufacturer": "Apple",
+          "model": "iPhone",
+          "name": "iPhone 13",
+          "token": "deviceToken",
+          "type": "iOS"
+        },
+        "library": {
+          "name": "rudder-ios-library",
+          "version": "1.3.1"
+        },
+        "locale": "en-US",
+        "network": {
+          "bluetooth": false,
+          "carrier": "unavailable",
+          "cellular": false,
+          "wifi": true
+        },
+        "os": {
+          "name": "iOS",
+          "version": "15.2"
+        },
+        "screen": {
+          "density": 3,
+          "height": 390,
+          "width": 844
+        },
+        "timezone": "Asia/Kolkata",
+        "traits": {
+          "anonymousId": "5d727a3e-a72b-4d00-8078-669c1494791d",
+          "email": "sofia@gmail.com",
+          "login_status": "Authenticated",
+          "name": "Sofia",
+          "phone_verified": 1,
+          "selected_city": "",
+          "selected_lat": 0,
+          "selected_long": 0,
+          "selected_neighborhood": "",
+          "selected_number": "",
+          "selected_postal_code": "",
+          "selected_state": "",
+          "selected_street": "",
+          "signed_up_for_newsletters": 0,
+          "userId": "e91e0378-63fe-11ec-82ac-0a028ee659c3"
+        }
+      },
+      "event": "device_token_registered",
+      "integrations": {
+        "All": true
+      },
+      "messageId": "1641808826-28d23237-f4f0-4f65-baa2-99141e422a8f",
+      "originalTimestamp": "2022-01-10T10:00:26.513Z",
+      "properties": {
+        "from_background": false
+      },
+      "receivedAt": "2022-01-10T20:53:43.680+05:30",
+      "request_ip": "[::1]",
+      "rudderId": "0aef312c-0dc0-4a49-b613-4f33fb4e9b46",
+      "sentAt": "2022-01-10T10:00:26.982Z",
+      "timestamp": "2022-01-10T20:53:43.211+05:30",
+      "type": "track"
+    },
+    "destination": {
+      "ID": "23Mi76khsFhY7bh9ZyRcvR3pHDt",
+      "Name": "Customer IO Dev",
+      "DestinationDefinition": {
+        "ID": "23MgSlHXsPLsiH7SbW7IzCP32fn",
+        "Name": "CUSTOMERIO",
+        "DisplayName": "Customer IO",
+        "Config": {
+          "destConfig": {
+            "defaultConfig": [
+              "apiKey",
+              "siteID",
+              "datacenterEU",
+              "deviceTokenEventName"
+            ],
+            "web": [
+              "useNativeSDK",
+              "blackListedEvents",
+              "whiteListedEvents"
+            ]
+          },
+          "excludeKeys": [],
+          "includeKeys": [
+            "apiKey",
+            "siteID",
+            "datacenterEU",
+            "blackListedEvents",
+            "whiteListedEvents"
+          ],
+          "saveDestinationResponse": true,
+          "secretKeys": [],
+          "supportedMessageTypes": [
+            "identify",
+            "page",
+            "screen",
+            "track"
+          ],
+          "supportedSourceTypes": [
+            "android",
+            "ios",
+            "web",
+            "unity",
+            "amp",
+            "cloud",
+            "warehouse",
+            "reactnative",
+            "flutter",
+            "cordova"
+          ],
+          "supportsVisualMapper": true,
+          "transformAt": "processor",
+          "transformAtV1": "processor"
+        },
+        "ResponseRules": {}
+      },
+      "Config": {
+        "apiKey": "DESAU SAI",
+        "datacenterEU": false,
+        "deviceTokenEventName": "device_token_registered",
+        "siteID": "DESU SAI"
+      },
+      "Enabled": true,
+      "Transformations": [],
+      "IsProcessorEnabled": true
+    }
+  },
+  {
+    "message": {
+      "anonymousId": "5d727a3e-a72b-4d00-8078-669c1494791d",
+      "channel": "mobile",
+      "context": {
+        "app": {
+          "build": "1",
+          "name": "zx_userid_missing",
+          "namespace": "org.reactjs.native.example.zx-userid-missing",
+          "version": "1.0"
+        },
+        "device": {
+          "attTrackingStatus": 0,
+          "id": "5d727a3e-a72b-4d00-8078-669c1494791d",
+          "manufacturer": "Apple",
+          "model": "iPhone",
+          "name": "iPhone 13",
+          "token": "deviceToken",
+          "type": "iOS"
+        },
+        "library": {
+          "name": "rudder-ios-library",
+          "version": "1.3.1"
+        },
+        "locale": "en-US",
+        "network": {
+          "bluetooth": false,
+          "carrier": "unavailable",
+          "cellular": false,
+          "wifi": true
+        },
+        "os": {
+          "name": "iOS",
+          "version": "15.2"
+        },
+        "screen": {
+          "density": 3,
+          "height": 390,
+          "width": 844
+        },
+        "timezone": "Asia/Kolkata",
+        "traits": {
+          "anonymousId": "5d727a3e-a72b-4d00-8078-669c1494791d",
+          "email": "sofia@gmail.com",
+          "login_status": "Authenticated",
+          "name": "Sofia",
+          "phone_verified": 1,
+          "selected_city": "",
+          "selected_lat": 0,
+          "selected_long": 0,
+          "selected_neighborhood": "",
+          "selected_number": "",
+          "selected_postal_code": "",
+          "selected_state": "",
+          "selected_street": "",
+          "signed_up_for_newsletters": 0,
+          "userId": "e91e0378-63fe-11ec-82ac-0a028ee659c3"
+        }
+      },
+      "event": "device_token_registered",
+      "integrations": {
+        "All": true
+      },
+      "messageId": "1641808826-28d23237-f4f0-4f65-baa2-99141e422a8f",
+      "originalTimestamp": "2022-01-10T10:00:26.513Z",
+      "receivedAt": "2022-01-10T20:55:03.845+05:30",
+      "request_ip": "[::1]",
+      "rudderId": "0aef312c-0dc0-4a49-b613-4f33fb4e9b46",
+      "sentAt": "2022-01-10T10:00:26.982Z",
+      "timestamp": "2022-01-10T20:55:03.376+05:30",
+      "type": "track"
+    },
+    "destination": {
+      "ID": "23Mi76khsFhY7bh9ZyRcvR3pHDt",
+      "Name": "Customer IO Dev",
+      "DestinationDefinition": {
+        "ID": "23MgSlHXsPLsiH7SbW7IzCP32fn",
+        "Name": "CUSTOMERIO",
+        "DisplayName": "Customer IO",
+        "Config": {
+          "destConfig": {
+            "defaultConfig": [
+              "apiKey",
+              "siteID",
+              "datacenterEU",
+              "deviceTokenEventName"
+            ],
+            "web": [
+              "useNativeSDK",
+              "blackListedEvents",
+              "whiteListedEvents"
+            ]
+          },
+          "excludeKeys": [],
+          "includeKeys": [
+            "apiKey",
+            "siteID",
+            "datacenterEU",
+            "blackListedEvents",
+            "whiteListedEvents"
+          ],
+          "saveDestinationResponse": true,
+          "secretKeys": [],
+          "supportedMessageTypes": [
+            "identify",
+            "page",
+            "screen",
+            "track"
+          ],
+          "supportedSourceTypes": [
+            "android",
+            "ios",
+            "web",
+            "unity",
+            "amp",
+            "cloud",
+            "warehouse",
+            "reactnative",
+            "flutter",
+            "cordova"
+          ],
+          "supportsVisualMapper": true,
+          "transformAt": "processor",
+          "transformAtV1": "processor"
+        },
+        "ResponseRules": {}
+      },
+      "Config": {
+        "apiKey": "DESAU SAI",
+        "datacenterEU": false,
+        "deviceTokenEventName": "device_token_registered",
+        "siteID": "DESU SAI"
+      },
+      "Enabled": true,
+      "Transformations": [],
+      "IsProcessorEnabled": true
+    }
   }
 ]

--- a/__tests__/data/customerio_output.json
+++ b/__tests__/data/customerio_output.json
@@ -853,5 +853,263 @@
     "files": {},
     "userId": "xaviercharles",
     "statusCode": 200
+  },
+  {
+    "version": "1",
+    "type": "REST",
+    "method": "PUT",
+    "endpoint": "https://track.customer.io/api/v1/customers/e91e0378-63fe-11ec-82ac-0a028ee659c3/devices",
+    "headers": {
+      "Authorization": "Basic REVTVSBTQUk6REVTQVUgU0FJ"
+    },
+    "params": {},
+    "body": {
+      "JSON": {
+        "device": {
+          "from_background": false,
+          "id": "deviceToken",
+          "platform": "ios",
+          "last_used": 1641808826
+        }
+      },
+      "JSON_ARRAY": {},
+      "XML": {},
+      "FORM": {}
+    },
+    "files": {},
+    "userId": "e91e0378-63fe-11ec-82ac-0a028ee659c3",
+    "statusCode": 200
+  },
+  {
+    "version": "1",
+    "type": "REST",
+    "method": "POST",
+    "endpoint": "https://track.customer.io/api/v1/customers/e91e0378-63fe-11ec-82ac-0a028ee659c3/events",
+    "headers": {
+      "Authorization": "Basic REVTVSBTQUk6REVTQVUgU0FJ"
+    },
+    "params": {},
+    "body": {
+      "JSON": {
+        "data": {
+          "from_background": false
+        },
+        "name": "Application Opened",
+        "type": "event",
+        "timestamp": 1641827343
+      },
+      "JSON_ARRAY": {},
+      "XML": {},
+      "FORM": {}
+    },
+    "files": {},
+    "userId": "e91e0378-63fe-11ec-82ac-0a028ee659c3",
+    "statusCode": 200
+  },
+  {
+    "version": "1",
+    "type": "REST",
+    "method": "PUT",
+    "endpoint": "https://track.customer.io/api/v1/customers/e91e0378-63fe-11ec-82ac-0a028ee659c3/devices",
+    "headers": {
+      "Authorization": "Basic REVTVSBTQUk6REVTQVUgU0FJ"
+    },
+    "params": {},
+    "body": {
+      "JSON": {
+        "device": {
+          "from_background": false,
+          "id": "deviceToken",
+          "platform": "ios",
+          "last_used": 1641808826
+        }
+      },
+      "JSON_ARRAY": {},
+      "XML": {},
+      "FORM": {}
+    },
+    "files": {},
+    "userId": "e91e0378-63fe-11ec-82ac-0a028ee659c3",
+    "statusCode": 200
+  },
+  {
+    "version": "1",
+    "type": "REST",
+    "method": "PUT",
+    "endpoint": "https://track.customer.io/api/v1/customers/e91e0378-63fe-11ec-82ac-0a028ee659c3/devices",
+    "headers": {
+      "Authorization": "Basic REVTVSBTQUk6REVTQVUgU0FJ"
+    },
+    "params": {},
+    "body": {
+      "JSON": {
+        "device": {
+          "from_background": false,
+          "id": "deviceToken",
+          "platform": "ios",
+          "last_used": 1641808826
+        }
+      },
+      "JSON_ARRAY": {},
+      "XML": {},
+      "FORM": {}
+    },
+    "files": {},
+    "userId": "e91e0378-63fe-11ec-82ac-0a028ee659c3",
+    "statusCode": 200
+  },
+  {
+    "version": "1",
+    "type": "REST",
+    "method": "PUT",
+    "endpoint": "https://track.customer.io/api/v1/customers/e91e0378-63fe-11ec-82ac-0a028ee659c3/devices",
+    "headers": {
+      "Authorization": "Basic REVTVSBTQUk6REVTQVUgU0FJ"
+    },
+    "params": {},
+    "body": {
+      "JSON": {
+        "device": {
+          "id": "deviceToken",
+          "platform": "ios",
+          "last_used": 1641808826
+        }
+      },
+      "JSON_ARRAY": {},
+      "XML": {},
+      "FORM": {}
+    },
+    "files": {},
+    "userId": "e91e0378-63fe-11ec-82ac-0a028ee659c3",
+    "statusCode": 200
+  },
+  {
+    "version": "1",
+    "type": "REST",
+    "method": "PUT",
+    "endpoint": "https://track.customer.io/api/v1/customers/e91e0378-63fe-11ec-82ac-0a028ee659c3/devices",
+    "headers": {
+      "Authorization": "Basic REVTVSBTQUk6REVTQVUgU0FJ"
+    },
+    "params": {},
+    "body": {
+      "JSON": {
+        "device": {
+          "from_background": false,
+          "id": "deviceToken",
+          "platform": "ios",
+          "last_used": 1641808826
+        }
+      },
+      "JSON_ARRAY": {},
+      "XML": {},
+      "FORM": {}
+    },
+    "files": {},
+    "userId": "e91e0378-63fe-11ec-82ac-0a028ee659c3",
+    "statusCode": 200
+  },
+  {
+    "version": "1",
+    "type": "REST",
+    "method": "POST",
+    "endpoint": "https://track.customer.io/api/v1/customers/e91e0378-63fe-11ec-82ac-0a028ee659c3/events",
+    "headers": {
+      "Authorization": "Basic REVTVSBTQUk6REVTQVUgU0FJ"
+    },
+    "params": {},
+    "body": {
+      "JSON": {
+        "data": {
+          "from_background": false
+        },
+        "name": "device_token_registered",
+        "type": "event",
+        "timestamp": 1641828016
+      },
+      "JSON_ARRAY": {},
+      "XML": {},
+      "FORM": {}
+    },
+    "files": {},
+    "userId": "e91e0378-63fe-11ec-82ac-0a028ee659c3",
+    "statusCode": 200
+  },
+  {
+    "version": "1",
+    "type": "REST",
+    "method": "PUT",
+    "endpoint": "https://track.customer.io/api/v1/customers/e91e0378-63fe-11ec-82ac-0a028ee659c3/devices",
+    "headers": {
+      "Authorization": "Basic REVTVSBTQUk6REVTQVUgU0FJ"
+    },
+    "params": {},
+    "body": {
+      "JSON": {
+        "device": {
+          "from_background": false,
+          "id": "deviceToken",
+          "platform": "ios",
+          "last_used": 1641808826
+        }
+      },
+      "JSON_ARRAY": {},
+      "XML": {},
+      "FORM": {}
+    },
+    "files": {},
+    "userId": "e91e0378-63fe-11ec-82ac-0a028ee659c3",
+    "statusCode": 200
+  },
+  {
+    "version": "1",
+    "type": "REST",
+    "method": "PUT",
+    "endpoint": "https://track.customer.io/api/v1/customers/e91e0378-63fe-11ec-82ac-0a028ee659c3/devices",
+    "headers": {
+      "Authorization": "Basic REVTVSBTQUk6REVTQVUgU0FJ"
+    },
+    "params": {},
+    "body": {
+      "JSON": {
+        "device": {
+          "from_background": false,
+          "id": "deviceToken",
+          "platform": "ios",
+          "last_used": 1641808826
+        }
+      },
+      "JSON_ARRAY": {},
+      "XML": {},
+      "FORM": {}
+    },
+    "files": {},
+    "userId": "e91e0378-63fe-11ec-82ac-0a028ee659c3",
+    "statusCode": 200
+  },
+  {
+    "version": "1",
+    "type": "REST",
+    "method": "PUT",
+    "endpoint": "https://track.customer.io/api/v1/customers/e91e0378-63fe-11ec-82ac-0a028ee659c3/devices",
+    "headers": {
+      "Authorization": "Basic REVTVSBTQUk6REVTQVUgU0FJ"
+    },
+    "params": {},
+    "body": {
+      "JSON": {
+        "device": {
+          "id": "deviceToken",
+          "platform": "ios",
+          "last_used": 1641808826
+        }
+      },
+      "JSON_ARRAY": {},
+      "XML": {},
+      "FORM": {}
+    },
+    "files": {},
+    "userId": "e91e0378-63fe-11ec-82ac-0a028ee659c3",
+    "statusCode": 200
   }
 ]

--- a/v0/destinations/customerio/transform.js
+++ b/v0/destinations/customerio/transform.js
@@ -36,6 +36,16 @@ const deviceRelatedEventNames = [
   "Application Opened",
   "Application Uninstalled"
 ];
+
+const isdeviceRelatedEventName = (eventName, destination) => {
+  return (
+    deviceRelatedEventNames.includes(eventName) ||
+    (destination.Config &&
+      destination.Config.deviceTokenEventName &&
+      destination.Config.deviceTokenEventName === eventName)
+  );
+};
+
 const deviceDeleteRelatedEventName = "Application Uninstalled";
 
 // Get the spec'd traits, for now only address needs treatment as 2 layers.
@@ -179,7 +189,7 @@ function responseBuilder(message, evType, evName, destination, messageType) {
     }
 
     // DEVICE registration
-    if (deviceRelatedEventNames.includes(evName) && userId && token) {
+    if (isdeviceRelatedEventName(evName, destination) && userId && token) {
       const devProps = message.properties || {};
       set(devProps, "id", get(message, "context.device.token"));
       const deviceType = get(message, "context.device.type");
@@ -212,7 +222,7 @@ function responseBuilder(message, evType, evName, destination, messageType) {
     }
 
     if (userId) {
-      if (deviceRelatedEventNames.includes(evName) && token) {
+      if (isdeviceRelatedEventName(evName, destination) && token) {
         endpoint = DEVICE_REGISTER_ENDPOINT.replace(":id", userId);
       } else {
         endpoint = USER_EVENT_ENDPOINT.replace(":id", userId);


### PR DESCRIPTION
## Description of the change

Previously we used to send device token to customer io only on the life cycle events which were sent by the Mobile SDK's, but this is resulting in a delay from sending it over to customer io, as the next life cycle event is sent on app launch/minimize from the moment the device token was handed over to RudderStack SDK's.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
