### PR TITLE
feat(destination): singular- add support for other apple os

### DIFF
--- a/__tests__/data/singular.json
+++ b/__tests__/data/singular.json
@@ -1330,7 +1330,7 @@
             "content": "some content"
           },
           "os": {
-            "name": "iOS",
+            "name": "ipados",
             "version": "9"
           },
           "screen": {

--- a/v0/destinations/singular/config.js
+++ b/v0/destinations/singular/config.js
@@ -28,7 +28,10 @@ const CONFIG_CATEGORIES = {
 
 const SUPPORTED_PLATFORM = {
   android: "ANDROID",
-  ios: "IOS"
+  ios: "IOS",
+  ipados: "IOS",
+  watchos: "IOS",
+  tvos: "IOS"
 };
 
 const SINGULAR_SESSION_ANDROID_EXCLUSION = [

--- a/v0/destinations/singular/config.js
+++ b/v0/destinations/singular/config.js
@@ -28,10 +28,7 @@ const CONFIG_CATEGORIES = {
 
 const SUPPORTED_PLATFORM = {
   android: "ANDROID",
-  ios: "IOS",
-  ipados: "IOS",
-  watchos: "IOS",
-  tvos: "IOS"
+  ios: "IOS"
 };
 
 const SINGULAR_SESSION_ANDROID_EXCLUSION = [

--- a/v0/destinations/singular/util.js
+++ b/v0/destinations/singular/util.js
@@ -109,7 +109,7 @@ const platformWisePayloadGenerator = (message, isSessionEvent) => {
     throw new CustomError("[Singular] :: Platform name is missing", 400);
   }
   // checking if the os is one of ios, ipados, watchos, tvos
-  if (isAppleFamily(platform)) {
+  if (typeof platform === "string" && isAppleFamily(platform)) {
     message.context.os.name = "iOS";
     platform = "iOS";
   }

--- a/v0/destinations/singular/util.js
+++ b/v0/destinations/singular/util.js
@@ -19,7 +19,8 @@ const {
   extractCustomFields,
   getValueFromMessage,
   isDefinedAndNotNull,
-  toUnixTimestamp
+  toUnixTimestamp,
+  isAppleFamily
 } = require("../../util");
 
 /*
@@ -109,6 +110,10 @@ const platformWisePayloadGenerator = (message, isSessionEvent) => {
     throw new CustomError("[Singular] :: Platform name is missing", 400);
   }
   platform = platform.toLowerCase();
+  // checking if the os is one of ios, ipados, watchos, tvos
+  if (isAppleFamily(platform)) {
+    message.context.os.name = "iOS";
+  }
   if (!SUPPORTED_PLATFORM[platform]) {
     throw new CustomError("[Singular] :: Platform is not supported");
   }

--- a/v0/destinations/singular/util.js
+++ b/v0/destinations/singular/util.js
@@ -109,7 +109,7 @@ const platformWisePayloadGenerator = (message, isSessionEvent) => {
     throw new CustomError("[Singular] :: Platform name is missing", 400);
   }
   // checking if the os is one of ios, ipados, watchos, tvos
-  if (typeof platform === "string" && isAppleFamily(platform)) {
+  if (typeof platform === "string" && isAppleFamily(platform.toLowerCase())) {
     message.context.os.name = "iOS";
     platform = "iOS";
   }

--- a/v0/destinations/singular/util.js
+++ b/v0/destinations/singular/util.js
@@ -19,7 +19,6 @@ const {
   extractCustomFields,
   getValueFromMessage,
   isDefinedAndNotNull,
-  toUnixTimestamp,
   isAppleFamily
 } = require("../../util");
 
@@ -109,11 +108,12 @@ const platformWisePayloadGenerator = (message, isSessionEvent) => {
   if (!platform) {
     throw new CustomError("[Singular] :: Platform name is missing", 400);
   }
-  platform = platform.toLowerCase();
   // checking if the os is one of ios, ipados, watchos, tvos
   if (isAppleFamily(platform)) {
     message.context.os.name = "iOS";
+    platform = "iOS";
   }
+  platform = platform.toLowerCase();
   if (!SUPPORTED_PLATFORM[platform]) {
     throw new CustomError("[Singular] :: Platform is not supported");
   }


### PR DESCRIPTION
## Description of the change

> Allow sending ios, ipados, watchos or tvos in contextual properties 

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
