### PR TITLE
fix [integration] : Pinterest user defined event temporary revert

### DIFF
--- a/__tests__/data/pinterest_tag_output.json
+++ b/__tests__/data/pinterest_tag_output.json
@@ -330,7 +330,7 @@
       "params": {},
       "body": {
         "JSON": {
-          "event_name": "custom event",
+          "event_name": "custom",
           "event_time": 1597383030,
           "event_id": "7208bbb6-2c4e-45bb-bf5b-ad426f3593e9",
           "app_id": "429047995",

--- a/cdk/v2/destinations/pinterest_tag/procWorkflow.yaml
+++ b/cdk/v2/destinations/pinterest_tag/procWorkflow.yaml
@@ -174,7 +174,7 @@ steps:
             $eventMap := destination.Config.eventsMapping.{from: to};
             $eventNames := $lookup($eventMap, $event);
             $count($eventNames) = 0 ? $eventNames := $ecomEventMaps[$lowercase($event) in src].dest;
-            $count($eventNames) = 0 ? $eventNames := [$event];
+            $count($eventNames) = 0 ? $eventNames := ["custom"];
             $eventNames
           )
   - name: destEvents

--- a/v0/destinations/pinterest_tag/utils.js
+++ b/v0/destinations/pinterest_tag/utils.js
@@ -193,7 +193,7 @@ const deduceTrackScreenEventName = (message, Config) => {
   Step 3: In case both of the above stated cases fail, will send the event name as it is.
           This is going to be reflected as "unknown" event in conversion API dashboard.
  */
-  return [trackEventOrScreenName];
+  return ["custom"];
 };
 
 /**


### PR DESCRIPTION
## Description of the change

> we need to release it along with device mode. Reverting temporarily for a hotfix release in transformer

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
