### PR TITLE
bugfix(active_campaign): Adding 'new' before customError

### DIFF
--- a/v0/destinations/active_campaign/transform.js
+++ b/v0/destinations/active_campaign/transform.js
@@ -67,7 +67,7 @@ const syncContact = async (contactPayload, category, destination) => {
   }
   const createdContact = get(res, "response.data.contact"); // null safe
   if (!createdContact) {
-    throw CustomError("Unable to Create Contact", 400);
+    throw new CustomError("Unable to Create Contact", 400);
   }
   return createdContact.id;
 };


### PR DESCRIPTION
## Description of the change

In one place before creating customError we were not provided new keyword.

## Type of change
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
