### PR TITLE
fb_pixel:  param issue

### DIFF
--- a/__tests__/data/facebook_pixel_input.json
+++ b/__tests__/data/facebook_pixel_input.json
@@ -2405,5 +2405,106 @@
       },
       "Enabled": true
     }
+  },
+  {
+    "message": {
+      "channel": "web",
+      "context": {
+        "app": {
+          "build": "1.0.0",
+          "name": "RudderLabs JavaScript SDK",
+          "namespace": "com.rudderlabs.javascript",
+          "version": "1.0.0"
+        },
+        "traits": {
+          "email": "sayan@gmail.com"
+        },
+        "library": {
+          "name": "RudderLabs JavaScript SDK",
+          "version": "1.0.0"
+        },
+        "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36",
+        "locale": "en-US",
+        "os": {
+          "name": "",
+          "version": ""
+        },
+        "screen": {
+          "density": 2
+        }
+      },
+      "type": "track",
+      "messageId": "ec5481b6-a926-4d2e-b293-0b3a77c4d3be",
+      "originalTimestamp": "2019-10-14T11:15:18.300Z",
+      "anonymousId": "00000000000000000000000000",
+      "userId": "12345",
+      "event": "order completed",
+      "properties": {
+        "category": [
+          "clothing"
+        ],
+        "order_id": "ruchiraorder1",
+        "total": 99.99,
+        "revenue": 12.24,
+        "shipping": 13.99,
+        "tax": 20.99,
+        "currency": "INR",
+        "products": [
+          {
+            "quantity": 1,
+            "price": 24.75,
+            "name": "my product",
+            "sku": "p-298"
+          },
+          {
+            "quantity": 3,
+            "price": 24.75,
+            "name": "other product",
+            "sku": "p-299"
+          }
+        ]
+      },
+      "integrations": {
+        "All": true
+      },
+      "sentAt": "2019-10-14T11:15:53.296Z"
+    },
+    "destination": {
+      "Config": {
+        "blacklistPiiProperties": [
+          {
+            "blacklistPiiProperties": "",
+            "blacklistPiiHash": true
+          }
+        ],
+        "categoryToContent": [
+          {
+            "from": "clothing",
+            "to": "product"
+          }
+        ],
+        "accessToken": "09876",
+        "pixelId": "dfgdfgdgd",
+        "eventsToEvents": [
+          {
+            "from": "",
+            "to": ""
+          }
+        ],
+        "eventCustomProperties": [
+          {
+            "eventCustomProperties": ""
+          }
+        ],
+        "valueFieldIdentifier": "properties.price",
+        "advancedMapping": false,
+        "whitelistPiiProperties": [
+          {
+            "whitelistPiiProperties": ""
+          }
+        ]
+      },
+      "Enabled": true
+    }
   }
 ]

--- a/__tests__/data/facebook_pixel_input.json
+++ b/__tests__/data/facebook_pixel_input.json
@@ -2441,7 +2441,7 @@
       "event": "order completed",
       "properties": {
         "category": [
-          "clothing"
+          "clothing", "fishing"
         ],
         "order_id": "ruchiraorder1",
         "total": 99.99,
@@ -2506,5 +2506,205 @@
       },
       "Enabled": true
     }
