### PR TITLE
feat(leanplum): Allow user to configure the disposition configuration…

### DIFF
--- a/v0/destinations/leanplum/data/LPTrackConfig.json
+++ b/v0/destinations/leanplum/data/LPTrackConfig.json
@@ -22,6 +22,11 @@
     "required": false
   },
   {
+    "destKey": "disposition",
+    "sourceKeys": "context.disposition",
+    "required": false,
+  },
+  {
     "destKey": "params",
     "sourceKeys": "properties",
     "required": false


### PR DESCRIPTION
## Description of the change

Added ability for user to configure the disposition of events sent to leanplum.

> Leanplum - Disposition
> Determines how tracked events affect sessions and user activity. If present, disposition must have one of the following values:

> active (default): Used for events reflect user activity. Active events should mark the user as active, and should be tracked within a session. (Replaces the deprecated option allowOffline: false.)
> passive: Used for events that do not correspond to user activity. These events do not need to occur within a session, and do not mark a user as active. For example, sending a user a message would be tracked passively, since it affects a user, but does not represent user activity. (Replaces the deprecated option allowOffline: true.)
> requireActive: Used for events that must only be tracked within a session. These events are rejected, and return a warning response with ignored: true if the user does not have an active session. Clients should detect the warning by the ignored field, as warning messages may change.

[https://docs.leanplum.com/reference/post_api-action-track](https://docs.leanplum.com/reference/post_api-action-track)

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
