### PR TITLE
BugFix Amplitude: Removed duplicate fields from event_properties and user_properties

### DIFF
--- a/__tests__/data/am_output.json
+++ b/__tests__/data/am_output.json
@@ -30,8 +30,6 @@
             "user_properties": {
               "anonymousId": "123456",
               "email": "sayan@gmail.com",
-              "city": "kolkata",
-              "country": "India",
               "postalCode": 712136,
               "state": "WB",
               "street": "",
@@ -261,8 +259,6 @@
             "user_properties": {
               "anonymousId": "123456",
               "email": "sayan@gmail.com",
-              "city": "kolkata",
-              "country": "India",
               "postalCode": 712136,
               "state": "WB",
               "street": "",
@@ -888,9 +884,6 @@
                 "tax": 2,
                 "total": 27.5,
                 "coupon": "hasbros",
-                "revenue": 48,
-                "price": 25,
-                "quantity": 2,
                 "currency": "USD",
                 "discount": 2.5,
                 "order_id": "50314b8e9bcf000000000000",
@@ -1034,9 +1027,6 @@
               "tax": 2,
               "total": 27.5,
               "coupon": "hasbros",
-              "revenue": 48,
-              "price": 25,
-              "quantity": 2,
               "currency": "USD",
               "discount": 2.5,
               "order_id": "50314b8e9bcf000000000000",
@@ -1162,11 +1152,10 @@
                 "sku": "45790-32",
                 "url": "https://www.example.com/product/path",
                 "name": "Monopoly: 3rd Edition",
-                "price": 19,
+                
                 "category": "Games",
-                "quantity": 1,
-                "image_url": "https:///www.example.com/product/path.jpg",
-                "product_id": "507f1f77bcf86cd799439011"
+                
+                "image_url": "https:///www.example.com/product/path.jpg"
               },
               "price": 19,
               "quantity": 1,
@@ -1211,10 +1200,8 @@
               "event_properties": {
                 "sku": "46493-32",
                 "name": "Uno Card Game",
-                "price": 3,
-                "category": "Games",
-                "quantity": 2,
-                "product_id": "505bd76785ebb509fc183733"
+                
+                "category": "Games"
               },
               "price": 3,
               "quantity": 2,
@@ -1333,11 +1320,8 @@
                 "sku": "45790-32",
                 "url": "https://www.example.com/product/path",
                 "name": "Monopoly: 3rd Edition",
-                "price": 19,
                 "category": "Games",
-                "quantity": 1,
-                "image_url": "https:///www.example.com/product/path.jpg",
-                "product_id": "507f1f77bcf86cd799439011"
+                "image_url": "https:///www.example.com/product/path.jpg"
               },
               "price": 19,
               "quantity": 1,
@@ -1382,10 +1366,7 @@
               "event_properties": {
                 "sku": "46493-32",
                 "name": "Uno Card Game",
-                "price": 3,
-                "category": "Games",
-                "quantity": 2,
-                "product_id": "505bd76785ebb509fc183733"
+                "category": "Games"
               },
               "price": 3,
               "quantity": 2,
@@ -1431,9 +1412,6 @@
               "tax": 2,
               "total": 27.5,
               "coupon": "hasbros",
-              "revenue": 48,
-              "price": 25,
-              "quantity": 2,
               "currency": "USD",
               "discount": 2.5,
               "order_id": "50314b8e9bcf000000000000",
@@ -1486,9 +1464,6 @@
               "tax": 2,
               "total": 27.5,
               "coupon": "hasbros",
-              "revenue": 48,
-              "price": 25,
-              "quantity": 2,
               "currency": "USD",
               "discount": 2.5,
               "order_id": "50314b8e9bcf000000000000",
@@ -1541,9 +1516,6 @@
               "tax": 2,
               "total": 27.5,
               "coupon": "hasbros",
-              "revenue": 48,
-              "price": 25,
-              "quantity": 2,
               "currency": "USD",
               "discount": 2.5,
               "order_id": "50314b8e9bcf000000000000",
@@ -1596,9 +1568,6 @@
               "tax": 2,
               "total": 27.5,
               "coupon": "hasbros",
-              "revenue": 48,
-              "price": 25,
-              "quantity": 2,
               "currency": "USD",
               "discount": 2.5,
               "order_id": "50314b8e9bcf000000000000",
