### PR TITLE
check if message id unavailable

### DIFF
--- a/util/customTransformer.js
+++ b/util/customTransformer.js
@@ -230,7 +230,9 @@ async function userTransformHandler(
       const eventMessages = events.map(event => event.message);
       const eventsMetadata = {};
       events.forEach(ev => {
-        eventsMetadata[ev.message.messageId] = ev.metadata;
+        if(ev.message !== undefined && ev.message.messageId !== undefined){
+          eventsMetadata[ev.message.messageId] = ev.metadata;
+        }
       });
 
       let userTransformedEvents = [];


### PR DESCRIPTION
## Description of the change

> In view of Redis store transformation enablement for SDKs, where the API can receive any object, "messageId" is being set as optional for the input event. 
## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
