### PR TITLE
fix(amplitude): send error response instead of discarding the event during batch processing

### DIFF
--- a/v0/destinations/am/transform.js
+++ b/v0/destinations/am/transform.js
@@ -888,9 +888,14 @@ function batch(destEvents) {
         : messageEvent
         ? messageEvent.device_id
         : undefined;
-    // this case shold not happen and should be filtered already
-    // by the first pass of single event transformation
+
     if (messageEvent && !userId && !deviceId) {
+      const errorResponse = getErrorRespEvents(
+        metadata,
+        400,
+        "Both userId and deviceId cannot be undefined"
+      );
+      respList.push(errorResponse);
       return;
     }
     // check if not a JSON body or (userId length < 5 && batchEventsWithUserIdLengthLowerThanFive is false) or

--- a/v0/destinations/am/transform.js
+++ b/v0/destinations/am/transform.js
@@ -888,8 +888,8 @@ function batch(destEvents) {
         : messageEvent
         ? messageEvent.device_id
         : undefined;
-     // this case shold not happen and should be filtered already
-     // by the first pass of single event transformation
+    // this case shold not happen and should be filtered already
+    // by the first pass of single event transformation
     if (messageEvent && !userId && !deviceId) {
       const errorResponse = getErrorRespEvents(
         metadata,

--- a/v0/destinations/am/transform.js
+++ b/v0/destinations/am/transform.js
@@ -888,7 +888,8 @@ function batch(destEvents) {
         : messageEvent
         ? messageEvent.device_id
         : undefined;
-
+     // this case shold not happen and should be filtered already
+     // by the first pass of single event transformation
     if (messageEvent && !userId && !deviceId) {
       const errorResponse = getErrorRespEvents(
         metadata,


### PR DESCRIPTION
… discarding the event

## Description of the change

> If userId and deviseId both are undefined, the event is just discarded instead of sending an error response back which is causing input output size mismatch. Corrected this by sending an error response along with the metadata.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
