### PR TITLE
feature: batch user deletion support for mixpanel and clevertap

### DIFF
--- a/__tests__/data/clevertap_deleteUsers_proxy_input.json
+++ b/__tests__/data/clevertap_deleteUsers_proxy_input.json
@@ -42,28 +42,5 @@
         }
       ]
     }
-  },
-  {
-    "request": {
-      "body": [
-        {
-          "destType": "CLEVERTAP",
-          "userAttributes": [
-            {
-              "email": "testUser@testMail.com"
-            },
-            {
-              "userId": "user_sdk2"
-            }
-          ],
-          "config": {
-            "passcode": "fbee74a147828e2932c701d19dc1f2dcfa4ac0048be3aa3a88d427090a59dc1c0fa002f1",
-            "accountId": "476550467",
-            "trackAnonymous": true,
-            "enableObjectIdMapping": false
-          }
-        }
-      ]
-    }
   }
 ]

--- a/__tests__/data/clevertap_deleteUsers_proxy_output.json
+++ b/__tests__/data/clevertap_deleteUsers_proxy_output.json
@@ -10,11 +10,5 @@
       "statusCode": 400,
       "error": "Project ID and Passcode is required for delete user"
     }
-  ],
-  [
-    {
-      "statusCode": 400,
-      "error": "User id for deletion not present"
-    }
   ]
 ]

--- a/__tests__/data/mp_deleteUsers_proxy_input.json
+++ b/__tests__/data/mp_deleteUsers_proxy_input.json
@@ -20,28 +20,5 @@
         }
       ]
     }
-  },
-  {
-    "request": {
-      "body": [
-        {
-          "destType": "MP",
-          "userAttributes": [
-            {
-              "email": "testUser@testMail.com"
-            },
-            {
-              "userId": "user_sdk2"
-            }
-          ],
-          "config": {
-            "apiKey": "9432f11f70f8ce386f5110c8c924b3ec4f825256",
-            "prefixProperties": true,
-            "token": "1231241asfdklhasdf",
-            "useNativeSDK": false
-          }
-        }
-      ]
-    }
   }
 ]

--- a/__tests__/data/mp_deleteUsers_proxy_output.json
+++ b/__tests__/data/mp_deleteUsers_proxy_output.json
@@ -4,11 +4,5 @@
       "statusCode": 400,
       "error": "API Token is a required field for user deletion"
     }
-  ],
-  [
-    {
-      "statusCode": 400,
-      "error": "User id for deletion not present"
-    }
   ]
 ]

