### PR TITLE
Fix(hs).comparing property values during search

### DIFF
--- a/v0/destinations/hs/util.js
+++ b/v0/destinations/hs/util.js
@@ -400,7 +400,7 @@ const splitEventsForCreateUpdate = async (inputs, destination) => {
     );
 
     let filteredInfo = updateHubspotIds.filter(
-      update => update.property === destinationExternalId
+      update => update.property.toString() === destinationExternalId.toString()
     );
 
     if (filteredInfo.length) {
@@ -545,7 +545,6 @@ const getExistingData = async (inputs, destination) => {
       });
     }
   }
-
   return updateHubspotIds;
 };
 


### PR DESCRIPTION
## Description of the change

> https://www.notion.so/rudderstacks/cfe8e8ef60a34485a373e789b7b6933a?v=a07a0b1350f84d46af9792260b39a194
during search/list all the property values from hubspot are returned as string irrespective of the type of property set in hubspot.
So converting values to string and then comparing for search.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
