### PR TITLE
converting merge event value to string before empty validation

### DIFF
--- a/warehouse/identity.js
+++ b/warehouse/identity.js
@@ -71,10 +71,10 @@ function getMergeRuleEvent(message = {}, eventType, options) {
     }
 
     if (
-      _.isEmpty(message.mergeProperties[0].type) ||
-      _.isEmpty(message.mergeProperties[0].value) ||
-      _.isEmpty(message.mergeProperties[1].type) ||
-      _.isEmpty(message.mergeProperties[1].value)
+      _.isEmpty(_.toString(message.mergeProperties[0].type)) ||
+      _.isEmpty(_.toString(message.mergeProperties[0].value)) ||
+      _.isEmpty(_.toString(message.mergeProperties[1].type)) ||
+      _.isEmpty(_.toString(message.mergeProperties[1].value))
     ) {
       throw new Error(
         "mergeProperties contains null values for expected inputs"


### PR DESCRIPTION
## Description of the change

> converting merge event value to string before empty validation

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
