### PR TITLE
Bugfix(integration):Adobe Analytics Page and Screen Calls expecting event field

### DIFF
--- a/__tests__/data/adobe_analytics_input.json
+++ b/__tests__/data/adobe_analytics_input.json
@@ -5410,5 +5410,569 @@
       "timestamp": "2019-09-01T15:46:51.693Z",
       "type": "track"
     }
-  }
+  },
+  {
+    "destination": {
+      "Config": {
+        "trackingServerUrl": "http://sadobemetrics.dr.dk",
+        "trackingServerSecureUrl": "https://sadobemetrics.dr.dk",
+        "reportSuiteIds": "drdev2",
+        "sslHeartbeat": true,
+        "heartbeatTrackingServerUrl": "",
+        "useUtf8Charset": true,
+        "useSecureServerSide": true,
+        "proxyNormalUrl": "",
+        "proxyHeartbeatUrl": "",
+        "marketingCloudOrgId": "00E287634SDFE6200A495E6B@AdobeOrg",
+        "dropVisitorId": false,
+        "timestampOption": "hybrid",
+        "timestampOptionalReporting": true,
+        "noFallbackVisitorId": false,
+        "preferVisitorId": false,
+        "trackPageName": true,
+        "contextDataPrefix": "",
+        "useLegacyLinkName": true,
+        "pageNameFallbackTostring": true,
+        "sendFalseValues": true,
+        "productIdentifier": "id",
+        "eventsToTypes": [
+          {
+            "from": "",
+            "to": ""
+          }
+        ],
+        "listDelimiter": [
+          {
+            "from": "del_1",
+            "to": "DEL_1"
+          }
+        ],
+        "listMapping": [
+          {
+            "from": "map_1",
+            "to": "MAP_1"
+          },
+          {
+            "from": "del_1",
+            "to": "DEL_1"
+          }
+        ],
+        "propsDelimiter": [
+          {
+            "from": "c2",
+            "to": "2"
+          },
+          {
+            "from": "c3",
+            "to": "3"
+          }
+        ],
+        "eventMerchProperties": [
+          {
+            "eventMerchProperties": "tournament_id"
+          }
+        ],
+        "productMerchProperties": [
+          {
+            "productMerchProperties": ""
+          }
+        ],
+        "eVarMapping": [
+          {
+            "from": "v1",
+            "to": "1"
+          },
+          {
+            "from": "v2",
+            "to": "2"
+          },
+          {
+            "from": "v3",
+            "to": "3"
+          },
+          {
+            "from": "v12",
+            "to": "12"
+          },
+          {
+            "from": "v13",
+            "to": "13"
+          },
+          {
+            "from": "v16",
+            "to": "16"
+          },
+          {
+            "from": "v17",
+            "to": "17"
+          },
+          {
+            "from": "v40",
+            "to": "40"
+          },
+          {
+            "from": "v41",
+            "to": "41"
+          },
+          {
+            "from": "v42",
+            "to": "42"
+          },
+          {
+            "from": "v69",
+            "to": "69"
+          },
+          {
+            "from": "v70",
+            "to": "70"
+          },
+          {
+            "from": "v89",
+            "to": "89"
+          }
+        ],
+        "eventDelivery": false,
+        "eventDeliveryTS": 1628171489456,
+        "rudderEventsToAdobeEvents": [
+          {
+            "from": "Custom Page View",
+            "to": "event1"
+          },
+          {
+            "from": "App Launch",
+            "to": "event31"
+          },
+          {
+            "from": "App Start",
+            "to": "event31"
+          }
+        ],
+        "useNativeSDK": {
+          "web": false
+        },
+        "eventMerchEventToAdobeEvent": [
+          {
+            "from": "Custom Page View",
+            "to": "merchEvent"
+          }
+        ],
+        "customPropsMapping": [
+          {
+            "from": "c2",
+            "to": "2"
+          },
+          {
+            "from": "c3",
+            "to": 3
+          }
+        ],
+        "contextDataMapping": [
+          {
+            "from": "bet_level",
+            "to": "rudder_bet_level"
+          }
+        ],
+        "hierMapping": [
+          {
+            "from": "game_name",
+            "to": "game_dest"
+          }
+        ],
+        "productMerchEventToAdobeEvent": [
+          {
+            "from": "Custom Page View",
+            "to": "scAdd"
+          }
+        ],
+        "productMerchEvarsMap": [
+          {
+            "from": "product_id",
+            "to": "2"
+          }
+        ]
+      }
+    },
+    "message": {
+      "anonymousId": "c82cbdff-e5be-4009-ac78-cdeea09ab4b1",
+      "context": {
+        "device": {
+          "id": "df16bffa-5c3d-4fbb-9bce-3bab098129a7R",
+          "manufacturer": "Xiaomi",
+          "model": "Redmi 6",
+          "name": "xiaomi"
+        },
+        "network": {
+          "carrier": "Banglalink"
+        },
+        "os": {
+          "name": "android",
+          "version": "8.1.0"
+        },
+        "traits": {
+          "address": {
+            "city": "Dhaka",
+            "country": "Bangladesh"
+          },
+          "anonymousId": "c82cbdff-e5be-4009-ac78-cdeea09ab4b1"
+        },
+        "externalId": [
+          {
+            "type": "AdobeFallbackVisitorId",
+            "id": 1
+          }
+        ],
+        "page": {
+          "url": "https://abc.com",
+          "name": "testName"
+        }
+      },
+      "name": "Custom Page View",
+      "integrations": {
+        "AM": true
+      },
+      "message_id": "a80f82be-9bdc-4a9f-b2a5-15621ee41df8",
+      "properties": {
+        "url": "https://app.rudderstack.com/signup?type=freetrial",
+        "path": "/signup",
+        "title": "",
+        "search": "?type=freetrial",
+        "tab_url": "https://app.rudderstack.com/signup?type=freetrial",
+        "referrer": "https://rudderstack.medium.com/kafka-vs-postgresql-how-we-implemented-our-queueing-system-using-postgresql-ec128650e3e",
+        "initial_referrer": "https://rudderstack.medium.com/kafka-vs-postgresql-how-we-implemented-our-queueing-system-using-postgresql-ec128650e3e",
+        "referring_domain": "rudderstack.medium.com",
+        "initial_referring_domain": "rudderstack.medium.com",
+        "additional_bet_index": 0,
+        "battle_id": "N/A",
+        "bet_amount": 9,
+        "bet_level": 1,
+        "bet_multiplier": 1,
+        "coin_balance": 9466052,
+        "current_module_name": "CasinoGameModule",
+        "days_in_game": 0,
+        "extra_param": "N/A",
+        "fb_profile": "0",
+        "featureGameType": "N/A",
+        "game_fps": 30,
+        "game_id": "fireEagleBase",
+        "game_name": "FireEagleSlots",
+        "gem_balance": 0,
+        "graphicsQuality": "HD",
+        "idfa": "2bf99787-33d2-4ae2-a76a-c49672f97252",
+        "internetReachability": "ReachableViaLocalAreaNetwork",
+        "isLowEndDevice": "False",
+        "is_auto_spin": "False",
+        "is_turbo": "False",
+        "isf": "False",
+        "ishighroller": "False",
+        "jackpot_win_amount": 90,
+        "jackpot_win_type": "Silver",
+        "level": 6,
+        "lifetime_gem_balance": 0,
+        "no_of_spin": 1,
+        "player_total_battles": 0,
+        "player_total_shields": 0,
+        "start_date": "2019-08-01",
+        "total_payments": 0,
+        "tournament_id": "T1561970819",
+        "versionSessionCount": 2,
+        "win_amount": 0,
+        "v1": 1,
+        "v2": 2,
+        "del_1": "delimeter",
+        "map_1": 1,
+        "c2": [
+          2,
+          3,
+          4
+        ],
+        "c3": "3",
+        "product_id": 2
+      },
+      "userId": "test_user_id",
+      "timestamp": "2019-09-01T15:46:51.693Z",
+      "type": "page"
+    }
+  },
+  {
+    "destination": {
+        "Config": {
+            "trackingServerUrl": "http://sadobemetrics.dr.dk",
+            "trackingServerSecureUrl": "https://sadobemetrics.dr.dk",
+            "reportSuiteIds": "drdev2",
+            "sslHeartbeat": true,
+            "heartbeatTrackingServerUrl": "",
+            "useUtf8Charset": true,
+            "useSecureServerSide": true,
+            "proxyNormalUrl": "",
+            "proxyHeartbeatUrl": "",
+            "marketingCloudOrgId": "00E287634SDFE6200A495E6B@AdobeOrg",
+            "dropVisitorId": false,
+            "timestampOption": "hybrid",
+            "timestampOptionalReporting": true,
+            "noFallbackVisitorId": false,
+            "preferVisitorId": false,
+            "trackPageName": true,
+            "contextDataPrefix": "",
+            "useLegacyLinkName": true,
+            "pageNameFallbackTostring": true,
+            "sendFalseValues": true,
+            "productIdentifier": "id",
+            "eventsToTypes": [
+                {
+                    "from": "",
+                    "to": ""
+                }
+            ],
+            "listDelimiter": [
+                {
+                    "from": "del_1",
+                    "to": "DEL_1"
+                }
+            ],
+            "listMapping": [
+                {
+                    "from": "map_1",
+                    "to": "MAP_1"
+                },
+                {
+                    "from": "del_1",
+                    "to": "DEL_1"
+                }
+            ],
+            "propsDelimiter": [
+                {
+                    "from": "c2",
+                    "to": "2"
+                },
+                {
+                    "from": "c3",
+                    "to": "3"
+                }
+            ],
+            "eventMerchProperties": [
+                {
+                    "eventMerchProperties": "tournament_id"
+                }
+            ],
+            "productMerchProperties": [
+                {
+                    "productMerchProperties": ""
+                }
+            ],
+            "eVarMapping": [
+                {
+                    "from": "v1",
+                    "to": "1"
+                },
+                {
+                    "from": "v2",
+                    "to": "2"
+                },
+                {
+                    "from": "v3",
+                    "to": "3"
+                },
+                {
+                    "from": "v12",
+                    "to": "12"
+                },
+                {
+                    "from": "v13",
+                    "to": "13"
+                },
+                {
+                    "from": "v16",
+                    "to": "16"
+                },
+                {
+                    "from": "v17",
+                    "to": "17"
+                },
+                {
+                    "from": "v40",
+                    "to": "40"
+                },
+                {
+                    "from": "v41",
+                    "to": "41"
+                },
+                {
+                    "from": "v42",
+                    "to": "42"
+                },
+                {
+                    "from": "v69",
+                    "to": "69"
+                },
+                {
+                    "from": "v70",
+                    "to": "70"
+                },
+                {
+                    "from": "v89",
+                    "to": "89"
+                }
+            ],
+            "eventDelivery": false,
+            "eventDeliveryTS": 1628171489456,
+            "rudderEventsToAdobeEvents": [
+                {
+                    "from": "Custom Page View",
+                    "to": "event1"
+                },
+                {
+                    "from": "App Launch",
+                    "to": "event31"
+                },
+                {
+                    "from": "App Start",
+                    "to": "event31"
+                }
+            ],
+            "useNativeSDK": {
+                "web": false
+            },
+            "eventMerchEventToAdobeEvent": [
+                {
+                    "from": "Custom Page View",
+                    "to": "merchEvent"
+                }
+            ],
+            "customPropsMapping": [
+                {
+                    "from": "c2",
+                    "to": "2"
+                },
+                {
+                    "from": "c3",
+                    "to": 3
+                }
+            ],
+            "contextDataMapping": [
+                {
+                    "from": "bet_level",
+                    "to": "rudder_bet_level"
+                }
+            ],
+            "hierMapping": [
+                {
+                    "from": "game_name",
+                    "to": "game_dest"
+                }
+            ],
+            "productMerchEventToAdobeEvent": [
+                {
+                    "from": "Custom Page View",
+                    "to": "scAdd"
+                }
+            ],
+            "productMerchEvarsMap": [
+                {
+                    "from": "product_id",
+                    "to": "2"
+                }
+            ]
+        }
+    },
+    "message": {
+        "anonymousId": "c82cbdff-e5be-4009-ac78-cdeea09ab4b1",
+        "context": {
+            "device": {
+                "id": "df16bffa-5c3d-4fbb-9bce-3bab098129a7R",
+                "manufacturer": "Xiaomi",
+                "model": "Redmi 6",
+                "name": "xiaomi"
+            },
+            "network": {
+                "carrier": "Banglalink"
+            },
+            "os": {
+                "name": "android",
+                "version": "8.1.0"
+            },
+            "traits": {
+                "address": {
+                    "city": "Dhaka",
+                    "country": "Bangladesh"
+                },
+                "anonymousId": "c82cbdff-e5be-4009-ac78-cdeea09ab4b1"
+            },
+            "externalId": [
+                {
+                    "type": "AdobeFallbackVisitorId",
+                    "id": 1
+                }
+            ],
+            "page": {
+                "url": "https://abc.com",
+                "name": "testName"
+            }
+        },
+        "name": "Custom Page View",
+        "integrations": {
+            "AM": true
+        },
+        "message_id": "a80f82be-9bdc-4a9f-b2a5-15621ee41df8",
+        "properties": {
+            "url": "https://app.rudderstack.com/signup?type=freetrial",
+            "path": "/signup",
+            "title": "",
+            "search": "?type=freetrial",
+            "tab_url": "https://app.rudderstack.com/signup?type=freetrial",
+            "referrer": "https://rudderstack.medium.com/kafka-vs-postgresql-how-we-implemented-our-queueing-system-using-postgresql-ec128650e3e",
+            "initial_referrer": "https://rudderstack.medium.com/kafka-vs-postgresql-how-we-implemented-our-queueing-system-using-postgresql-ec128650e3e",
+            "referring_domain": "rudderstack.medium.com",
+            "initial_referring_domain": "rudderstack.medium.com",
+            "additional_bet_index": 0,
+            "battle_id": "N/A",
+            "bet_amount": 9,
+            "bet_level": 1,
+            "bet_multiplier": 1,
+            "coin_balance": 9466052,
+            "current_module_name": "CasinoGameModule",
+            "days_in_game": 0,
+            "extra_param": "N/A",
+            "fb_profile": "0",
+            "featureGameType": "N/A",
+            "game_fps": 30,
+            "game_id": "fireEagleBase",
+            "game_name": "FireEagleSlots",
+            "gem_balance": 0,
+            "graphicsQuality": "HD",
+            "idfa": "2bf99787-33d2-4ae2-a76a-c49672f97252",
+            "internetReachability": "ReachableViaLocalAreaNetwork",
+            "isLowEndDevice": "False",
+            "is_auto_spin": "False",
+            "is_turbo": "False",
+            "isf": "False",
+            "ishighroller": "False",
+            "jackpot_win_amount": 90,
+            "jackpot_win_type": "Silver",
+            "level": 6,
+            "lifetime_gem_balance": 0,
+            "no_of_spin": 1,
+            "player_total_battles": 0,
+            "player_total_shields": 0,
+            "start_date": "2019-08-01",
+            "total_payments": 0,
+            "tournament_id": "T1561970819",
+            "versionSessionCount": 2,
+            "win_amount": 0,
+            "v1": 1,
+            "v2": 2,
+            "del_1": "delimeter",
+            "map_1": 1,
+            "c2": [
+                2,
+                3,
+                4
+            ],
+            "c3": "3",
+            "product_id": 2
+        },
+        "userId": "test_user_id",
+        "timestamp": "2019-09-01T15:46:51.693Z",
+        "type": "screen"
+    }
+}
 ]

