### PR TITLE
feat(integration): adobe_analytics-fix typo, add missing mapping

### DIFF
--- a/src/v0/destinations/adobe_analytics/data/AACommonConfig.json
+++ b/src/v0/destinations/adobe_analytics/data/AACommonConfig.json
@@ -43,6 +43,11 @@
     "required": false
   },
   {
+    "destKey": "transactionID",
+    "sourceKeys": ["properties.order_id", "properties.orderId"],
+    "required": false
+  },
+  {
     "destKey": "state",
     "sourceKeys": [
       "context.traits.address.state",

--- a/src/v0/destinations/adobe_analytics/transform.js
+++ b/src/v0/destinations/adobe_analytics/transform.js
@@ -395,7 +395,7 @@ const handleTrack = (message, destination) => {
           get(message, "properties.purchaseId") ||
           get(message, "properties.order_id"),
         transactionID:
-          get(message, "properties.transactionID") ||
+          get(message, "properties.transactionId") ||
           get(message, "properties.order_id")
       });
       break;
@@ -410,7 +410,7 @@ const handleTrack = (message, destination) => {
           get(message, "properties.purchaseId") ||
           get(message, "properties.order_id"),
         transactionID:
-          get(message, "properties.transactionID") ||
+          get(message, "properties.transactionId") ||
           get(message, "properties.order_id")
       });
       break;

--- a/test/__tests__/data/adobe_analytics_input.json
+++ b/test/__tests__/data/adobe_analytics_input.json
@@ -6254,5 +6254,185 @@
       "timestamp": "2019-09-01T15:46:51.693Z",
       "type": "track"
     }
+  },
+  {
+    "destination": {
+        "Config": {
+            "trackingServerUrl": "http://sadobemetrics.dr.dk",
+            "trackingServerSecureUrl": "https://sadobemetrics.dr.dk",
+            "reportSuiteIds": "drdev2",
+            "sslHeartbeat": true,
+            "heartbeatTrackingServerUrl": "",
+            "useUtf8Charset": true,
+            "useSecureServerSide": true,
+            "proxyNormalUrl": "",
+            "proxyHeartbeatUrl": "",
+            "marketingCloudOrgId": "00E287634SDFE6200A495E6B@AdobeOrg",
+            "dropVisitorId": true,
+            "timestampOption": "disabled",
+            "timestampOptionalReporting": false,
+            "noFallbackVisitorId": false,
+            "preferVisitorId": false,
+            "trackPageName": true,
+            "contextDataPrefix": "",
+            "useLegacyLinkName": true,
+            "pageNameFallbackTostring": true,
+            "sendFalseValues": true,
+            "productIdentifier": "name",
+            "eventsToTypes": [
+                {
+                    "from": "",
+                    "to": ""
+                }
+            ],
+            "listDelimiter": [
+                {
+                    "from": "",
+                    "to": ""
+                }
+            ],
+            "propsDelimiter": [
+                {
+                    "from": "",
+                    "to": ""
+                }
+            ],
+            "eventMerchProperties": [
+                {
+                    "eventMerchProperties": ""
+                }
+            ],
+            "productMerchProperties": [
+                {
+                    "productMerchProperties": ""
+                }
+            ],
+            "eVarMapping": [
+                {
+                    "from": "v1",
+                    "to": "1"
+                },
+                {
+                    "from": "v2",
+                    "to": "2"
+                },
+                {
+                    "from": "v3",
+                    "to": "3"
+                },
+                {
+                    "from": "v12",
+                    "to": "12"
+                },
+                {
+                    "from": "v13",
+                    "to": "13"
+                },
+                {
+                    "from": "v16",
+                    "to": "16"
+                },
+                {
+                    "from": "v17",
+                    "to": "17"
+                },
+                {
+                    "from": "v40",
+                    "to": "40"
+                },
+                {
+                    "from": "v41",
+                    "to": "41"
+                },
+                {
+                    "from": "v42",
+                    "to": "42"
+                },
+                {
+                    "from": "v69",
+                    "to": "69"
+                },
+                {
+                    "from": "v70",
+                    "to": "70"
+                },
+                {
+                    "from": "v89",
+                    "to": "89"
+                }
+            ],
+            "eventDelivery": false,
+            "eventDeliveryTS": 1628171489456,
+            "rudderEventsToAdobeEvents": [
+                {
+                    "from": "Custom Page View",
+                    "to": "event1"
+                },
+                {
+                    "from": "App Launch",
+                    "to": "event31"
+                },
+                {
+                    "from": "App Start",
+                    "to": "event31"
+                }
+            ],
+            "useNativeSDK": {
+                "web": false
+            },
+            "eventMerchEventToAdobeEvent": [
+                {
+                    "from": "",
+                    "to": ""
+                }
+            ],
+            "customPropsMapping": [
+                {
+                    "from": "c2",
+                    "to": "2"
+                },
+                {
+                    "from": "c3",
+                    "to": "3"
+                }
+            ]
+        }
+    },
+    "message": {
+        "anonymousId": "c82cbdff-e5be-4009-ac78-cdeea09ab4b1",
+        "context": {
+            "device": {
+                "id": "df16bffa-5c3d-4fbb-9bce-3bab098129a7R",
+                "manufacturer": "Xiaomi",
+                "model": "Redmi 6",
+                "name": "xiaomi"
+            },
+            "network": {
+                "carrier": "Banglalink"
+            },
+            "os": {
+                "name": "android",
+                "version": "8.1.0"
+            },
+            "traits": {
+                "address": {
+                    "city": "Dhaka",
+                    "country": "Bangladesh"
+                },
+                "anonymousId": "c82cbdff-e5be-4009-ac78-cdeea09ab4b1"
+            }
+        },
+        "event": "checkout started",
+        "integrations": {
+            "AM": true
+        },
+        "message_id": "a80f82be-9bdc-4a9f-b2a5-15621ee41df8",
+        "properties": {
+            "order_id": "oid100"
+        },
+        "userId": "test_user_id",
+        "timestamp": "2019-09-01T15:46:51.693Z",
+        "type": "track"
+    }
   }
 ]

--- a/test/__tests__/data/adobe_analytics_output.json
+++ b/test/__tests__/data/adobe_analytics_output.json
@@ -461,5 +461,24 @@
             "FORM": {}
         },
         "files": {}
+    },
+    {
+        "version": "1",
+        "type": "REST",
+        "method": "POST",
+        "endpoint": "https://sadobemetrics.dr.dk/b/ss//6",
+        "headers": {
+            "Content-type": "application/xml"
+        },
+        "params": {},
+        "body": {
+            "JSON": {},
+            "JSON_ARRAY": {},
+            "XML": {
+                "payload": "<?xml version=\"1.0\" encoding=\"utf-8\"?><request><purchaseID>oid100</purchaseID><transactionID>oid100</transactionID><marketingcloudorgid>00E287634SDFE6200A495E6B@AdobeOrg</marketingcloudorgid><events>scCheckout</events><products/><reportSuiteID>drdev2</reportSuiteID></request>"
+            },
+            "FORM": {}
+        },
+        "files": {}
     }
 ]


### PR DESCRIPTION
## Description of the change

> We are fixing 2 issues in this PR
> 1. transactionID was being referenced from a wrong property name.
> 2. In our [docs](https://www.rudderstack.com/docs/destinations/streaming-destinations/adobe-analytics/e-commerce-events/#checkout-started:~:text=order_id-,purchaseID/transactionID%20(If%20purchaseId%20or%20transactionId%20is%20not%20present),-Cart%20Opened), we offer setting both purchaseID and transactionID from order_id. This was missing in our instrumentation. 

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