-  }
+  },
+  {
+    "message": {
+      "channel": "web",
+      "context": {
+        "app": {
+          "build": "1.0.0",
+          "name": "RudderLabs JavaScript SDK",
+          "namespace": "com.rudderlabs.javascript",
+          "version": "1.0.0"
+        },
+        "traits": {
+          "email": "sayan@gmail.com"
+        },
+        "library": {
+          "name": "RudderLabs JavaScript SDK",
+          "version": "1.0.0"
+        },
+        "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36",
+        "locale": "en-US",
+        "os": {
+          "name": "",
+          "version": ""
+        },
+        "screen": {
+          "density": 2
+        }
+      },
+      "type": "track",
+      "messageId": "ec5481b6-a926-4d2e-b293-0b3a77c4d3be",
+      "originalTimestamp": "2019-10-14T11:15:18.300Z",
+      "anonymousId": "00000000000000000000000000",
+      "userId": "12345",
+      "event": "order completed",
+      "properties": {
+        "category": 100,
+        "order_id": "ruchiraorder1",
+        "total": 99.99,
+        "revenue": 12.24,
+        "shipping": 13.99,
+        "tax": 20.99,
+        "currency": "INR",
+        "products": [
+          {
+            "quantity": 1,
+            "price": 24.75,
+            "name": "my product",
+            "sku": "p-298"
+          },
+          {
+            "quantity": 3,
+            "price": 24.75,
+            "name": "other product",
+            "sku": "p-299"
+          }
+        ]
+      },
+      "integrations": {
+        "All": true
+      },
+      "sentAt": "2019-10-14T11:15:53.296Z"
+    },
+    "destination": {
+      "Config": {
+        "blacklistPiiProperties": [
+          {
+            "blacklistPiiProperties": "",
+            "blacklistPiiHash": true
+          }
+        ],
+        "categoryToContent": [
+          {
+            "from": "clothing",
+            "to": "product"
+          }
+        ],
+        "accessToken": "09876",
+        "pixelId": "dfgdfgdgd",
+        "eventsToEvents": [
+          {
+            "from": "",
+            "to": ""
+          }
+        ],
+        "eventCustomProperties": [
+          {
+            "eventCustomProperties": ""
+          }
+        ],
+        "valueFieldIdentifier": "properties.price",
+        "advancedMapping": false,
+        "whitelistPiiProperties": [
+          {
+            "whitelistPiiProperties": ""
+          }
+        ]
+      },
+      "Enabled": true
+    }
+  },
+  {
+    "message": {
+        "channel": "web",
+        "context": {
+            "app": {
+                "build": "1.0.0",
+                "name": "RudderLabs JavaScript SDK",
+                "namespace": "com.rudderlabs.javascript",
+                "version": "1.0.0"
+            },
+            "traits": {
+                "email": "sayan@gmail.com"
+            },
+            "library": {
+                "name": "RudderLabs JavaScript SDK",
+                "version": "1.0.0"
+            },
+            "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36",
+            "locale": "en-US",
+            "os": {
+                "name": "",
+                "version": ""
+            },
+            "screen": {
+                "density": 2
+            }
+        },
+        "type": "track",
+        "messageId": "ec5481b6-a926-4d2e-b293-0b3a77c4d3be",
+        "originalTimestamp": "2019-10-14T11:15:18.300Z",
+        "anonymousId": "00000000000000000000000000",
+        "userId": "12345",
+        "event": "order completed",
+        "properties": {
+            "category": {
+                "category1": "1"
+            },
+            "order_id": "ruchiraorder1",
+            "total": 99.99,
+            "revenue": 12.24,
+            "shipping": 13.99,
+            "tax": 20.99,
+            "currency": "INR",
+            "products": [
+                {
+                    "quantity": 1,
+                    "price": 24.75,
+                    "name": "my product",
+                    "sku": "p-298"
+                },
+                {
+                    "quantity": 3,
+                    "price": 24.75,
+                    "name": "other product",
+                    "sku": "p-299"
+                }
+            ]
+        },
+        "integrations": {
+            "All": true
+        },
+        "sentAt": "2019-10-14T11:15:53.296Z"
+    },
+    "destination": {
+        "Config": {
+            "blacklistPiiProperties": [
+                {
+                    "blacklistPiiProperties": "",
+                    "blacklistPiiHash": true
+                }
+            ],
+            "categoryToContent": [
+                {
+                    "from": "clothing",
+                    "to": "product"
+                }
+            ],
+            "accessToken": "09876",
+            "pixelId": "dfgdfgdgd",
+            "eventsToEvents": [
+                {
+                    "from": "",
+                    "to": ""
+                }
+            ],
+            "eventCustomProperties": [
+                {
+                    "eventCustomProperties": ""
+                }
+            ],
+            "valueFieldIdentifier": "properties.price",
+            "advancedMapping": false,
+            "whitelistPiiProperties": [
+                {
+                    "whitelistPiiProperties": ""
+                }
+            ]
+        },
+        "Enabled": true
+    }
+}
 ]