--- a/__tests__/data/adobe_analytics_input.json
+++ b/__tests__/data/adobe_analytics_input.json
@@ -5695,284 +5695,564 @@
   },
   {
     "destination": {
-        "Config": {
-            "trackingServerUrl": "http://sadobemetrics.dr.dk",
-            "trackingServerSecureUrl": "https://sadobemetrics.dr.dk",
-            "reportSuiteIds": "drdev2",
-            "sslHeartbeat": true,
-            "heartbeatTrackingServerUrl": "",
-            "useUtf8Charset": true,
-            "useSecureServerSide": true,
-            "proxyNormalUrl": "",
-            "proxyHeartbeatUrl": "",
-            "marketingCloudOrgId": "00E287634SDFE6200A495E6B@AdobeOrg",
-            "dropVisitorId": false,
-            "timestampOption": "hybrid",
-            "timestampOptionalReporting": true,
-            "noFallbackVisitorId": false,
-            "preferVisitorId": false,
-            "trackPageName": true,
-            "contextDataPrefix": "",
-            "useLegacyLinkName": true,
-            "pageNameFallbackTostring": true,
-            "sendFalseValues": true,
-            "productIdentifier": "id",
-            "eventsToTypes": [
-                {
-                    "from": "",
-                    "to": ""
-                }
-            ],
-            "listDelimiter": [
-                {
-                    "from": "del_1",
-                    "to": "DEL_1"
-                }
-            ],
-            "listMapping": [
-                {
-                    "from": "map_1",
-                    "to": "MAP_1"
-                },
-                {
-                    "from": "del_1",
-                    "to": "DEL_1"
-                }
-            ],
-            "propsDelimiter": [
-                {
-                    "from": "c2",
-                    "to": "2"
-                },
-                {
-                    "from": "c3",
-                    "to": "3"
-                }
-            ],
-            "eventMerchProperties": [
-                {
-                    "eventMerchProperties": "tournament_id"
-                }
-            ],
-            "productMerchProperties": [
-                {
-                    "productMerchProperties": ""
-                }
-            ],
-            "eVarMapping": [
-                {
-                    "from": "v1",
-                    "to": "1"
-                },
-                {
-                    "from": "v2",
-                    "to": "2"
-                },
-                {
-                    "from": "v3",
-                    "to": "3"
-                },
-                {
-                    "from": "v12",
-                    "to": "12"
-                },
-                {
-                    "from": "v13",
-                    "to": "13"
-                },
-                {
-                    "from": "v16",
-                    "to": "16"
-                },
-                {
-                    "from": "v17",
-                    "to": "17"
-                },
-                {
-                    "from": "v40",
-                    "to": "40"
-                },
-                {
-                    "from": "v41",
-                    "to": "41"
-                },
-                {
-                    "from": "v42",
-                    "to": "42"
-                },
-                {
-                    "from": "v69",
-                    "to": "69"
-                },
-                {
-                    "from": "v70",
-                    "to": "70"
-                },
-                {
-                    "from": "v89",
-                    "to": "89"
-                }
-            ],
-            "eventDelivery": false,
-            "eventDeliveryTS": 1628171489456,
-            "rudderEventsToAdobeEvents": [
-                {
-                    "from": "Custom Page View",
-                    "to": "event1"
-                },
-                {
-                    "from": "App Launch",
-                    "to": "event31"
-                },
-                {
-                    "from": "App Start",
-                    "to": "event31"
-                }
-            ],
-            "useNativeSDK": {
-                "web": false
-            },
-            "eventMerchEventToAdobeEvent": [
-                {
-                    "from": "Custom Page View",
-                    "to": "merchEvent"
-                }
-            ],
-            "customPropsMapping": [
-                {
-                    "from": "c2",
-                    "to": "2"
-                },
-                {
-                    "from": "c3",
-                    "to": 3
-                }
-            ],
-            "contextDataMapping": [
-                {
-                    "from": "bet_level",
-                    "to": "rudder_bet_level"
-                }
-            ],
-            "hierMapping": [
-                {
-                    "from": "game_name",
-                    "to": "game_dest"
-                }
-            ],
-            "productMerchEventToAdobeEvent": [
-                {
-                    "from": "Custom Page View",
-                    "to": "scAdd"
-                }
-            ],
-            "productMerchEvarsMap": [
-                {
-                    "from": "product_id",
-                    "to": "2"
-                }
-            ]
-        }
+      "Config": {
+        "trackingServerUrl": "http://sadobemetrics.dr.dk",
+        "trackingServerSecureUrl": "https://sadobemetrics.dr.dk",
+        "reportSuiteIds": "drdev2",
+        "sslHeartbeat": true,
+        "heartbeatTrackingServerUrl": "",
+        "useUtf8Charset": true,
+        "useSecureServerSide": true,
+        "proxyNormalUrl": "",
+        "proxyHeartbeatUrl": "",
+        "marketingCloudOrgId": "00E287634SDFE6200A495E6B@AdobeOrg",
+        "dropVisitorId": false,
+        "timestampOption": "hybrid",
+        "timestampOptionalReporting": true,
+        "noFallbackVisitorId": false,
+        "preferVisitorId": false,
+        "trackPageName": true,
+        "contextDataPrefix": "",
+        "useLegacyLinkName": true,
+        "pageNameFallbackTostring": true,
+        "sendFalseValues": true,
+        "productIdentifier": "id",
+        "eventsToTypes": [
+          {
+            "from": "",
+            "to": ""
+          }
+        ],
+        "listDelimiter": [
+          {
+            "from": "del_1",
+            "to": "DEL_1"
+          }
+        ],
+        "listMapping": [
+          {
+            "from": "map_1",
+            "to": "MAP_1"
+          },
+          {
+            "from": "del_1",
+            "to": "DEL_1"
+          }
+        ],
+        "propsDelimiter": [
+          {
+            "from": "c2",
+            "to": "2"
+          },
+          {
+            "from": "c3",
+            "to": "3"
+          }
+        ],
+        "eventMerchProperties": [
+          {
+            "eventMerchProperties": "tournament_id"
+          }
+        ],
+        "productMerchProperties": [
+          {
+            "productMerchProperties": ""
+          }
+        ],
+        "eVarMapping": [
+          {
+            "from": "v1",
+            "to": "1"
+          },
+          {
+            "from": "v2",
+            "to": "2"
+          },
+          {
+            "from": "v3",
+            "to": "3"
+          },
+          {
+            "from": "v12",
+            "to": "12"
+          },
+          {
+            "from": "v13",
+            "to": "13"
+          },
+          {
+            "from": "v16",
+            "to": "16"
+          },
+          {
+            "from": "v17",
+            "to": "17"
+          },
+          {
+            "from": "v40",
+            "to": "40"
+          },
+          {
+            "from": "v41",
+            "to": "41"
+          },
+          {
+            "from": "v42",
+            "to": "42"
+          },
+          {
+            "from": "v69",
+            "to": "69"
+          },
+          {
+            "from": "v70",
+            "to": "70"
+          },
+          {
+            "from": "v89",
+            "to": "89"
+          }
+        ],
+        "eventDelivery": false,
+        "eventDeliveryTS": 1628171489456,
+        "rudderEventsToAdobeEvents": [
+          {
+            "from": "Custom Page View",
+            "to": "event1"
+          },
+          {
+            "from": "App Launch",
+            "to": "event31"
+          },
+          {
+            "from": "App Start",
+            "to": "event31"
+          }
+        ],
+        "useNativeSDK": {
+          "web": false
+        },
+        "eventMerchEventToAdobeEvent": [
+          {
+            "from": "Custom Page View",
+            "to": "merchEvent"
+          }
+        ],
+        "customPropsMapping": [
+          {
+            "from": "c2",
+            "to": "2"
+          },
+          {
+            "from": "c3",
+            "to": 3
+          }
+        ],
+        "contextDataMapping": [
+          {
+            "from": "bet_level",
+            "to": "rudder_bet_level"
+          }
+        ],
+        "hierMapping": [
+          {
+            "from": "game_name",
+            "to": "game_dest"
+          }
+        ],
+        "productMerchEventToAdobeEvent": [
+          {
+            "from": "Custom Page View",
+            "to": "scAdd"
+          }
+        ],
+        "productMerchEvarsMap": [
+          {
+            "from": "product_id",
+            "to": "2"
+          }
+        ]
+      }
     },
     "message": {
-        "anonymousId": "c82cbdff-e5be-4009-ac78-cdeea09ab4b1",
-        "context": {
-            "device": {
-                "id": "df16bffa-5c3d-4fbb-9bce-3bab098129a7R",
-                "manufacturer": "Xiaomi",
-                "model": "Redmi 6",
-                "name": "xiaomi"
-            },
-            "network": {
-                "carrier": "Banglalink"
-            },
-            "os": {
-                "name": "android",
-                "version": "8.1.0"
-            },
-            "traits": {
-                "address": {
-                    "city": "Dhaka",
-                    "country": "Bangladesh"
-                },
-                "anonymousId": "c82cbdff-e5be-4009-ac78-cdeea09ab4b1"
-            },
-            "externalId": [
-                {
-                    "type": "AdobeFallbackVisitorId",
-                    "id": 1
-                }
-            ],
-            "page": {
-                "url": "https://abc.com",
-                "name": "testName"
-            }
+      "anonymousId": "c82cbdff-e5be-4009-ac78-cdeea09ab4b1",
+      "context": {
+        "device": {
+          "id": "df16bffa-5c3d-4fbb-9bce-3bab098129a7R",
+          "manufacturer": "Xiaomi",
+          "model": "Redmi 6",
+          "name": "xiaomi"
         },
-        "name": "Custom Page View",
-        "integrations": {
-            "AM": true
+        "network": {
+          "carrier": "Banglalink"
         },
-        "message_id": "a80f82be-9bdc-4a9f-b2a5-15621ee41df8",
-        "properties": {
-            "url": "https://app.rudderstack.com/signup?type=freetrial",
-            "path": "/signup",
-            "title": "",
-            "search": "?type=freetrial",
-            "tab_url": "https://app.rudderstack.com/signup?type=freetrial",
-            "referrer": "https://rudderstack.medium.com/kafka-vs-postgresql-how-we-implemented-our-queueing-system-using-postgresql-ec128650e3e",
-            "initial_referrer": "https://rudderstack.medium.com/kafka-vs-postgresql-how-we-implemented-our-queueing-system-using-postgresql-ec128650e3e",
-            "referring_domain": "rudderstack.medium.com",
-            "initial_referring_domain": "rudderstack.medium.com",
-            "additional_bet_index": 0,
-            "battle_id": "N/A",
-            "bet_amount": 9,
-            "bet_level": 1,
-            "bet_multiplier": 1,
-            "coin_balance": 9466052,
-            "current_module_name": "CasinoGameModule",
-            "days_in_game": 0,
-            "extra_param": "N/A",
-            "fb_profile": "0",
-            "featureGameType": "N/A",
-            "game_fps": 30,
-            "game_id": "fireEagleBase",
-            "game_name": "FireEagleSlots",
-            "gem_balance": 0,
-            "graphicsQuality": "HD",
-            "idfa": "2bf99787-33d2-4ae2-a76a-c49672f97252",
-            "internetReachability": "ReachableViaLocalAreaNetwork",
-            "isLowEndDevice": "False",
-            "is_auto_spin": "False",
-            "is_turbo": "False",
-            "isf": "False",
-            "ishighroller": "False",
-            "jackpot_win_amount": 90,
-            "jackpot_win_type": "Silver",
-            "level": 6,
-            "lifetime_gem_balance": 0,
-            "no_of_spin": 1,
-            "player_total_battles": 0,
-            "player_total_shields": 0,
-            "start_date": "2019-08-01",
-            "total_payments": 0,
-            "tournament_id": "T1561970819",
-            "versionSessionCount": 2,
-            "win_amount": 0,
-            "v1": 1,
-            "v2": 2,
-            "del_1": "delimeter",
-            "map_1": 1,
-            "c2": [
-                2,
-                3,
-                4
-            ],
-            "c3": "3",
-            "product_id": 2
+        "os": {
+          "name": "android",
+          "version": "8.1.0"
         },
-        "userId": "test_user_id",
-        "timestamp": "2019-09-01T15:46:51.693Z",
-        "type": "screen"
+        "traits": {
+          "address": {
+            "city": "Dhaka",
+            "country": "Bangladesh"
+          },
+          "anonymousId": "c82cbdff-e5be-4009-ac78-cdeea09ab4b1"
+        },
+        "externalId": [
+          {
+            "type": "AdobeFallbackVisitorId",
+            "id": 1
+          }
+        ],
+        "page": {
+          "url": "https://abc.com",
+          "name": "testName"
+        }
+      },
+      "name": "Custom Page View",
+      "integrations": {
+        "AM": true
+      },
+      "message_id": "a80f82be-9bdc-4a9f-b2a5-15621ee41df8",
+      "properties": {
+        "url": "https://app.rudderstack.com/signup?type=freetrial",
+        "path": "/signup",
+        "title": "",
+        "search": "?type=freetrial",
+        "tab_url": "https://app.rudderstack.com/signup?type=freetrial",
+        "referrer": "https://rudderstack.medium.com/kafka-vs-postgresql-how-we-implemented-our-queueing-system-using-postgresql-ec128650e3e",
+        "initial_referrer": "https://rudderstack.medium.com/kafka-vs-postgresql-how-we-implemented-our-queueing-system-using-postgresql-ec128650e3e",
+        "referring_domain": "rudderstack.medium.com",
+        "initial_referring_domain": "rudderstack.medium.com",
+        "additional_bet_index": 0,
+        "battle_id": "N/A",
+        "bet_amount": 9,
+        "bet_level": 1,
+        "bet_multiplier": 1,
+        "coin_balance": 9466052,
+        "current_module_name": "CasinoGameModule",
+        "days_in_game": 0,
+        "extra_param": "N/A",
+        "fb_profile": "0",
+        "featureGameType": "N/A",
+        "game_fps": 30,
+        "game_id": "fireEagleBase",
+        "game_name": "FireEagleSlots",
+        "gem_balance": 0,
+        "graphicsQuality": "HD",
+        "idfa": "2bf99787-33d2-4ae2-a76a-c49672f97252",
+        "internetReachability": "ReachableViaLocalAreaNetwork",
+        "isLowEndDevice": "False",
+        "is_auto_spin": "False",
+        "is_turbo": "False",
+        "isf": "False",
+        "ishighroller": "False",
+        "jackpot_win_amount": 90,
+        "jackpot_win_type": "Silver",
+        "level": 6,
+        "lifetime_gem_balance": 0,
+        "no_of_spin": 1,
+        "player_total_battles": 0,
+        "player_total_shields": 0,
+        "start_date": "2019-08-01",
+        "total_payments": 0,
+        "tournament_id": "T1561970819",
+        "versionSessionCount": 2,
+        "win_amount": 0,
+        "v1": 1,
+        "v2": 2,
+        "del_1": "delimeter",
+        "map_1": 1,
+        "c2": [
+          2,
+          3,
+          4
+        ],
+        "c3": "3",
+        "product_id": 2
+      },
+      "userId": "test_user_id",
+      "timestamp": "2019-09-01T15:46:51.693Z",
+      "type": "screen"
     }
-}
+  },
+  {
+    "destination": {
+      "Config": {
+        "trackingServerUrl": "http://sadobemetrics.dr.dk",
+        "trackingServerSecureUrl": "https://sadobemetrics.dr.dk",
+        "reportSuiteIds": "drdev2",
+        "sslHeartbeat": true,
+        "heartbeatTrackingServerUrl": "",
+        "useUtf8Charset": true,
+        "useSecureServerSide": true,
+        "proxyNormalUrl": "",
+        "proxyHeartbeatUrl": "",
+        "marketingCloudOrgId": "00E287634SDFE6200A495E6B@AdobeOrg",
+        "dropVisitorId": true,
+        "timestampOption": "disabled",
+        "timestampOptionalReporting": false,
+        "noFallbackVisitorId": false,
+        "preferVisitorId": false,
+        "trackPageName": true,
+        "contextDataPrefix": "",
+        "useLegacyLinkName": true,
+        "pageNameFallbackTostring": true,
+        "sendFalseValues": true,
+        "productIdentifier": "name",
+        "eventsToTypes": [
+          {
+            "from": "",
+            "to": ""
+          }
+        ],
+        "listDelimiter": [
+          {
+            "from": "",
+            "to": ""
+          }
+        ],
+        "propsDelimiter": [
+          {
+            "from": "",
+            "to": ""
+          }
+        ],
+        "eventMerchProperties": [
+          {
+            "eventMerchProperties": "prop1"
+          },
+          {
+            "eventMerchProperties": "prop2"
+          },
+          {
+            "eventMerchProperties": "prop3"
+          }
+        ],
+        "productMerchProperties": [
+          {
+            "productMerchProperties": "prop1"
+          },
+          {
+            "productMerchProperties": "products.product_id"
+          }
+        ],
+        "eVarMapping": [
+          {
+            "from": "v1",
+            "to": "1"
+          },
+          {
+            "from": "v2",
+            "to": "2"
+          },
+          {
+            "from": "v3",
+            "to": "3"
+          },
+          {
+            "from": "v12",
+            "to": "12"
+          },
+          {
+            "from": "v13",
+            "to": "13"
+          },
+          {
+            "from": "v16",
+            "to": "16"
+          },
+          {
+            "from": "v17",
+            "to": "17"
+          },
+          {
+            "from": "v40",
+            "to": "40"
+          },
+          {
+            "from": "v41",
+            "to": "41"
+          },
+          {
+            "from": "v42",
+            "to": "42"
+          },
+          {
+            "from": "v69",
+            "to": "69"
+          },
+          {
+            "from": "v70",
+            "to": "70"
+          },
+          {
+            "from": "v89",
+            "to": "89"
+          }
+        ],
+        "eventDelivery": false,
+        "eventDeliveryTS": 1628171489456,
+        "rudderEventsToAdobeEvents": [
+          {
+            "from": "Custom Page View",
+            "to": "event1"
+          },
+          {
+            "from": "App Launch",
+            "to": "event31"
+          },
+          {
+            "from": "App Start",
+            "to": "event31"
+          }
+        ],
+        "useNativeSDK": {
+          "web": false
+        },
+        "eventMerchEventToAdobeEvent": [
+          {
+            "from": "order completed",
+            "to": "abc completed"
+          },
+          {
+            "from": "checkout started",
+            "to": "cde completed"
+          }
+        ],
+        "customPropsMapping": [
+          {
+            "from": "c2",
+            "to": "2"
+          },
+          {
+            "from": "c3",
+            "to": "3"
+          }
+        ],
+        "productMerchEventToAdobeEvent": [
+          {
+            "from": "checkout started",
+            "to": "scCheckOut"
+          }
+        ]
+      }
+    },
+    "message": {
+      "anonymousId": "c82cbdff-e5be-4009-ac78-cdeea09ab4b1",
+      "context": {
+        "device": {
+          "id": "df16bffa-5c3d-4fbb-9bce-3bab098129a7R",
+          "manufacturer": "Xiaomi",
+          "model": "Redmi 6",
+          "name": "xiaomi"
+        },
+        "network": {
+          "carrier": "Banglalink"
+        },
+        "os": {
+          "name": "android",
+          "version": "8.1.0"
+        },
+        "traits": {
+          "address": {
+            "city": "Dhaka",
+            "country": "Bangladesh"
+          },
+          "anonymousId": "c82cbdff-e5be-4009-ac78-cdeea09ab4b1"
+        }
+      },
+      "event": "checkout started",
+      "integrations": {
+        "AM": true
+      },
+      "message_id": "a80f82be-9bdc-4a9f-b2a5-15621ee41df8",
+      "properties": {
+        "prop1": "testPropVal1",
+        "prop2": "testPropVal2",
+        "prop3": "testPropVal3",
+        "additional_bet_index": 0,
+        "battle_id": "N/A",
+        "bet_amount": 9,
+        "bet_level": 1,
+        "bet_multiplier": 1,
+        "coin_balance": 9466052,
+        "current_module_name": "CasinoGameModule",
+        "days_in_game": 0,
+        "extra_param": "N/A",
+        "fb_profile": "0",
+        "featureGameType": "N/A",
+        "game_fps": 30,
+        "game_id": "fireEagleBase",
+        "game_name": "FireEagleSlots",
+        "gem_balance": 0,
+        "graphicsQuality": "HD",
+        "idfa": "2bf99787-33d2-4ae2-a76a-c49672f97252",
+        "internetReachability": "ReachableViaLocalAreaNetwork",
+        "isLowEndDevice": "False",
+        "is_auto_spin": "False",
+        "is_turbo": "False",
+        "isf": "False",
+        "ishighroller": "False",
+        "jackpot_win_amount": 90,
+        "jackpot_win_type": "Silver",
+        "level": 6,
+        "lifetime_gem_balance": 0,
+        "no_of_spin": 1,
+        "player_total_battles": 0,
+        "player_total_shields": 0,
+        "start_date": "2019-08-01",
+        "total_payments": 0,
+        "tournament_id": "T1561970819",
+        "versionSessionCount": 2,
+        "win_amount": 0,
+        "products": [
+          {
+            "product_id": "prodID1",
+            "name": "Monopoly: 3rd Edition",
+            "coupon": "SUMMER_FUN",
+            "category": "Apparel",
+            "brand": "Google",
+            "variant": "green",
+            "price": "19",
+            "quantity": "2",
+            "position": "1",
+            "affiliation": "Google Merchandise Store",
+            "currency": "USD",
+            "discount": 2.22,
+            "item_category2": "Adult",
+            "item_category3": "Shirts",
+            "item_category4": "Crew",
+            "item_category5": "Short sleeve",
+            "item_list_id": "related_products",
+            "item_list_name": "Related Products",
+            "location_id": "L_12345"
+          },
+          {
+            "product_id": "prodID2",
+            "name": "Monopoly: 3rd Edition",
+            "coupon": "SUMMER_FUN",
+            "category": "Apparel",
+            "brand": "Google",
+            "variant": "green",
+            "price": "19",
+            "quantity": "2",
+            "position": "1",
+            "affiliation": "Google Merchandise Store",
+            "currency": "USD",
+            "discount": 2.22,
+            "item_category2": "Adult",
+            "item_category3": "Shirts",
+            "item_category4": "Crew",
+            "item_category5": "Short sleeve",
+            "item_list_id": "related_products",
+            "item_list_name": "Related Products",
+            "location_id": "L_12345"
+          }
+        ]
+      },
+      "userId": "test_user_id",
+      "timestamp": "2019-09-01T15:46:51.693Z",
+      "type": "track"
+    }
+  }
 ]

--- a/__tests__/data/adobe_analytics_output.json
+++ b/__tests__/data/adobe_analytics_output.json
@@ -406,27 +406,6 @@
         "files": {}
     },
     {
-        
-            "version": "1",
-            "type": "REST",
-            "method": "POST",
-            "endpoint": "https://sadobemetrics.dr.dk/b/ss//6",
-            "headers": {
-                "Content-type": "application/xml"
-            },
-            "params": {},
-            "body": {
-                "JSON": {},
-                "JSON_ARRAY": {},
-                "XML": {
-                    "payload": "<?xml version=\"1.0\" encoding=\"utf-8\"?><request><contextData><rudder_bet_level>1</rudder_bet_level></contextData><eVar1>1</eVar1><eVar2>2</eVar2><fallbackVisitorId>1</fallbackVisitorId><hiergame_dest>FireEagleSlots</hiergame_dest><listDEL_1>delimeter</listDEL_1><pageUrl>https://abc.com</pageUrl><pageName>testName</pageName><prop2>22324</prop2><prop3>3</prop3><timestamp>2019-09-01T15:46:51.693Z</timestamp><marketingcloudorgid>00E287634SDFE6200A495E6B@AdobeOrg</marketingcloudorgid><events>event1,merchEvent=T1561970819,scAdd</events><products>;2;1;0;;eVar2=2</products><reportSuiteID>drdev2</reportSuiteID></request>"
-                },
-                "FORM": {}
-            },
-            "files": {}
-    },
-    {
-        
         "version": "1",
         "type": "REST",
         "method": "POST",
@@ -444,5 +423,43 @@
             "FORM": {}
         },
         "files": {}
