### PR TITLE
fix : amplitude api endpoint version update

### DIFF
--- a/__tests__/data/am_batch_input.json
+++ b/__tests__/data/am_batch_input.json
@@ -91,7 +91,7 @@
         "userId": "my-anonymous-id-new",
         "headers": { "Content-Type": "application/json" },
         "version": "1",
-        "endpoint": "https://api.amplitude.com/2/httpapi"
+        "endpoint": "https://api2.amplitude.com/2/httpapi"
       },
       "metadata": { "job_id": 2 },
       "destination": {
@@ -135,7 +135,7 @@
         "userId": "my-anonymous-id-new",
         "headers": { "Content-Type": "application/json" },
         "version": "1",
-        "endpoint": "https://api.amplitude.com/2/httpapi"
+        "endpoint": "https://api2.amplitude.com/2/httpapi"
       },
       "metadata": { "job_id": 3 },
       "destination": {
@@ -180,7 +180,7 @@
         "userId": "my-anonymous-id-new",
         "headers": { "Content-Type": "application/json" },
         "version": "1",
-        "endpoint": "https://api.amplitude.com/2/httpapi"
+        "endpoint": "https://api2.amplitude.com/2/httpapi"
       },
       "metadata": { "job_id": 4 },
       "destination": {
@@ -225,7 +225,7 @@
         "userId": "my-anonymous-id-new",
         "headers": { "Content-Type": "application/json" },
         "version": "1",
-        "endpoint": "https://api.amplitude.com/2/httpapi"
+        "endpoint": "https://api2.amplitude.com/2/httpapi"
       },
       "metadata": { "job_id": 5 },
       "destination": {
@@ -254,7 +254,7 @@
         "userId": "my-anonymous-id-new",
         "headers": {},
         "version": "1",
-        "endpoint": "https://api.amplitude.com/groupidentify"
+        "endpoint": "https://api2.amplitude.com/groupidentify"
       },
       "metadata": { "job_id": 6 },
       "destination": {
@@ -283,7 +283,7 @@
         "userId": "my-anonymous-id-new",
         "headers": {},
         "version": "1",
-        "endpoint": "https://api.amplitude.com/usermap"
+        "endpoint": "https://api2.amplitude.com/usermap"
       },
       "metadata": { "job_id": 7 },
       "destination": {
@@ -339,7 +339,7 @@
         "userId": "my-anonymous-id-new",
         "headers": { "Content-Type": "application/json" },
         "version": "1",
-        "endpoint": "https://api.amplitude.com/2/httpapi"
+        "endpoint": "https://api2.amplitude.com/2/httpapi"
       },
       "metadata": { "job_id": 1 },
       "destination": {
@@ -381,7 +381,7 @@
         "userId": "my-anonymous-id-new",
         "headers": { "Content-Type": "application/json" },
         "version": "1",
-        "endpoint": "https://api.amplitude.com/2/httpapi"
+        "endpoint": "https://api2.amplitude.com/2/httpapi"
       },
       "metadata": { "job_id": 2 },
       "destination": {
@@ -423,7 +423,7 @@
         "userId": "my-anonymous-id-new",
         "headers": { "Content-Type": "application/json" },
         "version": "1",
-        "endpoint": "https://api.amplitude.com/2/httpapi"
+        "endpoint": "https://api2.amplitude.com/2/httpapi"
       },
       "metadata": { "job_id": 3 },
       "destination": {
@@ -466,7 +466,7 @@
         "userId": "my-anonymous-id-new",
         "headers": { "Content-Type": "application/json" },
         "version": "1",
-        "endpoint": "https://api.amplitude.com/2/httpapi"
+        "endpoint": "https://api2.amplitude.com/2/httpapi"
       },
       "metadata": { "job_id": 4 },
       "destination": {
@@ -509,7 +509,7 @@
         "userId": "my-anonymous-id-new",
         "headers": { "Content-Type": "application/json" },
         "version": "1",
-        "endpoint": "https://api.amplitude.com/2/httpapi"
+        "endpoint": "https://api2.amplitude.com/2/httpapi"
       },
       "metadata": { "job_id": 5 },
       "destination": {
@@ -538,7 +538,7 @@
         "userId": "my-anonymous-id-new",
         "headers": {},
         "version": "1",
-        "endpoint": "https://api.amplitude.com/groupidentify"
+        "endpoint": "https://api2.amplitude.com/groupidentify"
       },
       "metadata": { "job_id": 6 },
       "destination": {
@@ -567,7 +567,7 @@
         "userId": "my-anonymous-id-new",
         "headers": {},
         "version": "1",
-        "endpoint": "https://api.amplitude.com/usermap"
+        "endpoint": "https://api2.amplitude.com/usermap"
       },
       "metadata": { "job_id": 7 },
       "destination": {
@@ -617,7 +617,7 @@
         "userId": "anon_id",
         "headers": { "Content-Type": "application/json" },
         "version": "1",
-        "endpoint": "https://api.amplitude.com/2/httpapi"
+        "endpoint": "https://api2.amplitude.com/2/httpapi"
       },
       "metadata": {
         "userId": "90ca6da0-292e-4e79-9880-f8009e0ae4a3",
@@ -704,7 +704,7 @@
         "userId": "anon_id",
         "headers": { "Content-Type": "application/json" },
         "version": "1",
-        "endpoint": "https://api.amplitude.com/2/httpapi"
+        "endpoint": "https://api2.amplitude.com/2/httpapi"
       },
       "metadata": {
         "userId": "90ca6da0-292e-4e79-9880-f8009e0ae4a3",
@@ -791,7 +791,7 @@
         "userId": "anon_id",
         "headers": { "Content-Type": "application/json" },
         "version": "1",
-        "endpoint": "https://api.amplitude.com/2/httpapi"
+        "endpoint": "https://api2.amplitude.com/2/httpapi"
       },
       "metadata": {
         "userId": "90ca6da0-292e-4e79-9880-f8009e0ae4a3",
@@ -878,7 +878,7 @@
         "userId": "anon_id",
         "headers": { "Content-Type": "application/json" },
         "version": "1",
-        "endpoint": "https://api.amplitude.com/2/httpapi"
+        "endpoint": "https://api2.amplitude.com/2/httpapi"
       },
       "metadata": {
         "userId": "90ca6da0-292e-4e79-9880-f8009e0ae4a3",
@@ -965,7 +965,7 @@
         "userId": "anon_id",
         "headers": { "Content-Type": "application/json" },
         "version": "1",
-        "endpoint": "https://api.amplitude.com/2/httpapi"
+        "endpoint": "https://api2.amplitude.com/2/httpapi"
       },
       "metadata": {
         "userId": "90ca6da0-292e-4e79-9880-f8009e0ae4a3",
@@ -1064,7 +1064,7 @@
         "userId": "my-anonymous-id-new",
         "headers": { "Content-Type": "application/json" },
         "version": "1",
-        "endpoint": "https://api.amplitude.com/2/httpapi"
+        "endpoint": "https://api2.amplitude.com/2/httpapi"
       },
       "metadata": { "job_id": 1 },
       "destination": {
@@ -1108,7 +1108,7 @@
         "userId": "my-anonymous-id-new",
         "headers": { "Content-Type": "application/json" },
         "version": "1",
-        "endpoint": "https://api.amplitude.com/2/httpapi"
+        "endpoint": "https://api2.amplitude.com/2/httpapi"
       },
       "metadata": { "job_id": 2 },
       "destination": {
@@ -1152,7 +1152,7 @@
         "userId": "my-anonymous-id-new",
         "headers": { "Content-Type": "application/json" },
         "version": "1",
-        "endpoint": "https://api.amplitude.com/2/httpapi"
+        "endpoint": "https://api2.amplitude.com/2/httpapi"
       },
       "metadata": { "job_id": 3 },
       "destination": {
@@ -1197,7 +1197,7 @@
         "userId": "my-anonymous-id-new",
         "headers": { "Content-Type": "application/json" },
         "version": "1",
-        "endpoint": "https://api.amplitude.com/2/httpapi"
+        "endpoint": "https://api2.amplitude.com/2/httpapi"
       },
       "metadata": { "job_id": 4 },
       "destination": {
@@ -1242,7 +1242,7 @@
         "userId": "my-anonymous-id-new",
         "headers": { "Content-Type": "application/json" },
         "version": "1",
-        "endpoint": "https://api.amplitude.com/2/httpapi"
+        "endpoint": "https://api2.amplitude.com/2/httpapi"
       },
       "metadata": { "job_id": 5 },
       "destination": {
@@ -1271,7 +1271,7 @@
         "userId": "my-anonymous-id-new",
         "headers": {},
         "version": "1",
-        "endpoint": "https://api.amplitude.com/groupidentify"
+        "endpoint": "https://api2.amplitude.com/groupidentify"
       },
       "metadata": { "job_id": 6 },
       "destination": {
@@ -1300,7 +1300,7 @@
         "userId": "my-anonymous-id-new",
         "headers": {},
         "version": "1",
-        "endpoint": "https://api.amplitude.com/usermap"
+        "endpoint": "https://api2.amplitude.com/usermap"
       },
       "metadata": { "job_id": 7 },
       "destination": {
@@ -1358,7 +1358,7 @@
         "userId": "my-anonymous-id-new",
         "headers": { "Content-Type": "application/json" },
         "version": "1",
-        "endpoint": "https://api.amplitude.com/2/httpapi"
+        "endpoint": "https://api2.amplitude.com/2/httpapi"
       },
       "metadata": { "job_id": 1 },
       "destination": {
@@ -1402,7 +1402,7 @@
         "userId": "my-anonymous-id-new",
         "headers": { "Content-Type": "application/json" },
         "version": "1",
-        "endpoint": "https://api.amplitude.com/2/httpapi"
+        "endpoint": "https://api2.amplitude.com/2/httpapi"
       },
       "metadata": { "job_id": 2 },
       "destination": {
@@ -1446,7 +1446,7 @@
         "userId": "my-anonymous-id-new",
         "headers": { "Content-Type": "application/json" },
         "version": "1",
-        "endpoint": "https://api.amplitude.com/2/httpapi"
+        "endpoint": "https://api2.amplitude.com/2/httpapi"
       },
       "metadata": { "job_id": 3 },
       "destination": {
@@ -1491,7 +1491,7 @@
         "userId": "my-anonymous-id-new",
         "headers": { "Content-Type": "application/json" },
         "version": "1",
-        "endpoint": "https://api.amplitude.com/2/httpapi"
+        "endpoint": "https://api2.amplitude.com/2/httpapi"
       },
       "metadata": { "job_id": 4 },
       "destination": {
@@ -1536,7 +1536,7 @@
         "userId": "my-anonymous-id-new",
         "headers": { "Content-Type": "application/json" },
         "version": "1",
-        "endpoint": "https://api.amplitude.com/2/httpapi"
+        "endpoint": "https://api2.amplitude.com/2/httpapi"
       },
       "metadata": { "job_id": 5 },
       "destination": {
@@ -1565,7 +1565,7 @@
         "userId": "my-anonymous-id-new",
         "headers": {},
         "version": "1",
-        "endpoint": "https://api.amplitude.com/groupidentify"
+        "endpoint": "https://api2.amplitude.com/groupidentify"
       },
       "metadata": { "job_id": 6 },
       "destination": {
@@ -1594,7 +1594,7 @@
         "userId": "my-anonymous-id-new",
         "headers": {},
         "version": "1",
-        "endpoint": "https://api.amplitude.com/usermap"
+        "endpoint": "https://api2.amplitude.com/usermap"
       },
       "metadata": { "job_id": 7 },
       "destination": {

--- a/__tests__/data/am_batch_output.json
+++ b/__tests__/data/am_batch_output.json
@@ -80,7 +80,7 @@
         "userId": "my-anonymous-id-new",
         "headers": {},
         "version": "1",
-        "endpoint": "https://api.amplitude.com/groupidentify"
+        "endpoint": "https://api2.amplitude.com/groupidentify"
       },
       "metadata": [{ "job_id": 6 }],
       "destination": {
@@ -109,7 +109,7 @@
         "userId": "my-anonymous-id-new",
         "headers": {},
         "version": "1",
-        "endpoint": "https://api.amplitude.com/usermap"
+        "endpoint": "https://api2.amplitude.com/usermap"
       },
       "metadata": [{ "job_id": 7 }],
       "destination": {
@@ -213,7 +213,7 @@
           "Content-Type": "application/json"
         },
         "version": "1",
