### PR TITLE
chore(ci): fix the buildspec file for helm chart changes

### DIFF
--- a/buildspec.saas.yml
+++ b/buildspec.saas.yml
@@ -39,16 +39,19 @@ phases:
       - git config --global user.email \"$MAIL\"
       - git config --global user.name \"$USER_NAME\"
       - cd rudder-devops/helm-charts/shared-services/per-az
-      - git checkout -b shared-transformer-\"$VERSION\"
+      - git checkout -b shared-transformer-$VERSION
       - yq eval -i ".rudder-transformer.image.tag=\"$VERSION\"" values.blue-release.yaml
+      - yq eval -i ".user-transformer.image.tag=\"$VERSION\"" values.blue-release.yaml
       - yq eval -i ".rudder-transformer.image.tag=\"$VERSION\"" values.prod.yaml
+      - yq eval -i ".user-transformer.image.tag=\"$VERSION\"" values.prod.yaml
       - git add values.blue-release.yaml values.prod.yaml
       - cd ../../config-be-rudder-transformer
-      - yq eval -i ".image.tag=\"$VERSION\"" values.prod.yaml
+      - yq eval -i ".config-be-rudder-transformer.image.tag=\"$VERSION\"" values.prod.yaml
+      - yq eval -i ".config-be-user-transformer.image.tag=\"$VERSION\"" values.prod.yaml
       - git add values.prod.yaml
       - git commit -m "changing version for shared transformer"
-      - git push -u origin shared-transformer-\"$VERSION\"
-      - hub pull-request -m "rudder-transformer version change-\"$VERSION\" "
+      - git push -u origin shared-transformer-$VERSION
+      - hub pull-request -m "rudder-transformer version change-$VERSION"
 artifacts:
   files:
     - "**/*"


### PR DESCRIPTION
## Description of the change

Fixed the Saas buildspec file for changes to the prod helm charts in the DevOps repo (ex: https://github.com/rudderlabs/rudder-devops/pull/4220).

So, now we are upgrading the version both for rudder-transformer and user-transformer services alike.

Also, removed quotes around the version number to avoid confusion.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

N/A

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
