### PR TITLE
bugfix(integrations): Shopify Identity Resolution Fix

### DIFF
--- a/__tests__/data/shopify_source_input.json
+++ b/__tests__/data/shopify_source_input.json
@@ -95,7 +95,7 @@
     "buyer_accepts_marketing": false,
     "cancel_reason": null,
     "cancelled_at": null,
-    "cart_token": null,
+    "cart_token": "7ed2aa8c6e74666534b023e197fffd41",
     "checkout_id": 32397512573184,
     "checkout_token": "7ed2aa8c6e74666534b023e197fffd41",
     "client_details": {

--- a/__tests__/data/shopify_source_output.json
+++ b/__tests__/data/shopify_source_output.json
@@ -106,6 +106,7 @@
       "admin_graphql_api_id": "gid://shopify/Order/4617255092480",
       "app_id": 1354745,
       "buyer_accepts_marketing": false,
+      "cart_token": "7ed2aa8c6e74666534b023e197fffd41",
       "checkout_id": 32397512573184,
       "checkout_token": "7ed2aa8c6e74666534b023e197fffd41",
       "client_details": {

--- a/__tests__/data/shopify_source_output.json
+++ b/__tests__/data/shopify_source_output.json
@@ -385,7 +385,7 @@
       "SHOPIFY": true
     },
     "type": "track",
-    "event": "fulfillments_update",
+    "event": "Fulfillments Update",
     "properties": {
       "admin_graphql_api_id": "gid://shopify/Fulfillment/4124667937024",
       "created_at": "2022-01-05T18:13:02+05:30",
@@ -501,7 +501,7 @@
       "SHOPIFY": true
     },
     "type": "track",
-    "event": "fulfillments_update",
+    "event": "Fulfillments Update",
     "properties": {
       "admin_graphql_api_id": "gid://shopify/Fulfillment/4124667937024",
       "created_at": "2022-01-05T18:13:02+05:30",

--- a/v0/sources/shopify/util.js
+++ b/v0/sources/shopify/util.js
@@ -99,7 +99,7 @@ const setAnonymousId = message => {
   switch (message.event) {
     case SHOPIFY_TRACK_MAP.carts_create:
     case SHOPIFY_TRACK_MAP.carts_update:
-      message.setProperty("anonymousId", message.propertes.id);
+      message.setProperty("anonymousId", message.properties.id);
       break;
     case SHOPIFY_TRACK_MAP.orders_delete:
     case SHOPIFY_TRACK_MAP.orders_edited:
@@ -107,12 +107,11 @@ const setAnonymousId = message => {
     case SHOPIFY_TRACK_MAP.orders_fulfilled:
     case SHOPIFY_TRACK_MAP.orders_paid:
     case SHOPIFY_TRACK_MAP.orders_partially_fullfilled:
-    case SHOPIFY_TRACK_MAP.orders_placed:
     case RUDDER_ECOM_MAP.checkouts_create:
     case RUDDER_ECOM_MAP.checkouts_update:
     case RUDDER_ECOM_MAP.orders_create:
-    case RUDDER_ECOM_MAP.orders_update:
-      message.setProperty("anonymousId", message.propertes.cart_token);
+    case RUDDER_ECOM_MAP.orders_updated:
+      message.setProperty("anonymousId", message.properties.cart_token);
       break;
     default:
       message.setProperty("anonymousId", generateUUID());

--- a/v0/sources/shopify/util.js
+++ b/v0/sources/shopify/util.js
@@ -92,12 +92,17 @@ const extractEmailFromPayload = event => {
   return email;
 };
 
-// TODO: Hash the id and use it as anonymousId
+// Hash the id and use it as anonymousId (limiting 256 -> 36 chars)
 const setAnonymousId = message => {
   switch (message.event) {
     case SHOPIFY_TRACK_MAP.carts_create:
     case SHOPIFY_TRACK_MAP.carts_update:
-      message.setProperty("anonymousId", message.properties.id);
+      message.setProperty(
+        "anonymousId",
+        message.properties?.id
+          ? sha256(message.properties.id).toString().substring(0, 36)
+          : generateUUID()
+      );
       break;
     case SHOPIFY_TRACK_MAP.orders_delete:
     case SHOPIFY_TRACK_MAP.orders_edited:
@@ -112,7 +117,7 @@ const setAnonymousId = message => {
       message.setProperty(
         "anonymousId",
         message.properties?.cart_token
-          ? sha256(message.properties.cart_token)
+          ? sha256(message.properties.cart_token).toString().substring(0, 36)
           : generateUUID()
       );
       break;

--- a/v0/sources/shopify/util.js
+++ b/v0/sources/shopify/util.js
@@ -93,6 +93,9 @@ const extractEmailFromPayload = event => {
 
 // TODO: Hash the id and use it as anonymousId
 const setAnonymousId = message => {
+  logger.info(
+    `[Shopify] Setting anonymousId for message: ${JSON.stringify(message)}`
+  );
   switch (message.event) {
     case SHOPIFY_TRACK_MAP.carts_create:
     case SHOPIFY_TRACK_MAP.carts_update:
@@ -115,7 +118,6 @@ const setAnonymousId = message => {
       message.setProperty("anonymousId", generateUUID());
       break;
   }
-  return message;
 };
 
 module.exports = {

--- a/v0/sources/shopify/util.js
+++ b/v0/sources/shopify/util.js
@@ -26,7 +26,7 @@ const {
 const getShopifyTopic = event => {
   const { query_parameters: qParams } = event;
   logger.info(
-    `[Shopify] Input events: query_params: ${JSON.stringify(qParams)}`
+    `[Shopify] Input event: query_params: ${JSON.stringify(qParams)}`
   );
   if (!qParams) {
     throw new CustomError("[Shopify Source] query_parameters is missing", 400);

--- a/v0/sources/shopify/util.js
+++ b/v0/sources/shopify/util.js
@@ -111,7 +111,10 @@ const setAnonymousId = message => {
     case RUDDER_ECOM_MAP.checkouts_update:
     case RUDDER_ECOM_MAP.orders_create:
     case RUDDER_ECOM_MAP.orders_updated:
-      message.setProperty("anonymousId", message.properties.cart_token);
+      message.setProperty(
+        "anonymousId",
+        message.properties?.cart_token || generateUUID()
+      );
       break;
     default:
       message.setProperty("anonymousId", generateUUID());

--- a/v0/sources/shopify/util.js
+++ b/v0/sources/shopify/util.js
@@ -1,4 +1,5 @@
 /* eslint-disable camelcase */
+const sha256 = require("sha256");
 const {
   CustomError,
   constructPayload,
@@ -93,9 +94,6 @@ const extractEmailFromPayload = event => {
 
 // TODO: Hash the id and use it as anonymousId
 const setAnonymousId = message => {
-  logger.info(
-    `[Shopify] Setting anonymousId for message: ${JSON.stringify(message)}`
-  );
   switch (message.event) {
     case SHOPIFY_TRACK_MAP.carts_create:
     case SHOPIFY_TRACK_MAP.carts_update:
@@ -113,7 +111,9 @@ const setAnonymousId = message => {
     case RUDDER_ECOM_MAP.orders_updated:
       message.setProperty(
         "anonymousId",
-        message.properties?.cart_token || generateUUID()
+        message.properties?.cart_token
+          ? sha256(message.properties.cart_token)
+          : generateUUID()
       );
       break;
     default:


### PR DESCRIPTION
## Description of the change

This pr attempts to address the issue of identity resolution to downstream tools via Shopify connector. This transformation is used to transform Shopify server to server events pushed by webhooks, which currently might not have any user identifier if the user chooses to stay anonymous during the later stages of the journey where these events are generated.

The goal is to use use the `cart_token` available in such events and treat it as an `anonymousId` for these events.
To stitch these same events to the events collected by the tracking script, the tracking script will always check in cookies for the same `cart_token` whenever available the tracking script will shift anonymousId to `cart_token` and make a alias call for the same.

Essentially we user will be tracked by a common identifier for both server to server events and client side events with a common id to resolve the identity resolution issue

Other improvements: 

- We are updating some of our events tracked by server to server api's to more standard naming convention for better resolution at downstream tools

![Screenshot 2022-08-12 at 8 47 39 AM](https://user-images.githubusercontent.com/25389167/184278755-1f9c3325-ffc7-452f-9e0d-4a147964d874.png)
![Screenshot 2022-08-12 at 8 49 10 AM](https://user-images.githubusercontent.com/25389167/184278886-d7e18527-5135-4777-becc-ba4729b7a9e6.png)

As shown in above screen shot - as both the device_ids in AM (i.e anonymousIds) from front end and s2s remains consistent and as both of them are attached to the userId (Shopify customerId) we are able to stitch the user journey.
We have some unconventional events like fulfillment_create where we are not getting any user identifiers which are outliers but we are still collecting these events for any other downstream analysis. These can easily be filtered using user transform


## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
