### PR TITLE
refactor: add router support to benchmarking script

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,39 +1,58 @@
 {
-    // Use IntelliSense to learn about possible attributes.
-    // Hover to view descriptions of existing attributes.
-    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
-    "version": "0.2.0",
-    "configurations": [
-        {
-            "name": "transformer",
-            "type": "node",
-            "request": "launch",
-            "args": [
-                "${workspaceRoot}/destTransformer.js",
-            ],
-            "runtimeArgs": [
-                "--nolazy"
-            ],
-            "sourceMaps": true,
-            "runtimeExecutable":"/usr/local/bin/node"
-        },
-        {
-            "runtimeExecutable":"/usr/local/bin/node",
-            "type": "node",
-            "request": "launch",
-            "name": "Jest Current File",
-            "program": "${workspaceFolder}/node_modules/.bin/jest",
-            "args": [
-                "${fileBasenameNoExtension}",
-                "--config",
-                "jest.config.js"
-            ],
-            "console": "integratedTerminal",
-            "internalConsoleOptions": "neverOpen",
-            "disableOptimisticBPs": true,
-            "windows": {
-                "program": "${workspaceFolder}/node_modules/jest/bin/jest",
-            }
-        }
-    ]
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "transformer",
+      "type": "node",
+      "request": "launch",
+      "program": "${workspaceRoot}/destTransformer.js",
+      "runtimeArgs": ["--nolazy"],
+      "sourceMaps": true,
+      "runtimeExecutable": "/usr/local/bin/node"
+    },
+    {
+      "name": "benchmark",
+      "type": "node",
+      "request": "launch",
+      "program": "${workspaceRoot}/benchmark",
+      "args": [
+        "--destinations=${input:destinations}",
+        "--feature=${input:feature}"
+      ],
+      "runtimeArgs": ["--nolazy"],
+      "sourceMaps": true,
+      "runtimeExecutable": "/usr/local/bin/node"
+    },
+    {
+      "runtimeExecutable": "/usr/local/bin/node",
+      "type": "node",
+      "request": "launch",
+      "name": "Jest Current File",
+      "program": "${workspaceFolder}/node_modules/.bin/jest",
+      "args": ["${fileBasenameNoExtension}", "--config", "jest.config.js"],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "disableOptimisticBPs": true,
+      "windows": {
+        "program": "${workspaceFolder}/node_modules/jest/bin/jest"
+      }
+    }
+  ],
+  "inputs": [
+    {
+      "id": "destinations",
+      "type": "promptString",
+      "description": "Enter destinations",
+      "default": "algolia"
+    },
+    {
+      "id": "feature",
+      "type": "promptString",
+      "description": "Enter Feature",
+      "default": "proc"
+    }
+  ]
 }

--- a/benchmark/index.js
+++ b/benchmark/index.js
@@ -32,7 +32,13 @@ command
     "Enter the benchmark type (Operations or Memory)",
     "Operations"
   )
+  .option("-f, --feature <string>", "Enter feature name (proc or rt)", "proc")
   .parse();
