### PR TITLE
fix: refiner destination group call email value

### DIFF
--- a/__tests__/data/refiner.json
+++ b/__tests__/data/refiner.json
@@ -449,7 +449,6 @@
         "XML": {},
         "FORM": {
           "id": "test@12",
-          "email": "business@rudderstack.com",
           "account[businessEmail]": "business@rudderstack.com",
           "account[id]": "group@123",
           "account[name]": "rudder ventures"

--- a/__tests__/data/refiner_router.json
+++ b/__tests__/data/refiner_router.json
@@ -273,7 +273,6 @@
               "account[businessEmail]": "business@rudderstack.com",
               "account[id]": "group@123",
               "account[name]": "rudder ventures",
-              "email": "business@rudderstack.com",
               "id": "test@12"
             },
             "JSON": {},

--- a/v0/destinations/refiner/utils.js
+++ b/v0/destinations/refiner/utils.js
@@ -172,7 +172,7 @@ const pageEventPayloadBuilder = message => {
 const groupUsersPayloadBuilder = (message, destination) => {
   const payload = {};
   const userId = getFieldValueFromMessage(message, "userIdOnly");
-  const email = getFieldValueFromMessage(message, "email");
+  const email = getFieldValueFromMessage(message, "context.traits.email");
   if (userId) {
     payload.id = userId;
   }


### PR DESCRIPTION
## Description of the change
-> email value is conflicting with group email, now taking a user level email from context.traits

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ✅] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ✅] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
