### PR TITLE
Appsflyer Bugfix - adding support for anonymousId in appsflyer source

### DIFF
--- a/__tests__/appsflyer_source.test.js
+++ b/__tests__/appsflyer_source.test.js
@@ -21,6 +21,7 @@ inputData.forEach((input, index) => {
   it(`${name} Tests: payload: ${index}`, async () => {
     try {
       const output = await transformer.process(input);
+      delete output.anonymousId;
       expect(output).toEqual(expectedData[index]);
     } catch (error) {
       expect(error.message).toEqual(expectedData[index].message);

--- a/__tests__/data/appsflyer_source_output.json
+++ b/__tests__/data/appsflyer_source_output.json
@@ -315,7 +315,160 @@
     "statusCode": 400,
     "message": "Unknwon event type from Appsflyer"
   },
-  {},
+  {
+    "context": {
+      "library": {
+        "name": "unknown",
+        "version": "unknown"
+      },
+      "integration": {
+        "name": "AF"
+      },
+      "ip": "1.1.1.1",
+      "timezone": "UTC",
+      "userAgent": "AppsFlyer/1 CFNetwork/978.0.7 Darwin/18.6.0",
+      "app": {
+        "namespace": "com.appsflyer.AppsFlyer",
+        "version": "1.4.1",
+        "name": "AppsFlyer"
+      },
+      "device": {
+        "model": "iPhoneXR",
+        "advertisingId": "A7071198-3848-40A5-B3D0-94578D9BZZZZ",
+        "adTrackingEnabled": true
+      },
+      "network": {
+        "wifi": true
+      },
+      "os": {
+        "name": "ios",
+        "version": "12.3.1"
+      },
+      "traits": {
+        "address": {
+          "city": "Khu Pho Binh Hoa",
+          "zip": "823941",
+          "country": "VN"
+        }
+      },
+      "externalId": [
+        {
+          "type": "appsflyerExternalId",
+          "value": "1547985076649-5309999"
+        }
+      ]
+    },
+    "integrations": {
+      "AF": false
+    },
+    "type": "track",
+    "event": "My Apps",
+    "properties": {
+      "idfv": "868049A3-4B2F-4A11-9B00-CFFC362XXXXX",
+      "device_category": "phone",
+      "af_sub1": null,
+      "is_lat": null,
+      "contributor_2_af_prt": null,
+      "gp_broadcast_referrer": "",
+      "contributor_2_touch_time": null,
+      "contributor_3_touch_type": null,
+      "event_source": "SDK",
+      "af_cost_value": null,
+      "contributor_1_match_type": null,
+      "contributor_3_af_prt": null,
+      "custom_data": null,
+      "contributor_2_touch_type": null,
+      "gp_install_begin": null,
+      "amazon_aid": null,
+      "gp_referrer": null,
+      "af_cost_model": null,
+      "af_c_id": null,
+      "attributed_touch_time_selected_timezone": null,
+      "selected_currency": "USD",
+      "install_time_selected_timezone": "2019-01-20 04:51:16.000+0000",
+      "install_time": "2019-01-20 04:51:16.000",
+      "operator": null,
+      "attributed_touch_type": null,
+      "af_attribution_lookback": null,
+      "campaign_type": null,
+      "keyword_match_type": null,
+      "af_adset_id": null,
+      "device_download_time_selected_timezone": "2019-01-20 04:51:16.000+0000",
+      "contributor_2_media_source": null,
+      "conversion_type": null,
+      "contributor_2_match_type": null,
+      "api_version": "2.0",
+      "attributed_touch_time": null,
+      "revenue_in_selected_currency": null,
+      "is_retargeting": false,
+      "gp_click_time": null,
+      "contributor_1_af_prt": null,
+      "match_type": null,
+      "dma": "None",
+      "http_referrer": null,
+      "af_sub5": null,
+      "af_prt": null,
+      "event_revenue_currency": "USD",
+      "store_reinstall": null,
+      "install_app_store": null,
+      "media_source": "organic",
+      "deeplink_url": null,
+      "campaign": null,
+      "af_keywords": null,
+      "region": "AS",
+      "cost_in_selected_currency": null,
+      "event_value": "{}",
+      "oaid": null,
+      "is_receipt_validated": null,
+      "contributor_1_campaign": null,
+      "af_sub4": null,
+      "imei": null,
+      "contributor_3_campaign": null,
+      "event_revenue_usd": null,
+      "af_sub2": null,
+      "original_url": null,
+      "contributor_2_campaign": null,
+      "contributor_3_media_source": null,
+      "af_adset": null,
+      "af_ad": null,
+      "state": "57",
+      "network_account_id": null,
+      "retargeting_conversion_type": null,
+      "af_channel": null,
+      "af_cost_currency": null,
+      "contributor_1_media_source": null,
+      "keyword_id": null,
+      "device_download_time": "2019-01-20 04:51:16.000",
+      "contributor_1_touch_type": null,
+      "af_reengagement_window": null,
+      "af_siteid": null,
+      "language": "en-US",
+      "app_id": "id1217828636",
+      "contributor_1_touch_time": null,
+      "event_revenue": null,
+      "af_ad_type": null,
+      "event_name": "My Apps",
+      "af_sub_siteid": null,
+      "advertising_id": null,
+      "af_sub3": null,
+      "contributor_3_match_type": null,
+      "af_ad_id": null,
+      "contributor_3_touch_time": null,
+      "is_primary_attribution": true,
+      "sdk_version": "v4.10.0",
+      "event_time_selected_timezone": "2020-01-15 14:57:24.898+0000"
+    },
+    "timestamp": "2020-01-15 14:57:24.898",
+    "originalTimestamp": "2020-01-15 14:57:24.898",
+    "platform": "ios",
+    "traits": {
+      "address": {
+        "city": "Khu Pho Binh Hoa",
+        "zip": "823941",
+        "country": "VN"
+      }
+    }
+  },
   {
     "context": {
       "library": {

--- a/v0/sources/appsflyer/transform.js
+++ b/v0/sources/appsflyer/transform.js
@@ -1,7 +1,7 @@
 const path = require("path");
 const fs = require("fs");
 const Message = require("../message");
-
+const { generateUUID } = require("../../util");
 const mappingJson = JSON.parse(
   fs.readFileSync(path.resolve(__dirname, "./mapping.json"), "utf-8")
 );
@@ -71,11 +71,9 @@ function processEvent(event) {
         delete message.properties.appsflyer_id;
       }
     }
+    message.setProperty("anonymousId", generateUUID());
 
-    if (message.userId && message.userId !== "") {
-      return message;
-    }
-    return null;
+    return message;
   }
   throw new Error("Unknwon event type from Appsflyer");
 }

--- a/v0/sources/appsflyer/transform.js
+++ b/v0/sources/appsflyer/transform.js
@@ -2,6 +2,7 @@ const path = require("path");
 const fs = require("fs");
 const Message = require("../message");
 const { generateUUID } = require("../../util");
+
 const mappingJson = JSON.parse(
   fs.readFileSync(path.resolve(__dirname, "./mapping.json"), "utf-8")
 );


### PR DESCRIPTION
## Description of the change

> Existing behavior of Appsflyer source - discard events from Appsflyer which are missing `customer_user_id` which are mapped to `userId` at rudderstack, this leads to loss of events which are missing the above identifier. As `customer_user_id` is an optional field we are on-boarding `anonymousId` support for AF source to mitigate the issue 

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
