### PR TITLE
feat: refactor router transform implementation

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -6,7 +6,7 @@ module.exports = {
   // automock: false,
 
   // Stop running tests after `n` failures
-  bail: 1,
+  // bail: 1,
 
   // Respect "browser" field in package.json when resolving modules
   // browser: false,

--- a/jest.config.js
+++ b/jest.config.js
@@ -6,7 +6,7 @@ module.exports = {
   // automock: false,
 
   // Stop running tests after `n` failures
-  // bail: 1,
+  bail: 1,
 
   // Respect "browser" field in package.json when resolving modules
   // browser: false,

--- a/src/cdk/v2/handler.js
+++ b/src/cdk/v2/handler.js
@@ -65,7 +65,7 @@ async function processCdkV2Workflow(
   try {
     const workflowEngine = await getCachedWorkflowEngine(
       destType,
-      flowType,
+      feature,
       bindings
     );
     return process(workflowEngine, parsedEvent);

--- a/src/v0/destinations/am/transform.js
+++ b/src/v0/destinations/am/transform.js
@@ -974,6 +974,7 @@ const processRouterDest = async (inputs, reqMetadata) => {
             ...getEventReqMetadata(input)
           }
         );
+        return resp;
       }
     })
   );

--- a/src/v0/destinations/am/transform.js
+++ b/src/v0/destinations/am/transform.js
@@ -9,7 +9,6 @@ const {
   TraitsMapping,
   MappedToDestinationKey
 } = require("../../../constants");
-const { TRANSFORMER_METRIC } = require("../../util/constant");
 const {
   addExternalIdToTraits,
   adduserIdFromExternalId,
@@ -27,7 +26,8 @@ const {
   removeUndefinedAndNullValues,
   isDefinedAndNotNull,
   isAppleFamily,
-  isDefinedAndNotNullAndNotEmpty
+  isDefinedAndNotNullAndNotEmpty,
+  getEventReqMetadata
 } = require("../../util");
 const {
   BASE_URL,
@@ -921,19 +921,6 @@ function batch(destEvents) {
 }
 
 const processRouterDest = async (inputs, reqMetadata) => {
-  const getEventReqMetadata = event => {
-    try {
-      return {
-        destinationId: event?.destination?.ID,
-        destName: event?.destination?.Name,
-        metadata: event?.metadata
-      };
-    } catch (error) {
-      // Do nothing
-    }
-    return {};
-  };
-
   if (!Array.isArray(inputs) || inputs.length <= 0) {
     const respEvents = getErrorRespEvents(null, 400, "Invalid event array");
     return [respEvents];

--- a/src/v0/destinations/wootric/transform.js
+++ b/src/v0/destinations/wootric/transform.js
@@ -174,8 +174,13 @@ const process = async event => {
   return processEvent(event.message, event.destination);
 };
 
-const processRouterDest = async inputs => {
-  const respList = await simpleProcessRouterDest(inputs, "WOOTRIC", process);
+const processRouterDest = async (inputs, reqMetadata) => {
+  const respList = await simpleProcessRouterDest(
+    inputs,
+    "WOOTRIC",
+    process,
+    reqMetadata
+  );
   return respList;
 };
 

--- a/src/v0/util/errorTypes/base.js
+++ b/src/v0/util/errorTypes/base.js
@@ -1,6 +1,6 @@
 class BaseError extends Error {
   constructor(
-    message = "",
+    message = "Unknown error occurred",
     statusCode = 400,
     sTags = {},
     destResponse = "",

--- a/src/v0/util/index.js
+++ b/src/v0/util/index.js
@@ -1628,6 +1628,19 @@ const checkInvalidRtTfEvents = (inputs, destType) => {
   return [];
 };
 
+const getEventReqMetadata = event => {
+  try {
+    return {
+      destinationId: event?.destination?.ID,
+      destName: event?.destination?.Name,
+      metadata: event?.metadata
+    };
+  } catch (error) {
+    // Do nothing
+  }
+  return {};
+};
+
 /**
  * This function serves as a simple implementation of router transformation destinations
  *
@@ -1646,19 +1659,6 @@ const simpleProcessRouterDest = async (
   singleTfFunc,
   reqMetadata
 ) => {
-  const getEventReqMetadata = event => {
-    try {
-      return {
-        destinationId: event?.destination?.ID,
-        destName: event?.destination?.Name,
-        metadata: event?.metadata
-      };
-    } catch (error) {
-      // Do nothing
-    }
-    return {};
-  };
-
   const errorRespEvents = checkInvalidRtTfEvents(inputs, destType);
   if (errorRespEvents.length > 0) {
     return errorRespEvents;
@@ -1874,5 +1874,6 @@ module.exports = {
   handleRtTfSingleEventError,
   getErrorStatusCode,
   getDestAuthCacheInstance,
-  refinePayload
+  refinePayload,
+  getEventReqMetadata
 };


### PR DESCRIPTION
## Description of the change

Refactored router transform implementation.
It was missing two things:
- Bugsnag notifications (both at event level error handler and the global one)
- Translation of the handled error to the newly added error types

To send errors to Bugsnag with rich metadata, we have changed the signature of `processRouterDest` to accept a new argument, `reqMetadata`.

Some other minor updates:
- `flowType` to `feature` name change in CDK v2 flow
- The default error type is changed to `TransformationError`. It is functionally same as the previous logic.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

N/A

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
