### PR TITLE
chore: stop using cpu count for workers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.3
+# syntax=docker/dockerfile:1.4
 FROM node:14.20-alpine3.15
 
 RUN apk update

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1.3
 FROM node:14.20-alpine3.15
 
 RUN apk update
@@ -29,6 +30,10 @@ RUN npm install
 COPY --chown=node:node . .
 
 ENTRYPOINT ["/sbin/tini", "--"]
+
+HEALTHCHECK --interval=1s --timeout=30s --retries=30 \
+    CMD  wget --no-verbose --tries=5 --spider http://localhost:9090/health || exit 1
+
 CMD [ "npm", "start" ]
 
 

--- a/Dockerfile-no-func
+++ b/Dockerfile-no-func
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1.4
 FROM node:14.20-alpine3.15
 
 RUN apk update
@@ -20,6 +21,9 @@ COPY build.js ./
 RUN npm install --unsafe-perm=true
 
 COPY . .
+
+HEALTHCHECK --interval=1s --timeout=30s --retries=30 \
+    CMD  wget --no-verbose --tries=5 --spider http://localhost:9090/health || exit 1
 
 ENTRYPOINT ["/sbin/tini", "--"]
 CMD [ "npm", "start" ]

--- a/Dockerfile-ut-func
+++ b/Dockerfile-ut-func
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1.4
 FROM ubuntu:20.04
 
 RUN apt-get update \
@@ -24,6 +25,9 @@ COPY package*.json ./
 RUN npm install
 
 COPY --chown=node:node . .
+
+HEALTHCHECK --interval=1s --timeout=30s --retries=30 \
+    CMD  wget --no-verbose --tries=5 --spider http://localhost:9090/health || exit 1
 
 CMD [ "npm", "start" ]
 

--- a/util/cluster.js
+++ b/util/cluster.js
@@ -1,11 +1,10 @@
 /* eslint-disable gaurd-for-in */
 const cluster = require("cluster");
 const gracefulShutdown = require("http-graceful-shutdown");
-const numCPUs = require("os").cpus().length;
 const util = require("util");
 const logger = require("../logger");
 
-const numWorkers = process.env.NUM_PROCS || numCPUs;
+const numWorkers = process.env.NUM_PROCS || 1;
 
 function processInfo() {
   return {


### PR DESCRIPTION
## Description of the change

Using the number of CPUs can be problematic in several environments:
* locally, when running within docker M1 mac (10 cores), the number of workers creates a lot of CPU pressure causing integration tests to fail.
* on k8s environments, due to the number of CPUs detected (using the number of nodes, not pod requests/limits), the configuration is unpopular.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

https://github.com/rudderlabs/rudder-server/pull/2702

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