@@ -1655,7 +1624,6 @@
             "insert_id": "6f08cc45-95c3-40c1-90f2-2f44a92947ef",
             "event_type": "$identify",
             "user_properties": {
-              "city": "Durgapur",
               "name": "Manashi",
               "phone": "990099009900",
               "subjects": 5,
@@ -1709,7 +1677,6 @@
             "insert_id": "6f08cc45-95c3-40c1-90f2-2f44a92947ef",
             "event_type": "$identify",
             "user_properties": {
-              "city": "Durgapur",
               "name": "Manashi",
               "phone": "990099009900",
               "friends": 3,
@@ -1761,7 +1728,6 @@
             "insert_id": "6f08cc45-95c3-40c1-90f2-2f44a92947ef",
             "event_type": "$identify",
             "user_properties": {
-              "city": "Durgapur",
               "phone": "990099009900",
               "friends": 3,
               "age": 12,
@@ -1813,7 +1779,6 @@
             "insert_id": "6f08cc45-95c3-40c1-90f2-2f44a92947ef",
             "event_type": "$identify",
             "user_properties": {
-              "city": "Durgapur",
               "name": "Manashi",
               "phone": "990099009900",
               "friends": 3,
@@ -1865,7 +1830,6 @@
             "insert_id": "6f08cc45-95c3-40c1-90f2-2f44a92947ef",
             "event_type": "$identify",
             "user_properties": {
-              "city": "Durgapur",
               "phone": "990099009900",
               "$add": {
                 "age": 12,
@@ -1925,8 +1889,6 @@
               "user_properties": {
                 "anonymousId": "50be5c78-6c3f-4b60-be84-97805a31aaa1",
                 "address": {
-                  "city": "kolkata",
-                  "country": "India",
                   "postalCode": 712136,
                   "state": "WB",
                   "street": ""
@@ -1999,8 +1961,6 @@
               "user_properties": {
                 "anonymousId": "50be5c78-6c3f-4b60-be84-97805a31aaa1",
                 "address": {
-                  "city": "kolkata",
-                  "country": "India",
                   "postalCode": 712136,
                   "state": "WB",
                   "street": ""
@@ -2010,11 +1970,8 @@
                 "sku": "45790-32",
                 "url": "https://www.example.com/product/path",
                 "name": "Monopoly: 3rd Edition",
-                "price": 19,
                 "category": "Games",
-                "quantity": 1,
-                "image_url": "https:///www.example.com/product/path.jpg",
-                "product_id": "507f1f77bcf86cd799439011"
+                "image_url": "https:///www.example.com/product/path.jpg"
               },
               "country": "United States",
               "city": "San Francisco",
@@ -2071,8 +2028,6 @@
               "user_properties": {
                 "anonymousId": "50be5c78-6c3f-4b60-be84-97805a31aaa1",
                 "address": {
-                  "city": "kolkata",
-                  "country": "India",
                   "postalCode": 712136,
                   "state": "WB",
                   "street": ""
@@ -2081,10 +2036,10 @@
               "event_properties": {
                 "sku": "46493-32",
                 "name": "Uno Card Game",
-                "price": 3,
-                "category": "Games",
-                "quantity": 2,
-                "product_id": "505bd76785ebb509fc183733"
+                
+                "category": "Games"
+                
+                
               },
               "country": "United States",
               "city": "San Francisco",
@@ -2141,8 +2096,6 @@
             "user_properties": {
               "anonymousId": "50be5c78-6c3f-4b60-be84-97805a31aaa1",
               "address": {
-                "city": "kolkata",
-                "country": "India",
                 "postalCode": 712136,
                 "state": "WB",
                 "street": ""
@@ -2152,9 +2105,6 @@
               "tax": 2,
               "total": 27.5,
               "coupon": "hasbros",
-              "revenue": 48,
-              "price": 25,
-              "quantity": 2,
               "currency": "USD",
               "discount": 2.5,
               "order_id": "50314b8e9bcf000000000000",
@@ -2236,8 +2186,6 @@
             "user_properties": {
               "anonymousId": "50be5c78-6c3f-4b60-be84-97805a31aaa1",
               "address": {
-                "city": "kolkata",
-                "country": "India",
                 "postalCode": 712136,
                 "state": "WB",
                 "street": ""
@@ -2345,8 +2293,6 @@
               "user_properties": {
                 "anonymousId": "50be5c78-6c3f-4b60-be84-97805a31aaa1",
                 "address": {
-                  "city": "kolkata",
-                  "country": "India",
                   "postalCode": 712136,
                   "state": "WB",
                   "street": ""
@@ -2438,8 +2384,6 @@
               "user_properties": {
                 "anonymousId": "50be5c78-6c3f-4b60-be84-97805a31aaa1",
                 "address": {
-                  "city": "kolkata",
-                  "country": "India",
                   "postalCode": 712136,
                   "state": "WB",
                   "street": ""
@@ -2449,11 +2393,9 @@
                 "sku": "45790-32",
                 "url": "https://www.example.com/product/path",
                 "name": "Monopoly: 3rd Edition",
-                "price": 19,
                 "category": "Games",
-                "quantity": 1,
-                "image_url": "https:///www.example.com/product/path.jpg",
-                "product_id": "507f1f77bcf86cd799439011"
+                
+                "image_url": "https:///www.example.com/product/path.jpg"
               },
               "country": "India",
               "city": "kolkata",
@@ -2509,8 +2451,6 @@
               "user_properties": {
                 "anonymousId": "50be5c78-6c3f-4b60-be84-97805a31aaa1",
                 "address": {
-                  "city": "kolkata",
-                  "country": "India",
                   "postalCode": 712136,
                   "state": "WB",
                   "street": ""
@@ -2519,10 +2459,7 @@
               "event_properties": {
                 "sku": "46493-32",
                 "name": "Uno Card Game",
-                "price": 3,
-                "category": "Games",
-                "quantity": 2,
-                "product_id": "505bd76785ebb509fc183733"
+                "category": "Games"
               },
               "country": "India",
               "city": "kolkata",
@@ -2580,8 +2517,6 @@
             "user_properties": {
               "anonymousId": "50be5c78-6c3f-4b60-be84-97805a31aaa1",
               "address": {
-                "city": "kolkata",
-                "country": "India",
                 "postalCode": 712136,
                 "state": "WB",
                 "street": ""
@@ -2644,8 +2579,6 @@
             "user_properties": {
               "anonymousId": "50be5c79-6c3f-4b60-be84-97805a32aaa1",
               "address": {
-                "city": "kolkata",
-                "country": "India",
                 "postalCode": 712136,
                 "state": "WB",
                 "street": ""
@@ -2656,8 +2589,8 @@
             "device_brand": "samsung",
             "time": 1639061715808,
             "session_id": -1,
-            "country": "India",
             "city": "kolkata",
+            "country": "India",
             "library": "rudderstack"
           }
         ],
@@ -2821,65 +2754,5 @@
     },
     "files": {},
     "userId": "0572f78fa49c648e"
-  },
-  {
-    "version": "1",
-    "type": "REST",
-    "method": "POST",
-    "endpoint": "https://api.amplitude.com/2/httpapi",
-    "headers": {
-      "Content-Type": "application/json"
-    },
-    "params": {},
-    "body": {
-      "JSON": {
-        "api_key": "abcde",
-        "events": [
-          {
-            "os_name": "Android",
-            "os_version": "11",
-            "device_model": "SM-A025M",
-            "device_manufacturer": "samsung",
-            "device_id": "066a37dc92b16284",
-            "carrier": "T-Mobile",
-            "app_version": "2.6.0 v3",
-            "platform": "Android",
-            "language": "en-US",
-            "event_properties": {
-              "name": "Home",
-              "externalID": "1637763064336-7225034711957140329"
-            },
-            "insert_id": "1639061715808-a934f1c2-7b55-5e78-bd4d-df209c31d8a2",
-            "ip": "186.54.216.75",
-            "user_properties": {
-              "anonymousId": "50be5c79-6c3f-4b60-be84-97805a32aaa1",
-              "address": {
-                "city": "Sealdah",
-                "country": "India",
-                "postalCode": 700014,
-                "state": "WB",
-                "street": ""
-              }
-            },
-            "event_type": "Viewed Home Screen",
-            "user_id": "abcdef123456cf",
-            "device_brand": "samsung",
-            "time": 1639061715808,
-            "session_id": -1,
-            "country": "India",
-            "city": "Sealdah",
-            "library": "rudderstack"
-          }
-        ],
-        "options": {
-          "min_id_length": 1
-        }
-      },
-      "JSON_ARRAY": {},
-      "XML": {},
-      "FORM": {}
-    },
-    "files": {},
-    "userId": "066a37dc92b16284"
   }
 ]

--- a/__tests__/data/am_router_output.json
+++ b/__tests__/data/am_router_output.json
@@ -33,8 +33,6 @@
                   "initial_referring_domain": "docs.rudderstack.com",
                   "anonymousId": "123456",
                   "email": "sayan@gmail.com",
-                  "city": "kolkata",
-                  "country": "India",
                   "postalCode": 712136,
                   "state": "WB",
                   "street": "",

--- a/v0/destinations/am/transform.js
+++ b/v0/destinations/am/transform.js
@@ -297,6 +297,13 @@ function responseBuilderSimple(
       if (message.isRevenue) {
         // making the revenue payload
         rawPayload = createRevenuePayload(message, rawPayload);
+        // deleting the properties price, product_id, quantity and revenue from evemt_properties since it is already in root
+        if (rawPayload.event_properties) {
+          delete rawPayload.event_properties.price;
+          delete rawPayload.event_properties.product_id;
+          delete rawPayload.event_properties.quantity;
+          delete rawPayload.event_properties.revenue;
+        }
       }
       groups = groupInfo && Object.assign(groupInfo);
   }
@@ -377,6 +384,14 @@ function responseBuilderSimple(
       // ====================
       // fixVersion(payload, message);
 
+      if (payload.user_properties) {
+        delete payload.user_properties.city;
+        delete payload.user_properties.country;
+        if (payload.user_properties.address) {
+          delete payload.user_properties.address.city;
+          delete payload.user_properties.address.country;
+        }
+      }
       payload.ip = getParsedIP(message);
       payload.library = "rudderstack";
       payload = removeUndefinedAndNullValues(payload);


### PR DESCRIPTION
Removed duplicate fields `price`, `product_id`, `quantity`, `revenue` from `event_properties` and `city` and `country` from `user_properties`.

## Description of the change

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
