### PR TITLE
fix: suppress errors thrown from the transformers in bugsnag notifier

### DIFF
--- a/util/errorNotifier/bugsnag.js
+++ b/util/errorNotifier/bugsnag.js
@@ -1,11 +1,15 @@
 /* eslint-disable no-param-reassign */
 const Bugsnag = require("@bugsnag/js");
 const pkg = require("../../package.json");
+const { CustomError } = require("../../v0/util");
+const { ApiError, TransformationError } = require("../../v0/util/errors");
 
 const {
   BUGSNAG_API_KEY: apiKey,
   transformer_build_version: imageVersion
 } = process.env;
+
+const errorTypesDenyList = [CustomError, ApiError, TransformationError];
 
 function init() {
   Bugsnag.start({
@@ -23,6 +27,17 @@ function init() {
 }
 
 function notify(err, context, metadata) {
+  const deniedErrType = errorTypesDenyList.some(errType => {
+    return err instanceof errType;
+  });
+
+  if (deniedErrType) return;
+
+  // For errors thrown in the code using ErrorBuilder
+  // TODO: This need to be cleaned up once the entire code base
+  // moves into a consistent error reporting format
+  if (err.isExpected === true) return;
+
   Bugsnag.notify(err, event => {
     event.context = context;
     event.addMetadata("metadata", metadata);

--- a/util/errorNotifier/bugsnag.js
+++ b/util/errorNotifier/bugsnag.js
@@ -27,11 +27,11 @@ function init() {
 }
 
 function notify(err, context, metadata) {
-  const deniedErrType = errorTypesDenyList.some(errType => {
+  const isDeniedErrType = errorTypesDenyList.some(errType => {
     return err instanceof errType;
   });
 
-  if (deniedErrType) return;
+  if (isDeniedErrType) return;
 
   // For errors thrown in the code using ErrorBuilder
   // TODO: This need to be cleaned up once the entire code base

--- a/v0/destinations/adobe_analytics/transform.js
+++ b/v0/destinations/adobe_analytics/transform.js
@@ -451,7 +451,7 @@ const process = async event => {
       payload = handleTrack(messageClone, formattedDestination);
       break;
     default:
-      throw new Error("Message type is not supported");
+      throw new CustomError("Message type is not supported");
   }
   if (payload) {
     const response = await responseBuilderSimple(

--- a/v0/destinations/af/transform.js
+++ b/v0/destinations/af/transform.js
@@ -44,7 +44,7 @@ function responseBuilderSimple(payload, message, destination) {
   // else if (message.context.app.namespace) {
   //   endpoint = `${ENDPOINT}${message.context.app.namespace}`;
   // } else {
-  //   throw new Error("Invalid app endpoint");
+  //   throw new CustomError("Invalid app endpoint");
   // }
   // const afId = message.integrations
   //   ? message.integrations.AF

--- a/v0/destinations/attribution/transform.js
+++ b/v0/destinations/attribution/transform.js
@@ -4,7 +4,8 @@ const {
   defaultPostRequestConfig,
   defaultRequestConfig,
   removeUndefinedAndNullValues,
-  getFieldValueFromMessage
+  getFieldValueFromMessage,
+  CustomError
 } = require("../../util");
 
 function responseBuilderSimple(payload, attributionConfig) {
@@ -28,7 +29,7 @@ function responseBuilderSimple(payload, attributionConfig) {
 
 function getTransformedJSON(message) {
   if (!message.type) {
-    throw new Error("Event type is required");
+    throw new CustomError("Event type is required");
   }
 
   const traits = getFieldValueFromMessage(message, "traits");
@@ -47,7 +48,7 @@ function getTransformedJSON(message) {
 function getAttributionConfig(destination) {
   const { writeKey } = destination.Config;
   if (!writeKey) {
-    throw new Error("No writeKey in config");
+    throw new CustomError("No writeKey in config");
   }
 
   return { writeKey };

--- a/v0/destinations/customerio/transform.js
+++ b/v0/destinations/customerio/transform.js
@@ -250,7 +250,7 @@ function responseBuilder(message, evType, evName, destination, messageType) {
       // This will help in merging for subsequent calls
       const anonymousId = message.anonymousId ? message.anonymousId : undefined;
       if (!anonymousId) {
-        throw new Error("Anonymous id/ user id is required");
+        throw new CustomError("Anonymous id/ user id is required");
       } else {
         rawPayload.anonymous_id = anonymousId;
       }

--- a/v0/destinations/delighted/util.js
+++ b/v0/destinations/delighted/util.js
@@ -62,7 +62,7 @@ const userValidity = async (channel, Config, userId) => {
     ) {
       return response.data.length !== 0;
     }
-    throw new Error("Invalid response");
+    throw new CustomError("Invalid response");
   } catch (error) {
     let errMsg = "";
     let errStatus = 400;

--- a/v0/destinations/drip/util.js
+++ b/v0/destinations/drip/util.js
@@ -33,7 +33,7 @@ const userExists = async (Config, id) => {
     if (response && response.status) {
       return response.status === 200;
     }
-    throw new Error("Invalid response.");
+    throw new CustomError("Invalid response.");
   } catch (error) {
     let errMsg = "";
     let errStatus = 400;
@@ -65,7 +65,7 @@ const createUpdateUser = async (finalpayload, Config, basicAuth) => {
     if (response) {
       return response.status === 200 || response.status === 201;
     }
-    throw new Error("Invalid response.");
+    throw new CustomError("Invalid response.");
   } catch (error) {
     let errMsg = "";
     const errStatus = 400;

--- a/v0/destinations/eventbridge/transform.js
+++ b/v0/destinations/eventbridge/transform.js
@@ -41,7 +41,7 @@ function process(event) {
       );
     }
   } catch (error) {
-    throw new Error(
+    throw new CustomError(
       error.message || "EventBridge: Unknown error",
       error.status || 400
     );

--- a/v0/destinations/fb/transform.js
+++ b/v0/destinations/fb/transform.js
@@ -178,7 +178,7 @@ function processEventTypeGeneric(message, baseEvent, fbEventName) {
   const { properties } = message;
   if (properties) {
     if (properties.revenue && !properties.currency) {
-      throw new Error(
+      throw new CustomError(
         "If properties.revenue is present, properties.currency is required."
       );
     }

--- a/v0/destinations/gainsight_px/util.js
+++ b/v0/destinations/gainsight_px/util.js
@@ -52,7 +52,7 @@ const objectExists = async (id, Config, objectType) => {
     if (response && response.status === 200) {
       return { success: true, err: null };
     }
-    throw new Error(err);
+    throw new CustomError(err);
   } catch (error) {
     return handleErrorResponse(
       error,
@@ -74,7 +74,7 @@ const createAccount = async (payload, Config) => {
     if (response && response.status === 201) {
       return { success: true, err: null };
     }
-    throw new Error("invalid response while creating account");
+    throw new CustomError("invalid response while creating account");
   } catch (error) {
     return handleErrorResponse(error, "error while creating account", 400);
   }
@@ -96,7 +96,7 @@ const updateAccount = async (accountId, payload, Config) => {
     if (response && response.status === 204) {
       return { success: true, err: null };
     }
-    throw new Error("invalid response while updating account");
+    throw new CustomError("invalid response while updating account");
   } catch (error) {
     return handleErrorResponse(error, "error while updating account", 400);
   }

--- a/v0/destinations/googlepubsub/transform.js
+++ b/v0/destinations/googlepubsub/transform.js
@@ -1,4 +1,8 @@
-const { getSuccessRespEvents, getErrorRespEvents } = require("../../util");
+const {
+  getSuccessRespEvents,
+  getErrorRespEvents,
+  CustomError
+} = require("../../util");
 
 const { getTopic, createAttributesMetadata } = require("./util");
 
@@ -15,7 +19,7 @@ function process(event) {
       attributes
     };
   }
-  throw new Error("No topic set for this event");
+  throw new CustomError("No topic set for this event");
 }
 
 const processRouterDest = async inputs => {

--- a/v0/destinations/webengage/transform.js
+++ b/v0/destinations/webengage/transform.js
@@ -102,7 +102,7 @@ const processEvent = (message, destination) => {
       message.event = eventName;
       return responseBuilder(message, CONFIG_CATEGORIES.EVENT, destination);
     default:
-      throw new Error("[WEBENGAGE]: Message type not supported");
+      throw new CustomError("[WEBENGAGE]: Message type not supported");
   }
 };
 

--- a/v0/sources/appcenter/transform.js
+++ b/v0/sources/appcenter/transform.js
@@ -6,7 +6,7 @@ const mappingJson = JSON.parse(
   fs.readFileSync(path.resolve(__dirname, "./mapping.json"), "utf-8")
 );
 
-const { removeUndefinedAndNullValues } = require("../../util");
+const { removeUndefinedAndNullValues, CustomError } = require("../../util");
 
 function guidGenerator() {
   const S4 = () =>
@@ -38,7 +38,7 @@ function processEvent(event) {
   ) {
     message.setEventName("App Crashed");
   } else {
-    throw new Error("Unknown event type from Appcenter");
+    throw new CustomError("Unknown event type from Appcenter");
   }
   const properties = { ...event };
   message.setProperty("properties", properties);
@@ -55,7 +55,7 @@ function process(event) {
   const response = processEvent(event);
   const returnValue = removeUndefinedAndNullValues(response);
   // to bypass the unit testcases ( we may change this)
-  //returnValue.anonymousId = "7e32188a4dab669f";
+  // returnValue.anonymousId = "7e32188a4dab669f";
   return returnValue;
 }
 

--- a/v0/sources/appsflyer/transform.js
+++ b/v0/sources/appsflyer/transform.js
@@ -1,7 +1,7 @@
 const path = require("path");
 const fs = require("fs");
 const Message = require("../message");
-const { generateUUID } = require("../../util");
+const { generateUUID, CustomError } = require("../../util");
 
 const mappingJson = JSON.parse(
   fs.readFileSync(path.resolve(__dirname, "./mapping.json"), "utf-8")
@@ -76,7 +76,7 @@ function processEvent(event) {
 
     return message;
   }
-  throw new Error("Unknwon event type from Appsflyer");
+  throw new CustomError("Unknwon event type from Appsflyer");
 }
 
 function process(event) {

--- a/v0/sources/auth0/transform.js
+++ b/v0/sources/auth0/transform.js
@@ -6,6 +6,7 @@ const mapping = JSON.parse(
   fs.readFileSync(path.resolve(__dirname, "./mapping.json"), "utf-8")
 );
 const Message = require("../message");
+const { CustomError } = require("../../util");
 
 // Ref: https://auth0.com/docs/logs/references/log-event-type-codes
 const eventNameMap = JSON.parse(
@@ -50,7 +51,7 @@ function processEvent(event) {
     }
     return null;
   }
-  throw new Error("Unknwon event type from Auth0");
+  throw new CustomError("Unknwon event type from Auth0");
 }
 
 function process(events) {
@@ -74,7 +75,7 @@ function process(events) {
     }
   });
   if (responses.length === 0) {
-    throw new Error("All requests in the batch failed");
+    throw new CustomError("All requests in the batch failed");
   } else {
     return responses;
   }

--- a/v0/sources/braze/transform.js
+++ b/v0/sources/braze/transform.js
@@ -2,7 +2,11 @@ const set = require("set-value");
 const get = require("get-value");
 const path = require("path");
 const fs = require("fs");
-const { removeUndefinedAndNullValues, formatTimeStamp } = require("../../util");
+const {
+  removeUndefinedAndNullValues,
+  formatTimeStamp,
+  CustomError
+} = require("../../util");
 const Message = require("../message");
 
 // import mapping json using JSON.parse to preserve object key order
@@ -66,7 +70,7 @@ const processEvent = event => {
     // wrong data
     return null;
   }
-  throw new Error("Unknwon event type from Braze");
+  throw new CustomError("Unknwon event type from Braze");
 };
 
 const process = events => {
@@ -92,7 +96,7 @@ const process = events => {
     }
   });
   if (responses.length === 0) {
-    throw new Error("All requests in the batch failed");
+    throw new CustomError("All requests in the batch failed");
   } else {
     return responses;
   }

--- a/v0/sources/canny/transform.js
+++ b/v0/sources/canny/transform.js
@@ -1,11 +1,12 @@
-const Message = require("../message");
 const sha256 = require("sha256");
+const Message = require("../message");
 const {
   voterMapping,
   authorMapping,
   checkForRequiredFields
 } = require("./util");
 const { logger } = require("../../../logger");
+const { CustomError } = require("../../util");
 
 const CannyOperation = {
   VOTE_CREATED: "vote.created",
@@ -38,7 +39,7 @@ function settingIds(message, event, typeOfUser) {
     }
   } catch (e) {
     logger?.error(`Missing essential fields from Canny. Error: (${e})`);
-    throw new Error(`Missing essential fields from Canny. Error: (${e})`);
+    throw new CustomError(`Missing essential fields from Canny. Error: (${e})`);
   }
 }
 

--- a/v0/sources/customerio/transform.js
+++ b/v0/sources/customerio/transform.js
@@ -17,7 +17,7 @@ function process(event) {
 
   let eventName = mappingConfig[event.object_type.toLowerCase()][event.metric];
   if (!eventName) {
-    // throw new Error("Metric not supported");
+    // throw new CustomError("Metric not supported");
     eventName = "Unknown Event";
   }
   message.setEventName(eventName);

--- a/v0/sources/iterable/transform.js
+++ b/v0/sources/iterable/transform.js
@@ -2,6 +2,7 @@ const path = require("path");
 const fs = require("fs");
 const md5 = require("md5");
 const Message = require("../message");
+const { CustomError } = require("../../util");
 
 // import mapping json using JSON.parse to preserve object key order
 const mapping = JSON.parse(
@@ -11,7 +12,7 @@ const mapping = JSON.parse(
 function process(event) {
   // throw an error if (email, eventName) are not present
   if (!(event.email && event.eventName)) {
-    throw new Error("Unknwon event type from Iterable");
+    throw new CustomError("Unknwon event type from Iterable");
   }
   const message = new Message(`Iterable`);
 

--- a/v0/util/index.js
+++ b/v0/util/index.js
@@ -43,6 +43,15 @@ const flattenMap = collection => _.flatMap(collection, x => x);
 // GENERIC UTLITY
 // ========================================================================
 
+class CustomError extends Error {
+  constructor(message, statusCode, metadata) {
+    super(message);
+    // *Note*: This schema is being used by other endpoints like /poll, /fileUpload etc,.
+    // Apart from destination transformation
+    this.response = { status: statusCode || 400, metadata };
+  }
+}
+
 const getEventTime = message => {
   return new Date(message.timestamp).toISOString();
 };
@@ -227,7 +236,7 @@ const setValues = (payload, message, mappingJson) => {
         if (val) {
           set(payload, mapping.destKey, val);
         } else if (mapping.required) {
-          throw new Error(
+          throw new CustomError(
             `One of ${JSON.stringify(mapping.sourceKeys)} is required`
           );
         }
@@ -619,7 +628,7 @@ const getValueFromMessage = (message, sourceKeys) => {
     // wrong sourceKey type. abort
     // DEVELOPER ERROR
     // TODO - think of a way to crash the pod
-    throw new Error("Wrong sourceKey type or blank sourceKey array");
+    throw new CustomError("Wrong sourceKey type or blank sourceKey array");
   }
   return null;
 };
@@ -712,7 +721,7 @@ const handleMetadataForValue = (
     }
 
     if (pastTimeDifference > allowedPastTimeDifference) {
-      throw new Error(
+      throw new CustomError(
         `Allowed timestamp is [${allowedPastTimeDifference} ${allowedPastTimeUnit}] into the past`
       );
     }
@@ -739,7 +748,7 @@ const handleMetadataForValue = (
       }
 
       if (futureTimeDifference > allowedFutureTimeDifference) {
-        throw new Error(
+        throw new CustomError(
           `Allowed timestamp is [${allowedFutureTimeDifference} ${allowedFutureTimeUnit}] into the future`
         );
       }
@@ -1437,15 +1446,6 @@ const getErrorStatusCode = (error, defaultStatusCode = 400) => {
     return defaultStatusCode;
   }
 };
-
-class CustomError extends Error {
-  constructor(message, statusCode, metadata) {
-    super(message);
-    // *Note*: This schema is being used by other endpoints like /poll, /fileUpload etc,.
-    // Apart from destination transformation
-    this.response = { status: statusCode, metadata };
-  }
-}
 
 /**
  * Used for generating error response with stats from native and built errors


### PR DESCRIPTION
## Description of the change

The changes to suppress all the errors from notifying Bugsnag that are manually thrown from the transformers.

- Replaced all the instances of `Error` with `CustomError`. We have to clean up all the `CustomError` throws later.
- Also, defaulted the status code to `400` in the `CustomError` constructor.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

N/A

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
