### PR TITLE
Add error log for stats

### DIFF
--- a/versionedRouter.js
+++ b/versionedRouter.js
@@ -615,7 +615,7 @@ async function handleProxyRequest(destination, ctx) {
     destination
   );
   let response;
-  const { mockDestTime } = ctx.request.query;
+  const mockDestTime = ctx.request?.query?.mockDestTime;
   try {
     const startTime = new Date();
     if (!mockDestTime) {


### PR DESCRIPTION
Signed-off-by: Sai Sankeerth <sanpj2292@github.com>

## Description of the change

We are logging stats as error logs as we're not getting consistent results in grafana dashboard for latency stats


## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

- [Network Layer Issue](https://www.notion.so/rudderstacks/N-W-Layer-Deployment-89d975c914a249a5a042555976141cc5) 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
