### PR TITLE
feat(integration): user defined event support for pinterest conversions destination

### DIFF
--- a/__tests__/data/pinterest_tag_output.json
+++ b/__tests__/data/pinterest_tag_output.json
@@ -330,7 +330,7 @@
       "params": {},
       "body": {
         "JSON": {
-          "event_name": "custom",
+          "event_name": "custom event",
           "event_time": 1597383030,
           "event_id": "7208bbb6-2c4e-45bb-bf5b-ad426f3593e9",
           "app_id": "429047995",

--- a/cdk/v2/destinations/pinterest_tag/procWorkflow.yaml
+++ b/cdk/v2/destinations/pinterest_tag/procWorkflow.yaml
@@ -174,7 +174,7 @@ steps:
             $eventMap := destination.Config.eventsMapping.{from: to};
             $eventNames := $lookup($eventMap, $event);
             $count($eventNames) = 0 ? $eventNames := $ecomEventMaps[$lowercase($event) in src].dest;
-            $count($eventNames) = 0 ? $eventNames := ["custom"];
+            $count($eventNames) = 0 ? $eventNames := [$event];
             $eventNames
           )
   - name: destEvents

--- a/v0/destinations/pinterest_tag/utils.js
+++ b/v0/destinations/pinterest_tag/utils.js
@@ -190,9 +190,10 @@ const deduceTrackScreenEventName = (message, Config) => {
   }
 
   /*
-  Step 3: In case both of the above stated cases fail, will mark the event as "custom"
+  Step 3: In case both of the above stated cases fail, will send the event name as it is.
+          This is going to be reflected as "unknown" event in conversion API dashboard.
  */
-  return ["custom"];
+  return [trackEventOrScreenName];
 };
 
 /**


### PR DESCRIPTION
## Description of the change

> Previously any user-defined event was defaulted to "custom" event, now, we are sending back the exact event name, if no mapping is found. This will show up as "unknown" event in Pinterest dashboard

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
