### PR TITLE
fix: PostHog: send person properties correctly

### DIFF
--- a/v0/destinations/posthog/data/PHPropertiesConfig.json
+++ b/v0/destinations/posthog/data/PHPropertiesConfig.json
@@ -160,5 +160,9 @@
   {
     "destKey": "$performance_page_loaded",
     "sourceKeys": "context.page.loaded"
+  },
+  {
+    "destKey": "$set",
+    "sourceKeys": "context.traits"
   }
 ]


### PR DESCRIPTION
## Description of the change

Rudderstack is not sending `traits` correctly to PostHog.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