-        "endpoint": "https://api.amplitude.com/batch"
+        "endpoint": "https://api2.amplitude.com/batch"
       },
       "metadata": [
         { "job_id": 2 },
@@ -278,7 +278,7 @@
           "Content-Type": "application/json"
         },
         "version": "1",
-        "endpoint": "https://api.amplitude.com/2/httpapi"
+        "endpoint": "https://api2.amplitude.com/2/httpapi"
       },
       "metadata": [{ "job_id": 1 }],
       "destination": {
@@ -307,7 +307,7 @@
         "userId": "my-anonymous-id-new",
         "headers": {},
         "version": "1",
-        "endpoint": "https://api.amplitude.com/groupidentify"
+        "endpoint": "https://api2.amplitude.com/groupidentify"
       },
       "metadata": [{ "job_id": 6 }],
       "destination": {
@@ -336,7 +336,7 @@
         "userId": "my-anonymous-id-new",
         "headers": {},
         "version": "1",
-        "endpoint": "https://api.amplitude.com/usermap"
+        "endpoint": "https://api2.amplitude.com/usermap"
       },
       "metadata": [{ "job_id": 7 }],
       "destination": {
@@ -440,7 +440,7 @@
           "Content-Type": "application/json"
         },
         "version": "1",
-        "endpoint": "https://api.amplitude.com/batch"
+        "endpoint": "https://api2.amplitude.com/batch"
       },
       "metadata": [
         { "job_id": 2 },
@@ -577,7 +577,7 @@
           "Content-Type": "application/json"
         },
         "version": "1",
