### PR TITLE
Updated Intercom signed_up_at field to send seconds instead of milliseconds

### DIFF
--- a/__tests__/data/intercom_output.json
+++ b/__tests__/data/intercom_output.json
@@ -16,7 +16,7 @@
         "email": "test_1@test.com",
         "phone": "9876543210",
         "name": "Test Name",
-        "signed_up_at": 1601493060337,
+        "signed_up_at": 1601493060,
         "last_seen_user_agent": "unknown",
         "update_last_request_at": true,
         "user_id": "test_user_id_1",
@@ -48,7 +48,7 @@
       "JSON": {
         "email": "test_1@test.com",
         "phone": "9876543210",
-        "signed_up_at": 1601493060337,
+        "signed_up_at": 1601493060,
         "name": "Test Name",
         "last_seen_user_agent": "unknown",
         "update_last_request_at": true,
@@ -80,7 +80,7 @@
       "JSON": {
         "email": "test_1@test.com",
         "phone": "9876543210",
-        "signed_up_at": 1601493060337,
+        "signed_up_at": 1601493060,
         "last_seen_user_agent": "unknown",
         "update_last_request_at": true,
         "custom_attributes": {
@@ -112,7 +112,7 @@
       "JSON": {
         "email": "test_1@test.com",
         "phone": "9876543210",
-        "signed_up_at": 1601493060337,
+        "signed_up_at": 1601493060,
         "last_seen_user_agent": "unknown",
         "update_last_request_at": true,
         "custom_attributes": {
@@ -148,7 +148,7 @@
       "JSON": {
         "email": "test_1@test.com",
         "phone": "9876543210",
-        "signed_up_at": 1601493060337,
+        "signed_up_at": 1601493060,
         "last_seen_user_agent": "unknown",
         "update_last_request_at": true,
         "custom_attributes": {
@@ -190,7 +190,7 @@
       "JSON": {
         "email": "test_1@test.com",
         "phone": "9876543210",
-        "signed_up_at": 1601493060337,
+        "signed_up_at": 1601493060,
         "last_seen_user_agent": "unknown",
         "update_last_request_at": true,
         "custom_attributes": {
@@ -232,7 +232,7 @@
       "JSON": {
         "email": "test_1@test.com",
         "phone": "9876543210",
-        "signed_up_at": 1601493060337,
+        "signed_up_at": 1601493060,
         "last_seen_user_agent": "unknown",
         "update_last_request_at": true,
         "custom_attributes": {
@@ -358,7 +358,7 @@
       "JSON": {
         "phone": "9876543210",
         "name": "Test Name",
-        "signed_up_at": 1601493060337,
+        "signed_up_at": 1601493060,
         "last_seen_user_agent": "unknown",
         "custom_attributes": {
           "anonymousId": "58b21c2d-f8d5-4410-a2d0-b268a26b7e33",

--- a/__tests__/data/intercom_router_output.json
+++ b/__tests__/data/intercom_router_output.json
@@ -17,7 +17,7 @@
           "email": "test_1@test.com",
           "phone": "9876543210",
           "name": "Test Name",
-          "signed_up_at": 1601493060337,
+          "signed_up_at": 1601493060,
           "last_seen_user_agent": "unknown",
           "update_last_request_at": true,
           "user_id": "test_user_id_1",
@@ -65,7 +65,7 @@
         "JSON": {
           "email": "test_1@test.com",
           "phone": "9876543210",
-          "signed_up_at": 1601493060337,
+          "signed_up_at": 1601493060,
           "name": "Test Name",
           "last_seen_user_agent": "unknown",
           "update_last_request_at": true,

--- a/v0/destinations/intercom/data/INTERCOMIdentifyConfig.json
+++ b/v0/destinations/intercom/data/INTERCOMIdentifyConfig.json
@@ -42,7 +42,7 @@
     ],
     "required": false,
     "metadata": {
-      "type": "timestamp"
+      "type": "secondTimestamp"
     }
   },
   {


### PR DESCRIPTION
## Description of the change

> Description here

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
