### PR TITLE
bugfix(Amplitude) :: Getting event_id from integrations.Amplitude

### DIFF
--- a/__tests__/data/am_input.json
+++ b/__tests__/data/am_input.json
@@ -3207,11 +3207,11 @@
       "messageId": "7208abb6-2c4e-45bb-bf5b-aa426f3593a2",
       "timestamp": "2020-08-14T05:30:30.118Z",
       "properties": {
-        "externalID": "1637170658229-3961832492194264209",
-        "event_id": 3
+        "externalID": "1637170658229-3961832492194264209"
       },
       "integrations": {
-        "All": true
+        "All": true,
+        "Amplitude": { "event_id": 3 }
       },
       "originalTimestamp": "2021-11-17T19:13:51.143Z"
     },
@@ -3273,11 +3273,11 @@
       "messageId": "7208abb6-2c4e-45bb-bf5b-aa426f3593a2",
       "timestamp": "2020-08-14T05:30:30.118Z",
       "properties": {
-        "externalID": "1637170658229-3961832492194264209",
-        "event_id": 0
+        "externalID": "1637170658229-3961832492194264209"
       },
       "integrations": {
-        "All": true
+        "All": true,
+        "Amplitude": { "event_id": 0 }
       },
       "originalTimestamp": "2021-11-17T19:13:51.143Z"
     },
@@ -3339,11 +3339,11 @@
       "messageId": "7208abb6-2c4e-45bb-bf5b-aa426f3593a2",
       "timestamp": "2020-08-14T05:30:30.118Z",
       "properties": {
-        "externalID": "1637170658229-3961832492194264209",
-        "event_id": "0"
+        "externalID": "1637170658229-3961832492194264209"
       },
       "integrations": {
-        "All": true
+        "All": true,
+        "Amplitude": { "event_id": "0" }
       },
       "originalTimestamp": "2021-11-17T19:13:51.143Z"
     },
@@ -3384,8 +3384,7 @@
             "os_version": "test os"
           },
           "ip": "0.0.0.0",
-          "age": 26,
-          "event_id": 6
+          "age": 26
         },
         "library": {
           "name": "RudderLabs JavaScript SDK",
@@ -3432,7 +3431,8 @@
       "anonymousId": "123456",
       "userId": "123456",
       "integrations": {
-        "All": true
+        "All": true,
+        "Amplitude": { "event_id": 6 }
       },
       "sentAt": "2019-10-14T09:03:22.563Z"
     },
@@ -3515,8 +3515,7 @@
         },
         "os_version": "test os",
         "ip": "0.0.0.0",
-        "age": 26,
-        "event_id": 6
+        "age": 26
       },
       "type": "identify",
       "messageId": "84e26acc-56a5-4835-8233-591137fca468",
@@ -3524,7 +3523,8 @@
       "anonymousId": "123456",
       "userId": "123456",
       "integrations": {
-        "All": true
+        "All": true,
+        "Amplitude": { "event_id": 6 }
       },
       "sentAt": "2019-10-14T09:03:22.563Z"
     },
@@ -3555,8 +3555,7 @@
           "email": "chandra+r@rudderlabs.com",
           "plan": "Open source",
           "logins": 5,
-          "createdAt": 1599264000,
-          "event_id": 3
+          "createdAt": 1599264000
         },
         "library": {
           "name": "RudderLabs JavaScript SDK",
@@ -3596,7 +3595,8 @@
       "anonymousId": "my-anonymous-id-new",
       "userId": "sampleusrRudder3",
       "integrations": {
-        "All": true
+        "All": true,
+        "Amplitude": { "event_id": 3 }
       },
       "groupId": "Sample_groupId23",
       "traits": {
@@ -3637,6 +3637,7 @@
           "name": "http"
         }
       },
+      "integrations": { "All": true, "Amplitude": { "event_id": 7 } },
       "timestamp": "2020-02-02T00:23:09.544Z"
     },
     "destination": {
@@ -3698,11 +3699,11 @@
         "url": "https://docs.rudderstack.com/destinations/amplitude",
         "category": "destination",
         "initial_referrer": "https://docs.rudderstack.com",
-        "initial_referring_domain": "docs.rudderstack.com",
-        "event_id": 2
+        "initial_referring_domain": "docs.rudderstack.com"
       },
       "integrations": {
-        "All": true
+        "All": true,
+        "Amplitude": { "event_id": 2 }
       },
       "name": "ApplicationLoaded",
       "sentAt": "2019-10-14T11:15:53.296Z"
@@ -3729,8 +3730,7 @@
           "email": "chandra+r@rudderlabs.com",
           "plan": "Open source",
           "logins": 5,
