### PR TITLE
Bug Fix: User ID is reset to empty string when it is falsy

### DIFF
--- a/versionedRouter.js
+++ b/versionedRouter.js
@@ -109,6 +109,14 @@ async function handleDest(ctx, version, destination) {
           respList.push(
             ...respEvents.map(ev => {
               let { userId } = ev;
+              // Set the user ID to an empty string for 
+              // all the falsy values (including 0 and false)
+              // Otherwise, server panics while un-marshalling the response
+              // while expecting only strings.
+              if (!userId) {
+                userId = "";
+              }
+
               if (ev.statusCode !== 400 && userId) {
                 userId = `${userId}`;
               }


### PR DESCRIPTION
## Description of the change

> After the destination transformation, the user ID sent in the response is reset to an empty string if it is falsy (including 0 and false). Otherwise, the server panics while trying to unmarshal the response as it only expects a string type for the user ID.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> N/A

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests - N/A
- [ ] All tests related to the changed code pass in development - N/A

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