+
+const getTestFileName = (intg, testSufix) => {
+  const featureSufix = cmdOpts.feature === "rt" ? "_router" : "";
+  return `${intg}${featureSufix}${testSufix}.json`;
+};
 
 const testDataDir = path.join(__dirname, "./../__tests__/data");
 const getTestData = (intgList, fileNameSuffixes) => {
@@ -43,7 +49,7 @@ const getTestData = (intgList, fileNameSuffixes) => {
       try {
         intgTestData[intg] = JSON.parse(
           fs.readFileSync(
-            path.join(testDataDir, `${intg}${fileNameSuffix}.json`),
+            path.join(testDataDir, getTestFileName(intg, fileNameSuffix)),
             {
               encoding: "utf-8"
             }
@@ -67,7 +73,7 @@ const destinationsList = cmdOpts.destinations
   .split(",")
   .map(x => x.trim())
   .filter(x => x !== "");
-logger.info("Destinations selected: ", destinationsList);
+logger.info("Destinations:", destinationsList, "feature:", cmdOpts.feature);
 logger.info();
 const destDataset = getTestData(destinationsList, ["_input", ""]);
 
@@ -103,11 +109,11 @@ async function runDataset(suitDesc, input, intg, params) {
   const suite = new Benchmark(suitDesc, benchmarkType);
 
   Object.keys(params).forEach(opName => {
+    const handler = params[opName].handlerResolver(intg);
+    const args = params[opName].argsResolver(intg, input);
     suite.add(opName, async function() {
       try {
-        await params[opName].caller(
-          ...params[opName].argsResolver(intg, input)
-        );
+        await handler(...args);
       } catch (err) {
         // logger.info(err);
         // Do nothing
@@ -132,9 +138,7 @@ async function runDataset(suitDesc, input, intg, params) {
           if (benchmarkType === "Operations") {
             logger.info(
               `-> "${result.end.name}" is faster by ${(
-                result.end.stats.n /
-                result.end.stats.mean /
-                (results[impl].stats.n / results[impl].stats.mean)
+                results[impl].stats.mean / result.end.stats.mean
               ).toFixed(1)} times to "${impl}"`
             );
           } else {
@@ -157,8 +161,8 @@ async function runIntgDataset(dataset, type, params) {
   for (const intg in dataset) {
     for (const tc in dataset[intg]) {
       const curTcData = dataset[intg][tc];
-      let tcInput;
-      let tcDesc;
+      let tcInput = curTcData;
+      let tcDesc = `${type} - ${intg} - ${cmdOpts.feature} - ${tc}`;
       // New test data file structure
       if (
         "description" in curTcData &&
@@ -166,10 +170,7 @@ async function runIntgDataset(dataset, type, params) {
         "output" in curTcData
       ) {
         tcInput = curTcData.input;
-        tcDesc = `${type} - ${intg} - "${curTcData.description}"`;
-      } else {
-        tcInput = curTcData;
-        tcDesc = `${type} - ${intg} - "${tc}"`;
+        tcDesc += ` - "${curTcData.description}"`;
       }
 
       await runDataset(tcDesc, tcInput, intg, params);
@@ -184,16 +185,11 @@ async function run() {
   // Destinations
   await runIntgDataset(destDataset, "Destination", {
     native: {
-      caller: versionedRouter.handleV0Destination,
-      argsResolver: (intg, input) => [
-        nativeDestHandlers[intg],
-        intg,
-        input,
-        TRANSFORMER_METRIC.ERROR_AT.PROC
-      ]
+      handlerResolver: intg => nativeDestHandlers[intg],
+      argsResolver: (_intg, input) => [input]
     },
     "CDK 2.0": {
-      caller: cdkV2Handler.process,
+      handlerResolver: () => cdkV2Handler.process,
       argsResolver: (intg, input) => [destCdKWorkflowEngines[intg], input]
     }
   });

--- a/benchmark/index.js
+++ b/benchmark/index.js
@@ -13,7 +13,6 @@ const Commander = require("commander");
 const logger = require("./metaLogger");
 const versionedRouter = require("../versionedRouter");
 const cdkV2Handler = require("../cdk/v2/handler");
-const { TRANSFORMER_METRIC } = require("../v0/util/constant");
 
 const supportedDestinations = ["algolia", "pinterest_tag"];
 
@@ -82,20 +81,27 @@ const destCdKWorkflowEngines = {};
 
 const benchmarkType = cmdOpts.benchmarktype.trim();
 
+const getNativeHandleName = () => {
+  let handleName = "process";
+  if (cmdOpts.feature === "rt") {
+    handleName = "processRouterDest";
+  }
+  return handleName;
+};
+
 async function initializeHandlers() {
   for (const idx in destinationsList) {
     const dest = destinationsList[idx];
 
     // Native destination handler
-    nativeDestHandlers[dest] = versionedRouter.getDestHandler(
-      "v0",
-      dest
-    ).process;
+    nativeDestHandlers[dest] = versionedRouter.getDestHandler("v0", dest)[
+      getNativeHandleName()
+    ];
 
     // Get the CDK 2.0 workflow engine instance
     destCdKWorkflowEngines[dest] = await cdkV2Handler.getWorkflowEngine(
       dest,
-      TRANSFORMER_METRIC.ERROR_AT.PROC
+      cmdOpts.feature
     );
   }
 }


### PR DESCRIPTION
## Description of the change
Refactor native handlers to use direct destination handler instead of versionedRouter.handleV0Destination

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
