### PR TITLE
Fix typo in MixPanel Identity Config

### DIFF
--- a/v0/destinations/mp/data/MPIdentifyConfig.json
+++ b/v0/destinations/mp/data/MPIdentifyConfig.json
@@ -6,5 +6,5 @@
   "name": "$name",
   "username": "$username",
   "phone": "$phone",
-  "avator": "$avator"
+  "avatar": "$avatar"
 }


### PR DESCRIPTION
## Description of the change

> `avatar` had been incorrectly written as `avator`. This fixes it.

## Type of change
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> No related issues

## Checklists

### Development

- [X] Lint rules pass locally
- [X] The code changed/added as part of this pull request has been covered with tests
- [X] All tests related to the changed code pass in development

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