--- a/v0/destinations/af/config.js
+++ b/v0/destinations/af/config.js
@@ -58,6 +58,8 @@ const Event = {
 
 const ENDPOINT = "https://api2.appsflyer.com/inappevent/";
 
+const identityFormat = "raw";
+
 const mappingConfig = getMappingConfig(ConfigCategory, __dirname);
 
 const nameToEventMap = {};
@@ -67,9 +69,10 @@ events.forEach(event => {
 });
 
 module.exports = {
-  ConfigCategory,
-  ENDPOINT,
   Event,
+  ENDPOINT,
   mappingConfig,
-  nameToEventMap
+  identityFormat,
+  nameToEventMap,
+  ConfigCategory
 };

--- a/v0/destinations/af/config.js
+++ b/v0/destinations/af/config.js
@@ -58,8 +58,6 @@ const Event = {
 
 const ENDPOINT = "https://api2.appsflyer.com/inappevent/";
 
-const identityFormat = "raw";
-
 const mappingConfig = getMappingConfig(ConfigCategory, __dirname);
 
 const nameToEventMap = {};
@@ -69,10 +67,9 @@ events.forEach(event => {
 });
 
 module.exports = {
-  Event,
+  ConfigCategory,
   ENDPOINT,
+  Event,
   mappingConfig,
-  identityFormat,
-  nameToEventMap,
-  ConfigCategory
+  nameToEventMap
 };

--- a/v0/destinations/clevertap/config.js
+++ b/v0/destinations/clevertap/config.js
@@ -42,11 +42,14 @@ const CLEVERTAP_DEFAULT_EXCLUSION = [
   "ts"
 ];
 
+const maxBatchSize = 1000;
+
 const MAPPING_CONFIG = getMappingConfig(CONFIG_CATEGORIES, __dirname);
 
 module.exports = {
   getEndpoint,
-  CLEVERTAP_DEFAULT_EXCLUSION,
+  maxBatchSize,
+  MAPPING_CONFIG,
   CONFIG_CATEGORIES,
-  MAPPING_CONFIG
+  CLEVERTAP_DEFAULT_EXCLUSION
 };

--- a/v0/destinations/clevertap/config.js
+++ b/v0/destinations/clevertap/config.js
@@ -42,13 +42,13 @@ const CLEVERTAP_DEFAULT_EXCLUSION = [
   "ts"
 ];
 
-const maxBatchSize = 1000;
+const MAX_BATCH_SIZE = 1000;
 
 const MAPPING_CONFIG = getMappingConfig(CONFIG_CATEGORIES, __dirname);
 
 module.exports = {
   getEndpoint,
-  maxBatchSize,
+  MAX_BATCH_SIZE,
   MAPPING_CONFIG,
   CONFIG_CATEGORIES,
   CLEVERTAP_DEFAULT_EXCLUSION

--- a/v0/destinations/clevertap/deleteUsers.js
+++ b/v0/destinations/clevertap/deleteUsers.js
@@ -44,7 +44,7 @@ const userDeletionHandler = async (userAttributes, config) => {
   const processedDeletionRespone = processAxiosResponse(deletionRespone);
   if (processedDeletionRespone.status !== 200) {
     throw new ErrorBuilder()
-      .setMessage("[Mixpanel]::Deletion Request is not successful")
+      .setMessage("[Clevertap]::Deletion Request is not successful")
       .setStatus(processedDeletionRespone.status)
       .build();
   }

--- a/v0/destinations/clevertap/deleteUsers.js
+++ b/v0/destinations/clevertap/deleteUsers.js
@@ -1,7 +1,7 @@
 const _ = require("lodash");
 const { httpPOST } = require("../../../adapters/network");
 const ErrorBuilder = require("../../util/error");
-const { getEndpoint, maxBatchSize } = require("./config");
+const { getEndpoint, MAX_BATCH_SIZE } = require("./config");
 const {
   processAxiosResponse
 } = require("../../../adapters/utils/networkUtils");
@@ -45,7 +45,7 @@ const userDeletionHandler = async (userAttributes, config) => {
 
   // batchEvents = [[e1,e2,e3,..batchSize],[e1,e2,e3,..batchSize]..]
   // ref : https://developer.clevertap.com/docs/disassociate-api
-  const batchEvents = _.chunk(identity, maxBatchSize);
+  const batchEvents = _.chunk(identity, MAX_BATCH_SIZE);
   batchEvents.forEach(async batchEvent => {
     const deletionRespone = await httpPOST(
       endpoint,

--- a/v0/destinations/clevertap/deleteUsers.js
+++ b/v0/destinations/clevertap/deleteUsers.js
@@ -43,7 +43,7 @@ const userDeletionHandler = async (userAttributes, config) => {
     }
   });
 
-  // arrayChunks = [[e1,e2,e3,..batchSize],[e1,e2,e3,..batchSize]..]
+  // batchEvents = [[e1,e2,e3,..batchSize],[e1,e2,e3,..batchSize]..]
   // ref : https://developer.clevertap.com/docs/disassociate-api
   const batchEvents = _.chunk(identity, maxBatchSize);
   batchEvents.forEach(async batchEvent => {

--- a/v0/destinations/clevertap/deleteUsers.js
+++ b/v0/destinations/clevertap/deleteUsers.js
@@ -30,23 +30,19 @@ const userDeletionHandler = async (userAttributes, config) => {
     "X-CleverTap-Passcode": passcode,
     "Content-Type": "application/json"
   };
-  for (let i = 0; i < userAttributes.length; i += 1) {
-    const identity = [];
-    if (userAttributes[i].userId) {
-      identity.push(userAttributes[i].userId);
-    } else
-      throw new ErrorBuilder()
-        .setMessage("User id for deletion not present")
-        .setStatus(400)
-        .build();
-    // eslint-disable-next-line no-await-in-loop
-    const response = await httpPOST(endpoint, { identity }, { headers });
-    if (!response || !response.response) {
-      throw new ErrorBuilder()
-        .setMessage("Could not get response")
-        .setStatus(500)
-        .build();
+  const identity = [];
+  userAttributes.forEach(userAttribute => {
+    // Dropping the user if userId is not present
+    if (userAttribute.userId) {
+      identity.push(userAttribute.userId);
     }
+  });
+  const response = await httpPOST(endpoint, { identity }, { headers });
+  if (!response || !response.response) {
+    throw new ErrorBuilder()
+      .setMessage("Could not get response")
+      .setStatus(500)
+      .build();
   }
   return { statusCode: 200, status: "successful" };
 };

--- a/v0/destinations/clevertap/deleteUsers.js
+++ b/v0/destinations/clevertap/deleteUsers.js
@@ -1,6 +1,9 @@
 const { httpPOST } = require("../../../adapters/network");
 const ErrorBuilder = require("../../util/error");
 const { getEndpoint } = require("./config");
+const {
+  processAxiosResponse
+} = require("../../../adapters/utils/networkUtils");
 
 /**
  * This function will help to delete the users one by one from the userAttributes array.
@@ -37,11 +40,12 @@ const userDeletionHandler = async (userAttributes, config) => {
       identity.push(userAttribute.userId);
     }
   });
-  const response = await httpPOST(endpoint, { identity }, { headers });
-  if (!response || !response.response) {
+  const deletionRespone = await httpPOST(endpoint, { identity }, { headers });
+  const processedDeletionRespone = processAxiosResponse(deletionRespone);
+  if (processedDeletionRespone.status !== 200) {
     throw new ErrorBuilder()
-      .setMessage("Could not get response")
-      .setStatus(500)
+      .setMessage("[Mixpanel]::Deletion Request is not successful")
+      .setStatus(processedDeletionRespone.status)
       .build();
   }
   return { statusCode: 200, status: "successful" };

--- a/v0/destinations/mp/config.js
+++ b/v0/destinations/mp/config.js
@@ -42,12 +42,14 @@ const MP_IDENTIFY_EXCLUSION_LIST = [
 ];
 
 const GEO_SOURCE_ALLOWED_VALUES = [null, "reverse_geocoding"];
+const maxBatchSize = 1000;
 
 module.exports = {
-  ConfigCategory,
+  maxBatchSize,
   mappingConfig,
-  MP_IDENTIFY_EXCLUSION_LIST,
-  GEO_SOURCE_ALLOWED_VALUES,
   BASE_ENDPOINT,
-  BASE_ENDPOINT_EU
+  ConfigCategory,
+  BASE_ENDPOINT_EU,
+  GEO_SOURCE_ALLOWED_VALUES,
+  MP_IDENTIFY_EXCLUSION_LIST
 };

--- a/v0/destinations/mp/config.js
+++ b/v0/destinations/mp/config.js
@@ -42,12 +42,12 @@ const MP_IDENTIFY_EXCLUSION_LIST = [
 ];
 
 const GEO_SOURCE_ALLOWED_VALUES = [null, "reverse_geocoding"];
-const maxBatchSize = 1000;
+const MAX_BATCH_SIZE = 1000;
 
 module.exports = {
-  maxBatchSize,
   mappingConfig,
   BASE_ENDPOINT,
+  MAX_BATCH_SIZE,
   ConfigCategory,
   BASE_ENDPOINT_EU,
   GEO_SOURCE_ALLOWED_VALUES,

--- a/v0/destinations/mp/deleteUsers.js
+++ b/v0/destinations/mp/deleteUsers.js
@@ -50,7 +50,7 @@ const userDeletionHandler = async (userAttributes, config) => {
     "content-type": "application/json"
   };
 
-  // arrayChunks = [[e1,e2,e3,..batchSize],[e1,e2,e3,..batchSize]..]
+  // batchEvents = [[e1,e2,e3,..batchSize],[e1,e2,e3,..batchSize]..]
   // ref : https://help.mixpanel.com/hc/en-us/articles/115004565806-Delete-User-Profiles#:~:text=Bulk%20Delete%20Profiles,Please%20delete%20with%20caution!
   const batchEvents = _.chunk(data, maxBatchSize);
   batchEvents.forEach(async batchEvent => {

--- a/v0/destinations/mp/deleteUsers.js
+++ b/v0/destinations/mp/deleteUsers.js
@@ -5,7 +5,7 @@ const {
 } = require("../../../adapters/utils/networkUtils");
 const ErrorBuilder = require("../../util/error");
 const { isHttpStatusSuccess } = require("../../util");
-const { maxBatchSize } = require("./config");
+const { MAX_BATCH_SIZE } = require("./config");
 
 /**
  * This function will help to delete the users one by one from the userAttributes array.
@@ -52,7 +52,7 @@ const userDeletionHandler = async (userAttributes, config) => {
 
   // batchEvents = [[e1,e2,e3,..batchSize],[e1,e2,e3,..batchSize]..]
   // ref : https://help.mixpanel.com/hc/en-us/articles/115004565806-Delete-User-Profiles#:~:text=Bulk%20Delete%20Profiles,Please%20delete%20with%20caution!
-  const batchEvents = _.chunk(data, maxBatchSize);
+  const batchEvents = _.chunk(data, MAX_BATCH_SIZE);
   batchEvents.forEach(async batchEvent => {
     const deletionRespone = await httpPOST(endpoint, batchEvent, headers);
     const processedDeletionRespone = processAxiosResponse(deletionRespone);

--- a/v0/destinations/mp/deleteUsers.js
+++ b/v0/destinations/mp/deleteUsers.js
@@ -1,4 +1,7 @@
 const { httpPOST } = require("../../../adapters/network");
+const {
+  processAxiosResponse
+} = require("../../../adapters/utils/networkUtils");
 const ErrorBuilder = require("../../util/error");
 
 /**
@@ -37,11 +40,12 @@ const userDeletionHandler = async (userAttributes, config) => {
     accept: "text/plain",
     "content-type": "application/json"
   };
-  const response = await httpPOST(endpoint, data, headers);
-  if (!response || !response.response) {
+  const deletionRespone = await httpPOST(endpoint, data, headers);
+  const processedDeletionRespone = processAxiosResponse(deletionRespone);
+  if (processedDeletionRespone.status !== 200) {
     throw new ErrorBuilder()
-      .setMessage("Could not get response")
-      .setStatus(500)
+      .setMessage("[Mixpanel]::Deletion Request is not successful")
+      .setStatus(processedDeletionRespone.status)
       .build();
   }
   return { statusCode: 200, status: "successful" };


### PR DESCRIPTION
## Description of the change

- as of now for existing destination if we want to delete users then we are doing it one by one. like for every user we are making user deletion request to destination which is impecting the performance of the api
- in this pr for mixpanel and clevertap destination we are making user deletion request in batch since they are supporting batch user deletion
- also, for a perticular user if we don't found required key(ex **userId**) then we will drop that perticular user and proceed for remaining users

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ✅] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ✅] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
