### PR TITLE
fix(router): Adding counter stats to proxy request

### DIFF
--- a/versionedRouter.js
+++ b/versionedRouter.js
@@ -650,7 +650,7 @@ async function handleProxyRequest(destination, ctx) {
     if (!err.responseTransformFailure) {
       response.message = `[Error occurred while processing response for destination ${destination}]: ${err.message}`;
     }
-    stats.counter("tf_proxy_err_response_count", 1, {
+    stats.counter("tf_proxy_err_count", 1, {
       destination
     });
   }
@@ -668,9 +668,6 @@ if (transformerProxy) {
       router.post(
         `/${version}/destinations/${destination}/proxy`,
         async ctx => {
-          stats.counter("tf_proxy_input_count", 1, {
-            destination
-          });
           const startTime = new Date();
           ctx.set("apiVersion", API_VERSION);
           await handleProxyRequest(destination, ctx);

--- a/versionedRouter.js
+++ b/versionedRouter.js
@@ -641,6 +641,8 @@ async function handleProxyRequest(destination, ctx) {
       destination
     });
   } catch (err) {
+    logger.error("Error occurred while completing proxy request:");
+    logger.error(err);
     response = generateErrorObject(
       err,
       destination,


### PR DESCRIPTION
## Description of the change

As part of this [CFD](https://www.notion.so/rudderstacks/Duplicate-events-in-downstream-destinations-RudderStack-ad13926a1153441091aced26bb1b157d?d=f7c7d944be8a415da74c7cb8c950d96c) counter stats have been added to the transformer proxy request
- tf_proxy_input_count
- tf_proxy_dest_req_count
- tf_proxy_dest_resp_count
- tf_proxy_proc_ax_response_count
- tf_proxy_resp_handler_count
- tf_proxy_err_response_count


> All the above stats are prefixed with `transformer_` while checking in the grafana dashboard


## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