-        "endpoint": "https://api.amplitude.com/batch"
+        "endpoint": "https://api2.amplitude.com/batch"
       },
       "metadata": [
         {
@@ -686,7 +686,7 @@
         "userId": "my-anonymous-id-new",
         "headers": {},
         "version": "1",
-        "endpoint": "https://api.amplitude.com/groupidentify"
+        "endpoint": "https://api2.amplitude.com/groupidentify"
       },
       "metadata": [
         {
@@ -719,7 +719,7 @@
         "userId": "my-anonymous-id-new",
         "headers": {},
         "version": "1",
-        "endpoint": "https://api.amplitude.com/usermap"
+        "endpoint": "https://api2.amplitude.com/usermap"
       },
       "metadata": [
         {
@@ -853,7 +853,7 @@
           "Content-Type": "application/json"
         },
         "version": "1",
-        "endpoint": "https://api.amplitude.com/batch"
+        "endpoint": "https://api2.amplitude.com/batch"
       },
       "metadata": [
         {
@@ -930,7 +930,7 @@
           "Content-Type": "application/json"
         },
         "version": "1",
-        "endpoint": "https://api.amplitude.com/2/httpapi"
+        "endpoint": "https://api2.amplitude.com/2/httpapi"
       },
       "metadata": [
         {
@@ -963,7 +963,7 @@
         "userId": "my-anonymous-id-new",
         "headers": {},
         "version": "1",
-        "endpoint": "https://api.amplitude.com/groupidentify"
+        "endpoint": "https://api2.amplitude.com/groupidentify"
       },
       "metadata": [
         {
@@ -996,7 +996,7 @@
         "userId": "my-anonymous-id-new",
         "headers": {},
         "version": "1",
-        "endpoint": "https://api.amplitude.com/usermap"
+        "endpoint": "https://api2.amplitude.com/usermap"
       },
       "metadata": [
         {
@@ -1104,7 +1104,7 @@
           "Content-Type": "application/json"
         },
         "version": "1",
-        "endpoint": "https://api.amplitude.com/batch"
+        "endpoint": "https://api2.amplitude.com/batch"
       },
       "metadata": [
         {

--- a/__tests__/data/am_output.json
+++ b/__tests__/data/am_output.json
@@ -3,7 +3,7 @@
     "version": "1",
     "type": "REST",
     "method": "POST",
-    "endpoint": "https://api.amplitude.com/2/httpapi",
+    "endpoint": "https://api2.amplitude.com/2/httpapi",
     "headers": {
       "Content-Type": "application/json"
     },
@@ -59,7 +59,7 @@
     "version": "1",
     "type": "REST",
     "method": "POST",
-    "endpoint": "https://api.amplitude.com/2/httpapi",
+    "endpoint": "https://api2.amplitude.com/2/httpapi",
     "headers": {
       "Content-Type": "application/json"
     },
@@ -114,7 +114,7 @@
     "version": "1",
     "type": "REST",
     "method": "POST",
-    "endpoint": "https://api.amplitude.com/2/httpapi",
+    "endpoint": "https://api2.amplitude.com/2/httpapi",
     "headers": {
       "Content-Type": "application/json"
     },
@@ -173,7 +173,7 @@
     "version": "1",
     "type": "REST",
     "method": "POST",
-    "endpoint": "https://api.amplitude.com/2/httpapi",
+    "endpoint": "https://api2.amplitude.com/2/httpapi",
     "headers": {
       "Content-Type": "application/json"
     },
@@ -235,7 +235,7 @@
     "version": "1",
     "type": "REST",
     "method": "POST",
-    "endpoint": "https://api.amplitude.com/2/httpapi",
+    "endpoint": "https://api2.amplitude.com/2/httpapi",
     "headers": {
       "Content-Type": "application/json"
     },
@@ -288,7 +288,7 @@
     "version": "1",
     "type": "REST",
     "method": "POST",
-    "endpoint": "https://api.amplitude.com/2/httpapi",
+    "endpoint": "https://api2.amplitude.com/2/httpapi",
     "headers": {
       "Content-Type": "application/json"
     },
@@ -343,7 +343,7 @@
     "version": "1",
     "type": "REST",
     "method": "POST",
-    "endpoint": "https://api.amplitude.com/2/httpapi",
+    "endpoint": "https://api2.amplitude.com/2/httpapi",
     "headers": {
       "Content-Type": "application/json"
     },
@@ -383,7 +383,7 @@
     "version": "1",
     "type": "REST",
     "method": "POST",
-    "endpoint": "https://api.amplitude.com/2/httpapi",
+    "endpoint": "https://api2.amplitude.com/2/httpapi",
     "headers": {
       "Content-Type": "application/json"
     },
@@ -423,7 +423,7 @@
     "version": "1",
     "type": "REST",
     "method": "POST",
-    "endpoint": "https://api.amplitude.com/2/httpapi",
+    "endpoint": "https://api2.amplitude.com/2/httpapi",
     "headers": {
       "Content-Type": "application/json"
     },
@@ -463,7 +463,7 @@
     "version": "1",
     "type": "REST",
     "method": "POST",
-    "endpoint": "https://api.amplitude.com/2/httpapi",
+    "endpoint": "https://api2.amplitude.com/2/httpapi",
     "headers": {
       "Content-Type": "application/json"
     },
@@ -504,7 +504,7 @@
       "version": "1",
       "type": "REST",
       "method": "POST",
-      "endpoint": "https://api.amplitude.com/2/httpapi",
+      "endpoint": "https://api2.amplitude.com/2/httpapi",
       "headers": {
         "Content-Type": "application/json"
       },
@@ -558,7 +558,7 @@
       "version": "1",
       "type": "REST",
       "method": "POST",
-      "endpoint": "https://api.amplitude.com/groupidentify",
+      "endpoint": "https://api2.amplitude.com/groupidentify",
       "headers": {},
       "params": {},
       "body": {
@@ -583,7 +583,7 @@
     "version": "1",
     "type": "REST",
     "method": "POST",
-    "endpoint": "https://api.amplitude.com/usermap",
+    "endpoint": "https://api2.amplitude.com/usermap",
     "headers": {},
     "params": {},
     "body": {
@@ -604,7 +604,7 @@
     "version": "1",
     "type": "REST",
     "method": "POST",
-    "endpoint": "https://api.amplitude.com/usermap",
+    "endpoint": "https://api2.amplitude.com/usermap",
     "headers": {},
     "params": {},
     "body": {
@@ -625,7 +625,7 @@
     "version": "1",
     "type": "REST",
     "method": "POST",
-    "endpoint": "https://api.amplitude.com/2/httpapi",
+    "endpoint": "https://api2.amplitude.com/2/httpapi",
     "headers": {
       "Content-Type": "application/json"
     },
@@ -674,7 +674,7 @@
     "version": "1",
     "type": "REST",
     "method": "POST",
-    "endpoint": "https://api.amplitude.com/2/httpapi",
+    "endpoint": "https://api2.amplitude.com/2/httpapi",
     "headers": {
       "Content-Type": "application/json"
     },
@@ -725,7 +725,7 @@
     "version": "1",
     "type": "REST",
     "method": "POST",
-    "endpoint": "https://api.amplitude.com/2/httpapi",
+    "endpoint": "https://api2.amplitude.com/2/httpapi",
     "headers": {
       "Content-Type": "application/json"
     },
@@ -777,7 +777,7 @@
     "version": "1",
     "type": "REST",
     "method": "POST",
-    "endpoint": "https://api.amplitude.com/2/httpapi",
+    "endpoint": "https://api2.amplitude.com/2/httpapi",
     "headers": {
       "Content-Type": "application/json"
     },
@@ -829,7 +829,7 @@
     "version": "1",
     "type": "REST",
     "method": "POST",
-    "endpoint": "https://api.amplitude.com/2/httpapi",
+    "endpoint": "https://api2.amplitude.com/2/httpapi",
     "headers": {
       "Content-Type": "application/json"
     },
@@ -882,7 +882,7 @@
     "version": "1",
     "type": "REST",
     "method": "POST",
-    "endpoint": "https://api.amplitude.com/2/httpapi",
+    "endpoint": "https://api2.amplitude.com/2/httpapi",
     "headers": {
       "Content-Type": "application/json"
     },
@@ -922,7 +922,7 @@
       "version": "1",
       "type": "REST",
       "method": "POST",
-      "endpoint": "https://api.amplitude.com/2/httpapi",
+      "endpoint": "https://api2.amplitude.com/2/httpapi",
       "headers": {
         "Content-Type": "application/json"
       },
@@ -974,7 +974,7 @@
       "version": "1",
       "type": "REST",
       "method": "POST",
-      "endpoint": "https://api.amplitude.com/2/httpapi",
+      "endpoint": "https://api2.amplitude.com/2/httpapi",
       "headers": {
         "Content-Type": "application/json"
       },
@@ -1020,7 +1020,7 @@
       "version": "1",
       "type": "REST",
       "method": "POST",
-      "endpoint": "https://api.amplitude.com/2/httpapi",
+      "endpoint": "https://api2.amplitude.com/2/httpapi",
       "headers": {
         "Content-Type": "application/json"
       },
@@ -1065,7 +1065,7 @@
     "version": "1",
     "type": "REST",
     "method": "POST",
-    "endpoint": "https://api.amplitude.com/2/httpapi",
+    "endpoint": "https://api2.amplitude.com/2/httpapi",
     "headers": {
       "Content-Type": "application/json"
     },
@@ -1138,7 +1138,7 @@
       "version": "1",
       "type": "REST",
       "method": "POST",
-      "endpoint": "https://api.amplitude.com/2/httpapi",
+      "endpoint": "https://api2.amplitude.com/2/httpapi",
       "headers": {
         "Content-Type": "application/json"
       },
@@ -1189,7 +1189,7 @@
       "version": "1",
       "type": "REST",
       "method": "POST",
-      "endpoint": "https://api.amplitude.com/2/httpapi",
+      "endpoint": "https://api2.amplitude.com/2/httpapi",
       "headers": {
         "Content-Type": "application/json"
       },
@@ -1236,7 +1236,7 @@
       "version": "1",
       "type": "REST",
       "method": "POST",
-      "endpoint": "https://api.amplitude.com/2/httpapi",
+      "endpoint": "https://api2.amplitude.com/2/httpapi",
       "headers": {
         "Content-Type": "application/json"
       },
@@ -1283,7 +1283,7 @@
       "version": "1",
       "type": "REST",
       "method": "POST",
-      "endpoint": "https://api.amplitude.com/2/httpapi",
+      "endpoint": "https://api2.amplitude.com/2/httpapi",
       "headers": {
         "Content-Type": "application/json"
       },
@@ -1354,7 +1354,7 @@
       "version": "1",
       "type": "REST",
       "method": "POST",
-      "endpoint": "https://api.amplitude.com/2/httpapi",
+      "endpoint": "https://api2.amplitude.com/2/httpapi",
       "headers": {
         "Content-Type": "application/json"
       },
@@ -1401,7 +1401,7 @@
       "version": "1",
       "type": "REST",
       "method": "POST",
-      "endpoint": "https://api.amplitude.com/2/httpapi",
+      "endpoint": "https://api2.amplitude.com/2/httpapi",
       "headers": {
         "Content-Type": "application/json"
       },
@@ -1447,7 +1447,7 @@
     "version": "1",
     "type": "REST",
     "method": "POST",
-    "endpoint": "https://api.amplitude.com/2/httpapi",
+    "endpoint": "https://api2.amplitude.com/2/httpapi",
     "headers": {
       "Content-Type": "application/json"
     },
@@ -1499,7 +1499,7 @@
     "version": "1",
     "type": "REST",
     "method": "POST",
-    "endpoint": "https://api.amplitude.com/2/httpapi",
+    "endpoint": "https://api2.amplitude.com/2/httpapi",
     "headers": {
       "Content-Type": "application/json"
     },
@@ -1551,7 +1551,7 @@
     "version": "1",
     "type": "REST",
     "method": "POST",
-    "endpoint": "https://api.amplitude.com/2/httpapi",
+    "endpoint": "https://api2.amplitude.com/2/httpapi",
     "headers": {
       "Content-Type": "application/json"
     },
@@ -1603,7 +1603,7 @@
     "version": "1",
     "type": "REST",
     "method": "POST",
-    "endpoint": "https://api.amplitude.com/2/httpapi",
+    "endpoint": "https://api2.amplitude.com/2/httpapi",
     "headers": {
       "Content-Type": "application/json"
     },
@@ -1655,7 +1655,7 @@
     "version": "1",
     "type": "REST",
     "method": "POST",
-    "endpoint": "https://api.amplitude.com/2/httpapi",
+    "endpoint": "https://api2.amplitude.com/2/httpapi",
     "headers": {
       "Content-Type": "application/json"
     },
@@ -1708,7 +1708,7 @@
     "version": "1",
     "type": "REST",
     "method": "POST",
-    "endpoint": "https://api.amplitude.com/2/httpapi",
+    "endpoint": "https://api2.amplitude.com/2/httpapi",
     "headers": {
       "Content-Type": "application/json"
     },
@@ -1759,7 +1759,7 @@
     "version": "1",
     "type": "REST",
     "method": "POST",
-    "endpoint": "https://api.amplitude.com/2/httpapi",
+    "endpoint": "https://api2.amplitude.com/2/httpapi",
     "headers": {
       "Content-Type": "application/json"
     },
@@ -1810,7 +1810,7 @@
     "version": "1",
     "type": "REST",
     "method": "POST",
-    "endpoint": "https://api.amplitude.com/2/httpapi",
+    "endpoint": "https://api2.amplitude.com/2/httpapi",
     "headers": {
       "Content-Type": "application/json"
     },
@@ -1861,7 +1861,7 @@
     "version": "1",
     "type": "REST",
     "method": "POST",
-    "endpoint": "https://api.amplitude.com/2/httpapi",
+    "endpoint": "https://api2.amplitude.com/2/httpapi",
     "headers": {
       "Content-Type": "application/json"
     },
@@ -1919,7 +1919,7 @@
       "version": "1",
       "type": "REST",
       "method": "POST",
-      "endpoint": "https://api.amplitude.com/2/httpapi",
+      "endpoint": "https://api2.amplitude.com/2/httpapi",
       "headers": {
         "Content-Type": "application/json"
       },
@@ -1990,7 +1990,7 @@
       "version": "1",
       "type": "REST",
       "method": "POST",
-      "endpoint": "https://api.amplitude.com/2/httpapi",
+      "endpoint": "https://api2.amplitude.com/2/httpapi",
       "headers": {
         "Content-Type": "application/json"
       },
@@ -2057,7 +2057,7 @@
       "version": "1",
       "type": "REST",
       "method": "POST",
-      "endpoint": "https://api.amplitude.com/2/httpapi",
+      "endpoint": "https://api2.amplitude.com/2/httpapi",
       "headers": {
         "Content-Type": "application/json"
       },
@@ -2123,7 +2123,7 @@
     "version": "1",
     "type": "REST",
     "method": "POST",
-    "endpoint": "https://api.amplitude.com/2/httpapi",
+    "endpoint": "https://api2.amplitude.com/2/httpapi",
     "headers": {
       "Content-Type": "application/json"
     },
@@ -2214,7 +2214,7 @@
     "version": "1",
     "type": "REST",
     "method": "POST",
-    "endpoint": "https://api.amplitude.com/2/httpapi",
+    "endpoint": "https://api2.amplitude.com/2/httpapi",
     "headers": {
       "Content-Type": "application/json"
     },
@@ -2271,7 +2271,7 @@
     "version": "1",
     "type": "REST",
     "method": "POST",
-    "endpoint": "https://api.amplitude.com/2/httpapi",
+    "endpoint": "https://api2.amplitude.com/2/httpapi",
     "headers": {
       "Content-Type": "application/json"
     },
@@ -2317,7 +2317,7 @@
       "version": "1",
       "type": "REST",
       "method": "POST",
-      "endpoint": "https://api.amplitude.com/2/httpapi",
+      "endpoint": "https://api2.amplitude.com/2/httpapi",
       "headers": {
         "Content-Type": "application/json"
       },
@@ -2407,7 +2407,7 @@
       "version": "1",
       "type": "REST",
       "method": "POST",
-      "endpoint": "https://api.amplitude.com/2/httpapi",
+      "endpoint": "https://api2.amplitude.com/2/httpapi",
       "headers": {
         "Content-Type": "application/json"
       },
@@ -2473,7 +2473,7 @@
       "version": "1",
       "type": "REST",
       "method": "POST",
-      "endpoint": "https://api.amplitude.com/2/httpapi",
+      "endpoint": "https://api2.amplitude.com/2/httpapi",
       "headers": {
         "Content-Type": "application/json"
       },
@@ -2538,7 +2538,7 @@
     "version": "1",
     "type": "REST",
     "method": "POST",
-    "endpoint": "https://api.amplitude.com/2/httpapi",
+    "endpoint": "https://api2.amplitude.com/2/httpapi",
     "headers": {
       "Content-Type": "application/json"
     },
@@ -2600,7 +2600,7 @@
     "version": "1",
     "type": "REST",
     "method": "POST",
-    "endpoint": "https://api.amplitude.com/2/httpapi",
+    "endpoint": "https://api2.amplitude.com/2/httpapi",
     "headers": {
       "Content-Type": "application/json"
     },
@@ -2658,7 +2658,7 @@
     "version": "1",
     "type": "REST",
     "method": "POST",
-    "endpoint": "https://api.amplitude.com/2/httpapi",
+    "endpoint": "https://api2.amplitude.com/2/httpapi",
     "headers": {
       "Content-Type": "application/json"
     },
@@ -2708,7 +2708,7 @@
     "version": "1",
     "type": "REST",
     "method": "POST",
-    "endpoint": "https://api.amplitude.com/2/httpapi",
+    "endpoint": "https://api2.amplitude.com/2/httpapi",
     "headers": {
       "Content-Type": "application/json"
     },
@@ -2758,7 +2758,7 @@
     "version": "1",
     "type": "REST",
     "method": "POST",
-    "endpoint": "https://api.amplitude.com/2/httpapi",
+    "endpoint": "https://api2.amplitude.com/2/httpapi",
     "headers": {
       "Content-Type": "application/json"
     },
@@ -2808,7 +2808,7 @@
     "version": "1",
     "type": "REST",
     "method": "POST",
-    "endpoint": "https://api.amplitude.com/2/httpapi",
+    "endpoint": "https://api2.amplitude.com/2/httpapi",
     "headers": {
       "Content-Type": "application/json"
     },
@@ -2865,7 +2865,7 @@
     "version": "1",
     "type": "REST",
     "method": "POST",
-    "endpoint": "https://api.amplitude.com/2/httpapi",
+    "endpoint": "https://api2.amplitude.com/2/httpapi",
     "headers": {
       "Content-Type": "application/json"
     },
@@ -2916,7 +2916,7 @@
     "version": "1",
     "type": "REST",
     "method": "POST",
-    "endpoint": "https://api.amplitude.com/2/httpapi",
+    "endpoint": "https://api2.amplitude.com/2/httpapi",
     "headers": {
       "Content-Type": "application/json"
     },
@@ -3111,7 +3111,7 @@
     "version": "1",
     "type": "REST",
     "method": "POST",
-    "endpoint": "https://api.amplitude.com/2/httpapi",
+    "endpoint": "https://api2.amplitude.com/2/httpapi",
     "headers": {
       "Content-Type": "application/json"
     },
@@ -3169,7 +3169,7 @@
     "version": "1",
     "type": "REST",
     "method": "POST",
-    "endpoint": "https://api.amplitude.com/2/httpapi",
+    "endpoint": "https://api2.amplitude.com/2/httpapi",
     "headers": {
       "Content-Type": "application/json"
     },
@@ -3227,7 +3227,7 @@
     "version": "1",
     "type": "REST",
     "method": "POST",
-    "endpoint": "https://api.amplitude.com/2/httpapi",
+    "endpoint": "https://api2.amplitude.com/2/httpapi",
     "headers": {
       "Content-Type": "application/json"
     },
@@ -3284,7 +3284,7 @@
     "version": "1",
     "type": "REST",
     "method": "POST",
-    "endpoint": "https://api.amplitude.com/2/httpapi",
+    "endpoint": "https://api2.amplitude.com/2/httpapi",
     "headers": {
       "Content-Type": "application/json"
     },
@@ -3341,7 +3341,7 @@
     "version": "1",
     "type": "REST",
     "method": "POST",
-    "endpoint": "https://api.amplitude.com/2/httpapi",
+    "endpoint": "https://api2.amplitude.com/2/httpapi",
     "headers": {
       "Content-Type": "application/json"
     },
@@ -3399,7 +3399,7 @@
       "version": "1",
       "type": "REST",
       "method": "POST",
-      "endpoint": "https://api.amplitude.com/2/httpapi",
+      "endpoint": "https://api2.amplitude.com/2/httpapi",
       "headers": {
         "Content-Type": "application/json"
       },
@@ -3454,7 +3454,7 @@
       "version": "1",
       "type": "REST",
       "method": "POST",
-      "endpoint": "https://api.amplitude.com/groupidentify",
+      "endpoint": "https://api2.amplitude.com/groupidentify",
       "headers": {},
       "params": {},
       "body": {
@@ -3476,7 +3476,7 @@
     "version": "1",
     "type": "REST",
     "method": "POST",
-    "endpoint": "https://api.amplitude.com/2/httpapi",
+    "endpoint": "https://api2.amplitude.com/2/httpapi",
     "headers": {
       "Content-Type": "application/json"
     },
@@ -3517,7 +3517,7 @@
     "version": "1",
     "type": "REST",
     "method": "POST",
-    "endpoint": "https://api.amplitude.com/2/httpapi",
+    "endpoint": "https://api2.amplitude.com/2/httpapi",
     "headers": {
       "Content-Type": "application/json"
     },
@@ -3577,7 +3577,7 @@
     "version": "1",
     "type": "REST",
     "method": "POST",
-    "endpoint": "https://api.amplitude.com/usermap",
+    "endpoint": "https://api2.amplitude.com/usermap",
     "headers": {},
     "params": {},
     "body": {
@@ -3598,7 +3598,7 @@
     "version": "1",
     "type": "REST",
     "method": "POST",
-    "endpoint": "https://api.amplitude.com/2/httpapi",
+    "endpoint": "https://api2.amplitude.com/2/httpapi",
     "headers": {
       "Content-Type": "application/json"
     },
@@ -3650,7 +3650,7 @@
     "version": "1",
     "type": "REST",
     "method": "POST",
-    "endpoint": "https://api.amplitude.com/2/httpapi",
+    "endpoint": "https://api2.amplitude.com/2/httpapi",
     "headers": {
       "Content-Type": "application/json"
     },
@@ -3706,7 +3706,7 @@
     "version": "1",
     "type": "REST",
     "method": "POST",
-    "endpoint": "https://api.amplitude.com/2/httpapi",
+    "endpoint": "https://api2.amplitude.com/2/httpapi",
     "headers": {
       "Content-Type": "application/json"
     },

--- a/__tests__/data/am_router_output.json
+++ b/__tests__/data/am_router_output.json
@@ -5,7 +5,7 @@
         "version": "1",
         "type": "REST",
         "method": "POST",
-        "endpoint": "https://api.amplitude.com/2/httpapi",
+        "endpoint": "https://api2.amplitude.com/2/httpapi",
         "headers": {
           "Content-Type": "application/json"
         },
@@ -78,7 +78,7 @@
         "version": "1",
         "type": "REST",
         "method": "POST",
-        "endpoint": "https://api.amplitude.com/2/httpapi",
+        "endpoint": "https://api2.amplitude.com/2/httpapi",
         "headers": {
           "Content-Type": "application/json"
         },

--- a/v0/destinations/am/config.js
+++ b/v0/destinations/am/config.js
@@ -107,7 +107,7 @@ const Event = {
   }
 };
 
-const BASE_URL = "https://api.amplitude.com";
+const BASE_URL = "https://api2.amplitude.com";
 const BASE_URL_EU = "https://api.eu.amplitude.com";
 
 const mappingConfig = getMappingConfig(ConfigCategory, __dirname);


### PR DESCRIPTION
## Description of the change

- changed the BASE_URL value in config.js file for amplitude from **https://api.amplitude.com** to **https://api2.amplitude.com**

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ✅] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