--- a/__tests__/data/facebook_pixel_output.json
+++ b/__tests__/data/facebook_pixel_output.json
@@ -517,22 +517,48 @@
     }
   },
   {
-    "version": "1",
-    "type": "REST",
-    "method": "POST",
-    "endpoint": "https://graph.facebook.com/v11.0/dfgdfgdgd/events?access_token=09876",
-    "headers": {},
-    "params": {},
-    "body": {
-      "JSON": {},
-      "JSON_ARRAY": {},
-      "XML": {},
-      "FORM": {
-        "data": [
-          "{\"user_data\":{\"external_id\":\"5994471abb01112afcc18159f6cc74b4f511b99806da59b3caf5a9c173cacfc5\",\"em\":\"4e59b5130b3a248457336e2fe5e40a3e8604f28d1804be14e6b227e2d88d7ce2\",\"client_user_agent\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36\"},\"event_name\":\"Purchase\",\"event_time\":1571051718,\"custom_data\":{\"content_ids\":[\"p-298\",\"p-299\"],\"content_type\":\"product\",\"currency\":\"INR\",\"value\":12.24,\"contents\":[{\"id\":\"p-298\",\"quantity\":1,\"item_price\":24.75},{\"id\":\"p-299\",\"quantity\":3,\"item_price\":24.75}],\"num_items\":2}}"
-        ]
-      }
-    },
-    "files": {}
-  }
+    
+        "version": "1",
+        "type": "REST",
+        "method": "POST",
+        "endpoint": "https://graph.facebook.com/v11.0/dfgdfgdgd/events?access_token=09876",
+        "headers": {},
+        "params": {},
+        "body": {
+            "JSON": {},
+            "JSON_ARRAY": {},
+            "XML": {},
+            "FORM": {
+                "data": [
+                    "{\"user_data\":{\"external_id\":\"5994471abb01112afcc18159f6cc74b4f511b99806da59b3caf5a9c173cacfc5\",\"em\":\"4e59b5130b3a248457336e2fe5e40a3e8604f28d1804be14e6b227e2d88d7ce2\",\"client_user_agent\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36\"},\"event_name\":\"Purchase\",\"event_time\":1571051718,\"custom_data\":{\"content_category\":\"clothing-fishing\",\"content_ids\":[\"p-298\",\"p-299\"],\"content_type\":\"product\",\"currency\":\"INR\",\"value\":12.24,\"contents\":[{\"id\":\"p-298\",\"quantity\":1,\"item_price\":24.75},{\"id\":\"p-299\",\"quantity\":3,\"item_price\":24.75}],\"num_items\":2}}"
+                ]
+            }
+        },
+        "files": {}
+    
+},
+{
+      "version": "1",
+      "type": "REST",
+      "method": "POST",
+      "endpoint": "https://graph.facebook.com/v11.0/dfgdfgdgd/events?access_token=09876",
+      "headers": {},
+      "params": {},
+      "body": {
+          "JSON": {},
+          "JSON_ARRAY": {},
+          "XML": {},
+          "FORM": {
+              "data": [
+                  "{\"user_data\":{\"external_id\":\"5994471abb01112afcc18159f6cc74b4f511b99806da59b3caf5a9c173cacfc5\",\"em\":\"4e59b5130b3a248457336e2fe5e40a3e8604f28d1804be14e6b227e2d88d7ce2\",\"client_user_agent\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36\"},\"event_name\":\"Purchase\",\"event_time\":1571051718,\"custom_data\":{\"content_category\":\"100\",\"content_ids\":[\"p-298\",\"p-299\"],\"content_type\":\"product\",\"currency\":\"INR\",\"value\":12.24,\"contents\":[{\"id\":\"p-298\",\"quantity\":1,\"item_price\":24.75},{\"id\":\"p-299\",\"quantity\":3,\"item_price\":24.75}],\"num_items\":2}}"
+              ]
+          }
+      },
+      "files": {}
+  
+},
+{
+  "statusCode": 400,
+  "error": "Category must be must be a string"
+}
 ]

--- a/__tests__/data/facebook_pixel_output.json
+++ b/__tests__/data/facebook_pixel_output.json
@@ -530,7 +530,7 @@
             "XML": {},
             "FORM": {
                 "data": [
-                    "{\"user_data\":{\"external_id\":\"5994471abb01112afcc18159f6cc74b4f511b99806da59b3caf5a9c173cacfc5\",\"em\":\"4e59b5130b3a248457336e2fe5e40a3e8604f28d1804be14e6b227e2d88d7ce2\",\"client_user_agent\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36\"},\"event_name\":\"Purchase\",\"event_time\":1571051718,\"custom_data\":{\"content_category\":\"clothing-fishing\",\"content_ids\":[\"p-298\",\"p-299\"],\"content_type\":\"product\",\"currency\":\"INR\",\"value\":12.24,\"contents\":[{\"id\":\"p-298\",\"quantity\":1,\"item_price\":24.75},{\"id\":\"p-299\",\"quantity\":3,\"item_price\":24.75}],\"num_items\":2}}"
+                    "{\"user_data\":{\"external_id\":\"5994471abb01112afcc18159f6cc74b4f511b99806da59b3caf5a9c173cacfc5\",\"em\":\"4e59b5130b3a248457336e2fe5e40a3e8604f28d1804be14e6b227e2d88d7ce2\",\"client_user_agent\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36\"},\"event_name\":\"Purchase\",\"event_time\":1571051718,\"custom_data\":{\"content_category\":\"clothing,fishing\",\"content_ids\":[\"p-298\",\"p-299\"],\"content_type\":\"product\",\"currency\":\"INR\",\"value\":12.24,\"contents\":[{\"id\":\"p-298\",\"quantity\":1,\"item_price\":24.75},{\"id\":\"p-299\",\"quantity\":3,\"item_price\":24.75}],\"num_items\":2}}"
                 ]
             }
         },

