### PR TITLE
feature(enhancement): GA4- allow custom dimension passthrough

### DIFF
--- a/__tests__/data/ga4_input.json
+++ b/__tests__/data/ga4_input.json
@@ -6228,5 +6228,192 @@
       },
       "Enabled": true
     }
+  },
+  {
+    "message": {
+      "channel": "web",
+      "messageId": "ec5481b6-a926-4d2e-b293-0b3a77c4d3be",
+      "originalTimestamp": "2022-04-26T05:17:09Z",
+      "anonymousId": "ea5cfab2-3961-4d8a-8187-3d1858c99090",
+      "context": {
+        "app": {
+          "build": "1.0.0",
+          "name": "RudderLabs JavaScript SDK",
+          "namespace": "com.rudderlabs.javascript",
+          "version": "1.0.0"
+        },
+        "device": {
+          "adTrackingEnabled": "false",
+          "advertisingId": "T0T0T072-5e28-45a1-9eda-ce22a3e36d1a",
+          "id": "3f034872-5e28-45a1-9eda-ce22a3e36d1a",
+          "manufacturer": "Google",
+          "model": "AOSP on IA Emulator",
+          "name": "generic_x86_arm",
+          "type": "ios",
+          "attTrackingStatus": 3
+        },
+        "ip": "0.0.0.0",
+        "library": {
+          "name": "RudderLabs JavaScript SDK",
+          "version": "1.0.0"
+        },
+        "locale": "en-US",
+        "os": {
+          "name": "iOS",
+          "version": "14.4.1"
+        },
+        "screen": {
+          "density": 2
+        },
+        "externalId": [
+          {
+            "type": "ga4AppInstanceId",
+            "id": "f0dd99b6f979fb551ce583373900f937"
+          }
+        ],
+        "client_id": "client_id",
+        "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.88 Safari/537.36"
+      },
+      "type": "track",
+      "event": "order completed",
+      "properties": {
+        "checkout_id": "12345",
+        "order_id": "1234",
+        "myCustomProp": "My arbitray value",
+        "affiliation": "Apple Store",
+        "total": 20,
+        "revenue": 15.0,
+        "shipping": 22,
+        "tax": 1,
+        "discount": 1.5,
+        "coupon": "ImagePro",
+        "currency": "USD",
+        "products": [
+          {
+            "product_id": "123",
+            "sku": "G-32",
+            "name": "Monopoly",
+            "price": 14,
+            "quantity": 1,
+            "category": "Games",
+            "item_category2": "Board games",
+            "url": "https://www.website.com/product/path",
+            "image_url": "https://www.website.com/product/path.jpg"
+          }
+        ]
+      },
+      "integrations": {
+        "All": true
+      },
+      "sentAt": "2022-04-20T15:20:57Z"
+    },
+    "destination": {
+      "Config": {
+        "apiSecret": "QyWIGHj8QhG2L4ePAPiXCA",
+        "measurementId": "G-T40PE6KET4",
+        "firebaseAppId": "",
+        "blockPageViewEvent": false,
+        "typesOfClient": "gtag",
+        "extendPageViewParams": false,
+        "sendUserId": false,
+        "eventFilteringOption": "disable",
+        "blacklistedEvents": [
+          {
+            "eventName": ""
+          }
+        ],
+        "whitelistedEvents": [
+          {
+            "eventName": ""
+          }
+        ]
+      },
+      "Enabled": true
+    }
+  },
+  {
+    "message": {
+      "channel": "web",
+      "messageId": "ec5481b6-a926-4d2e-b293-0b3a77c4d3be",
+      "originalTimestamp": "2022-04-26T05:17:09Z",
+      "anonymousId": "ea5cfab2-3961-4d8a-8187-3d1858c99090",
+      "context": {
+        "app": {
+          "build": "1.0.0",
+          "name": "RudderLabs JavaScript SDK",
+          "namespace": "com.rudderlabs.javascript",
+          "version": "1.0.0"
+        },
+        "device": {
+          "adTrackingEnabled": "false",
+          "advertisingId": "T0T0T072-5e28-45a1-9eda-ce22a3e36d1a",
+          "id": "3f034872-5e28-45a1-9eda-ce22a3e36d1a",
+          "manufacturer": "Google",
+          "model": "AOSP on IA Emulator",
+          "name": "generic_x86_arm",
+          "type": "ios",
+          "attTrackingStatus": 3
+        },
+        "ip": "0.0.0.0",
+        "library": {
+          "name": "RudderLabs JavaScript SDK",
+          "version": "1.0.0"
+        },
+        "locale": "en-US",
+        "os": {
+          "name": "iOS",
+          "version": "14.4.1"
+        },
+        "screen": {
+          "density": 2
+        },
+        "externalId": [
+          {
+            "type": "ga4AppInstanceId",
+            "id": "f0dd99b6f979fb551ce583373900f937"
+          }
+        ],
+        "client_id": "client_id",
+        "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.88 Safari/537.36"
+      },
+      "type": "track",
+      "event": "promotion clicked",
+      "properties": {
+        "customProp-1": "check-1",
+        "customProp-2": "check-2",
+        "creative_name": "Summer Banner",
+        "creative_slot": "featured_app_1",
+        "position": "L_12345",
+        "promotion_id": "P_12345",
+        "promotion_name": "Summer Sale"
+      },
+      "integrations": {
+        "All": true
+      },
+      "sentAt": "2022-04-20T15:20:57Z"
+    },
+    "destination": {
+      "Config": {
+        "apiSecret": "QyWIGHj8QhG2L4ePAPiXCA",
+        "measurementId": "G-T40PE6KET4",
+        "firebaseAppId": "",
+        "blockPageViewEvent": false,
+        "typesOfClient": "gtag",
+        "extendPageViewParams": false,
+        "sendUserId": false,
+        "eventFilteringOption": "disable",
+        "blacklistedEvents": [
+          {
+            "eventName": ""
+          }
+        ],
+        "whitelistedEvents": [
+          {
+            "eventName": ""
+          }
+        ]
+      },
+      "Enabled": true
+    }
   }
 ]