-}
+    },
+    {
+        "version": "1",
+        "type": "REST",
+        "method": "POST",
+        "endpoint": "https://sadobemetrics.dr.dk/b/ss//6",
+        "headers": {
+            "Content-type": "application/xml"
+        },
+        "params": {},
+        "body": {
+            "JSON": {},
+            "JSON_ARRAY": {},
+            "XML": {
+                "payload": "<?xml version=\"1.0\" encoding=\"utf-8\"?><request><contextData><rudder_bet_level>1</rudder_bet_level></contextData><eVar1>1</eVar1><eVar2>2</eVar2><fallbackVisitorId>1</fallbackVisitorId><hiergame_dest>FireEagleSlots</hiergame_dest><listDEL_1>delimeter</listDEL_1><pageUrl>https://abc.com</pageUrl><pageName>testName</pageName><prop2>22324</prop2><prop3>3</prop3><timestamp>2019-09-01T15:46:51.693Z</timestamp><marketingcloudorgid>00E287634SDFE6200A495E6B@AdobeOrg</marketingcloudorgid><events>event1,merchEvent=T1561970819,scAdd</events><products>;2;1;0;;eVar2=2</products><reportSuiteID>drdev2</reportSuiteID></request>"
+            },
+            "FORM": {}
+        },
+        "files": {}
+    },
+    {
+        "version": "1",
+        "type": "REST",
+        "method": "POST",
+        "endpoint": "https://sadobemetrics.dr.dk/b/ss//6",
+        "headers": {
+            "Content-type": "application/xml"
+        },
+        "params": {},
+        "body": {
+            "JSON": {},
+            "JSON_ARRAY": {},
+            "XML": {
+                "payload": "<?xml version=\"1.0\" encoding=\"utf-8\"?><request><marketingcloudorgid>00E287634SDFE6200A495E6B@AdobeOrg</marketingcloudorgid><purchaseID>undefined</purchaseID><transactionID>undefined</transactionID><events>scCheckout,cde completed=testPropVal1,cde completed=testPropVal2,cde completed=testPropVal3,scCheckOut</events><products>Apparel;Monopoly: 3rd Edition;2;38.00;scCheckOut=testPropVal1|scCheckOut=prodID1;Apparel;Monopoly: 3rd Edition;2;38.00;scCheckOut=testPropVal1|scCheckOut=prodID2;</products><reportSuiteID>drdev2</reportSuiteID></request>"
+            },
+            "FORM": {}
+        },
+        "files": {}
+    }
 ]

