### PR TITLE
fix: missing schemaId bugfix

### DIFF
--- a/v0/destinations/kafka/transform.js
+++ b/v0/destinations/kafka/transform.js
@@ -19,7 +19,7 @@ function batch(destEvents) {
 
 function process(event) {
   const integrationsObj = getIntegrationsObj(event.message, "kafka");
-  const { schemaId } = integrationsObj;
+  const { schemaId } = integrationsObj || {};
   if (schemaId) {
     return {
       message: event.message,


### PR DESCRIPTION
## Description of the change

This PR is to fix this error that we are now getting on RudderServer:

> 2022-07-13T08:03:12.8581833Z 2022-07-13T08:03:12.857Z	DEBUG	trace/annotation.go:141	[Processor: getFailedEventJobs] Failure [400] for source "xxxyyyzzEaEurW247ad9WYZLUyk" and destination "xxxyyyzzhyrw8v0CrTMrDZ4ovej": Cannot destructure property 'schemaId' of 'integrationsObj' as it is null.

