### PR TITLE
bugfix(CFD): Facebook Pixel error handling

### DIFF
--- a/__tests__/data/facebook_pixel_input.json
+++ b/__tests__/data/facebook_pixel_input.json
@@ -3034,5 +3034,84 @@
       },
       "Enabled": true
     }
+  },
+  {
+    "message": {
+      "channel": "web",
+      "context": {
+        "app": {
+          "build": "1.0.0",
+          "name": "RudderLabs JavaScript SDK",
+          "namespace": "com.rudderlabs.javascript",
+          "version": "1.0.0"
+        },
+        "traits": {
+          "email": "sayan@gmail.com"
+        },
+        "library": {
+          "name": "RudderLabs JavaScript SDK",
+          "version": "1.0.0"
+        },
+        "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36",
+        "locale": "en-US",
+        "os": {
+          "name": "",
+          "version": ""
+        },
+        "screen": {
+          "density": 2
+        }
+      },
+      "type": "track",
+      "messageId": "ec5481b6-a926-4d2e-b293-0b3a77c4d3be",
+      "originalTimestamp": "2019-09-01T15:46:51.693229+05:30",
+      "anonymousId": "00000000000000000000000000",
+      "userId": "12345",
+      "event": "products searched",
+      "properties": {
+        "query": {"key1":"HDMI cable"}
+      },
+      "integrations": {
+        "All": true
+      },
+      "sentAt": "2019-10-14T11:15:53.296Z"
+    },
+    "destination": {
+      "Config": {
+        "blacklistPiiProperties": [
+          {
+            "blacklistPiiProperties": "",
+            "blacklistPiiHash": true
+          }
+        ],
+        "categoryToContent": [
+          {
+            "from": "clothing",
+            "to": "product"
+          }
+        ],
+        "accessToken": "09876",
+        "pixelId": "dfgdfgdgd",
+        "eventsToEvents": [
+          {
+            "from": "",
+            "to": ""
+          }
+        ],
+        "eventCustomProperties": [
+          {
+            "eventCustomProperties": ""
+          }
+        ],
+        "valueFieldIdentifier": "properties.price",
+        "advancedMapping": false,
+        "whitelistPiiProperties": [
+          {
+            "whitelistPiiProperties": ""
+          }
+        ]
+      },
+      "Enabled": true
+    }
   }
 ]

--- a/__tests__/data/facebook_pixel_input.json
+++ b/__tests__/data/facebook_pixel_input.json
@@ -3113,5 +3113,84 @@
       },
       "Enabled": true
     }
+  },
+  {
+    "message": {
+      "channel": "web",
+      "context": {
+        "app": {
+          "build": "1.0.0",
+          "name": "RudderLabs JavaScript SDK",
+          "namespace": "com.rudderlabs.javascript",
+          "version": "1.0.0"
+        },
+        "traits": {
+          "email": "sayan@gmail.com"
+        },
+        "library": {
+          "name": "RudderLabs JavaScript SDK",
+          "version": "1.0.0"
+        },
+        "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36",
+        "locale": "en-US",
+        "os": {
+          "name": "",
+          "version": ""
+        },
+        "screen": {
+          "density": 2
+        }
+      },
+      "type": "track",
+      "messageId": "ec5481b6-a926-4d2e-b293-0b3a77c4d3be",
+      "originalTimestamp": "2019-09-01T15:46:51.693229+05:30",
+      "anonymousId": "00000000000000000000000000",
+      "userId": "12345",
+      "event": "products searched",
+      "properties": {
+        "query": 50
+      },
+      "integrations": {
+        "All": true
+      },
+      "sentAt": "2019-10-14T11:15:53.296Z"
+    },
+    "destination": {
+      "Config": {
+        "blacklistPiiProperties": [
+          {
+            "blacklistPiiProperties": "",
+            "blacklistPiiHash": true
+          }
+        ],
+        "categoryToContent": [
+          {
+            "from": "clothing",
+            "to": "product"
+          }
+        ],
+        "accessToken": "09876",
+        "pixelId": "dfgdfgdgd",
+        "eventsToEvents": [
+          {
+            "from": "",
+            "to": ""
+          }
+        ],
+        "eventCustomProperties": [
+          {
+            "eventCustomProperties": ""
+          }
+        ],
+        "valueFieldIdentifier": "properties.price",
+        "advancedMapping": false,
+        "whitelistPiiProperties": [
+          {
+            "whitelistPiiProperties": ""
+          }
+        ]
+      },
+      "Enabled": true
+    }
   }
 ]

--- a/__tests__/data/facebook_pixel_output.json
+++ b/__tests__/data/facebook_pixel_output.json
@@ -598,5 +598,9 @@
   {
     "statusCode": 400,
     "error": "Product id is required for product 0. Event not sent"
+  },
+  {
+    "statusCode": 400,
+    "error": "'query' should be in string format only"
   }
 ]

