### PR TITLE
feat: support 'event' alias for 'message' in dynamic config

### DIFF
--- a/__tests__/data/dynamicConfig_input.json
+++ b/__tests__/data/dynamicConfig_input.json
@@ -265,7 +265,7 @@
             "key": "{{ event.key || \" default value \" }}",
             "key1": "{{ event.key1 || \" default value  }}",
             "key2": "{{ event.key1 || default value \" }}",
-            "key3": "{{ event.traits.appId || 123.1234 }}",
+            "key3": "{{ message.traits.appId || 123.1234 }}",
             "key4": [
               "{{ event.traits.key4 || defaultVal }}",
               "{{ event.key4 || defaultVal }}"

--- a/__tests__/data/dynamicConfig_input.json
+++ b/__tests__/data/dynamicConfig_input.json
@@ -256,6 +256,47 @@
             "appId": "testAppId"
           }
         }
+      },
+      {
+        "destination": {
+          "Config": {
+            "appId": "{{ event.traits.appId || appId }} ",
+            "email": "   {{ event.trait.email || \"test@gmail.com  \" }}",
+            "key": "{{ event.key || \" default value \" }}",
+            "key1": "{{ event.key1 || \" default value  }}",
+            "key2": "{{ event.key1 || default value \" }}",
+            "key3": "{{ event.traits.appId || 123.1234 }}",
+            "key4": [
+              "{{ event.traits.key4 || defaultVal }}",
+              "{{ event.key4 || defaultVal }}"
+            ],
+            "key5": [
+              { "key2": { "key3": "{{ event.key5 || defaultVal }}" } }
+            ],
+            "key6": [
+              [
+                { "key2": { "key3": "{{ event.key5 || defaultVal }}" } },
+                { "key4": "{{ evnt.traits.key4 || defaultVal }}" }
+              ],
+              "defaultVal"
+            ]
+          }
+        },
+        "metadata": {
+          "jobId": 2
+        },
+        "message": {
+          "anonymousId": "sampath",
+          "channel": "web",
+          "key": "val",
+          "key4": "val4",
+          "key5": "val5",
+          "context": {},
+          "traits": {
+            "anonymousId": "sampath",
+            "appId": "testAppId"
+          }
+        }
       }
     ]
   }

--- a/__tests__/data/dynamicConfig_output.json
+++ b/__tests__/data/dynamicConfig_output.json
@@ -215,5 +215,34 @@
         "anonymousId": "sampath"
       }
     }
+  },
+  {
+    "destination": {
+      "Config": {
+        "appId": "testAppId",
+        "email": "test@gmail.com",
+        "key": "val",
+        "key1": "default value",
+        "key2": "default value",
+        "key3": "123.1234",
+        "key4": ["defaultVal", "val4"],
+        "key5": [{ "key2": { "key3": "val5" } }],
+        "key6": [
+          [{ "key2": { "key3": "defaultVal" } }, { "key4": "defaultVal" }],
+          "defaultVal"
+        ]
+      }
+    },
+    "metadata": {
+      "jobId": 2
+    },
+    "message": {
+      "anonymousId": "sampath",
+      "channel": "web",
+      "context": {},
+      "traits": {
+        "anonymousId": "sampath"
+      }
+    }
   }
 ]

--- a/util/dynamicConfig.js
+++ b/util/dynamicConfig.js
@@ -9,7 +9,7 @@ function getDynamicConfigValue(event, value) {
   const defFormat = /^\s*\{\{\s*(?<path>[a-zA-Z_]([a-zA-Z0-9_]*\.[a-zA-Z_][a-zA-Z0-9_]*)+)+\s*\|\|\s*(?<defaultVal>.*)\s*\}\}\s*$/;
   const matResult = value.match(defFormat);
   if (matResult) {
-    // Support "event.<obj1>.key" alias for "message.<obj1>.key"
+    // Support "event.<obj1>.<key>" alias for "message.<obj1>.<key>"
     const fieldPath = matResult.groups.path.replace(
       /^event\.(.*)$/,
       "message.$1"

--- a/util/dynamicConfig.js
+++ b/util/dynamicConfig.js
@@ -3,16 +3,21 @@ const get = require("get-value");
 const unset = require("unset-value");
 
 function getDynamicConfigValue(event, value) {
-  // this rgegex checks for pattern  "only spaces {{ path || defaultvalue }}  only spaces" .
+  // this regex checks for pattern  "only spaces {{ path || defaultvalue }}  only spaces" .
   //  " {{message.traits.key  ||   \"email\" }} "
   //  " {{ message.traits.key || 1233 }} "
   const defFormat = /^\s*\{\{\s*(?<path>[a-zA-Z_]([a-zA-Z0-9_]*\.[a-zA-Z_][a-zA-Z0-9_]*)+)+\s*\|\|\s*(?<defaultVal>.*)\s*\}\}\s*$/;
   const matResult = value.match(defFormat);
   if (matResult) {
-    const pathVal = get(event, matResult.groups.path);
+    // Support "event.<obj1>.key" alias for "message.<obj1>.key"
+    const fieldPath = matResult.groups.path.replace(
+      /^event\.(.*)$/,
+      "message.$1"
+    );
+    const pathVal = get(event, fieldPath);
     if (pathVal) {
       value = pathVal;
-      unset(event, matResult.groups.path);
+      unset(event, fieldPath);
     } else {
       value = matResult.groups.defaultVal.replace(/"/g, "").trim();
     }


### PR DESCRIPTION
## Description of the change

Added support for `event.` alias for `message.` in dynamic configuration values for destinations.
The `message.` notation in dynamic configuration values is valid since the event structure as seen by the transformer is below:
```
{
  "message": {
    "properties": {
      "key1": "val1"
    },
    ...
  },
  "destination": {
    "Config": {
      "someKey": "{{ message.properties.key1 || \"defaultVal\" }}"
      ...
    }
  }
}
```

Without this update, it can confuse the users when going through the examples in our [documentation](https://www.rudderstack.com/docs/user-guides/how-to-guides/dynamic-destination-configuration/). 
Everywhere in our documentation, an event object is accessed as `event.`.

Now the users can also specify dynamic configuration values as `{{ event.properties.somekey || "defaultVal" }}` which would be equivalent to `{{ message.properties.somekey || "defaultVal" }}`.


## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

N/A

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
