### PR TITLE
fix(clevertap): correction for the max_batch_size value

### DIFF
--- a/src/v0/destinations/clevertap/config.js
+++ b/src/v0/destinations/clevertap/config.js
@@ -42,7 +42,7 @@ const CLEVERTAP_DEFAULT_EXCLUSION = [
   "ts"
 ];
 
-const MAX_BATCH_SIZE = 1000;
+const MAX_BATCH_SIZE = 100;
 
 const MAPPING_CONFIG = getMappingConfig(CONFIG_CATEGORIES, __dirname);
 


### PR DESCRIPTION
## Description of the change

> While validating the max batch size, that is, batch limit for user deletion for clever tap we found the limit was 100, not 1000. This PR mainly changes the limit number.
We found this number when we were testing for 1000 records it returned us with message "Max 100 are allowed"

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