--- a/__tests__/data/facebook_pixel_output.json
+++ b/__tests__/data/facebook_pixel_output.json
@@ -602,5 +602,24 @@
   {
     "statusCode": 400,
     "error": "'query' should be in (string (or) number) format only"
+  },
+  {
+    "version": "1",
+    "type": "REST",
+    "method": "POST",
+    "endpoint": "https://graph.facebook.com/v13.0/dfgdfgdgd/events?access_token=09876",
+    "headers": {},
+    "params": {},
+    "body": {
+      "JSON": {},
+      "XML": {},
+      "JSON_ARRAY": {},
+      "FORM": {
+        "data": [
+          "{\"user_data\":{\"external_id\":\"5994471abb01112afcc18159f6cc74b4f511b99806da59b3caf5a9c173cacfc5\",\"em\":\"4e59b5130b3a248457336e2fe5e40a3e8604f28d1804be14e6b227e2d88d7ce2\",\"client_user_agent\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36\"},\"event_name\":\"Search\",\"event_time\":1567333011,\"event_id\":\"ec5481b6-a926-4d2e-b293-0b3a77c4d3be\",\"custom_data\":{\"search_string\":50,\"currency\":\"USD\"}}"
+        ]
+      }
+    },
+    "files": {}
   }
 ]

--- a/__tests__/data/facebook_pixel_output.json
+++ b/__tests__/data/facebook_pixel_output.json
@@ -601,7 +601,7 @@
   },
   {
     "statusCode": 400,
-    "error": "'query' should be in (string (or) number) format only"
+    "error": "'query' should be in string format only"
   },
   {
     "version": "1",

--- a/__tests__/data/facebook_pixel_output.json
+++ b/__tests__/data/facebook_pixel_output.json
@@ -601,6 +601,6 @@
   },
   {
     "statusCode": 400,
-    "error": "'query' should be in string format only"
+    "error": "'query' should be in (string (or) number) format only"
   }
 ]

--- a/v0/destinations/facebook_pixel/transform.js
+++ b/v0/destinations/facebook_pixel/transform.js
@@ -493,8 +493,8 @@ const responseBuilderSimple = (
           break;
         case "products searched":
           const query = message.properties?.query;
-          if (query && typeof query !== "string") {
-            throw new CustomError("'query' should be in string format only", 400);
+          if (query && typeof query !== "string" && typeof query !== "number") {
+            throw new CustomError("'query' should be in (string (or) number) format only", 400);
           }
           customData = {
             ...customData,

--- a/v0/destinations/facebook_pixel/transform.js
+++ b/v0/destinations/facebook_pixel/transform.js
@@ -492,6 +492,12 @@ const responseBuilderSimple = (
           break;
         case "products searched":
           const query = message.properties?.query;
+          /**
+           * Facebook Pixel states "search_string" a string type
+           * ref: https://developers.facebook.com/docs/meta-pixel/reference#:~:text=an%20exact%20value.-,search_string,-String
+           * But it accepts "number" and "boolean" types. So, we are also doing the same by accepting "number" and "boolean"
+           * and throwing an error if "Object" or other types are being sent.
+           */
           const validQueryType = ["string", "number", "boolean"];
           if (query && !validQueryType.includes(typeof query)) {
             throw new CustomError(

--- a/v0/destinations/facebook_pixel/transform.js
+++ b/v0/destinations/facebook_pixel/transform.js
@@ -25,6 +25,7 @@ const {
   isObject,
   getValidDynamicFormConfig
 } = require("../../util");
+const logger = require("../../../logger");
 
 /**  format revenue according to fb standards with max two decimal places.
  * @param revenue
@@ -491,6 +492,10 @@ const responseBuilderSimple = (
           commonData.event_name = "Purchase";
           break;
         case "products searched":
+          const query = message.properties?.query;
+          if (query && typeof query !== "string") {
+            throw new CustomError("'query' should be in string format only", 400);
+          }
           customData = {
             ...customData,
             search_string: message.properties.query

--- a/v0/destinations/facebook_pixel/transform.js
+++ b/v0/destinations/facebook_pixel/transform.js
@@ -25,7 +25,6 @@ const {
   isObject,
   getValidDynamicFormConfig
 } = require("../../util");
-const logger = require("../../../logger");
 
 /**  format revenue according to fb standards with max two decimal places.
  * @param revenue
@@ -493,8 +492,12 @@ const responseBuilderSimple = (
           break;
         case "products searched":
           const query = message.properties?.query;
-          if (query && typeof query !== "string" && typeof query !== "number") {
-            throw new CustomError("'query' should be in (string (or) number) format only", 400);
+          const validQueryType = ["string", "number", "boolean"];
+          if (query && !validQueryType.includes(typeof query)) {
+            throw new CustomError(
+              "'query' should be in string format only",
+              400
+            );
           }
           customData = {
             ...customData,


### PR DESCRIPTION
## Description of the change

> **_Issue_:**
Facebook Pixel `custom_data` expects a string or number
According to Rudderstacks documentation of the [product searched](https://www.rudderstack.com/docs/rudderstack-api/api-specification/rudderstack-ecommerce-events-specification/browsing/#products-searched) event, the query should be a string / Object
So, [here](https://github.com/rudderlabs/rudder-transformer/blob/1537d3ec5d932e603a011a33c0fc53a43623b33d/v0/destinations/facebook_pixel/transform.js#L496) query should be a string or number.
**_Fix:_**
We are handling it inside the transformer by throwing an appropriate error.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
