### PR TITLE
bugfix(mailchimp): Adding support for backward compatibility.

### DIFF
--- a/__tests__/data/mailchimp_input.json
+++ b/__tests__/data/mailchimp_input.json
@@ -74,7 +74,7 @@
         "apiKey": "94f71917d8522770c97449b0c90caa4c-us20",
         "audienceId": "df42a82d07",
         "datacenterId": "us20",
-        "useUpdatedMapping": true
+        "enableMergeFields": true
       },
       "Enabled": true,
       "Transformations": []

--- a/__tests__/data/mailchimp_input.json
+++ b/__tests__/data/mailchimp_input.json
@@ -73,7 +73,8 @@
       "Config": {
         "apiKey": "94f71917d8522770c97449b0c90caa4c-us20",
         "audienceId": "df42a82d07",
-        "datacenterId": "us20"
+        "datacenterId": "us20",
+        "useUpdatedMapping": true
       },
       "Enabled": true,
       "Transformations": []
@@ -567,6 +568,68 @@
       "sentAt": "2019-11-15T10:22:37Z",
       "source_id": "1TdhTcwsUVOeEMWyPUpQIgF3pYr",
       "timestamp": "2019-11-15T15:52:32+05:30",
+      "type": "identify",
+      "userId": "userId12345"
+    }
+  },
+  {
+    "destination": {
+      "ID": "1Tdi0lpXwSVwXG1lcdP2pXHKrJ6",
+      "Name": "test-mc",
+      "DestinationDefinition": {
+        "ID": "1SujZGrVEPqYmpUJcV4vSl9tfxn",
+        "Name": "MC",
+        "DisplayName": "MailChimp"
+      },
+      "Config": {
+        "apiKey": "94f71917d8522770c97449b0c90caa4c-us20",
+        "audienceId": "df42a82d07",
+        "datacenterId": "us20"
+      },
+      "Enabled": true,
+      "Transformations": []
+    },
+    "message": {
+      "anonymousId": "userId12345",
+      "channel": "web",
+      "context": {
+        "app": {
+          "build": "1.0.0",
+          "name": "RudderLabs JavaScript SDK",
+          "namespace": "com.rudderlabs.javascript",
+          "version": "1.0.0"
+        },
+        "ip": "0.0.0.0",
+        "library": {
+          "name": "RudderLabs JavaScript SDK",
+          "version": "1.0.0"
+        },
+        "locale": "en-US",
+        "os": {
+          "name": "",
+          "version": ""
+        },
+        "screen": {
+          "density": 2
+        },
+        "traits": {
+          "anonymousId": "userId12345",
+          "email": "bob.dole@initech.com"
+        },
+        "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.97 Safari/537.36"
+      },
+      "integrations": {
+        "MailChimp": {
+          "subscriptionStatus": "subscribed"
+        }
+      },
+      "messageId": "6d1f3ca8-e2d0-4d34-9926-44596171af0c",
+      "originalTimestamp": "2019-11-15T10:26:53Z",
+      "receivedAt": "2019-11-15T15:56:58+05:30",
+      "request_ip": "[::1]:62921",
+      "sentAt": "2019-11-15T10:26:58Z",
+      "source_id": "1TdhTcwsUVOeEMWyPUpQIgF3pYr",
+      "timestamp": "2019-11-15T15:56:53+05:30",
       "type": "identify",
       "userId": "userId12345"
     }

--- a/__tests__/data/mailchimp_output.json
+++ b/__tests__/data/mailchimp_output.json
@@ -137,5 +137,28 @@
     },
     "version": "1",
     "endpoint": "https://us20.api.mailchimp.com/3.0/lists/df42a82d07/members/48cd6232dc124497369f59c33d3eb4ab"
+  },
+  {
+    "version": "1",
+    "type": "REST",
+    "method": "PUT",
+    "endpoint": "https://us20.api.mailchimp.com/3.0/lists/df42a82d07/members/48cd6232dc124497369f59c33d3eb4ab",
+    "headers": {
+      "Content-Type": "application/json",
+      "Authorization": "Basic YXBpS2V5Ojk0ZjcxOTE3ZDg1MjI3NzBjOTc0NDliMGM5MGNhYTRjLXVzMjA="
+    },
+    "params": {},
+    "body": {
+      "JSON": {
+        "status": "subscribed",
+        "email_address": "bob.dole@initech.com",
+        "merge_fields": {}
+      },
+      "XML": {},
+      "JSON_ARRAY": {},
+      "FORM": {}
+    },
+    "files": {},
+    "userId": "userId12345"
   }
 ]