--- a/__tests__/data/facebook_pixel_output.json
+++ b/__tests__/data/facebook_pixel_output.json
@@ -515,5 +515,24 @@
       "stage": "transform",
       "scope": "exception"
     }
+  },
+  {
+    "version": "1",
+    "type": "REST",
+    "method": "POST",
+    "endpoint": "https://graph.facebook.com/v11.0/dfgdfgdgd/events?access_token=09876",
+    "headers": {},
+    "params": {},
+    "body": {
+      "JSON": {},
+      "JSON_ARRAY": {},
+      "XML": {},
+      "FORM": {
+        "data": [
+          "{\"user_data\":{\"external_id\":\"5994471abb01112afcc18159f6cc74b4f511b99806da59b3caf5a9c173cacfc5\",\"em\":\"4e59b5130b3a248457336e2fe5e40a3e8604f28d1804be14e6b227e2d88d7ce2\",\"client_user_agent\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36\"},\"event_name\":\"Purchase\",\"event_time\":1571051718,\"custom_data\":{\"content_ids\":[\"p-298\",\"p-299\"],\"content_type\":\"product\",\"currency\":\"INR\",\"value\":12.24,\"contents\":[{\"id\":\"p-298\",\"quantity\":1,\"item_price\":24.75},{\"id\":\"p-299\",\"quantity\":3,\"item_price\":24.75}],\"num_items\":2}}"
+        ]
+      }
+    },
+    "files": {}
   }
 ]

--- a/v0/destinations/facebook_pixel/transform.js
+++ b/v0/destinations/facebook_pixel/transform.js
@@ -527,6 +527,16 @@ const responseBuilderSimple = (message, category, destination) => {
     }
   }
 
+  // content_category should only be a string ref: https://developers.facebook.com/docs/marketing-api/conversions-api/parameters/custom-data
+
+  if (
+    customData &&
+    customData.content_category &&
+    typeof customData.content_category !== "string"
+  ) {
+    delete customData.content_category;
+  }
+
   if (userData && commonData) {
     const response = defaultRequestConfig();
     response.endpoint = endpoint;

--- a/v0/destinations/facebook_pixel/transform.js
+++ b/v0/destinations/facebook_pixel/transform.js
@@ -534,10 +534,12 @@ const responseBuilderSimple = (message, category, destination) => {
     customData.content_category &&
     typeof customData.content_category !== "string"
   ) {
-    if(Array.isArray(customData.content_category)) {
-      customData.content_category = customData.content_category.map(String).join('-')
+    if (Array.isArray(customData.content_category)) {
+      customData.content_category = customData.content_category
+        .map(String)
+        .join(",");
     } else if (typeof customData.content_category === 'object') {
-      throw new CustomError ("Category must be must be a string");
+      throw new CustomError("Category must be must be a string");
     } else {
       customData.content_category = String(customData.content_category);
     }

--- a/v0/destinations/facebook_pixel/transform.js
+++ b/v0/destinations/facebook_pixel/transform.js
@@ -534,7 +534,14 @@ const responseBuilderSimple = (message, category, destination) => {
     customData.content_category &&
     typeof customData.content_category !== "string"
   ) {
-    delete customData.content_category;
+    if(Array.isArray(customData.content_category)) {
+      customData.content_category = customData.content_category.map(String).join('-')
+    } else if (typeof customData.content_category === 'object') {
+      throw new CustomError ("Category must be must be a string");
+    } else {
+      customData.content_category = String(customData.content_category);
+    }
+   // delete customData.content_category;
   }
 
   if (userData && commonData) {


### PR DESCRIPTION
## Description of the change

Facebook Pixel does not allow any other data type than `string` as `content_category`. 

1. Hence, we are converting all types of data into strings. 
2. In the case of arrays, without throwing errors, we are concatenating the elements with a comma (,) separator. 
3. For any other types of data ( example: objects ) we will throw an error.


## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
