### PR TITLE
fix(destination): PostHog: set timestamp in right place of the payload

### DIFF
--- a/v0/destinations/posthog/transform.js
+++ b/v0/destinations/posthog/transform.js
@@ -83,6 +83,9 @@ const responseBuilderSimple = (message, category, destination) => {
     // fail-safety for developer error
     throw new CustomError(ErrorMessage.FailedToConstructPayload, 400);
   }
+  if(!payload.timestamp && isDefinedAndNotNull(payload.properties['$timestamp'])) {
+    payload.timestamp = payload.properties['$timestamp']
+  }
 
   payload.properties = {
     ...generatePropertyDefination(message),


### PR DESCRIPTION
## Description of the change

The PostHog transformer doesn't set the timestamp in the right place, causing all events to be set to the current timestamp.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

N/A

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