--- a/__tests__/data/ga4_output.json
+++ b/__tests__/data/ga4_output.json
@@ -2473,5 +2473,100 @@
       "stage": "transform",
       "scope": "exception"
     }
+  },
+  {
+    "version": "1",
+    "type": "REST",
+    "method": "POST",
+    "endpoint": "https://www.google-analytics.com/mp/collect",
+    "headers": {
+      "HOST": "www.google-analytics.com",
+      "Content-Type": "application/json"
+    },
+    "params": {
+      "api_secret": "QyWIGHj8QhG2L4ePAPiXCA",
+      "measurement_id": "G-T40PE6KET4"
+    },
+    "body": {
+      "JSON": {
+        "client_id": "client_id",
+        "timestamp_micros": 1650950229000000,
+        "non_personalized_ads": false,
+        "events": [
+          {
+            "name": "purchase",
+            "params": {
+              "checkout_id": "12345",
+              "transaction_id": "1234",
+              "myCustomProp": "My arbitray value",
+              "affiliation": "Apple Store",
+              "value": 20,
+              "revenue": 15.0,
+              "shipping": 22,
+              "tax": 1,
+              "discount": 1.5,
+              "coupon": "ImagePro",
+              "currency": "USD",
+              "items": [
+                {
+                  "item_id": "123",
+                  "sku": "G-32",
+                  "item_name": "Monopoly",
+                  "price": 14,
+                  "quantity": 1,
+                  "item_category": "Games",
+                  "item_category2": "Board games",
+                  "url": "https://www.website.com/product/path",
+                  "image_url": "https://www.website.com/product/path.jpg"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "JSON_ARRAY": {},
+      "XML": {},
+      "FORM": {}
+    },
+    "files": {}
+  },
+  {
+    "version": "1",
+    "type": "REST",
+    "method": "POST",
+    "endpoint": "https://www.google-analytics.com/mp/collect",
+    "headers": {
+      "HOST": "www.google-analytics.com",
+      "Content-Type": "application/json"
+    },
+    "params": {
+      "api_secret": "QyWIGHj8QhG2L4ePAPiXCA",
+      "measurement_id": "G-T40PE6KET4"
+    },
+    "body": {
+      "JSON": {
+        "client_id": "client_id",
+        "timestamp_micros": 1650950229000000,
+        "non_personalized_ads": false,
+        "events": [
+          {
+            "name": "select_promotion",
+            "params": {
+              "customProp-1": "check-1",
+              "customProp-2": "check-2",
+              "creative_name": "Summer Banner",
+              "creative_slot": "featured_app_1",
+              "location_id": "L_12345",
+              "promotion_id": "P_12345",
+              "promotion_name": "Summer Sale"
+            }
+          }
+        ]
+      },
+      "JSON_ARRAY": {},
+      "XML": {},
+      "FORM": {}
+    },
+    "files": {}
   }
 ]

--- a/__tests__/data/ga4_output.json
+++ b/__tests__/data/ga4_output.json
@@ -20,8 +20,7 @@
           {
             "name": "search",
             "params": {
-              "search_term": "t-shirts",
-              "query": "t-shirts"
+              "search_term": "t-shirts"
             }
           }
         ]
@@ -78,9 +77,7 @@
                   "item_list_name": "Related Products",
                   "location_id": "L_12345"
                 }
-              ],
-              "list_id": "related_products",
-              "category": "Related_products"
+              ]
             }
           }
         ]
@@ -118,7 +115,6 @@
               "location_id": "L_12345",
               "promotion_id": "P_12345",
               "promotion_name": "Summer Sale",
-              "position": "L_12345",
               "items": [
                 {
                   "item_id": "507f1f77bcf86cd799439011",
@@ -183,7 +179,6 @@
               "location_id": "L_12345",
               "promotion_id": "P_12345",
               "promotion_name": "Summer Sale",
-              "position": "L_12345",
               "items": [
                 {
                   "item_id": "507f1f77bcf86cd799439011",
@@ -247,8 +242,7 @@
               "creative_slot": "featured_app_1",
               "location_id": "L_12345",
               "promotion_id": "P_12345",
-              "promotion_name": "Summer Sale",
-              "position": "L_12345"
+              "promotion_name": "Summer Sale"
             }
           }
         ]
@@ -305,9 +299,7 @@
                   "item_list_name": "Related Products",
                   "location_id": "L_12345"
                 }
-              ],
-              "category": "Related_products",
-              "list_id": "related_products"
+              ]
             }
           }
         ]
@@ -402,7 +394,6 @@
               "location_id": "L_12345",
               "promotion_id": "P_12345",
               "promotion_name": "Summer Sale",
