### PR TITLE
bugfix(personalize): allowing non string properties to personalize

### DIFF
--- a/__tests__/data/personalize_input.json
+++ b/__tests__/data/personalize_input.json
@@ -3055,7 +3055,107 @@
         ],
         "datasetARN": "",
         "eventChoice": "PutEvents",
-        "stringifyProperty": false,
+        "disableStringify": true,
+        "region": "us-east-1",
+        "secretAccessKey": "DEF",
+        "trackingId": "c60"
+      },
+      "Enabled": true,
+      "Transformations": [],
+      "IsProcessorEnabled": true
+    },
+    "libraries": [],
+    "request": {
+      "query": {}
+    }
+  },
+  {
+    "message": {
+      "anonymousId": "anon-id-new",
+      "context": {
+        "ip": "14.5.67.21",
+        "library": {
+          "name": "http"
+        }
+      },
+      "event": "PRODUCT ADDED",
+      "messageId": "4bb69e26-b5a6-446a-a140-dbb6263369c9",
+      "originalTimestamp": "2021-03-13T01:56:46.896+05:30",
+      "properties": {
+        "numberOfRatings": "checking with webapp change",
+        "movieWatched": 2,
+        "eventValue": 7.06
+      },
+      "receivedAt": "2021-03-13T01:56:44.340+05:30",
+      "request_ip": "[::1]",
+      "rudderId": "daf823fb-e8d3-413a-8313-d34cd756f968",
+      "sentAt": "2021-03-13T01:56:46.896+05:30",
+      "timestamp": "2020-02-02T00:23:09.544Z",
+      "type": "track",
+      "userId": "identified user id"
+    },
+    "metadata": {
+      "sourceId": "1pe7ty3hMMQCnrfZ0Mn2QG48884",
+      "destinationId": "1pe9WgFOuFHOSIfmUkkhVTD1Rsd",
+      "jobId": 1,
+      "destinationType": "PERSONALIZE",
+      "messageId": "4bb69e26-b5a6-446a-a140-dbb6263369c9",
+      "messageIds": null,
+      "rudderId": "daf823fb-e8d3-413a-8313-d34cd756f968",
+      "receivedAt": "2021-03-13T01:56:44.340+05:30"
+    },
+    "destination": {
+      "ID": "1pe9WgFOuFHOSIfmUkkhVTD1Rsd",
+      "Name": "personalize Dev Testing",
+      "DestinationDefinition": {
+        "ID": "1pdthjPnz8gQhSTE2QTbm2LUMGM",
+        "Name": "PERSONALIZE",
+        "DisplayName": "AWS Personalize",
+        "Config": {
+          "destConfig": {
+            "defaultConfig": [
+              "accessKeyId",
+              "secretAccessKey",
+              "region",
+              "trackingId",
+              "eventName",
+              "customMappings"
+            ]
+          },
+          "excludeKeys": [],
+          "includeKeys": [],
+          "saveDestinationResponse": true,
+          "secretKeys": [
+            "accessKeyId",
+            "secretAccessKey"
+          ],
+          "supportedSourceTypes": [
+            "android",
+            "ios",
+            "web",
+            "unity",
+            "amp",
+            "cloud",
+            "reactnative"
+          ],
+          "transformAt": "processor"
+        }
+      },
+      "Config": {
+        "accessKeyId": "ABC",
+        "customMappings": [
+          {
+            "from": "MOVIE_WATCHED",
+            "to": "movieWatched"
+          },
+          {
+            "from": "NUMBER_OF_RATINGS",
+            "to": "numberOfRatings"
+          }
+        ],
+        "datasetARN": "",
+        "eventChoice": "PutEvents",
+        "disableStringify": false,
         "region": "us-east-1",
         "secretAccessKey": "DEF",
         "trackingId": "c60"

--- a/__tests__/data/personalize_input.json
+++ b/__tests__/data/personalize_input.json
@@ -2868,5 +2868,205 @@
     "request": {
       "query": {}
     }
+  },
+  {
+    "message": {
+      "anonymousId": "anon-id-new",
+      "context": {
+        "ip": "14.5.67.21",
+        "library": {
+          "name": "http"
+        }
+      },
+      "event": "PRODUCT ADDED",
+      "messageId": "4bb69e26-b5a6-446a-a140-dbb6263369c9",
+      "originalTimestamp": "2021-03-13T01:56:46.896+05:30",
+      "properties": {
+        "numberOfRatings": "checking with webapp change",
+        "movieWatched": 2,
+        "eventValue": 7.06
+      },
+      "receivedAt": "2021-03-13T01:56:44.340+05:30",
+      "request_ip": "[::1]",
+      "rudderId": "daf823fb-e8d3-413a-8313-d34cd756f968",
+      "sentAt": "2021-03-13T01:56:46.896+05:30",
+      "timestamp": "2020-02-02T00:23:09.544Z",
+      "type": "track",
+      "userId": "identified user id"
+    },
+    "metadata": {
+      "sourceId": "1pe7ty3hMMQCnrfZ0Mn2QG48884",
+      "destinationId": "1pe9WgFOuFHOSIfmUkkhVTD1Rsd",
+      "jobId": 1,
+      "destinationType": "PERSONALIZE",
+      "messageId": "4bb69e26-b5a6-446a-a140-dbb6263369c9",
+      "messageIds": null,
+      "rudderId": "daf823fb-e8d3-413a-8313-d34cd756f968",
+      "receivedAt": "2021-03-13T01:56:44.340+05:30"
+    },
+    "destination": {
+      "ID": "1pe9WgFOuFHOSIfmUkkhVTD1Rsd",
+      "Name": "personalize Dev Testing",
+      "DestinationDefinition": {
+        "ID": "1pdthjPnz8gQhSTE2QTbm2LUMGM",
+        "Name": "PERSONALIZE",
+        "DisplayName": "AWS Personalize",
+        "Config": {
+          "destConfig": {
+            "defaultConfig": [
+              "accessKeyId",
+              "secretAccessKey",
+              "region",
+              "trackingId",
+              "eventName",
+              "customMappings"
+            ]
+          },
+          "excludeKeys": [],
+          "includeKeys": [],
+          "saveDestinationResponse": true,
+          "secretKeys": [
+            "accessKeyId",
+            "secretAccessKey"
+          ],
+          "supportedSourceTypes": [
+            "android",
+            "ios",
+            "web",
+            "unity",
+            "amp",
+            "cloud",
+            "reactnative"
+          ],
+          "transformAt": "processor"
+        }
+      },
+      "Config": {
+        "accessKeyId": "ABC",
+        "customMappings": [
+          {
+            "from": "MOVIE_WATCHED",
+            "to": "movieWatched"
+          },
+          {
+            "from": "NUMBER_OF_RATINGS",
+            "to": "numberOfRatings"
+          }
+        ],
+        "datasetARN": "",
+        "eventChoice": "PutEvents",
+        "stringifyProperty": true,
+        "region": "us-east-1",
+        "secretAccessKey": "DEF",
+        "trackingId": "c60"
+      },
+      "Enabled": true,
+      "Transformations": [],
+      "IsProcessorEnabled": true
+    },
+    "libraries": [],
+    "request": {
+      "query": {}
+    }
+  },
+  {
+    "message": {
+      "anonymousId": "anon-id-new",
+      "context": {
+        "ip": "14.5.67.21",
+        "library": {
+          "name": "http"
+        }
+      },
+      "event": "PRODUCT ADDED",
+      "messageId": "4bb69e26-b5a6-446a-a140-dbb6263369c9",
+      "originalTimestamp": "2021-03-13T01:56:46.896+05:30",
+      "properties": {
+        "numberOfRatings": "checking with webapp change",
+        "movieWatched": 2,
+        "eventValue": 7.06
+      },
+      "receivedAt": "2021-03-13T01:56:44.340+05:30",
+      "request_ip": "[::1]",
+      "rudderId": "daf823fb-e8d3-413a-8313-d34cd756f968",
+      "sentAt": "2021-03-13T01:56:46.896+05:30",
+      "timestamp": "2020-02-02T00:23:09.544Z",
+      "type": "track",
+      "userId": "identified user id"
+    },
+    "metadata": {
+      "sourceId": "1pe7ty3hMMQCnrfZ0Mn2QG48884",
+      "destinationId": "1pe9WgFOuFHOSIfmUkkhVTD1Rsd",
+      "jobId": 1,
+      "destinationType": "PERSONALIZE",
+      "messageId": "4bb69e26-b5a6-446a-a140-dbb6263369c9",
+      "messageIds": null,
+      "rudderId": "daf823fb-e8d3-413a-8313-d34cd756f968",
+      "receivedAt": "2021-03-13T01:56:44.340+05:30"
+    },
+    "destination": {
+      "ID": "1pe9WgFOuFHOSIfmUkkhVTD1Rsd",
+      "Name": "personalize Dev Testing",
+      "DestinationDefinition": {
+        "ID": "1pdthjPnz8gQhSTE2QTbm2LUMGM",
+        "Name": "PERSONALIZE",
+        "DisplayName": "AWS Personalize",
+        "Config": {
+          "destConfig": {
+            "defaultConfig": [
+              "accessKeyId",
+              "secretAccessKey",
+              "region",
+              "trackingId",
+              "eventName",
+              "customMappings"
+            ]
+          },
+          "excludeKeys": [],
+          "includeKeys": [],
+          "saveDestinationResponse": true,
+          "secretKeys": [
+            "accessKeyId",
+            "secretAccessKey"
+          ],
+          "supportedSourceTypes": [
+            "android",
+            "ios",
+            "web",
+            "unity",
+            "amp",
+            "cloud",
+            "reactnative"
+          ],
+          "transformAt": "processor"
+        }
+      },
+      "Config": {
+        "accessKeyId": "ABC",
+        "customMappings": [
+          {
+            "from": "MOVIE_WATCHED",
+            "to": "movieWatched"
+          },
+          {
+            "from": "NUMBER_OF_RATINGS",
+            "to": "numberOfRatings"
+          }
+        ],
+        "datasetARN": "",
+        "eventChoice": "PutEvents",
+        "stringifyProperty": false,
+        "region": "us-east-1",
+        "secretAccessKey": "DEF",
+        "trackingId": "c60"
+      },
+      "Enabled": true,
+      "Transformations": [],
+      "IsProcessorEnabled": true
+    },
+    "libraries": [],
+    "request": {
+      "query": {}
+    }
   }
 ]

--- a/__tests__/data/personalize_output.json
+++ b/__tests__/data/personalize_output.json
@@ -276,5 +276,37 @@
   },
   {
     "error": "Message type not supported"
+  },
+  {
+    "sessionId": "anon-id-new",
+    "trackingId": "c60",
+    "userId": "identified user id",
+    "eventList": [
+      {
+        "itemId": "4bb69e26-b5a6-446a-a140-dbb6263369c9",
+        "eventType": "PRODUCT ADDED",
+        "sentAt": "2020-02-02T00:23:09.544Z",
+        "properties": {
+          "movieWatched": "2",
+          "numberOfRatings": "checking with webapp change"
+        }
+      }
+    ]
+  },
+  {
+    "sessionId": "anon-id-new",
+    "trackingId": "c60",
+    "userId": "identified user id",
+    "eventList": [
+      {
+        "itemId": "4bb69e26-b5a6-446a-a140-dbb6263369c9",
+        "eventType": "PRODUCT ADDED",
+        "sentAt": "2020-02-02T00:23:09.544Z",
+        "properties": {
+          "movieWatched": 2,
+          "numberOfRatings": "checking with webapp change"
+        }
+      }
+    ]
   }
 ]

