### PR TITLE
Fix `identify` calls for Intercom

### DIFF
--- a/v0/destinations/intercom/data/INTERCOMIdentifyConfig.json
+++ b/v0/destinations/intercom/data/INTERCOMIdentifyConfig.json
@@ -42,7 +42,7 @@
     ],
     "required": false,
     "metadata": {
-      "type": "timestamp"
+      "type": "secondTimestamp"
     }
   },
   {


### PR DESCRIPTION
Intercom's version of the `identify` call uses "second" timestamps, not millisecond. This ensures the right format goes up to that endpoint

## Description of the change

> Description here

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