-              "position": "L_12345",
               "items": [
                 {
                   "item_id": "507f1f77bcf86cd799439011",
@@ -467,7 +458,6 @@
               "location_id": "L_12345",
               "promotion_id": "P_12345",
               "promotion_name": "Summer Sale",
-              "position": "L_12345",
               "items": [
                 {
                   "item_id": "507f1f77bcf86cd799439011",
@@ -755,9 +745,8 @@
         "events": [
           {
             "params": {
-              "payment_method": "Credit Card",
               "currency": "USD",
-              "value": "7.77",
+              "value": 7.77,
               "coupon": "SUMMER_FUN",
               "payment_type": "Credit Card",
               "items": [
@@ -815,9 +804,8 @@
         "events": [
           {
             "params": {
-              "shipping_method": "Ground",
               "currency": "USD",
-              "value": "7.77",
+              "value": 7.77,
               "coupon": "SUMMER_FUN",
               "shipping_tier": "Ground",
               "items": [
@@ -1098,8 +1086,7 @@
             "params": {
               "method": "Twitter",
               "content_type": "image",
-              "item_id": "C_12345",
-              "share_via": "Twitter"
+              "item_id": "C_12345"
             }
           }
         ]
@@ -1164,8 +1151,7 @@
             "params": {
               "method": "Twitter",
               "content_type": "image",
-              "item_id": "C_12345",
-              "share_via": "Twitter"
+              "item_id": "C_12345"
             }
           }
         ]

--- a/__tests__/data/ga4_output.json
+++ b/__tests__/data/ga4_output.json
@@ -20,7 +20,8 @@
           {
             "name": "search",
             "params": {
-              "search_term": "t-shirts"
+              "search_term": "t-shirts",
+              "query": "t-shirts"
             }
           }
         ]
@@ -77,7 +78,9 @@
                   "item_list_name": "Related Products",
                   "location_id": "L_12345"
                 }
-              ]
+              ],
+              "list_id": "related_products",
+              "category": "Related_products"
             }
           }
         ]
@@ -115,6 +118,7 @@
               "location_id": "L_12345",
               "promotion_id": "P_12345",
               "promotion_name": "Summer Sale",
+              "position": "L_12345",
               "items": [
                 {
                   "item_id": "507f1f77bcf86cd799439011",
@@ -179,6 +183,7 @@
               "location_id": "L_12345",
               "promotion_id": "P_12345",
               "promotion_name": "Summer Sale",
+              "position": "L_12345",
               "items": [
                 {
                   "item_id": "507f1f77bcf86cd799439011",
@@ -242,7 +247,8 @@
               "creative_slot": "featured_app_1",
               "location_id": "L_12345",
               "promotion_id": "P_12345",
-              "promotion_name": "Summer Sale"
+              "promotion_name": "Summer Sale",
+              "position": "L_12345"
             }
           }
         ]
@@ -299,7 +305,9 @@
                   "item_list_name": "Related Products",
                   "location_id": "L_12345"
                 }
-              ]
+              ],
+              "category": "Related_products",
+              "list_id": "related_products"
             }
           }
         ]
@@ -394,6 +402,7 @@
               "location_id": "L_12345",
               "promotion_id": "P_12345",
               "promotion_name": "Summer Sale",
