### PR TITLE
Hotfix for fixing panic in server

### DIFF
--- a/__mocks__/data/salesforce/proxy_response.json
+++ b/__mocks__/data/salesforce/proxy_response.json
@@ -1,0 +1,9 @@
+{
+  "https://rudderstack.my.salesforce.com/services/data/v50.0/sobjects/Lead/1": {
+    "response": {
+      "data": ""
+    },
+    "status": 204,
+    "statusText": "No Content"
+  }
+}

--- a/__mocks__/network.js
+++ b/__mocks__/network.js
@@ -10,6 +10,7 @@ const urlDirectoryMap = {
   "active.campaigns.rudder.com": "active_campaigns",
   "api.aptrinsic.com": "gainsight_px",
   "api.amplitude.com": "am",
+  "rudderstack.my.salesforce.com": "salesforce",
   "braze.com": "braze",
   "bigquery.googleapis.com": "bqstream",
   "pi.pardot.com": "pardot",

--- a/__tests__/data/proxy_input.json
+++ b/__tests__/data/proxy_input.json
@@ -274,5 +274,35 @@
         "files": {}
       }
     }
+  },
+  {
+    "request": {
+      "body": {
+        "type": "REST",
+        "files": {},
+        "method": "POST",
+        "params": {},
+        "userId": "",
+        "headers": {
+          "Content-Type": "application/json",
+          "Authorization": "Bearer 00A7g1234553sZ3!AQsAQAADPNb4QWb2ZFGpWA2KD22sZ8rXKxELhpFu28v_uylzpsybJUlY0aoqFJFAo2cbzu.zCUbAItPgcDQ94Iyfr4QbA4Lg"
+        },
+        "version": "1",
+        "endpoint": "https://rudderstack.my.salesforce.com/services/data/v50.0/sobjects/Lead/1",
+        "body": {
+          "XML": {},
+          "FORM": {},
+          "JSON": {
+            "Email": "denis.kornilov@sbermarket.ru",
+            "Company": "sbermarket.ru",
+            "LastName": "Корнилов",
+            "FirstName": "Денис",
+            "LeadSource": "App Signup",
+            "account_type__c": "free_trial"
+          },
+          "JSON_ARRAY": {}
+        }
+      }
+    }    
   }
 ]

--- a/__tests__/data/proxy_output.json
+++ b/__tests__/data/proxy_output.json
@@ -98,5 +98,15 @@
         "meta": "retryable"
       }
     }
+  },
+  {
+    "output": {
+      "status": 200,
+      "message": "[Generic Response Handler] Request for destination: any Processed Successfully",
+      "destinationResponse": {
+        "response": "",
+        "status": 204
+      }
+    }
   }
 ]

--- a/__tests__/data/proxy_output.json
+++ b/__tests__/data/proxy_output.json
@@ -101,7 +101,7 @@
   },
   {
     "output": {
-      "status": 200,
+      "status": 204,
       "message": "[Generic Response Handler] Request for destination: any Processed Successfully",
       "destinationResponse": {
         "response": "",

--- a/adapters/networkhandler/genericNetworkHandler.js
+++ b/adapters/networkhandler/genericNetworkHandler.js
@@ -40,8 +40,10 @@ const responseHandler = (destinationResponse, dest) => {
       })
       .build();
   }
+  // Sending `204` status(obtained from destination) is not working as expected
+  // Since this is success scenario, we'll be forcefully sending `200` status-code to server
   return {
-    status,
+    status: 200,
     message,
     destinationResponse
   };

--- a/adapters/networkhandler/genericNetworkHandler.js
+++ b/adapters/networkhandler/genericNetworkHandler.js
@@ -40,10 +40,8 @@ const responseHandler = (destinationResponse, dest) => {
       })
       .build();
   }
-  // Sending `204` status(obtained from destination) is not working as expected
-  // Since this is success scenario, we'll be forcefully sending `200` status-code to server
   return {
-    status: 200,
+    status,
     message,
     destinationResponse
   };

--- a/versionedRouter.js
+++ b/versionedRouter.js
@@ -12,7 +12,8 @@ const {
   isNonFuncObject,
   getMetadata,
   generateErrorObject,
-  CustomError
+  CustomError,
+  isHttpStatusSuccess
 } = require("./v0/util");
 const { processDynamicConfig } = require("./util/dynamicConfig");
 const { DestHandlerMap } = require("./constants/destinationCanonicalNames");

--- a/versionedRouter.js
+++ b/versionedRouter.js
@@ -637,7 +637,9 @@ async function handleProxyRequest(destination, ctx) {
     }
   }
   ctx.body = { output: response };
-  ctx.status = response.status;
+  // Sending `204` status(obtained from destination) is not working as expected
+  // Since this is success scenario, we'll be forcefully sending `200` status-code to server
+  ctx.status = isHttpStatusSuccess(response.status) ? 200 : response.status;
   return ctx.body;
 }
 


### PR DESCRIPTION
## Description of the change

The issue was that for Salesforce we were getting an unmarshal failure which compounded to panic because postgres was not allowing to insert `\u000` character

The reason for unmarshalling error was that the response from transformer was empty

## Root-cause

When the status-code with `204` was being sent to `server`, the response body is empty even when from transformer the response body was being set.
Hence for now, all the `2xx` status, we'll be sending a `200` status to server

## Changes in PR

- Test-cases to see when we get a `204` status if we're indeed sending a JSON
- Change to send `200` for all `2xx` status we receive from destination(s)

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