-          "createdAt": 1599264000,
-          "event_id": 67
+          "createdAt": 1599264000
         },
         "library": {
           "name": "RudderLabs JavaScript SDK",
@@ -3770,7 +3770,8 @@
       "anonymousId": "my-anonymous-id-new",
       "userId": "newUserIdAlias",
       "integrations": {
-        "All": true
+        "All": true,
+        "Amplitude": { "event_id": 67 }
       },
       "previousId": "sampleusrRudder3",
       "sentAt": "2020-10-20T08:14:28.778Z"

--- a/__tests__/data/am_output.json
+++ b/__tests__/data/am_output.json
@@ -3490,7 +3490,8 @@
             "device_id": "anon-id-new",
             "event_properties": {
               "prop1": "5",
-              "name": "Screen View"
+              "name": "Screen View",
+              "event_id": 7
             },
             "user_properties": {},
             "event_type": "Viewed Screen View Screen",

--- a/v0/destinations/am/data/AmplitudeAliasConfig.json
+++ b/v0/destinations/am/data/AmplitudeAliasConfig.json
@@ -1,7 +1,7 @@
 {
   "userId": "global_user_id",
   "previousId": "user_id",
-  "context.traits.event_id": {
+  "integrations.Amplitude.event_id": {
     "isFunc": true,
     "funcName": "getEventId",
     "outKey": "event_id"

--- a/v0/destinations/am/data/AmplitudeDefaultConfig.json
+++ b/v0/destinations/am/data/AmplitudeDefaultConfig.json
@@ -29,7 +29,7 @@
     "funcName": "getBrand",
     "outKey": "device_brand"
   },
-  "context.traits.event_id": {
+  "integrations.Amplitude.event_id": {
     "isFunc": true,
     "funcName": "getEventId",
     "outKey": "event_id"

--- a/v0/destinations/am/data/AmplitudeGroupConfig.json
+++ b/v0/destinations/am/data/AmplitudeGroupConfig.json
@@ -29,7 +29,7 @@
     "funcName": "getBrand",
     "outKey": "device_brand"
   },
-  "context.traits.event_id": {
+  "integrations.Amplitude.event_id": {
     "isFunc": true,
     "funcName": "getEventId",
     "outKey": "event_id"

--- a/v0/destinations/am/data/AmplitudeIdentifyConfig.json
+++ b/v0/destinations/am/data/AmplitudeIdentifyConfig.json
@@ -29,7 +29,7 @@
     "funcName": "getBrand",
     "outKey": "device_brand"
   },
-  "context.traits.event_id": {
+  "integrations.Amplitude.event_id": {
     "isFunc": true,
     "funcName": "getEventId",
     "outKey": "event_id"

--- a/v0/destinations/am/data/AmplitudePageConfig.json
+++ b/v0/destinations/am/data/AmplitudePageConfig.json
@@ -44,7 +44,7 @@
   "messageId": "insert_id",
   "request_ip": "ip",
   "name": "event_properties.name",
-  "context.traits.event_id": {
+  "integrations.Amplitude.event_id": {
     "isFunc": true,
     "funcName": "getEventId",
     "outKey": "event_id"

--- a/v0/destinations/am/data/AmplitudeScreenConfig.json
+++ b/v0/destinations/am/data/AmplitudeScreenConfig.json
@@ -8,7 +8,7 @@
     "funcName": "getBrand",
     "outKey": "device_brand"
   },
-  "context.traits.event_id": {
+  "integrations.Amplitude.event_id": {
     "isFunc": true,
     "funcName": "getEventId",
     "outKey": "event_id"

--- a/v0/destinations/am/transform.js
+++ b/v0/destinations/am/transform.js
@@ -369,12 +369,6 @@ function responseBuilderSimple(
           );
         }
       }
-      if (isDefinedAndNotNull(rawPayload?.user_properties?.event_id)) {
-        delete rawPayload?.user_properties?.event_id;
-      }
-      if (isDefinedAndNotNull(rawPayload?.event_properties?.event_id)) {
-        delete rawPayload?.event_properties?.event_id;
-      }
       break;
     case EventType.ALIAS:
       endpoint = aliasEndpoint(destination.Config);
@@ -402,12 +396,6 @@ function responseBuilderSimple(
           delete rawPayload.event_properties.quantity;
           delete rawPayload.event_properties.revenue;
         }
-      }
-      if (isDefinedAndNotNull(rawPayload?.event_properties?.event_id)) {
-        delete rawPayload?.event_properties?.event_id;
-      }
-      if (isDefinedAndNotNull(rawPayload?.user_properties?.event_id)) {
-        delete rawPayload?.user_properties?.event_id;
       }
       groups = groupInfo && Object.assign(groupInfo);
   }

--- a/v0/destinations/am/utils.js
+++ b/v0/destinations/am/utils.js
@@ -71,15 +71,13 @@ function getBrand(payload, sourceKey, Config) {
   return undefined;
 }
 
-function getEventId(payload) {
-  const event_id =
-    payload?.context?.traits?.event_id ||
-    payload?.traits?.event_id ||
-    payload?.properties?.event_id;
-  if (isDefinedAndNotNull(event_id)) {
-    if (typeof event_id === "string") {
+function getEventId(payload, sourceKey) {
+  const eventId = get(payload, sourceKey);
+
+  if (isDefinedAndNotNull(eventId)) {
+    if (typeof eventId === "string") {
       logger.info(`event_id should be integer only`);
-    } else return event_id;
+    } else return eventId;
   }
   return undefined;
 }


### PR DESCRIPTION
## Description of the change

Amplitude support event_id as an incrementor whose value is help to differentiate among events. We were mapping it from context.traits, properties, etc. But as it is only related to `Amplitude` we should take it from `integrations.Amplitude`. We are implementing that here.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