--- a/__tests__/data/mailchimp_router_input.json
+++ b/__tests__/data/mailchimp_router_input.json
@@ -76,7 +76,8 @@
       "Config": {
         "apiKey": "94f71917d8522770c97449b0c90caa4c-us20",
         "audienceId": "df42a82d07",
-        "datacenterId": "us20"
+        "datacenterId": "us20",
+        "useUpdatedMapping": true
       },
       "Enabled": true,
       "Transformations": []

--- a/__tests__/data/mailchimp_router_input.json
+++ b/__tests__/data/mailchimp_router_input.json
@@ -77,7 +77,7 @@
         "apiKey": "94f71917d8522770c97449b0c90caa4c-us20",
         "audienceId": "df42a82d07",
         "datacenterId": "us20",
-        "useUpdatedMapping": true
+        "enableMergeFields": true
       },
       "Enabled": true,
       "Transformations": []

--- a/__tests__/data/mailchimp_router_output.json
+++ b/__tests__/data/mailchimp_router_output.json
@@ -94,7 +94,8 @@
       "Config": {
         "apiKey": "94f71917d8522770c97449b0c90caa4c-us20",
         "audienceId": "df42a82d07",
-        "datacenterId": "us20"
+        "datacenterId": "us20",
+        "useUpdatedMapping": true
       },
       "Enabled": true,
       "Transformations": []

--- a/__tests__/data/mailchimp_router_output.json
+++ b/__tests__/data/mailchimp_router_output.json
@@ -95,7 +95,7 @@
         "apiKey": "94f71917d8522770c97449b0c90caa4c-us20",
         "audienceId": "df42a82d07",
         "datacenterId": "us20",
-        "useUpdatedMapping": true
+        "enableMergeFields": true
       },
       "Enabled": true,
       "Transformations": []

--- a/v0/destinations/mailchimp/transform.js
+++ b/v0/destinations/mailchimp/transform.js
@@ -137,7 +137,7 @@ async function getPayload(
     Object.keys(traits).forEach(trait => {
       if (trait === "email") {
         rawPayload.email_address = traits[trait];
-      } else if (mailChimpConfig.useUpdatedMapping) {
+      } else if (mailChimpConfig.enableMergeFields) {
         const tag = filterTagValue(trait);
         rawPayload.merge_fields[tag] = traits[trait];
       }
@@ -214,9 +214,9 @@ function getMailChimpConfig(message, destination) {
       case destinationConfigKeys.dataCenterId:
         mailChimpConfig.dataCenterId = `${destination.Config[key]}`;
         break;
-      case "useUpdatedMapping":
-        mailChimpConfig.useUpdatedMapping =
-          destination.Config.useUpdatedMapping;
+      case "enableMergeFields":
+        mailChimpConfig.enableMergeFields =
+          destination.Config.enableMergeFields;
         break;
       default:
         logger.debug("MailChimp: Unknown key type: ", key);

--- a/v0/destinations/mailchimp/transform.js
+++ b/v0/destinations/mailchimp/transform.js
@@ -137,7 +137,7 @@ async function getPayload(
     Object.keys(traits).forEach(trait => {
       if (trait === "email") {
         rawPayload.email_address = traits[trait];
-      } else {
+      } else if (mailChimpConfig.useUpdatedMapping) {
         const tag = filterTagValue(trait);
         rawPayload.merge_fields[tag] = traits[trait];
       }
@@ -214,6 +214,10 @@ function getMailChimpConfig(message, destination) {
       case destinationConfigKeys.dataCenterId:
         mailChimpConfig.dataCenterId = `${destination.Config[key]}`;
         break;
+      case "useUpdatedMapping":
+        mailChimpConfig.useUpdatedMapping =
+          destination.Config.useUpdatedMapping;
+        break;
       default:
         logger.debug("MailChimp: Unknown key type: ", key);
         break;
@@ -277,8 +281,8 @@ const processRouterDest = async inputs => {
           error.response
             ? error.response.status
             : error.code
-              ? error.code
-              : 400,
+            ? error.code
+            : 400,
           error.message || "Error occurred while processing payload."
         );
       }


### PR DESCRIPTION
Adding support for backward compatibility, with adding merge_fields while updating a subscriber. The support for merge_fields is added by an open-source [here](https://github.com/rudderlabs/rudder-transformer/pull/1098/files) is the PR link.

## Description of the change

> Description here

## Type of change
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [X] The code changed/added as part of this pull request has been covered with tests
- [X] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [X] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
