### PR TITLE
fix(destination): do not update event properties to lowercase in hubspot

### DIFF
--- a/__tests__/data/hs_input.json
+++ b/__tests__/data/hs_input.json
@@ -1338,7 +1338,7 @@
       "properties": {
         "user_actual_role": "system_admin, system_user",
         "user_actual_id": 12345,
-        "revenue": 100
+        "Revenue": 100
       },
       "sentAt": "2019-10-14T11:15:53.296Z"
     },
@@ -1871,7 +1871,7 @@
       },
       "event": "Purchase",
       "properties": {
-        "revenue": "name1"
+        "Revenue": "name1"
       }
     },
     "destination": {

--- a/__tests__/data/hs_router_input.json
+++ b/__tests__/data/hs_router_input.json
@@ -254,7 +254,7 @@
       },
       "event": "Purchase",
       "properties": {
-        "revenue": "name1"
+        "Revenue": "name1"
       }
     },
     "metadata": {

--- a/v0/destinations/hs/util.js
+++ b/v0/destinations/hs/util.js
@@ -375,7 +375,7 @@ const getEventAndPropertiesFromConfig = (message, destination, payload) => {
   }
 
   // 2. fetch event properties from webapp config
-  eventProperties = getHashFromArray(eventProperties);
+  eventProperties = getHashFromArray(eventProperties, ...Array(2), false);
 
   Object.keys(eventProperties).forEach(key => {
     const value = get(message, `properties.${key}`);


### PR DESCRIPTION
## Description of the change

Inside the `getHashFromArray` function we are setting properties to lowercase, which is causing mismatch with dashboard properties. So updated the code not to change whatever we are getting in properties.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