--- a/__tests__/data/personalize_output.json
+++ b/__tests__/data/personalize_output.json
@@ -308,5 +308,21 @@
         }
       }
     ]
+  },
+  {
+    "sessionId": "anon-id-new",
+    "trackingId": "c60",
+    "userId": "identified user id",
+    "eventList": [
+      {
+        "itemId": "4bb69e26-b5a6-446a-a140-dbb6263369c9",
+        "eventType": "PRODUCT ADDED",
+        "sentAt": "2020-02-02T00:23:09.544Z",
+        "properties": {
+          "movieWatched": "2",
+          "numberOfRatings": "checking with webapp change"
+        }
+      }
+    ]
   }
 ]

--- a/v0/destinations/personalize/transform.js
+++ b/v0/destinations/personalize/transform.js
@@ -14,7 +14,7 @@ const {
 
 const putEventsHandler = (message, destination) => {
   const { properties, anonymousId, event } = message;
-  const { customMappings, trackingId, stringifyProperty } = destination.Config;
+  const { customMappings, trackingId, disableStringify } = destination.Config;
 
   if (!event || !isDefinedAndNotNull(event) || isBlank(event)) {
     throw new CustomError(" Cannot process if no event name specified", 400);
@@ -45,7 +45,7 @@ const putEventsHandler = (message, destination) => {
       if (!isDefined(value)) {
         throw new CustomError(`Mapped property ${keyMap[key]} not found`, 400);
       }
-      if (isDefined(stringifyProperty) && !stringifyProperty) {
+      if (isDefined(disableStringify) && disableStringify) {
         outputEvent.properties[_.camelCase(key)] = value;
       } else {
         // users using old config will have stringified property by default

--- a/v0/destinations/personalize/transform.js
+++ b/v0/destinations/personalize/transform.js
@@ -14,7 +14,7 @@ const {
 
 const putEventsHandler = (message, destination) => {
   const { properties, anonymousId, event } = message;
-  const { customMappings, trackingId } = destination.Config;
+  const { customMappings, trackingId, stringifyProperty } = destination.Config;
 
   if (!event || !isDefinedAndNotNull(event) || isBlank(event)) {
     throw new CustomError(" Cannot process if no event name specified", 400);
@@ -45,8 +45,12 @@ const putEventsHandler = (message, destination) => {
       if (!isDefined(value)) {
         throw new CustomError(`Mapped property ${keyMap[key]} not found`, 400);
       }
-      // all the values inside property has to be sent as strings
-      outputEvent.properties[_.camelCase(key)] = String(value);
+      if (isDefined(stringifyProperty) && !stringifyProperty) {
+        outputEvent.properties[_.camelCase(key)] = value;
+      } else {
+        // users using old config will have stringified property by default
+        outputEvent.properties[_.camelCase(key)] = String(value);
+      }
     } else if (!MANDATORY_PROPERTIES.includes(key.toUpperCase())) {
       if (
         (!isDefinedAndNotNull(value) || isBlank(value)) &&


### PR DESCRIPTION
## Description of the change

putEvents will not convert every properties data to a string. Also backward compatibility is ensured by introducing new toggle button in webapp

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
