### PR TITLE
fix(hubspot): legacy track api

### DIFF
--- a/__tests__/data/hs_output.json
+++ b/__tests__/data/hs_output.json
@@ -742,6 +742,7 @@
       "Authorization": "Bearer pat-na1-6f0a6b6d-f623-4e0e-8a51-1a810f31ea37"
     },
     "params": {
+      "_a": "6405167",
       "_n": "test track event HS",
       "email": "testhubspot2@email.com",
       "firstname": "Test Hubspot"

--- a/v0/destinations/hs/HSTransform-v1.js
+++ b/v0/destinations/hs/HSTransform-v1.js
@@ -144,6 +144,14 @@ const processLegacyIdentify = async (message, destination, propertyMap) => {
  */
 const processLegacyTrack = async (message, destination, propertyMap) => {
   const { Config } = destination;
+
+  if (!Config.hubID) {
+    throw new CustomError(
+      "Invalid hub id value provided in the destination configuration",
+      400
+    );
+  }
+
   const parameters = {
     _a: Config.hubID,
     _n: message.event,
@@ -173,8 +181,6 @@ const processLegacyTrack = async (message, destination, propertyMap) => {
 
   // choosing API Type
   if (Config.authorizationType === "newPrivateAppApi") {
-    // eslint-disable-next-line no-underscore-dangle
-    delete params._a;
     response.headers = {
       ...response.headers,
       Authorization: `Bearer ${Config.accessToken}`


### PR DESCRIPTION
## Description of the change

> Hub id is required to track the event successfully in Hubspot. Passing the hub id in legacy track API

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