--- a/__tests__/data/adobe_analytics_output.json
+++ b/__tests__/data/adobe_analytics_output.json
@@ -404,5 +404,45 @@
             "FORM": {}
         },
         "files": {}
-    }
+    },
+    {
+        
+            "version": "1",
+            "type": "REST",
+            "method": "POST",
+            "endpoint": "https://sadobemetrics.dr.dk/b/ss//6",
+            "headers": {
+                "Content-type": "application/xml"
+            },
+            "params": {},
+            "body": {
+                "JSON": {},
+                "JSON_ARRAY": {},
+                "XML": {
+                    "payload": "<?xml version=\"1.0\" encoding=\"utf-8\"?><request><contextData><rudder_bet_level>1</rudder_bet_level></contextData><eVar1>1</eVar1><eVar2>2</eVar2><fallbackVisitorId>1</fallbackVisitorId><hiergame_dest>FireEagleSlots</hiergame_dest><listDEL_1>delimeter</listDEL_1><pageUrl>https://abc.com</pageUrl><pageName>testName</pageName><prop2>22324</prop2><prop3>3</prop3><timestamp>2019-09-01T15:46:51.693Z</timestamp><marketingcloudorgid>00E287634SDFE6200A495E6B@AdobeOrg</marketingcloudorgid><events>event1,merchEvent=T1561970819,scAdd</events><products>;2;1;0;;eVar2=2</products><reportSuiteID>drdev2</reportSuiteID></request>"
+                },
+                "FORM": {}
+            },
+            "files": {}
+    },
+    {
+        
+        "version": "1",
+        "type": "REST",
+        "method": "POST",
+        "endpoint": "https://sadobemetrics.dr.dk/b/ss//6",
+        "headers": {
+            "Content-type": "application/xml"
+        },
+        "params": {},
+        "body": {
+            "JSON": {},
+            "JSON_ARRAY": {},
+            "XML": {
+                "payload": "<?xml version=\"1.0\" encoding=\"utf-8\"?><request><contextData><rudder_bet_level>1</rudder_bet_level></contextData><eVar1>1</eVar1><eVar2>2</eVar2><fallbackVisitorId>1</fallbackVisitorId><hiergame_dest>FireEagleSlots</hiergame_dest><listDEL_1>delimeter</listDEL_1><pageUrl>https://abc.com</pageUrl><pageName>testName</pageName><prop2>22324</prop2><prop3>3</prop3><timestamp>2019-09-01T15:46:51.693Z</timestamp><marketingcloudorgid>00E287634SDFE6200A495E6B@AdobeOrg</marketingcloudorgid><events>event1,merchEvent=T1561970819,scAdd</events><products>;2;1;0;;eVar2=2</products><reportSuiteID>drdev2</reportSuiteID></request>"
+            },
+            "FORM": {}
+        },
+        "files": {}
+}
 ]