+              "position": "L_12345",
               "items": [
                 {
                   "item_id": "507f1f77bcf86cd799439011",
@@ -458,6 +467,7 @@
               "location_id": "L_12345",
               "promotion_id": "P_12345",
               "promotion_name": "Summer Sale",
+              "position": "L_12345",
               "items": [
                 {
                   "item_id": "507f1f77bcf86cd799439011",
@@ -745,8 +755,9 @@
         "events": [
           {
             "params": {
+              "payment_method": "Credit Card",
               "currency": "USD",
-              "value": 7.77,
+              "value": "7.77",
               "coupon": "SUMMER_FUN",
               "payment_type": "Credit Card",
               "items": [
@@ -804,8 +815,9 @@
         "events": [
           {
             "params": {
+              "shipping_method": "Ground",
               "currency": "USD",
-              "value": 7.77,
+              "value": "7.77",
               "coupon": "SUMMER_FUN",
               "shipping_tier": "Ground",
               "items": [
@@ -1086,7 +1098,8 @@
             "params": {
               "method": "Twitter",
               "content_type": "image",
-              "item_id": "C_12345"
+              "item_id": "C_12345",
+              "share_via": "Twitter"
             }
           }
         ]
@@ -1151,7 +1164,8 @@
             "params": {
               "method": "Twitter",
               "content_type": "image",
-              "item_id": "C_12345"
+              "item_id": "C_12345",
+              "share_via": "Twitter"
             }
           }
         ]

--- a/v0/destinations/ga4/transform.js
+++ b/v0/destinations/ga4/transform.js
@@ -28,7 +28,8 @@ const {
   removeReservedUserPropertyPrefixNames,
   isReservedWebCustomEventName,
   isReservedWebCustomPrefixName,
-  getDestinationItemProperties
+  getDestinationItemProperties,
+  getExclusionList
 } = require("./utils");
 
 function trackResponseBuilder(message, { Config }) {
@@ -94,6 +95,12 @@ function trackResponseBuilder(message, { Config }) {
           message,
           mappingConfig[ConfigCategory.PRODUCTS_SEARCHED.name]
         );
+        payload.params = extractCustomFields(
+          message,
+          payload.params,
+          ["properties"],
+          getExclusionList(mappingConfig[ConfigCategory.ORDER_COMPLETED.name])
+        );
         break;
       case "product_list_viewed":
         payload.name = eventNameMapping[event.toLowerCase()];
@@ -102,6 +109,12 @@ function trackResponseBuilder(message, { Config }) {
           mappingConfig[ConfigCategory.PRODUCT_LIST_VIEWED.name]
         );
         payload.params.items = getDestinationItemProperties(message, true);
+        payload.params = extractCustomFields(
+          message,
+          payload.params,
+          ["properties"],
+          getExclusionList(mappingConfig[ConfigCategory.ORDER_COMPLETED.name])
+        );
         break;
       /* Promotions Section */
       case "promotion_viewed":
@@ -111,6 +124,12 @@ function trackResponseBuilder(message, { Config }) {
           mappingConfig[ConfigCategory.PROMOTION_VIEWED.name]
         );
         payload.params.items = getDestinationItemProperties(message, true);
+        payload.params = extractCustomFields(
+          message,
+          payload.params,
+          ["properties"],
+          getExclusionList(mappingConfig[ConfigCategory.ORDER_COMPLETED.name])
+        );
         break;
       case "promotion_clicked":
         payload.name = eventNameMapping[event.toLowerCase()];
@@ -119,6 +138,12 @@ function trackResponseBuilder(message, { Config }) {
           mappingConfig[ConfigCategory.PROMOTION_CLICKED.name]
         );
         payload.params.items = getDestinationItemProperties(message, false);
+        payload.params = extractCustomFields(
+          message,
+          payload.params,
+          ["properties"],
+          getExclusionList(mappingConfig[ConfigCategory.ORDER_COMPLETED.name])
+        );
         break;
       /* Ordering Section */
       case "product_clicked":
@@ -128,6 +153,12 @@ function trackResponseBuilder(message, { Config }) {
           mappingConfig[ConfigCategory.PRODUCT_CLICKED.name]
         );
         payload.params.items = getDestinationItemProperties(message, true);
+        payload.params = extractCustomFields(
+          message,
+          payload.params,
+          ["properties"],
+          getExclusionList(mappingConfig[ConfigCategory.ORDER_COMPLETED.name])
+        );
         break;
       case "product_viewed":
         payload.name = eventNameMapping[event.toLowerCase()];
@@ -136,6 +167,12 @@ function trackResponseBuilder(message, { Config }) {
           mappingConfig[ConfigCategory.PRODUCT_VIEWED.name]
         );
         payload.params.items = getDestinationItemProperties(message, true);
+        payload.params = extractCustomFields(
+          message,
+          payload.params,
+          ["properties"],
+          getExclusionList(mappingConfig[ConfigCategory.ORDER_COMPLETED.name])
+        );
         break;
       case "product_added":
         payload.name = eventNameMapping[event.toLowerCase()];
@@ -144,6 +181,12 @@ function trackResponseBuilder(message, { Config }) {
           mappingConfig[ConfigCategory.PRODUCT_ADDED.name]
         );
         payload.params.items = getDestinationItemProperties(message, true);
+        payload.params = extractCustomFields(
+          message,
+          payload.params,
+          ["properties"],
+          getExclusionList(mappingConfig[ConfigCategory.ORDER_COMPLETED.name])
+        );
         break;
       case "product_removed":
         payload.name = eventNameMapping[event.toLowerCase()];
@@ -152,6 +195,12 @@ function trackResponseBuilder(message, { Config }) {
           mappingConfig[ConfigCategory.PRODUCT_REMOVED.name]
         );
         payload.params.items = getDestinationItemProperties(message, true);
+        payload.params = extractCustomFields(
+          message,
+          payload.params,
+          ["properties"],
+          getExclusionList(mappingConfig[ConfigCategory.ORDER_COMPLETED.name])
+        );
         break;
       case "cart_viewed":
         payload.name = eventNameMapping[event.toLowerCase()];
@@ -160,6 +209,12 @@ function trackResponseBuilder(message, { Config }) {
           mappingConfig[ConfigCategory.CART_VIEWED.name]
         );
         payload.params.items = getDestinationItemProperties(message, true);
+        payload.params = extractCustomFields(
+          message,
+          payload.params,
+          ["properties"],
+          getExclusionList(mappingConfig[ConfigCategory.ORDER_COMPLETED.name])
+        );
         break;
       case "checkout_started":
         payload.name = eventNameMapping[event.toLowerCase()];
@@ -168,6 +223,12 @@ function trackResponseBuilder(message, { Config }) {
           mappingConfig[ConfigCategory.CHECKOUT_STARTED.name]
         );
         payload.params.items = getDestinationItemProperties(message, true);
+        payload.params = extractCustomFields(
+          message,
+          payload.params,
+          ["properties"],
+          getExclusionList(mappingConfig[ConfigCategory.ORDER_COMPLETED.name])
+        );
         break;
       case "payment_info_entered":
         payload.params = constructPayload(
@@ -180,6 +241,12 @@ function trackResponseBuilder(message, { Config }) {
           payload.name = "add_payment_info";
         }
         payload.params.items = getDestinationItemProperties(message, true);
+        payload.params = extractCustomFields(
+          message,
+          payload.params,
+          ["properties"],
+          getExclusionList(mappingConfig[ConfigCategory.ORDER_COMPLETED.name])
+        );
         break;
       case "order_completed":
         payload.name = eventNameMapping[event.toLowerCase()];
@@ -188,6 +255,12 @@ function trackResponseBuilder(message, { Config }) {
           mappingConfig[ConfigCategory.ORDER_COMPLETED.name]
         );
         payload.params.items = getDestinationItemProperties(message, true);
+        payload.params = extractCustomFields(
+          message,
+          payload.params,
+          ["properties"],
+          getExclusionList(mappingConfig[ConfigCategory.ORDER_COMPLETED.name])
+        );
         break;
       case "order_refunded":
         payload.name = eventNameMapping[event.toLowerCase()];
@@ -196,6 +269,12 @@ function trackResponseBuilder(message, { Config }) {
           mappingConfig[ConfigCategory.ORDER_REFUNDED.name]
         );
         payload.params.items = getDestinationItemProperties(message, false);
+        payload.params = extractCustomFields(
+          message,
+          payload.params,
+          ["properties"],
+          getExclusionList(mappingConfig[ConfigCategory.ORDER_COMPLETED.name])
+        );
         break;
       /* Wishlist Section */
       case "product_added_to_wishlist":
@@ -205,6 +284,12 @@ function trackResponseBuilder(message, { Config }) {
           mappingConfig[ConfigCategory.PRODUCT_ADDED_TO_WISHLIST.name]
         );
         payload.params.items = getDestinationItemProperties(message, true);
+        payload.params = extractCustomFields(
+          message,
+          payload.params,
+          ["properties"],
+          getExclusionList(mappingConfig[ConfigCategory.ORDER_COMPLETED.name])
+        );
         break;
       /* Sharing Section */
       case "product_shared":
@@ -213,12 +298,24 @@ function trackResponseBuilder(message, { Config }) {
           message,
           mappingConfig[ConfigCategory.PRODUCT_SHARED.name]
         );
+        payload.params = extractCustomFields(
+          message,
+          payload.params,
+          ["properties"],
+          getExclusionList(mappingConfig[ConfigCategory.ORDER_COMPLETED.name])
+        );
         break;
       case "cart_shared":
         payload.name = eventNameMapping[event.toLowerCase()];
         payload.params = constructPayload(
           message,
           mappingConfig[ConfigCategory.CART_SHARED.name]
+        );
+        payload.params = extractCustomFields(
+          message,
+          payload.params,
+          ["properties"],
+          getExclusionList(mappingConfig[ConfigCategory.ORDER_COMPLETED.name])
         );
         break;
       /* Group */
@@ -228,6 +325,12 @@ function trackResponseBuilder(message, { Config }) {
           message,
           mappingConfig[ConfigCategory.GROUP.name]
         );
+        payload.params = extractCustomFields(
+          message,
+          payload.params,
+          ["properties"],
+          getExclusionList(mappingConfig[ConfigCategory.ORDER_COMPLETED.name])
+        );
         break;
       /* GA4 Events */
       case "earn_virtual_currency":
@@ -236,12 +339,24 @@ function trackResponseBuilder(message, { Config }) {
           message,
           mappingConfig[ConfigCategory.EARN_VIRTUAL_CURRENCY.name]
         );
+        payload.params = extractCustomFields(
+          message,
+          payload.params,
+          ["properties"],
+          getExclusionList(mappingConfig[ConfigCategory.ORDER_COMPLETED.name])
+        );
         break;
       case "generate_lead":
         payload.name = eventNameMapping[event.toLowerCase()];
         payload.params = constructPayload(
           message,
           mappingConfig[ConfigCategory.GENERATE_LEAD.name]
+        );
+        payload.params = extractCustomFields(
+          message,
+          payload.params,
+          ["properties"],
+          getExclusionList(mappingConfig[ConfigCategory.ORDER_COMPLETED.name])
         );
         break;
       case "level_up":
@@ -250,12 +365,24 @@ function trackResponseBuilder(message, { Config }) {
           message,
           mappingConfig[ConfigCategory.LEVEL_UP.name]
         );
+        payload.params = extractCustomFields(
+          message,
+          payload.params,
+          ["properties"],
+          getExclusionList(mappingConfig[ConfigCategory.ORDER_COMPLETED.name])
+        );
         break;
       case "login":
         payload.name = eventNameMapping[event.toLowerCase()];
         payload.params = constructPayload(
           message,
           mappingConfig[ConfigCategory.LOGIN.name]
+        );
+        payload.params = extractCustomFields(
+          message,
+          payload.params,
+          ["properties"],
+          getExclusionList(mappingConfig[ConfigCategory.ORDER_COMPLETED.name])
         );
         break;
       case "post_score":
@@ -264,12 +391,24 @@ function trackResponseBuilder(message, { Config }) {
           message,
           mappingConfig[ConfigCategory.POST_SCORE.name]
         );
+        payload.params = extractCustomFields(
+          message,
+          payload.params,
+          ["properties"],
+          getExclusionList(mappingConfig[ConfigCategory.ORDER_COMPLETED.name])
+        );
         break;
       case "select_content":
         payload.name = eventNameMapping[event.toLowerCase()];
         payload.params = constructPayload(
           message,
           mappingConfig[ConfigCategory.SELECT_CONTENT.name]
+        );
+        payload.params = extractCustomFields(
+          message,
+          payload.params,
+          ["properties"],
+          getExclusionList(mappingConfig[ConfigCategory.ORDER_COMPLETED.name])
         );
         break;
       case "sign_up":
@@ -278,12 +417,24 @@ function trackResponseBuilder(message, { Config }) {
           message,
           mappingConfig[ConfigCategory.SIGN_UP.name]
         );
+        payload.params = extractCustomFields(
+          message,
+          payload.params,
+          ["properties"],
+          getExclusionList(mappingConfig[ConfigCategory.ORDER_COMPLETED.name])
+        );
         break;
       case "spend_virtual_currency":
         payload.name = eventNameMapping[event.toLowerCase()];
         payload.params = constructPayload(
           message,
           mappingConfig[ConfigCategory.SPEND_VIRTUAL_CURRENCY.name]
+        );
+        payload.params = extractCustomFields(
+          message,
+          payload.params,
+          ["properties"],
+          getExclusionList(mappingConfig[ConfigCategory.ORDER_COMPLETED.name])
         );
         break;
       case "tutorial_begin":
@@ -298,6 +449,12 @@ function trackResponseBuilder(message, { Config }) {
           message,
           mappingConfig[ConfigCategory.UNLOCK_ACHIEVEMENT.name]
         );
+        payload.params = extractCustomFields(
+          message,
+          payload.params,
+          ["properties"],
+          getExclusionList(mappingConfig[ConfigCategory.ORDER_COMPLETED.name])
+        );
         break;
       case "view_search_results":
         payload.name = eventNameMapping[event.toLowerCase()];
@@ -306,6 +463,12 @@ function trackResponseBuilder(message, { Config }) {
           mappingConfig[ConfigCategory.VIEW_SEARCH_RESULTS.name]
         );
         payload.params.items = getDestinationItemProperties(message, false);
+        payload.params = extractCustomFields(
+          message,
+          payload.params,
+          ["properties"],
+          getExclusionList(mappingConfig[ConfigCategory.ORDER_COMPLETED.name])
+        );
         break;
       default:
         break;

--- a/v0/destinations/ga4/transform.js
+++ b/v0/destinations/ga4/transform.js
@@ -99,7 +99,7 @@ function trackResponseBuilder(message, { Config }) {
           message,
           payload.params,
           ["properties"],
-          getExclusionList(mappingConfig[ConfigCategory.ORDER_COMPLETED.name])
+          getExclusionList(mappingConfig[ConfigCategory.PRODUCTS_SEARCHED.name])
         );
         break;
       case "product_list_viewed":
@@ -113,7 +113,9 @@ function trackResponseBuilder(message, { Config }) {
           message,
           payload.params,
           ["properties"],
-          getExclusionList(mappingConfig[ConfigCategory.ORDER_COMPLETED.name])
+          getExclusionList(
+            mappingConfig[ConfigCategory.PRODUCT_LIST_VIEWED.name]
+          )
         );
         break;
       /* Promotions Section */
@@ -128,7 +130,7 @@ function trackResponseBuilder(message, { Config }) {
           message,
           payload.params,
           ["properties"],
-          getExclusionList(mappingConfig[ConfigCategory.ORDER_COMPLETED.name])
+          getExclusionList(mappingConfig[ConfigCategory.PROMOTION_VIEWED.name])
         );
         break;
       case "promotion_clicked":
@@ -142,7 +144,7 @@ function trackResponseBuilder(message, { Config }) {
           message,
           payload.params,
           ["properties"],
-          getExclusionList(mappingConfig[ConfigCategory.ORDER_COMPLETED.name])
+          getExclusionList(mappingConfig[ConfigCategory.PROMOTION_CLICKED.name])
         );
         break;
       /* Ordering Section */
@@ -157,7 +159,7 @@ function trackResponseBuilder(message, { Config }) {
           message,
           payload.params,
           ["properties"],
-          getExclusionList(mappingConfig[ConfigCategory.ORDER_COMPLETED.name])
+          getExclusionList(mappingConfig[ConfigCategory.PRODUCT_CLICKED.name])
         );
         break;
       case "product_viewed":
@@ -171,7 +173,7 @@ function trackResponseBuilder(message, { Config }) {
           message,
           payload.params,
           ["properties"],
-          getExclusionList(mappingConfig[ConfigCategory.ORDER_COMPLETED.name])
+          getExclusionList(mappingConfig[ConfigCategory.PRODUCT_VIEWED.name])
         );
         break;
       case "product_added":
@@ -185,7 +187,7 @@ function trackResponseBuilder(message, { Config }) {
           message,
           payload.params,
           ["properties"],
-          getExclusionList(mappingConfig[ConfigCategory.ORDER_COMPLETED.name])
+          getExclusionList(mappingConfig[ConfigCategory.PRODUCT_ADDED.name])
         );
         break;
       case "product_removed":
@@ -199,7 +201,7 @@ function trackResponseBuilder(message, { Config }) {
           message,
           payload.params,
           ["properties"],
-          getExclusionList(mappingConfig[ConfigCategory.ORDER_COMPLETED.name])
+          getExclusionList(mappingConfig[ConfigCategory.PRODUCT_REMOVED.name])
         );
         break;
       case "cart_viewed":
@@ -213,7 +215,7 @@ function trackResponseBuilder(message, { Config }) {
           message,
           payload.params,
           ["properties"],
-          getExclusionList(mappingConfig[ConfigCategory.ORDER_COMPLETED.name])
+          getExclusionList(mappingConfig[ConfigCategory.CART_VIEWED.name])
         );
         break;
       case "checkout_started":
@@ -227,7 +229,7 @@ function trackResponseBuilder(message, { Config }) {
           message,
           payload.params,
           ["properties"],
-          getExclusionList(mappingConfig[ConfigCategory.ORDER_COMPLETED.name])
+          getExclusionList(mappingConfig[ConfigCategory.CHECKOUT_STARTED.name])
         );
         break;
       case "payment_info_entered":
@@ -245,7 +247,9 @@ function trackResponseBuilder(message, { Config }) {
           message,
           payload.params,
           ["properties"],
-          getExclusionList(mappingConfig[ConfigCategory.ORDER_COMPLETED.name])
+          getExclusionList(
+            mappingConfig[ConfigCategory.PAYMENT_INFO_ENTERED.name]
+          )
         );
         break;
       case "order_completed":
@@ -273,7 +277,7 @@ function trackResponseBuilder(message, { Config }) {
           message,
           payload.params,
           ["properties"],
-          getExclusionList(mappingConfig[ConfigCategory.ORDER_COMPLETED.name])
+          getExclusionList(mappingConfig[ConfigCategory.ORDER_REFUNDED.name])
         );
         break;
       /* Wishlist Section */
@@ -288,7 +292,9 @@ function trackResponseBuilder(message, { Config }) {
           message,
           payload.params,
           ["properties"],
-          getExclusionList(mappingConfig[ConfigCategory.ORDER_COMPLETED.name])
+          getExclusionList(
+            mappingConfig[ConfigCategory.PRODUCT_ADDED_TO_WISHLIST.name]
+          )
         );
         break;
       /* Sharing Section */
@@ -302,7 +308,7 @@ function trackResponseBuilder(message, { Config }) {
           message,
           payload.params,
           ["properties"],
-          getExclusionList(mappingConfig[ConfigCategory.ORDER_COMPLETED.name])
+          getExclusionList(mappingConfig[ConfigCategory.PRODUCT_SHARED.name])
         );
         break;
       case "cart_shared":
@@ -315,7 +321,7 @@ function trackResponseBuilder(message, { Config }) {
           message,
           payload.params,
           ["properties"],
-          getExclusionList(mappingConfig[ConfigCategory.ORDER_COMPLETED.name])
+          getExclusionList(mappingConfig[ConfigCategory.CART_SHARED.name])
         );
         break;
       /* Group */
@@ -329,7 +335,7 @@ function trackResponseBuilder(message, { Config }) {
           message,
           payload.params,
           ["properties"],
-          getExclusionList(mappingConfig[ConfigCategory.ORDER_COMPLETED.name])
+          getExclusionList(mappingConfig[ConfigCategory.GROUP.name])
         );
         break;
       /* GA4 Events */
@@ -343,7 +349,9 @@ function trackResponseBuilder(message, { Config }) {
           message,
           payload.params,
           ["properties"],
-          getExclusionList(mappingConfig[ConfigCategory.ORDER_COMPLETED.name])
+          getExclusionList(
+            mappingConfig[ConfigCategory.EARN_VIRTUAL_CURRENCY.name]
+          )
         );
         break;
       case "generate_lead":
@@ -356,7 +364,7 @@ function trackResponseBuilder(message, { Config }) {
           message,
           payload.params,
           ["properties"],
-          getExclusionList(mappingConfig[ConfigCategory.ORDER_COMPLETED.name])
+          getExclusionList(mappingConfig[ConfigCategory.GENERATE_LEAD.name])
         );
         break;
       case "level_up":
@@ -369,7 +377,7 @@ function trackResponseBuilder(message, { Config }) {
           message,
           payload.params,
           ["properties"],
-          getExclusionList(mappingConfig[ConfigCategory.ORDER_COMPLETED.name])
+          getExclusionList(mappingConfig[ConfigCategory.LEVEL_UP.name])
         );
         break;
       case "login":
@@ -382,7 +390,7 @@ function trackResponseBuilder(message, { Config }) {
           message,
           payload.params,
           ["properties"],
-          getExclusionList(mappingConfig[ConfigCategory.ORDER_COMPLETED.name])
+          getExclusionList(mappingConfig[ConfigCategory.LOGIN.name])
         );
         break;
       case "post_score":
@@ -395,7 +403,7 @@ function trackResponseBuilder(message, { Config }) {
           message,
           payload.params,
           ["properties"],
-          getExclusionList(mappingConfig[ConfigCategory.ORDER_COMPLETED.name])
+          getExclusionList(mappingConfig[ConfigCategory.POST_SCORE.name])
         );
         break;
       case "select_content":
@@ -408,7 +416,7 @@ function trackResponseBuilder(message, { Config }) {
           message,
           payload.params,
           ["properties"],
-          getExclusionList(mappingConfig[ConfigCategory.ORDER_COMPLETED.name])
+          getExclusionList(mappingConfig[ConfigCategory.SELECT_CONTENT.name])
         );
         break;
       case "sign_up":
@@ -421,7 +429,7 @@ function trackResponseBuilder(message, { Config }) {
           message,
           payload.params,
           ["properties"],
-          getExclusionList(mappingConfig[ConfigCategory.ORDER_COMPLETED.name])
+          getExclusionList(mappingConfig[ConfigCategory.SIGN_UP.name])
         );
         break;
       case "spend_virtual_currency":
@@ -434,7 +442,9 @@ function trackResponseBuilder(message, { Config }) {
           message,
           payload.params,
           ["properties"],
-          getExclusionList(mappingConfig[ConfigCategory.ORDER_COMPLETED.name])
+          getExclusionList(
+            mappingConfig[ConfigCategory.SPEND_VIRTUAL_CURRENCY.name]
+          )
         );
         break;
       case "tutorial_begin":
@@ -453,7 +463,9 @@ function trackResponseBuilder(message, { Config }) {
           message,
           payload.params,
           ["properties"],
-          getExclusionList(mappingConfig[ConfigCategory.ORDER_COMPLETED.name])
+          getExclusionList(
+            mappingConfig[ConfigCategory.UNLOCK_ACHIEVEMENT.name]
+          )
         );
         break;
       case "view_search_results":
@@ -467,7 +479,9 @@ function trackResponseBuilder(message, { Config }) {
           message,
           payload.params,
           ["properties"],
-          getExclusionList(mappingConfig[ConfigCategory.ORDER_COMPLETED.name])
+          getExclusionList(
+            mappingConfig[ConfigCategory.VIEW_SEARCH_RESULTS.name]
+          )
         );
         break;
       default:

--- a/v0/destinations/ga4/utils.js
+++ b/v0/destinations/ga4/utils.js
@@ -300,7 +300,10 @@ function getExclusionList(mappingJson) {
       });
     }
   });
+
+  // We are mapping "products" to "items", so to remove redundancy we should not send products again
   ga4ExclusionList.push("products");
+
   return ga4ExclusionList;
 }
 

--- a/v0/destinations/ga4/utils.js
+++ b/v0/destinations/ga4/utils.js
@@ -291,7 +291,7 @@ function getDestinationItemProperties(message, isItemsRequired) {
  * @returns
  */
 function getExclusionList(mappingJson) {
-  const ga4ExclusionList = [];
+  let ga4ExclusionList = [];
 
   mappingJson.forEach(element => {
     const mappingSourceKeys = element.sourceKeys;
@@ -307,7 +307,7 @@ function getExclusionList(mappingJson) {
 
   // We are mapping "products" to "items", so to remove redundancy we should not send products again
   ga4ExclusionList.push("products");
-  ga4ExclusionList.concat(GA4_RESERVED_PARAMETER_EXCLUSION);
+  ga4ExclusionList = ga4ExclusionList.concat(GA4_RESERVED_PARAMETER_EXCLUSION);
 
   return ga4ExclusionList;
 }

--- a/v0/destinations/ga4/utils.js
+++ b/v0/destinations/ga4/utils.js
@@ -284,8 +284,12 @@ function getDestinationItemProperties(message, isItemsRequired) {
   return items;
 }
 
-// This function will return exclusion list for a particular event.
-// Exclusion list= sourceKeys that are already mapped
+/**
+ * get exclusion list for a particular event
+ * ga4ExclusionList contains the sourceKeys that are already mapped
+ * @param {*} mappingJson
+ * @returns
+ */
 function getExclusionList(mappingJson) {
   const ga4ExclusionList = [];
 
@@ -303,6 +307,7 @@ function getExclusionList(mappingJson) {
 
   // We are mapping "products" to "items", so to remove redundancy we should not send products again
   ga4ExclusionList.push("products");
+  ga4ExclusionList.concat(GA4_RESERVED_PARAMETER_EXCLUSION);
 
   return ga4ExclusionList;
 }

--- a/v0/destinations/ga4/utils.js
+++ b/v0/destinations/ga4/utils.js
@@ -284,6 +284,26 @@ function getDestinationItemProperties(message, isItemsRequired) {
   return items;
 }
 
+// This function will return exclusion list for a particular event.
+// Exclusion list= sourceKeys that are already mapped
+function getExclusionList(mappingJson) {
+  const ga4ExclusionList = [];
+
+  mappingJson.forEach(element => {
+    const mappingSourceKeys = element.sourceKeys;
+
+    if (typeof mappingSourceKeys === "string") {
+      ga4ExclusionList.push(mappingSourceKeys.split(".").pop());
+    } else {
+      mappingSourceKeys.forEach(item => {
+        ga4ExclusionList.push(item.split(".").pop());
+      });
+    }
+  });
+  ga4ExclusionList.push("products");
+  return ga4ExclusionList;
+}
+
 const responseHandler = (destinationResponse, dest) => {
   const message = `[GA4 Response Handler] - Request Processed Successfully`;
   let { status } = destinationResponse;
@@ -332,5 +352,6 @@ module.exports = {
   removeReservedUserPropertyPrefixNames,
   isReservedWebCustomEventName,
   isReservedWebCustomPrefixName,
-  getDestinationItemProperties
+  getDestinationItemProperties,
+  getExclusionList
 };


### PR DESCRIPTION
## Description of the change

> Allowing users to send custom properties to GA4.
> To add these custom properties to the payload, we have excluded(using EXCLUSION lists for every event) some fields(which are already mapped) and then added all other fields to the event payload(using the `extractCustomFields` function) before sending it to GA4.

## Type of change
- [ ] New feature (non-breaking change that adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
