### PR TITLE
[Salesforce] :: Use contactId for converted lead

### DIFF
--- a/v0/destinations/salesforce/transform.js
+++ b/v0/destinations/salesforce/transform.js
@@ -236,8 +236,26 @@ async function getSalesforceIdFromPayload(message, authorizationData) {
       }
     }
 
+    const convertedDetails = await axios.get(
+      `${authorizationData.instanceUrl}/services/data/v${SF_API_VERSION}/sobjects/Lead/${leadObjectId}?fields=IsConverted,ConvertedContactId,IsDeleted`,
+      {
+        headers: { Authorization: authorizationData.token }
+      }
+    );
+
+    if (convertedDetails.data.IsConverted) {
+      leadObjectId = convertedDetails.data.ConvertedContactId;
+    }
+
     // add a Lead Object to the response
-    salesforceMaps.push({ salesforceType: "Lead", salesforceId: leadObjectId });
+    if (convertedDetails.data.IsDeleted === false)
+      salesforceMaps.push({
+        salesforceType: "Lead",
+        salesforceId: leadObjectId
+      });
+    else {
+      throw new CustomError("The lead/contact has been deleted.", 400);
+    }
   }
 
   return salesforceMaps;

--- a/v0/destinations/salesforce/transform.js
+++ b/v0/destinations/salesforce/transform.js
@@ -235,29 +235,33 @@ async function getSalesforceIdFromPayload(message, authorizationData) {
         leadObjectId = leadQueryResponse.data.searchRecords[0].Id;
       }
     }
+    if (leadObjectId) {
+      const convertedDetails = await axios.get(
+        `${authorizationData.instanceUrl}/services/data/v${SF_API_VERSION}/sobjects/Lead/${leadObjectId}?fields=IsConverted,ConvertedContactId,IsDeleted`,
+        {
+          headers: { Authorization: authorizationData.token }
+        }
+      );
 
-    const convertedDetails = await axios.get(
-      `${authorizationData.instanceUrl}/services/data/v${SF_API_VERSION}/sobjects/Lead/${leadObjectId}?fields=IsConverted,ConvertedContactId,IsDeleted`,
-      {
-        headers: { Authorization: authorizationData.token }
+      if (convertedDetails.data.IsConverted) {
+        leadObjectId = convertedDetails.data.ConvertedContactId;
       }
-    );
 
-    if (convertedDetails.data.IsConverted) {
-      leadObjectId = convertedDetails.data.ConvertedContactId;
-    }
-
-    // add a Lead Object to the response
-    if (convertedDetails.data.IsDeleted === false)
+      if (convertedDetails.data.IsDeleted === false)
+        salesforceMaps.push({
+          salesforceType: "Lead",
+          salesforceId: leadObjectId
+        });
+      else {
+        throw new CustomError("The lead/contact has been deleted.", 400);
+      }
+    } else {
       salesforceMaps.push({
         salesforceType: "Lead",
         salesforceId: leadObjectId
       });
-    else {
-      throw new CustomError("The lead/contact has been deleted.", 400);
     }
   }
-
   return salesforceMaps;
 }
 

--- a/v0/destinations/salesforce/transform.js
+++ b/v0/destinations/salesforce/transform.js
@@ -235,31 +235,41 @@ async function getSalesforceIdFromPayload(message, authorizationData) {
         leadObjectId = leadQueryResponse.data.searchRecords[0].Id;
       }
     }
-    if (leadObjectId) {
-      const convertedDetails = await axios.get(
-        `${authorizationData.instanceUrl}/services/data/v${SF_API_VERSION}/sobjects/Lead/${leadObjectId}?fields=IsConverted,ConvertedContactId,IsDeleted`,
-        {
-          headers: { Authorization: authorizationData.token }
+    // if leadObjectId is undefined => push it into the SalesforceMap. SF will create a leadObjectId
+    // for it, which can be referenced later to upfate, or check for converted status.
+    // -----------------------
+    // Checking lead for converted status, whether it is lead or contact.
+    try {
+      if (leadObjectId) {
+        const convertedDetails = await axios.get(
+          `${authorizationData.instanceUrl}/services/data/v${SF_API_VERSION}/sobjects/Lead/${leadObjectId}?fields=IsConverted,ConvertedContactId,IsDeleted`,
+          {
+            headers: { Authorization: authorizationData.token }
+          }
+        );
+        if (convertedDetails.data.IsDeleted === true) {
+          throw new CustomError("The lead/contact has been deleted.", 400);
         }
-      );
-
-      if (convertedDetails.data.IsConverted) {
-        leadObjectId = convertedDetails.data.ConvertedContactId;
-      }
-
-      if (convertedDetails.data.IsDeleted === false)
+        if (convertedDetails.data.IsConverted) {
+          leadObjectId = convertedDetails.data.ConvertedContactId;
+          salesforceMaps.push({
+            salesforceType: "Contact",
+            salesforceId: leadObjectId
+          });
+        } else {
+          salesforceMaps.push({
+            salesforceType: "Lead",
+            salesforceId: leadObjectId
+          });
+        }
+      } else {
         salesforceMaps.push({
           salesforceType: "Lead",
           salesforceId: leadObjectId
         });
-      else {
-        throw new CustomError("The lead/contact has been deleted.", 400);
       }
-    } else {
-      salesforceMaps.push({
-        salesforceType: "Lead",
-        salesforceId: leadObjectId
-      });
+    } catch (error) {
+      throw new CustomError("Failed to create lead", 500);
     }
   }
   return salesforceMaps;


### PR DESCRIPTION
## Description of the change

> Use contactId instead of leadId for leads converted to contacts.
> Abort lead updation if lead is deleted. Create a new one.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