--- a/v0/destinations/adobe_analytics/transform.js
+++ b/v0/destinations/adobe_analytics/transform.js
@@ -435,14 +435,16 @@ const process = async event => {
   const formattedDestination = formatDestinationConfig(destination.Config);
   let payload;
 
+  const messageClone = { ...message };
+  if (messageType === EventType.PAGE || messageType === EventType.SCREEN) {
+    messageClone.event = message.name;
+  }
+
   switch (messageType) {
     case EventType.TRACK:
     case EventType.PAGE:
     case EventType.SCREEN:
-      if (messageType === "page" || messageType === "screen") {
-        message.event = message.name;
-      }
-      payload = handleTrack(message, formattedDestination);
+      payload = handleTrack(messageClone, formattedDestination);
       break;
     default:
       throw new Error("Message type is not supported");

--- a/v0/destinations/adobe_analytics/transform.js
+++ b/v0/destinations/adobe_analytics/transform.js
@@ -439,6 +439,9 @@ const process = async event => {
     case EventType.TRACK:
     case EventType.PAGE:
     case EventType.SCREEN:
+      if (messageType === "page" || messageType === "screen") {
+        message.event = message.name;
+      }
       payload = handleTrack(message, formattedDestination);
       break;
     default:

--- a/v0/destinations/adobe_analytics/transform.js
+++ b/v0/destinations/adobe_analytics/transform.js
@@ -261,7 +261,7 @@ const processTrackEvent = (
   }
 
   // product string section
-  let adobeProdEvent = productMerchEventToAdobeEvent[event.toLowerCase()];
+  const adobeProdEvent = productMerchEventToAdobeEvent[event.toLowerCase()];
   const prodString = [];
   if (adobeProdEvent) {
     const isSingleProdEvent =
@@ -271,6 +271,7 @@ const processTrackEvent = (
         event.toLowerCase() !== "product list viewed") ||
       !Array.isArray(properties.products);
     const productsArr = isSingleProdEvent ? [properties] : properties.products;
+    const adobeProdEventArr = adobeProdEvent.split(",");
 
     productsArr.forEach(value => {
       const category = value.category || "";
@@ -288,7 +289,6 @@ const processTrackEvent = (
         productMerchEventToAdobeEvent[event.toLowerCase()] &&
         productMerchProperties
       ) {
-        adobeProdEvent = adobeProdEvent.toString().split(",");
         productMerchProperties.forEach(rudderProp => {
           if (
             rudderProp.productMerchProperties.startsWith("products.") &&
@@ -297,14 +297,14 @@ const processTrackEvent = (
             const key = rudderProp.productMerchProperties.split(".");
             const v = get(value, key[1]);
             if (isDefinedAndNotNull(v)) {
-              Object.keys(adobeProdEvent).forEach(val => {
-                merchMap.push(`${adobeProdEvent[val]}=${v}`);
+              Object.keys(adobeProdEventArr).forEach(val => {
+                merchMap.push(`${adobeProdEventArr[val]}=${v}`);
               });
             }
           } else if (rudderProp.productMerchProperties in properties) {
-            Object.keys(adobeProdEvent).forEach(val => {
+            Object.keys(adobeProdEventArr).forEach(val => {
               merchMap.push(
-                `${adobeProdEvent[val]}=${
+                `${adobeProdEventArr[val]}=${
                   properties[rudderProp.productMerchProperties]
                 }`
               );

--- a/v0/destinations/adobe_analytics/transform.js
+++ b/v0/destinations/adobe_analytics/transform.js
@@ -290,7 +290,6 @@ const processTrackEvent = (
         productMerchProperties
       ) {
         productMerchProperties.forEach(rudderProp => {
-
           // adding product level merchandise properties
           if (
             rudderProp.productMerchProperties.startsWith("products.") &&

--- a/v0/destinations/adobe_analytics/transform.js
+++ b/v0/destinations/adobe_analytics/transform.js
@@ -261,7 +261,7 @@ const processTrackEvent = (
   }
 
   // product string section
-  const adobeProdEvent = productMerchEventToAdobeEvent[event.toLowerCase()];
+  let adobeProdEvent = productMerchEventToAdobeEvent[event.toLowerCase()];
   const prodString = [];
   if (adobeProdEvent) {
     const isSingleProdEvent =
@@ -288,10 +288,14 @@ const processTrackEvent = (
         productMerchEventToAdobeEvent[event.toLowerCase()] &&
         productMerchProperties
       ) {
+        adobeProdEvent = adobeProdEvent.toString().split(",");
         productMerchProperties.forEach(rudderProp => {
-          if (rudderProp.productMerchProperties.startsWith("products.")) {
+          if (
+            rudderProp.productMerchProperties.startsWith("products.") &&
+            isSingleProdEvent === false
+          ) {
             const key = rudderProp.productMerchProperties.split(".");
-            const v = get(properties, key[1]);
+            const v = get(value, key[1]);
             if (isDefinedAndNotNull(v)) {
               Object.keys(adobeProdEvent).forEach(val => {
                 merchMap.push(`${adobeProdEvent[val]}=${v}`);

--- a/v0/destinations/adobe_analytics/transform.js
+++ b/v0/destinations/adobe_analytics/transform.js
@@ -290,6 +290,8 @@ const processTrackEvent = (
         productMerchProperties
       ) {
         productMerchProperties.forEach(rudderProp => {
+
+          // adding product level merchandise properties
           if (
             rudderProp.productMerchProperties.startsWith("products.") &&
             isSingleProdEvent === false
@@ -297,16 +299,15 @@ const processTrackEvent = (
             const key = rudderProp.productMerchProperties.split(".");
             const v = get(value, key[1]);
             if (isDefinedAndNotNull(v)) {
-              Object.keys(adobeProdEventArr).forEach(val => {
-                merchMap.push(`${adobeProdEventArr[val]}=${v}`);
+              adobeProdEventArr.forEach(val => {
+                merchMap.push(`${val}=${v}`);
               });
             }
           } else if (rudderProp.productMerchProperties in properties) {
-            Object.keys(adobeProdEventArr).forEach(val => {
+            // adding root level merchandise properties
+            adobeProdEventArr.forEach(val => {
               merchMap.push(
-                `${adobeProdEventArr[val]}=${
-                  properties[rudderProp.productMerchProperties]
-                }`
+                `${val}=${properties[rudderProp.productMerchProperties]}`
               );
             });
           }


### PR DESCRIPTION
## Description of the change

The page and screen events do not have `event` field. Adobe analytics was expecting this and was generating error in transformer.

- while adding properties for merchandise events, if `products.propertyName` is mentioned, it was still finding in the root properties, instead of products array. Which is a bug
- here is the [statement](https://github.com/rudderlabs/rudder-transformer/blob/master/v0/destinations/adobe_analytics/transform.js#L300-L310), where we are forEach looping on Object.keys(adobeProdEvent) which adobeProdEvent is a string equal to "custom" so it turns into
c=3.3|u=3.3|s=3.3|t=3.3|o=3.3|m=3.3, which is not the case in device mode. ref: [here](https://github.com/rudderlabs/rudder-sdk-js/blob/e98f9c440aaefeefdcc8e4d8c624969045160519/integrations/AdobeAnalytics/util.js#L515)



## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
