### PR TITLE
fix(destination): avoid parallel delete user requests in clevertap

### DIFF
--- a/src/v0/destinations/clevertap/deleteUsers.js
+++ b/src/v0/destinations/clevertap/deleteUsers.js
@@ -39,35 +39,40 @@ const userDeletionHandler = async (userAttributes, config) => {
     }
   });
 
-  // batchEvents = [[e1,e2,e3,..batchSize],[e1,e2,e3,..batchSize]..]
+  // userIdBatches = [[u1,u2,u3,...batchSize],[u1,u2,u3,...batchSize]...]
   // ref : https://developer.clevertap.com/docs/disassociate-api
-  const batchEvents = _.chunk(identity, MAX_BATCH_SIZE);
-  await Promise.all(
-    batchEvents.map(async batchEvent => {
-      const deletionResponse = await httpPOST(
-        endpoint,
-        {
-          identity: batchEvent
-        },
-        {
-          headers
-        }
-      );
-      const handledDelResponse = processAxiosResponse(deletionResponse);
-      if (!isHttpStatusSuccess(handledDelResponse.status)) {
-        throw new NetworkError(
-          "User deletion request failed",
-          handledDelResponse.status,
-          {
-            [tags.TAG_NAMES.ERROR_TYPE]: getDynamicErrorType(
-              handledDelResponse.status
-            )
-          },
-          handledDelResponse
-        );
+  const userIdBatches = _.chunk(identity, MAX_BATCH_SIZE);
+
+  // Note: The logic here intentionally avoided to use Promise.all
+  // where all the batch deletion requests are parallelized as
+  // simultaneous requests to CleverTap resulted in hitting API rate limits.
+  // Also, the rate limit is not clearly documented.
+  for (let idx = 0; idx < userIdBatches.length; idx += 1) {
+    const curBatch = userIdBatches[idx];
+    // eslint-disable-next-line no-await-in-loop
+    const deletionResponse = await httpPOST(
+      endpoint,
+      {
+        identity: curBatch
+      },
+      {
+        headers
       }
-    })
-  );
+    );
+    const handledDelResponse = processAxiosResponse(deletionResponse);
+    if (!isHttpStatusSuccess(handledDelResponse.status)) {
+      throw new NetworkError(
+        "User deletion request failed",
+        handledDelResponse.status,
+        {
+          [tags.TAG_NAMES.ERROR_TYPE]: getDynamicErrorType(
+            handledDelResponse.status
+          )
+        },
+        handledDelResponse
+      );
+    }
+  }
 
   return {
     statusCode: 200,


### PR DESCRIPTION
## Description of the change

As parallelizing all the batch deletion requests in Clevertap is resulting in hitting rate limits, the logic is updated to use a for-loop.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

N/A

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
