### PR TITLE
fix: email not required for update call

### DIFF
--- a/__tests__/data/persistiq.json
+++ b/__tests__/data/persistiq.json
@@ -1,13 +1,12 @@
 [
   {
-    "description": "[::IDENTIFY::]-> Update call with leadId in externalId",
+    "description": "[::IDENTIFY::]-> Update call with leadId in externalId and no email",
     "input": {
       "message": {
         "userId": "test@16",
         "type": "identify",
         "context": {
           "traits": {
-            "email": "test@rudderstack.com",
             "firstName": "test",
             "lastName": "rudderstack",
             "age": 15,
@@ -49,7 +48,6 @@
         "FORM": {},
         "JSON": {
           "data": {
-            "email": "test@rudderstack.com",
             "age": 15,
             "country": "india",
             "extra": "extraVal",
@@ -336,6 +334,51 @@
       },
       "version": "1",
       "endpoint": "https://api.persistiq.com/v1/campaigns/testgroup1/leads/lel1c5u1wuk8"
+    }
+  },
+  {
+    "description": "[::IDENTIFY::]-> Create new call",
+    "input": {
+      "message": {
+        "userId": "test@16",
+        "type": "identify",
+        "context": {
+          "traits": {
+            "address": {
+              "cityName": "Delhi",
+              "country": "India"
+            },
+            "firstName": "test",
+            "lastName": "rudderstack",
+            "age": 15,
+            "dup": "update",
+            "gender": "male",
+            "phone": "9225467887",
+            "useroccupation": "software engineer",
+            "Snippet": "extra value",
+            "extra": "extraVal",
+            "creator_id": "mVEv91Y3oW5o3PnBOyKw"
+          }
+        },
+        "traits": {
+          "linkedinUrl": "www.google.com",
+          "dup": "update"
+        }
+      },
+      "destination": {
+        "Config": {
+          "apiKey": "2c646069cc5ae3f22cc0dab36cd060ad",
+          "persistIqAttributesMapping": [
+            {
+              "from": "useroccupation",
+              "to": "occupation"
+            }
+          ]
+        }
+      }
+    },
+    "output": {
+      "error": "Email is required for new lead."
     }
   }
 ]

--- a/__tests__/data/persistiq.json
+++ b/__tests__/data/persistiq.json
@@ -28,7 +28,10 @@
         "traits": {
           "linkedinUrl": "www.google.com",
           "dup": "update",
-          "status": "open"
+          "status": "open",
+          "company": {
+            "name": "abc123"
+          }
         }
       },
       "destination": {
@@ -56,7 +59,8 @@
             "Snippet": "extra value",
             "last_name": "rudderstack",
             "linkedin": "www.google.com",
-            "phone": "9225467887"
+            "phone": "9225467887",
+            "company_name": "abc123"
           },
           "status": "open"
         },
@@ -75,7 +79,7 @@
     }
   },
   {
-    "description": "[::IDENTIFY::]-> Create new call",
+    "description": "[::IDENTIFY::]-> Create new call with company name",
     "input": {
       "message": {
         "userId": "test@16",
@@ -96,7 +100,8 @@
             "useroccupation": "software engineer",
             "Snippet": "extra value",
             "extra": "extraVal",
-            "creator_id": "mVEv91Y3oW5o3PnBOyKw"
+            "creator_id": "mVEv91Y3oW5o3PnBOyKw",
+            "company":"abc1234"
           }
         },
         "traits": {
@@ -133,6 +138,7 @@
               "last_name": "rudderstack",
               "linkedin": "www.google.com",
               "phone": "9225467887",
+              "company_name":"abc1234",
               "cityName": "Delhi",
               "country": "India"
             }

--- a/v0/destinations/persistiq/data/persistIqIdentifyConfig.json
+++ b/v0/destinations/persistiq/data/persistIqIdentifyConfig.json
@@ -1,9 +1,10 @@
 [
     {
         "destKey": "email",
-        "sourceKeys": "email",
-        "required": true,
-        "sourceFromGenericMap": true
+        "sourceKeys": [
+            "traits.email",
+            "context.traits.email"
+        ]
     },
     {
         "destKey": "phone",
@@ -97,7 +98,10 @@
     },
     {
         "destKey": "company_name",
-        "sourceKeys": ["conapny.name", "company"],
+        "sourceKeys": [
+            "conapny.name",
+            "company"
+        ],
         "required": false
     }
 ]

--- a/v0/destinations/persistiq/data/persistIqIdentifyConfig.json
+++ b/v0/destinations/persistiq/data/persistIqIdentifyConfig.json
@@ -99,8 +99,10 @@
     {
         "destKey": "company_name",
         "sourceKeys": [
-            "conapny.name",
-            "company"
+            "traits.company.name",
+            "context.traits.company.name",
+            "traits.company",
+            "context.traits.company"
         ],
         "required": false
     }

--- a/v0/destinations/persistiq/transform.js
+++ b/v0/destinations/persistiq/transform.js
@@ -31,6 +31,19 @@ const identifyResponseBuilder = (message, Config, leadId) => {
   const leadInfo = buildLeadPayload(message, traits, Config);
   if (!leadId) {
     // creating new Lead
+    if (!leadInfo?.email) {
+      throw new ErrorBuilder()
+        .setMessage("Email is required for new lead.")
+        .setStatus(400)
+        .setStatTags({
+          destType: DESTINATION,
+          stage: TRANSFORMER_METRIC.TRANSFORMER_STAGE.TRANSFORM,
+          scope: TRANSFORMER_METRIC.MEASUREMENT_TYPE.TRANSFORMATION.SCOPE,
+          meta:
+            TRANSFORMER_METRIC.MEASUREMENT_TYPE.TRANSFORMATION.META.BAD_PARAM
+        })
+        .build();
+    }
     set(payload, "leads", [leadInfo]);
 
     // Adding some traits at root level of payload


### PR DESCRIPTION
## Description of the change

> Email was marked as a required field for creating and updating lead calls, which is not the case. It is only required on creating one.
This PR fixes that along with test cases.
## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
