### PR TITLE
chore: add workspaceId as stat-tag

### DIFF
--- a/src/v0/util/tags.js
+++ b/src/v0/util/tags.js
@@ -11,6 +11,7 @@ const TAG_NAMES = {
   NAMESPACE: "namespace",
   CUSTOMER: "customer",
   DESTINATION_ID: "destinationId",
+  WORKSPACE_ID: "workspaceId",
   SOURCE_ID: "sourceId"
 };
 

--- a/src/versionedRouter.js
+++ b/src/versionedRouter.js
@@ -316,7 +316,8 @@ async function handleDest(ctx, version, destination) {
           [tags.TAG_NAMES.MODULE]: tags.MODULES.DESTINATION,
           [tags.TAG_NAMES.IMPLEMENTATION]: implementation,
           [tags.TAG_NAMES.FEATURE]: tags.FEATURES.PROCESSOR,
-          [tags.TAG_NAMES.DESTINATION_ID]: event.metadata?.destinationId
+          [tags.TAG_NAMES.DESTINATION_ID]: event.metadata?.destinationId,
+          [tags.TAG_NAMES.WORKSPACE_ID]: event.metadata?.workspaceId
         });
 
         const resp = {
@@ -526,7 +527,8 @@ async function routerHandleDest(ctx) {
         resp.statTags = {
           ...resp.statTags,
           ...defTags,
-          [tags.TAG_NAMES.DESTINATION_ID]: resp.metadata[0]?.destinationId
+          [tags.TAG_NAMES.DESTINATION_ID]: resp.metadata[0]?.destinationId,
+          [tags.TAG_NAMES.WORKSPACE_ID]: resp.metadata[0]?.workspaceId
         };
       });
   } catch (error) {
@@ -1021,8 +1023,9 @@ async function handleProxyRequest(destination, ctx) {
       [tags.TAG_NAMES.DEST_TYPE]: destination.toUpperCase(),
       [tags.TAG_NAMES.MODULE]: tags.MODULES.DESTINATION,
       [tags.TAG_NAMES.IMPLEMENTATION]: tags.IMPLEMENTATIONS.NATIVE,
-      [tags.TAG_NAMES.FEATURE]: tags.FEATURES.DATA_DELIVERY
-      // [tags.TAG_NAMES.DESTINATION_ID]: TBD
+      [tags.TAG_NAMES.FEATURE]: tags.FEATURES.DATA_DELIVERY,
+      [tags.TAG_NAMES.DESTINATION_ID]: metadata?.destinationId,
+      [tags.TAG_NAMES.WORKSPACE_ID]: metadata?.workspaceId
     });
 
     response = {
@@ -1142,7 +1145,8 @@ const batchHandler = ctx => {
         [tags.TAG_NAMES.MODULE]: tags.MODULES.DESTINATION,
         [tags.TAG_NAMES.IMPLEMENTATION]: tags.IMPLEMENTATIONS.NATIVE,
         [tags.TAG_NAMES.FEATURE]: tags.FEATURES.BATCH,
-        [tags.TAG_NAMES.DESTINATION_ID]: destEvents[0].metadata?.destinationId
+        [tags.TAG_NAMES.DESTINATION_ID]: destEvents[0].metadata?.destinationId,
+        [tags.TAG_NAMES.WORKSPACE_ID]: destEvents[0].metadata?.workspaceId
       });
       const errResp = getErrorRespEvents(
         destEvents.map(d => d.metadata),


### PR DESCRIPTION
## Description of the change

We are adding `workspaceId` as one of the stat-tags(wherever `destinationId` is being currently used in source-code)

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
