### PR TITLE
fix: send dest info for failed events

### DIFF
--- a/src/cdk/v2/destinations/pinterest_tag/rtWorkflow.yaml
+++ b/src/cdk/v2/destinations/pinterest_tag/rtWorkflow.yaml
@@ -23,6 +23,7 @@ steps:
     template: |
       $.outputs.transform#idx.error.({
         "metadata": ^[idx].metadata[],
+        "destination": ^[idx].destination,
         "batched": false,
         "statusCode": .status,
         "error": .message,

--- a/src/v0/destinations/algolia/transform.js
+++ b/src/v0/destinations/algolia/transform.js
@@ -137,8 +137,8 @@ const processRouterDest = async (inputs, reqMetadata) => {
 
     // using the first destination Config in chunk for
     // transforming the events in one chunk into a batch
-    const { destination } = chunk[0];
     chunk.forEach(async input => {
+      const { destination } = input;
       try {
         set(input, "destination", destination);
         // input.destination = destination;
@@ -156,6 +156,7 @@ const processRouterDest = async (inputs, reqMetadata) => {
     });
 
     if (eventsList.length !== 0) {
+      const { destination } = chunk[0];
       // setting up the batched request json here
       const batchedRequest = defaultRequestConfig();
       batchedRequest.endpoint = ENDPOINT;

--- a/src/v0/destinations/am/transform.js
+++ b/src/v0/destinations/am/transform.js
@@ -37,6 +37,7 @@ const {
 const {
   client: errNotificationClient
 } = require("../../../util/errorNotifier");
+const tags = require("../../util/tags");
 
 const AMUtils = require("./utils");
 
@@ -871,7 +872,12 @@ function batch(destEvents) {
       const errorResponse = getErrorRespEvents(
         metadata,
         400,
-        "Both userId and deviceId cannot be undefined"
+        "Both userId and deviceId cannot be undefined",
+        {
+          [tags.TAG_NAMES.ERROR_CATEGORY]:
+            tags.ERROR_CATEGORIES.DATA_VALIDATION,
+          [tags.TAG_NAMES.ERROR_TYPE]: tags.ERROR_TYPES.INSTRUMENTATION
+        }
       );
       respList.push(errorResponse);
       return;

--- a/src/v0/destinations/marketo/transform.js
+++ b/src/v0/destinations/marketo/transform.js
@@ -518,7 +518,7 @@ const processRouterDest = async (inputs, reqMetadata) => {
       errObj.message,
       errObj.statTags
     );
-    return [{ ...respEvents, destination: inputs[0].destination }];
+    return [{ ...respEvents, destination: inputs?.[0]?.destination }];
   }
 
   // Checking previous status Code. Initially setting to false.

--- a/src/v0/destinations/marketo/transform.js
+++ b/src/v0/destinations/marketo/transform.js
@@ -27,7 +27,6 @@ const {
   isDefinedAndNotNull,
   generateErrorObject,
   checkInvalidRtTfEvents,
-  getEventReqMetadata,
   handleRtTfSingleEventError
 } = require("../../util");
 const Cache = require("../../util/cache");
@@ -519,7 +518,7 @@ const processRouterDest = async (inputs, reqMetadata) => {
       errObj.message,
       errObj.statTags
     );
-    return [respEvents];
+    return [{ ...respEvents, destination: inputs[0].destination }];
   }
 
   // Checking previous status Code. Initially setting to false.

--- a/src/v0/destinations/marketo_static_list/transform.js
+++ b/src/v0/destinations/marketo_static_list/transform.js
@@ -139,7 +139,7 @@ const processRouterDest = async (inputs, reqMetadata) => {
         errResp.message,
         errResp.statTags
       );
-      return [respEvents];
+      return [{ ...respEvents, destination: inputs?.[0]?.destination }];
     }
   } catch (error) {
     // Not using handleRtTfSingleEventError here as this is for multiple events
@@ -150,7 +150,7 @@ const processRouterDest = async (inputs, reqMetadata) => {
       errObj.message,
       errObj.statTags
     );
-    return [respEvents];
+    return [{ ...respEvents, destination: inputs?.[0]?.destination }];
   }
 
   // Checking previous status Code. Initially setting to false.

--- a/src/v0/destinations/salesforce/transform.js
+++ b/src/v0/destinations/salesforce/transform.js
@@ -366,7 +366,7 @@ const processRouterDest = async (inputs, reqMetadata) => {
       `Authorisation failed: ${error.message}`,
       errObj.statTags
     );
-    return [respEvents];
+    return [{ ...respEvents, destination: inputs[0].destination }];
   }
 
   const respList = await Promise.all(

--- a/src/v0/destinations/salesforce/transform.js
+++ b/src/v0/destinations/salesforce/transform.js
@@ -366,7 +366,7 @@ const processRouterDest = async (inputs, reqMetadata) => {
       `Authorisation failed: ${error.message}`,
       errObj.statTags
     );
-    return [{ ...respEvents, destination: inputs[0].destination }];
+    return [{ ...respEvents, destination: inputs?.[0]?.destination }];
   }
 
   const respList = await Promise.all(

--- a/src/v0/util/index.js
+++ b/src/v0/util/index.js
@@ -1640,7 +1640,7 @@ const handleRtTfSingleEventError = (input, error, reqMetadata) => {
     ...getEventReqMetadata(input)
   });
 
-  return { ...resp, destination: input.destination };
+  return { ...resp, destination: input?.destination };
 };
 
 /**

--- a/src/v0/util/index.js
+++ b/src/v0/util/index.js
@@ -1640,7 +1640,7 @@ const handleRtTfSingleEventError = (input, error, reqMetadata) => {
     ...getEventReqMetadata(input)
   });
 
-  return resp;
+  return { ...resp, destination: input.destination };
 };
 
 /**

--- a/src/versionedRouter.js
+++ b/src/versionedRouter.js
@@ -317,6 +317,7 @@ async function handleDest(ctx, version, destination) {
 
         const resp = {
           metadata: event.metadata,
+          destination: event.destination,
           statusCode: errObj.status,
           error: errObj.message,
           statTags: errObj.statTags
@@ -1152,7 +1153,10 @@ const batchHandler = ctx => {
         errorObj.message,
         errorObj.statTags
       );
-      response.errors.push(errResp);
+      response.errors.push({
+        ...errResp,
+        destination: destEvents[0].destination
+      });
       errNotificationClient.notify(error, "Batch Transformation", {
         ...errResp,
         ...getCommonMetadata(ctx),

--- a/test/__tests__/data/algolia_router_input.json
+++ b/test/__tests__/data/algolia_router_input.json
@@ -234,8 +234,8 @@
           "ResponseRules": {}
         },
         "Config": {
-          "apiKey": "apiKey",
-          "applicationId": "appId",
+          "apiKey": "apiKey-2",
+          "applicationId": "appId-2",
           "eventTypeSettings": [
             {
               "from": "product clicked",

--- a/test/__tests__/data/algolia_router_output.json
+++ b/test/__tests__/data/algolia_router_output.json
@@ -8,6 +8,18 @@
       "statTags": {
         "errorCategory": "dataValidation",
         "errorType": "instrumentation"
+      },
+      "destination": {
+        "Config": {
+          "apiKey": "34d8efa09c5b048bbacc6af157f2e687",
+          "applicationId": "O2YARRI15I",
+          "eventTypeSettings": [
+            {
+              "from": "product clicked",
+              "to": "cLick "
+            }
+          ]
+        }
       }
     },
     {

--- a/test/__tests__/data/campaign_manager_router_output.json
+++ b/test/__tests__/data/campaign_manager_router_output.json
@@ -124,6 +124,15 @@
     }
   },
   {
+    "destination": {
+      "Config": {
+        "treatmentForUnderage": false,
+        "limitAdTracking": false,
+        "childDirectedTreatment": false,
+        "nonPersonalizedAd": false,
+        "rudderAccountId": "2EOknn1JNH7WK1MfNku4fGYKkRK"
+      }
+    },
     "batched": false,
     "error": "[CAMPAIGN MANAGER (DCM)]: properties.requestType must be one of batchinsert or batchupdate.",
     "metadata": [

--- a/test/__tests__/data/clickup_router_output.json
+++ b/test/__tests__/data/clickup_router_output.json
@@ -220,6 +220,19 @@
     "statusCode": 200
   },
   {
+    "destination": {
+      "Config": {
+        "apiToken": "pk_123",
+        "listId": "correctListId123",
+        "keyToCustomFieldName": [
+          {
+            "from": "location",
+            "to": "Location"
+          }
+        ]
+      },
+      "ID": "clickup-1234"
+    },
     "batched": false,
     "error": "Invalid value specified for latitude. Latitude must be in range \"[-90, 90]\"",
     "metadata": [

--- a/test/__tests__/data/discord_router.json
+++ b/test/__tests__/data/discord_router.json
@@ -1,403 +1,425 @@
 [
-    {
-      "description": "Discord batch events",
-      "input": [
-        {
-                "destination": {
-                  "ID": "1ZQVSU9SXNg6KYgZALaqjAO3PIL",
-                  "Name": "test-Discord",
-                  "DestinationDefinition": {
-                    "ID": "1ZQUiJVMlmF7lfsdfXg7KXQnlLV",
-                    "Name": "DISCORD",
-                    "DisplayName": "Discord",
-                    "Config": {
-                      "excludeKeys": [],
-                      "includeKeys": []
-                    }
-                  },
-                  "Config": {
-                    "eventChannelSettings": [],
-                    "eventTemplateSettings": [],
-                    "IdentifyTemplate": "identified {{name}} with {{traits}}",
-                    "webhookUrl": "https://abcd.com/efgh/89078/979868/98678",
-                    "whitelistedTraitsSettings": []
-                  },
-                  "Enabled": true,
-                  "Transformations": [],
-                  "IsProcessorEnabled": true
-                },
-                "message": {
-                  "anonymousId": "4de817fb-7f8e-4e23-b9be-f6736dbda20f",
-                  "channel": "web",
-                  "context": {
-                    "app": {
-                      "build": "1.0.0",
-                      "name": "RudderLabs JavaScript SDK",
-                      "namespace": "com.rudderlabs.javascript",
-                      "version": "1.1.1-rc.1"
-                    },
-                    "library": {
-                      "name": "RudderLabs JavaScript SDK",
-                      "version": "1.1.1-rc.1"
-                    },
-                    "locale": "en-US",
-                    "os": {
-                      "name": "",
-                      "version": ""
-                    },
-                    "page": {
-                      "path": "/tests/html/script-test.html",
-                      "referrer": "http://localhost:1111/tests/html/",
-                      "search": "",
-                      "title": "",
-                      "url": "http://localhost:1111/tests/html/script-test.html"
-                    },
-                    "screen": {
-                      "density": 1.7999999523162842
-                    },
-                    "traits": {
-                      "country": "India",
-                      "email": "name@domain.com",
-                      "hiji": "hulala",
-                      "name": "my-name"
-                    },
-                    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.149 Safari/537.36"
-                  },
-                  "integrations": {
-                    "All": true
-                  },
-                  "messageId": "9ecc0183-89ed-48bd-87eb-b2d8e1ca6780",
-                  "originalTimestamp": "2020-03-23T03:46:30.916Z",
-                  "properties": {
-                    "path": "/tests/html/script-test.html",
-                    "referrer": "http://localhost:1111/tests/html/",
-                    "search": "",
-                    "title": "",
-                    "url": "http://localhost:1111/tests/html/script-test.html"
-                  },
-                  "receivedAt": "2020-03-23T09:16:31.041+05:30",
-                  "request_ip": "[::1]:52056",
-                  "sentAt": "2020-03-23T03:46:30.916Z",
-                  "timestamp": "2020-03-23T09:16:31.041+05:30",
-                  "type": "page",
-                  "userId": "12345"
-                },
-          "metadata": {
+  {
+    "description": "Discord batch events",
+    "input": [
+      {
+        "destination": {
+          "ID": "1ZQVSU9SXNg6KYgZALaqjAO3PIL",
+          "Name": "test-Discord",
+          "DestinationDefinition": {
+            "ID": "1ZQUiJVMlmF7lfsdfXg7KXQnlLV",
+            "Name": "DISCORD",
+            "DisplayName": "Discord",
+            "Config": {
+              "excludeKeys": [],
+              "includeKeys": []
+            }
+          },
+          "Config": {
+            "eventChannelSettings": [],
+            "eventTemplateSettings": [],
+            "IdentifyTemplate": "identified {{name}} with {{traits}}",
+            "webhookUrl": "https://abcd.com/efgh/89078/979868/98678",
+            "whitelistedTraitsSettings": []
+          },
+          "Enabled": true,
+          "Transformations": [],
+          "IsProcessorEnabled": true
+        },
+        "message": {
+          "anonymousId": "4de817fb-7f8e-4e23-b9be-f6736dbda20f",
+          "channel": "web",
+          "context": {
+            "app": {
+              "build": "1.0.0",
+              "name": "RudderLabs JavaScript SDK",
+              "namespace": "com.rudderlabs.javascript",
+              "version": "1.1.1-rc.1"
+            },
+            "library": {
+              "name": "RudderLabs JavaScript SDK",
+              "version": "1.1.1-rc.1"
+            },
+            "locale": "en-US",
+            "os": {
+              "name": "",
+              "version": ""
+            },
+            "page": {
+              "path": "/tests/html/script-test.html",
+              "referrer": "http://localhost:1111/tests/html/",
+              "search": "",
+              "title": "",
+              "url": "http://localhost:1111/tests/html/script-test.html"
+            },
+            "screen": {
+              "density": 1.7999999523162842
+            },
+            "traits": {
+              "country": "India",
+              "email": "name@domain.com",
+              "hiji": "hulala",
+              "name": "my-name"
+            },
+            "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.149 Safari/537.36"
+          },
+          "integrations": {
+            "All": true
+          },
+          "messageId": "9ecc0183-89ed-48bd-87eb-b2d8e1ca6780",
+          "originalTimestamp": "2020-03-23T03:46:30.916Z",
+          "properties": {
+            "path": "/tests/html/script-test.html",
+            "referrer": "http://localhost:1111/tests/html/",
+            "search": "",
+            "title": "",
+            "url": "http://localhost:1111/tests/html/script-test.html"
+          },
+          "receivedAt": "2020-03-23T09:16:31.041+05:30",
+          "request_ip": "[::1]:52056",
+          "sentAt": "2020-03-23T03:46:30.916Z",
+          "timestamp": "2020-03-23T09:16:31.041+05:30",
+          "type": "page",
+          "userId": "12345"
+        },
+        "metadata": {
+          "jobId": 1
+        }
+      },
+      {
+        "destination": {
+          "ID": "1ZQVSU9SXNg6KYgZALaqjAO3PIL",
+          "Name": "test-Discord",
+          "DestinationDefinition": {
+            "ID": "1ZQUiJVMlmF7lfsdfXg7KXQnlLV",
+            "Name": "DISCORD",
+            "DisplayName": "Discord",
+            "Config": {
+              "excludeKeys": [],
+              "includeKeys": []
+            }
+          },
+          "Config": {
+            "eventChannelSettings": [],
+            "eventTemplateSettings": [],
+            "webhookUrl": "https://abcd.com/efgh/89078/979868/98678",
+            "whitelistedTraitsSettings": [
+              {
+                "trait": "country"
+              },
+              {
+                "trait": "email"
+              },
+              {
+                "trait": "name"
+              }
+            ]
+          },
+          "Enabled": true,
+          "Transformations": [],
+          "IsProcessorEnabled": true
+        },
+        "message": {
+          "anonymousId": "12345",
+          "channel": "web",
+          "context": {
+            "screen": {
+              "density": 1.7999999523162842
+            },
+            "traits": {
+              "country": "India",
+              "email": "name@domain.com",
+              "hiji": "hulala",
+              "name": "my-name"
+            },
+            "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.149 Safari/537.36"
+          },
+          "traits": {
+            "country": "USA",
+            "email": "test@domain.com",
+            "hiji": "hulala-1",
+            "name": "my-name-1"
+          },
+          "integrations": {
+            "All": true
+          },
+          "messageId": "4aaecff2-a513-4bbf-9824-c471f4ac9777",
+          "originalTimestamp": "2020-03-23T03:41:46.122Z",
+          "receivedAt": "2020-03-23T09:11:46.244+05:30",
+          "request_ip": "[::1]:52055",
+          "sentAt": "2020-03-23T03:41:46.123Z",
+          "timestamp": "2020-03-23T09:11:46.243+05:30",
+          "type": "Identify",
+          "userId": "12345"
+        },
+        "metadata": {
+          "anonymousId": "12345",
+          "destinationId": "1ZQVSU9SXNg6KYgZALaqjAO3PIL",
+          "destinationType": "DISCORD",
+          "jobId": 123,
+          "messageId": "4aaecff2-a513-4bbf-9824-c471f4ac9777",
+          "sourceId": "1YhwKyDcKstudlGxkeN5p2wgsrp"
+        }
+      },
+      {
+        "destination": {
+          "ID": "1ZQVSU9SXNg6KYgZALaqjAO3PIL",
+          "Name": "test-Discord",
+          "DestinationDefinition": {
+            "ID": "1ZQUiJVMlmF7lfsdfXg7KXQnlLV",
+            "Name": "DISCORD",
+            "DisplayName": "Discord",
+            "Config": {
+              "excludeKeys": [],
+              "includeKeys": []
+            }
+          },
+          "Config": {
+            "eventTemplateSettings": [
+              {
+                "eventName": "is",
+                "eventRegex": true,
+                "eventTemplate": "{{name}} performed {{event}} with {{properties.key1}} {{properties.key2}}"
+              },
+              {
+                "eventName": "test",
+                "eventRegex": true,
+                "eventTemplate": "{{event}} is performed by {{name}} with {{properties}}"
+              }
+            ],
+            "IdentifyTemplate": "identified {{name}} with {{traits}}",
+            "webhookUrl": "https://abcd.com/efgh/89078/979868/98678",
+            "whitelistedTraitsSettings": [
+              {
+                "trait": "hiji"
+              },
+              {
+                "trait": ""
+              }
+            ]
+          },
+          "Enabled": true,
+          "Transformations": [],
+          "IsProcessorEnabled": true
+        },
+        "message": {
+          "anonymousId": "00000000000000000000000000",
+          "channel": "web",
+          "context": {
+            "traits": {
+              "country": "India",
+              "email": "name@domain.com",
+              "hiji": "hulala",
+              "name": "my-name"
+            },
+            "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.149 Safari/537.36"
+          },
+          "event": "test_eventing_testis",
+          "integrations": {
+            "All": true
+          },
+          "messageId": "8b8d5937-09bc-49dc-a35e-8cd6370575f8",
+          "originalTimestamp": "2020-03-23T03:46:30.922Z",
+          "properties": {
+            "currency": "USD",
+            "key1": "test_val1",
+            "key2": "test_val2",
+            "revenue": 30,
+            "user_actual_id": 12345
+          },
+          "receivedAt": "2020-03-23T09:16:31.064+05:30",
+          "request_ip": "[::1]:52054",
+          "sentAt": "2020-03-23T03:46:30.923Z",
+          "timestamp": "2020-03-23T09:16:31.063+05:30",
+          "type": "track",
+          "userId": "12345"
+        },
+        "metadata": {
+          "anonymousId": "00000000000000000000000000",
+          "destinationId": "1ZQVSU9SXNg6KYgZALaqjAO3PIL",
+          "destinationType": "DISCORD",
+          "jobId": 129,
+          "messageId": "8b8d5937-09bc-49dc-a35e-8cd6370575f8",
+          "sourceId": "1YhwKyDcKstudlGxkeN5p2wgsrp"
+        }
+      }
+    ],
+    "output": [
+      {
+        "destination": {
+          "ID": "1ZQVSU9SXNg6KYgZALaqjAO3PIL",
+          "Name": "test-Discord",
+          "DestinationDefinition": {
+            "ID": "1ZQUiJVMlmF7lfsdfXg7KXQnlLV",
+            "Name": "DISCORD",
+            "DisplayName": "Discord",
+            "Config": {
+              "excludeKeys": [],
+              "includeKeys": []
+            }
+          },
+          "Config": {
+            "eventChannelSettings": [],
+            "eventTemplateSettings": [],
+            "IdentifyTemplate": "identified {{name}} with {{traits}}",
+            "webhookUrl": "https://abcd.com/efgh/89078/979868/98678",
+            "whitelistedTraitsSettings": []
+          },
+          "Enabled": true,
+          "Transformations": [],
+          "IsProcessorEnabled": true
+        },
+        "metadata": [
+          {
             "jobId": 1
           }
+        ],
+        "statTags": {
+          "errorCategory": "dataValidation",
+          "errorType": "instrumentation"
         },
-        {
-            "destination": {
-              "ID": "1ZQVSU9SXNg6KYgZALaqjAO3PIL",
-              "Name": "test-Discord",
-              "DestinationDefinition": {
-                "ID": "1ZQUiJVMlmF7lfsdfXg7KXQnlLV",
-                "Name": "DISCORD",
-                "DisplayName": "Discord",
-                "Config": {
-                  "excludeKeys": [],
-                  "includeKeys": []
-                }
-              },
-              "Config": {
-                "eventChannelSettings": [],
-                "eventTemplateSettings": [],
-                "webhookUrl": "https://abcd.com/efgh/89078/979868/98678",
-                "whitelistedTraitsSettings": [
-                  {
-                    "trait": "country"
-                  },
-                  {
-                    "trait": "email"
-                  },
-                  {
-                    "trait": "name"
-                  }
-                ]
-              },
-              "Enabled": true,
-              "Transformations": [],
-              "IsProcessorEnabled": true
-            },
-            "message": {
-              "anonymousId": "12345",
-              "channel": "web",
-              "context": {
-                "screen": {
-                  "density": 1.7999999523162842
-                },
-                "traits": {
-                  "country": "India",
-                  "email": "name@domain.com",
-                  "hiji": "hulala",
-                  "name": "my-name"
-                },
-                "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.149 Safari/537.36"
-              },
-              "traits": {
-                "country": "USA",
-                "email": "test@domain.com",
-                "hiji": "hulala-1",
-                "name": "my-name-1"
-              },
-              "integrations": {
-                "All": true
-              },
-              "messageId": "4aaecff2-a513-4bbf-9824-c471f4ac9777",
-              "originalTimestamp": "2020-03-23T03:41:46.122Z",
-              "receivedAt": "2020-03-23T09:11:46.244+05:30",
-              "request_ip": "[::1]:52055",
-              "sentAt": "2020-03-23T03:41:46.123Z",
-              "timestamp": "2020-03-23T09:11:46.243+05:30",
-              "type": "Identify",
-              "userId": "12345"
-            },
-            "metadata": {
-              "anonymousId": "12345",
-              "destinationId": "1ZQVSU9SXNg6KYgZALaqjAO3PIL",
-              "destinationType": "DISCORD",
-              "jobId": 123,
-              "messageId": "4aaecff2-a513-4bbf-9824-c471f4ac9777",
-              "sourceId": "1YhwKyDcKstudlGxkeN5p2wgsrp"
-            }
+        "batched": false,
+        "statusCode": 400,
+        "error": "Event type page is not supported"
+      },
+      {
+        "batchedRequest": {
+          "version": "1",
+          "type": "REST",
+          "method": "POST",
+          "endpoint": "https://abcd.com/efgh/89078/979868/98678",
+          "headers": {
+            "Content-Type": "application/json"
           },
-          {
-            "destination": {
-              "ID": "1ZQVSU9SXNg6KYgZALaqjAO3PIL",
-              "Name": "test-Discord",
-              "DestinationDefinition": {
-                "ID": "1ZQUiJVMlmF7lfsdfXg7KXQnlLV",
-                "Name": "DISCORD",
-                "DisplayName": "Discord",
-                "Config": {
-                  "excludeKeys": [],
-                  "includeKeys": []
-                }
-              },
-              "Config": {
-                "eventTemplateSettings": [
-                  {
-                    "eventName": "is",
-                    "eventRegex": true,
-                    "eventTemplate": "{{name}} performed {{event}} with {{properties.key1}} {{properties.key2}}"
-                  },
-                  {
-                    "eventName": "test",
-                    "eventRegex": true,
-                    "eventTemplate": "{{event}} is performed by {{name}} with {{properties}}"
-                  }
-                ],
-                "IdentifyTemplate": "identified {{name}} with {{traits}}",
-                "webhookUrl": "https://abcd.com/efgh/89078/979868/98678",
-                "whitelistedTraitsSettings": [
-                  {
-                    "trait": "hiji"
-                  },
-                  {
-                    "trait": ""
-                  }
-                ]
-              },
-              "Enabled": true,
-              "Transformations": [],
-              "IsProcessorEnabled": true
+          "params": {},
+          "body": {
+            "JSON": {
+              "content": "Identified my-name-1 with country: USA email: test@domain.com name: my-name-1 "
             },
-            "message": {
-              "anonymousId": "00000000000000000000000000",
-              "channel": "web",
-              "context": {
-                "traits": {
-                  "country": "India",
-                  "email": "name@domain.com",
-                  "hiji": "hulala",
-                  "name": "my-name"
-                },
-                "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.149 Safari/537.36"
-              },
-              "event": "test_eventing_testis",
-              "integrations": {
-                "All": true
-              },
-              "messageId": "8b8d5937-09bc-49dc-a35e-8cd6370575f8",
-              "originalTimestamp": "2020-03-23T03:46:30.922Z",
-              "properties": {
-                "currency": "USD",
-                "key1": "test_val1",
-                "key2": "test_val2",
-                "revenue": 30,
-                "user_actual_id": 12345
-              },
-              "receivedAt": "2020-03-23T09:16:31.064+05:30",
-              "request_ip": "[::1]:52054",
-              "sentAt": "2020-03-23T03:46:30.923Z",
-              "timestamp": "2020-03-23T09:16:31.063+05:30",
-              "type": "track",
-              "userId": "12345"
-            },
-            "metadata": {
-              "anonymousId": "00000000000000000000000000",
-              "destinationId": "1ZQVSU9SXNg6KYgZALaqjAO3PIL",
-              "destinationType": "DISCORD",
-              "jobId": 129,
-              "messageId": "8b8d5937-09bc-49dc-a35e-8cd6370575f8",
-              "sourceId": "1YhwKyDcKstudlGxkeN5p2wgsrp"
-            }
-          }
-      ],
-      "output": [
-        {
-            "metadata": [
-              {
-                "jobId": 1
-              }
-            ],
-            "statTags": {
-              "errorCategory": "dataValidation",
-              "errorType": "instrumentation"
-            },
-            "batched": false,
-            "statusCode": 400,
-            "error": "Event type page is not supported"
+            "XML": {},
+            "JSON_ARRAY": {},
+            "FORM": {}
           },
-        {
-          "batchedRequest": {
-            "version": "1",
-            "type": "REST",
-            "method": "POST",
-            "endpoint": "https://abcd.com/efgh/89078/979868/98678",
-            "headers": {
-              "Content-Type": "application/json"
-            },
-            "params": {},
-            "body": {
-              "JSON": {
-                "content": "Identified my-name-1 with country: USA email: test@domain.com name: my-name-1 "
-              },
-              "XML": {},
-              "JSON_ARRAY": {},
-              "FORM": {}
-            },
-            "files": {}
-          },
-          "destination": {
-            "ID": "1ZQVSU9SXNg6KYgZALaqjAO3PIL",
-            "Name": "test-Discord",
-            "DestinationDefinition": {
-              "ID": "1ZQUiJVMlmF7lfsdfXg7KXQnlLV",
-              "Name": "DISCORD",
-              "DisplayName": "Discord",
-              "Config": {
-                "excludeKeys": [],
-                "includeKeys": []
-              }
-            },
+          "files": {}
+        },
+        "destination": {
+          "ID": "1ZQVSU9SXNg6KYgZALaqjAO3PIL",
+          "Name": "test-Discord",
+          "DestinationDefinition": {
+            "ID": "1ZQUiJVMlmF7lfsdfXg7KXQnlLV",
+            "Name": "DISCORD",
+            "DisplayName": "Discord",
             "Config": {
-              "eventChannelSettings": [],
-              "eventTemplateSettings": [],
-              "webhookUrl": "https://abcd.com/efgh/89078/979868/98678",
-              "whitelistedTraitsSettings": [
-                {
-                  "trait": "country"
-                },
-                {
-                  "trait": "email"
-                },
-                {
-                  "trait": "name"
-                }
-              ]
-            },
-            "Enabled": true,
-            "Transformations": [],
-            "IsProcessorEnabled": true
+              "excludeKeys": [],
+              "includeKeys": []
+            }
           },
-          "metadata": [
-            {
-                "anonymousId": "12345",
-                "destinationId": "1ZQVSU9SXNg6KYgZALaqjAO3PIL",
-                "destinationType": "DISCORD",
-                "jobId": 123,
-                "messageId": "4aaecff2-a513-4bbf-9824-c471f4ac9777",
-                "sourceId": "1YhwKyDcKstudlGxkeN5p2wgsrp"
+          "Config": {
+            "eventChannelSettings": [],
+            "eventTemplateSettings": [],
+            "webhookUrl": "https://abcd.com/efgh/89078/979868/98678",
+            "whitelistedTraitsSettings": [
+              {
+                "trait": "country"
+              },
+              {
+                "trait": "email"
+              },
+              {
+                "trait": "name"
               }
-          ],
-          "batched": false,
-          "statusCode": 200
+            ]
+          },
+          "Enabled": true,
+          "Transformations": [],
+          "IsProcessorEnabled": true
         },
-        {
-            "batchedRequest": {
-                "version": "1",
-                "type": "REST",
-                "method": "POST",
-                "endpoint": "https://abcd.com/efgh/89078/979868/98678",
-                "headers": {
-                  "Content-Type": "application/json"
-                },
-                "params": {},
-                "body": {
-                  "JSON": {
-                    "content": "my-name performed test_eventing_testis with test_val1 test_val2"
-                  },
-                  "XML": {},
-                  "JSON_ARRAY": {},
-                  "FORM": {}
-                },
-                "files": {}
-              },
-              "destination": {
-                "ID": "1ZQVSU9SXNg6KYgZALaqjAO3PIL",
-                "Name": "test-Discord",
-                "DestinationDefinition": {
-                  "ID": "1ZQUiJVMlmF7lfsdfXg7KXQnlLV",
-                  "Name": "DISCORD",
-                  "DisplayName": "Discord",
-                  "Config": {
-                    "excludeKeys": [],
-                    "includeKeys": []
-                  }
-                },
-                "Config": {
-                  "eventTemplateSettings": [
-                    {
-                      "eventName": "is",
-                      "eventRegex": true,
-                      "eventTemplate": "{{name}} performed {{event}} with {{properties.key1}} {{properties.key2}}"
-                    },
-                    {
-                      "eventName": "test",
-                      "eventRegex": true,
-                      "eventTemplate": "{{event}} is performed by {{name}} with {{properties}}"
-                    }
-                  ],
-                  "IdentifyTemplate": "identified {{name}} with {{traits}}",
-                  "webhookUrl": "https://abcd.com/efgh/89078/979868/98678",
-                  "whitelistedTraitsSettings": [
-                    {
-                      "trait": "hiji"
-                    },
-                    {
-                      "trait": ""
-                    }
-                  ]
-                },
-                "Enabled": true,
-                "Transformations": [],
-                "IsProcessorEnabled": true
-              },
-            "metadata": [
-                {
-                    "anonymousId": "00000000000000000000000000",
-                    "destinationId": "1ZQVSU9SXNg6KYgZALaqjAO3PIL",
-                    "destinationType": "DISCORD",
-                    "jobId": 129,
-                    "messageId": "8b8d5937-09bc-49dc-a35e-8cd6370575f8",
-                    "sourceId": "1YhwKyDcKstudlGxkeN5p2wgsrp"
-                  }
-            ],
-            "batched": false,
-            "statusCode": 200
+        "metadata": [
+          {
+            "anonymousId": "12345",
+            "destinationId": "1ZQVSU9SXNg6KYgZALaqjAO3PIL",
+            "destinationType": "DISCORD",
+            "jobId": 123,
+            "messageId": "4aaecff2-a513-4bbf-9824-c471f4ac9777",
+            "sourceId": "1YhwKyDcKstudlGxkeN5p2wgsrp"
           }
-      ]
-    }
-  ]
-  
+        ],
+        "batched": false,
+        "statusCode": 200
+      },
+      {
+        "batchedRequest": {
+          "version": "1",
+          "type": "REST",
+          "method": "POST",
+          "endpoint": "https://abcd.com/efgh/89078/979868/98678",
+          "headers": {
+            "Content-Type": "application/json"
+          },
+          "params": {},
+          "body": {
+            "JSON": {
+              "content": "my-name performed test_eventing_testis with test_val1 test_val2"
+            },
+            "XML": {},
+            "JSON_ARRAY": {},
+            "FORM": {}
+          },
+          "files": {}
+        },
+        "destination": {
+          "ID": "1ZQVSU9SXNg6KYgZALaqjAO3PIL",
+          "Name": "test-Discord",
+          "DestinationDefinition": {
+            "ID": "1ZQUiJVMlmF7lfsdfXg7KXQnlLV",
+            "Name": "DISCORD",
+            "DisplayName": "Discord",
+            "Config": {
+              "excludeKeys": [],
+              "includeKeys": []
+            }
+          },
+          "Config": {
+            "eventTemplateSettings": [
+              {
+                "eventName": "is",
+                "eventRegex": true,
+                "eventTemplate": "{{name}} performed {{event}} with {{properties.key1}} {{properties.key2}}"
+              },
+              {
+                "eventName": "test",
+                "eventRegex": true,
+                "eventTemplate": "{{event}} is performed by {{name}} with {{properties}}"
+              }
+            ],
+            "IdentifyTemplate": "identified {{name}} with {{traits}}",
+            "webhookUrl": "https://abcd.com/efgh/89078/979868/98678",
+            "whitelistedTraitsSettings": [
+              {
+                "trait": "hiji"
+              },
+              {
+                "trait": ""
+              }
+            ]
+          },
+          "Enabled": true,
+          "Transformations": [],
+          "IsProcessorEnabled": true
+        },
+        "metadata": [
+          {
+            "anonymousId": "00000000000000000000000000",
+            "destinationId": "1ZQVSU9SXNg6KYgZALaqjAO3PIL",
+            "destinationType": "DISCORD",
+            "jobId": 129,
+            "messageId": "8b8d5937-09bc-49dc-a35e-8cd6370575f8",
+            "sourceId": "1YhwKyDcKstudlGxkeN5p2wgsrp"
+          }
+        ],
+        "batched": false,
+        "statusCode": 200
+      }
+    ]
+  }
+]

--- a/test/__tests__/data/engage_router_output.json
+++ b/test/__tests__/data/engage_router_output.json
@@ -56,7 +56,10 @@
             "hasPurchased": "yes"
           },
           "email": "anant@r.com",
-          "lists": ["100c983ry8934hf3094yfh348gf1", "4r40hfio3rbfln"],
+          "lists": [
+            "100c983ry8934hf3094yfh348gf1",
+            "4r40hfio3rbfln"
+          ],
           "last_name": "jain",
           "created_at": "2020-09-28T19:53:31.900Z",
           "first_name": "Anant"
@@ -102,6 +105,20 @@
         "jobId": 3
       }
     ],
+    "destination": {
+      "Config": {
+        "publicKey": "49ur490rjfo34gi04y38r9go",
+        "privateKey": "n89g389yr389fgbef0u2rff",
+        "listIds": [
+          {
+            "listId": "9834trg3rgy3g08oi9893rgfb"
+          },
+          {
+            "listId": "f39487tyh49go3h093gh2if2f2"
+          }
+        ]
+      }
+    },
     "statTags": {
       "errorCategory": "dataValidation",
       "errorType": "instrumentation"

--- a/test/__tests__/data/facebook_offline_conversions_router.json
+++ b/test/__tests__/data/facebook_offline_conversions_router.json
@@ -332,7 +332,32 @@
           "errorCategory": "dataValidation",
           "errorType": "configuration"
         },
-        "statusCode": 500
+        "statusCode": 500,
+        "destination": {
+          "Config": {
+            "accessToken": "ABC...",
+            "valueFieldIdentifier": "properties.price",
+            "eventsToStandard": [
+              { "from": "Product Searched", "to": "Search" },
+              { "to": "ViewContent", "from": "Product Viewed" },
+              { "to": "AddToCart", "from": "Cart Checkout" },
+              { "to": "AddPaymentInfo", "from": "Card Details Added" },
+              { "to": "Lead", "from": "Order Completed" },
+              { "to": "CompleteRegistration", "from": "Signup" },
+              { "to": "AddToWishlist", "from": "Button Clicked" }
+            ],
+            "eventsToIds": [
+              { "from": "Search", "to": "582603376981640" },
+              { "from": "Search", "to": "506289934669334" },
+              { "from": "ViewContent", "to": "1166826033904512" },
+              { "from": "AddToCart", "to": "1148872185708962" },
+              { "from": "CompleteRegistration", "to": "597443908839411" },
+              { "from": "Lead", "to": "1024592094903800" },
+              { "from": "AddToWishlist", "to": "506289934669334" }
+            ],
+            "isHashRequired": true
+          }
+        }
       },
       {
         "error": "Please Map Your Standard Events With Event Set Ids",
@@ -346,7 +371,31 @@
           "errorType": "configuration"
         },
         "batched": false,
-        "statusCode": 500
+        "statusCode": 500,
+        "destination": {
+          "Config": {
+            "accessToken": "ABC...",
+            "valueFieldIdentifier": "properties.price",
+            "eventsToStandard": [
+              { "from": "Product Searched", "to": "Search" },
+              { "to": "ViewContent", "from": "Product Viewed" },
+              { "to": "AddToCart", "from": "Cart Checkout" },
+              { "to": "AddPaymentInfo", "from": "Card Details Added" },
+              { "to": "Lead", "from": "Order Completed" },
+              { "to": "CompleteRegistration", "from": "Signup" },
+              { "to": "AddToWishlist", "from": "Button Clicked" }
+            ],
+            "eventsToIds": [
+              { "from": "Search", "to": "582603376981640" },
+              { "from": "Search", "to": "506289934669334" },
+              { "from": "ViewContent", "to": "1166826033904512" },
+              { "from": "AddToCart", "to": "1148872185708962" },
+              { "from": "CompleteRegistration", "to": "597443908839411" },
+              { "from": "Lead", "to": "1024592094903800" }
+            ],
+            "isHashRequired": true
+          }
+        }
       },
       {
         "metadata": [

--- a/test/__tests__/data/fb_router_output.json
+++ b/test/__tests__/data/fb_router_output.json
@@ -9,6 +9,11 @@
       "errorCategory": "dataValidation",
       "errorType": "instrumentation"
     },
+    "destination": {
+      "Config": {
+        "appID": "RudderFbApp"
+      }
+    },
     "batched": false,
     "statusCode": 400,
     "error": "If properties.revenue is present, properties.currency is required."
@@ -19,6 +24,11 @@
         "jobId": 2
       }
     ],
+    "destination": {
+      "Config": {
+        "appID": "RudderFbApp"
+      }
+    },
     "statTags": {
       "errorCategory": "dataValidation",
       "errorType": "instrumentation"

--- a/test/__tests__/data/google_adwords_enhanced_conversions_router_output.json
+++ b/test/__tests__/data/google_adwords_enhanced_conversions_router_output.json
@@ -87,6 +87,23 @@
         }
       }
     ],
+    "destination": {
+      "Config": {
+        "rudderAccountId": "25u5whFH7gVTnCiAjn4ykoCLGoC",
+        "customerId": "1234567890",
+        "subAccount": true,
+        "loginCustomerId": "",
+        "listOfConversions": [
+          {
+            "conversions": "Page View"
+          },
+          {
+            "conversions": "Product Added"
+          }
+        ],
+        "authStatus": "active"
+      }
+    },
     "batched": false,
     "statusCode": 400,
     "error": "Message Type identify is not supported. Aborting message.",
@@ -101,6 +118,23 @@
         "secret": {}
       }
     ],
+    "destination": {
+      "Config": {
+        "rudderAccountId": "25u5whFH7gVTnCiAjn4ykoCLGoC",
+        "customerId": "1234567890",
+        "subAccount": true,
+        "loginCustomerId": "11",
+        "listOfConversions": [
+          {
+            "conversions": "Page View"
+          },
+          {
+            "conversions": "Product Added"
+          }
+        ],
+        "authStatus": "active"
+      }
+    },
     "batched": false,
     "statusCode": 500,
     "error": "Empty/Invalid access token",

--- a/test/__tests__/data/google_cloud_function_router_output.json
+++ b/test/__tests__/data/google_cloud_function_router_output.json
@@ -34,6 +34,15 @@
     }
   },
   {
+    "destination": {
+      "Config": {
+        "triggerType": "Http",
+        "apiKeyId": "randomAPI",
+        "enableBatchInput": true,
+        "googleCloudFunctionUrl": "",
+        "maxBatchSize": "2"
+      }
+    },
     "metadata": [{ "jobId": "2" }],
     "batched": false,
     "statusCode": 500,

--- a/test/__tests__/data/june_router_output.json
+++ b/test/__tests__/data/june_router_output.json
@@ -41,6 +41,12 @@
     "statusCode": 200
   },
   {
+    "destination": {
+      "Config": {
+        "apiKey": "93EMyDLvfpbRxxYn"
+      },
+      "ID": "june123"
+    },
     "batched": false,
     "error": "Missing required value from \"userIdOnly\"",
     "metadata": [

--- a/test/__tests__/data/mailchimp_batch_output.json
+++ b/test/__tests__/data/mailchimp_batch_output.json
@@ -68,6 +68,22 @@
     }
   },
   {
+    "destination": {
+      "ID": "1Tdi0lpXwSVwXG1lcdP2pXHKrJ6",
+      "Name": "test-mc",
+      "DestinationDefinition": {
+        "ID": "1SujZGrVEPqYmpUJcV4vSl9tfxn",
+        "Name": "MC",
+        "DisplayName": "MailChimp"
+      },
+      "Config": {
+        "apiKey": "94f71917d8522770c97449b0c90caa4c-us20",
+        "audienceId": "1232yyqw22",
+        "datacenterId": "us20"
+      },
+      "Enabled": true,
+      "Transformations": []
+    },
     "metadata": [
       {
         "jobId": 5

--- a/test/__tests__/data/mailchimp_output.json
+++ b/test/__tests__/data/mailchimp_output.json
@@ -59,9 +59,41 @@
     "audienceId": "df42a82d07"
   },
   {
-    "error": "User does not have access to the requested operation"
+    "error": "User does not have access to the requested operation",
+    "destination": {
+      "ID": "1Tdi0lpXwSVwXG1lcdP2pXHKrJ6",
+      "Name": "Titli Ganguly",
+      "DestinationDefinition": {
+        "ID": "1SujZGrVEPqYmpUJcV4vSl9tfxn",
+        "Name": "MC",
+        "DisplayName": "MailChimp"
+      },
+      "Config": {
+        "apiKey": "25adacdcd8c4ef4672fbdc626fbcf331-us6",
+        "audienceId": "df42a82d07",
+        "datacenterId": "us20"
+      },
+      "Enabled": true,
+      "Transformations": []
+    }
   },
   {
+    "destination": {
+      "ID": "1Tdi0lpXwSVwXG1lcdP2pXHKrJ6",
+      "Name": "Titli Ganguly",
+      "DestinationDefinition": {
+        "ID": "1SujZGrVEPqYmpUJcV4vSl9tfxn",
+        "Name": "MC",
+        "DisplayName": "MailChimp"
+      },
+      "Config": {
+        "apiKey": "25adacdcd8c4ef4442fbdc626fbcf331-us6",
+        "audienceId": "df42a82d07",
+        "datacenterId": "us20"
+      },
+      "Enabled": true,
+      "Transformations": []
+    },
     "error": "message type page is not supported"
   },
   {
@@ -90,9 +122,41 @@
     "audienceId": "df42a82d07"
   },
   {
+    "destination": {
+      "ID": "1Tdi0lpXwSVwXG1lcdP2pXHKrJ6",
+      "Name": "test-mc",
+      "DestinationDefinition": {
+        "ID": "1SujZGrVEPqYmpUJcV4vSl9tfxn",
+        "Name": "MC",
+        "DisplayName": "MailChimp"
+      },
+      "Config": {
+        "apiKey": "94f71917d8522770c97449b0c90caa4c-us20",
+        "audienceId": "df42a82d07",
+        "datacenterId": "us20"
+      },
+      "Enabled": true,
+      "Transformations": []
+    },
     "error": "The status must be one of [subscribed, unsubscribed, cleaned, pending, transactional]"
   },
   {
+    "destination": {
+      "ID": "1Tdi0lpXwSVwXG1lcdP2pXHKrJ6",
+      "Name": "test-mc",
+      "DestinationDefinition": {
+        "ID": "1SujZGrVEPqYmpUJcV4vSl9tfxn",
+        "Name": "MC",
+        "DisplayName": "MailChimp"
+      },
+      "Config": {
+        "apiKey": "d966df2e59d105c00f13de330d94000b-us14",
+        "audienceId": "ff21810ddc",
+        "datacenterId": "us14"
+      },
+      "Enabled": true,
+      "Transformations": []
+    },
     "statusCode": 400,
     "error": "Email is required for identify",
     "statTags": {
@@ -168,15 +232,78 @@
     "audienceId": "df42a82d07"
   },
   {
+    "destination": {
+      "ID": "1Tdi0lpXwSVwXG1lcdP2pXHKrJ6",
+      "Name": "test-mc",
+      "DestinationDefinition": {
+        "ID": "1SujZGrVEPqYmpUJcV4vSl9tfxn",
+        "Name": "MC",
+        "DisplayName": "MailChimp"
+      },
+      "Config": {
+        "apiKey": "",
+        "audienceId": "df42a82d07",
+        "datacenterId": "us20"
+      },
+      "Enabled": true,
+      "Transformations": []
+    },
     "error": "API Key not found. Aborting"
   },
   {
+    "destination": {
+      "ID": "1Tdi0lpXwSVwXG1lcdP2pXHKrJ6",
+      "Name": "test-mc",
+      "DestinationDefinition": {
+        "ID": "1SujZGrVEPqYmpUJcV4vSl9tfxn",
+        "Name": "MC",
+        "DisplayName": "MailChimp"
+      },
+      "Config": {
+        "apiKey": "awesrdcfgvhbjnkkjhgf",
+        "datacenterId": "us20"
+      },
+      "Enabled": true,
+      "Transformations": []
+    },
     "error": "Audience Id not found. Aborting"
   },
   {
+    "destination": {
+      "ID": "1Tdi0lpXwSVwXG1lcdP2pXHKrJ6",
+      "Name": "test-mc",
+      "DestinationDefinition": {
+        "ID": "1SujZGrVEPqYmpUJcV4vSl9tfxn",
+        "Name": "MC",
+        "DisplayName": "MailChimp"
+      },
+      "Config": {
+        "apiKey": "w4a5346yeu75jyhrgfred",
+        "audienceId": "df42a82d07",
+        "datacenterId": ""
+      },
+      "Enabled": true,
+      "Transformations": []
+    },
     "error": "DataCenter Id not found. Aborting"
   },
   {
+    "destination": {
+      "ID": "1Tdi0lpXwSVwXG1lcdP2pXHKrJ6",
+      "Name": "test-mc",
+      "DestinationDefinition": {
+        "ID": "1SujZGrVEPqYmpUJcV4vSl9tfxn",
+        "Name": "MC",
+        "DisplayName": "MailChimp"
+      },
+      "Config": {
+        "apiKey": "zesrxdthfcjg345yruikyhntbgrafvd",
+        "audienceId": "df42a82d07",
+        "datacenterId": "us20"
+      },
+      "Enabled": true,
+      "Transformations": []
+    },
     "error": "message type track is not supported"
   }
 ]

--- a/test/__tests__/data/mailchimp_router_output.json
+++ b/test/__tests__/data/mailchimp_router_output.json
@@ -67,6 +67,23 @@
     }
   },
   {
+    "destination": {
+      "ID": "1Tdi0lpXwSVwXG1lcdP2pXHKrJ6",
+      "Name": "test-mc",
+      "DestinationDefinition": {
+        "ID": "1SujZGrVEPqYmpUJcV4vSl9tfxn",
+        "Name": "MC",
+        "DisplayName": "MailChimp"
+      },
+      "Config": {
+        "apiKey": "94f71917d8522770c97449b0c90caa4c-us20",
+        "audienceId": "df42a82d07",
+        "datacenterId": "us20",
+        "enableMergeFields": true
+      },
+      "Enabled": true,
+      "Transformations": []
+    },
     "metadata": [
       {
         "jobId": 4

--- a/test/__tests__/data/mailmodo_router_output.json
+++ b/test/__tests__/data/mailmodo_router_output.json
@@ -109,6 +109,13 @@
       "errorCategory": "dataValidation",
       "errorType": "instrumentation"
     },
-    "statusCode": 400
+    "statusCode": 400,
+    "destination": {
+      "Config": {
+        "apiKey": "62d12498c37c4fd8a1a546c2d35c2f60",
+        "listName": ""
+      },
+      "Enabled": true
+    }
   }
 ]

--- a/test/__tests__/data/marketo_router_output.json
+++ b/test/__tests__/data/marketo_router_output.json
@@ -42,13 +42,29 @@
         "clientSecret": "marketo_client_secret_success",
         "trackAnonymousEvents": true,
         "customActivityEventMap": [
-          { "from": "Product Clicked", "to": "100001" }
+          {
+            "from": "Product Clicked",
+            "to": "100001"
+          }
         ],
-        "customActivityPropertyMap": [{ "from": "name", "to": "productName" }],
+        "customActivityPropertyMap": [
+          {
+            "from": "name",
+            "to": "productName"
+          }
+        ],
         "customActivityPrimaryKeyMap": [
-          { "from": "Product Clicked", "to": "name" }
+          {
+            "from": "Product Clicked",
+            "to": "name"
+          }
         ],
-        "leadTraitMapping": [{ "from": "leadScore", "to": "customLeadScore" }]
+        "leadTraitMapping": [
+          {
+            "from": "leadScore",
+            "to": "customLeadScore"
+          }
+        ]
       },
       "secretConfig": {},
       "ID": "1mMy5cqbtfuaKZv1IhVQKnBdVwe",
@@ -72,7 +88,9 @@
               "leadTraitMapping"
             ]
           },
-          "secretKeys": ["clientSecret"],
+          "secretKeys": [
+            "clientSecret"
+          ],
           "excludeKeys": [],
           "includeKeys": [],
           "routerTransform": true,
@@ -90,20 +108,56 @@
           "responseType": "JSON",
           "rules": {
             "retryable": [
-              { "success": "false", "errors.0.code": 600 },
-              { "success": "false", "errors.0.code": 601 },
-              { "success": "false", "errors.0.code": 602 },
-              { "success": "false", "errors.0.code": 604 },
-              { "success": "false", "errors.0.code": 606 },
-              { "success": "false", "errors.0.code": 607 },
-              { "success": "false", "errors.0.code": 608 },
-              { "success": "false", "errors.0.code": 611 }
+              {
+                "success": "false",
+                "errors.0.code": 600
+              },
+              {
+                "success": "false",
+                "errors.0.code": 601
+              },
+              {
+                "success": "false",
+                "errors.0.code": 602
+              },
+              {
+                "success": "false",
+                "errors.0.code": 604
+              },
+              {
+                "success": "false",
+                "errors.0.code": 606
+              },
+              {
+                "success": "false",
+                "errors.0.code": 607
+              },
+              {
+                "success": "false",
+                "errors.0.code": 608
+              },
+              {
+                "success": "false",
+                "errors.0.code": 611
+              }
             ],
             "abortable": [
-              { "success": "false", "errors.0.code": 603 },
-              { "success": "false", "errors.0.code": 605 },
-              { "success": "false", "errors.0.code": 609 },
-              { "success": "false", "errors.0.code": 610 }
+              {
+                "success": "false",
+                "errors.0.code": 603
+              },
+              {
+                "success": "false",
+                "errors.0.code": 605
+              },
+              {
+                "success": "false",
+                "errors.0.code": 609
+              },
+              {
+                "success": "false",
+                "errors.0.code": 610
+              }
             ]
           }
         },
@@ -161,13 +215,29 @@
         "clientSecret": "marketo_client_secret_success",
         "trackAnonymousEvents": true,
         "customActivityEventMap": [
-          { "from": "Product Clicked", "to": "100001" }
+          {
+            "from": "Product Clicked",
+            "to": "100001"
+          }
         ],
-        "customActivityPropertyMap": [{ "from": "name", "to": "productName" }],
+        "customActivityPropertyMap": [
+          {
+            "from": "name",
+            "to": "productName"
+          }
+        ],
         "customActivityPrimaryKeyMap": [
-          { "from": "Product Clicked", "to": "name" }
+          {
+            "from": "Product Clicked",
+            "to": "name"
+          }
         ],
-        "leadTraitMapping": [{ "from": "leadScore", "to": "customLeadScore" }]
+        "leadTraitMapping": [
+          {
+            "from": "leadScore",
+            "to": "customLeadScore"
+          }
+        ]
       },
       "secretConfig": {},
       "ID": "1mMy5cqbtfuaKZv1IhVQKnBdVwe",
@@ -191,7 +261,9 @@
               "leadTraitMapping"
             ]
           },
-          "secretKeys": ["clientSecret"],
+          "secretKeys": [
+            "clientSecret"
+          ],
           "excludeKeys": [],
           "includeKeys": [],
           "routerTransform": true,
@@ -209,20 +281,56 @@
           "responseType": "JSON",
           "rules": {
             "retryable": [
-              { "success": "false", "errors.0.code": 600 },
-              { "success": "false", "errors.0.code": 601 },
-              { "success": "false", "errors.0.code": 602 },
-              { "success": "false", "errors.0.code": 604 },
-              { "success": "false", "errors.0.code": 606 },
-              { "success": "false", "errors.0.code": 607 },
-              { "success": "false", "errors.0.code": 608 },
-              { "success": "false", "errors.0.code": 611 }
+              {
+                "success": "false",
+                "errors.0.code": 600
+              },
+              {
+                "success": "false",
+                "errors.0.code": 601
+              },
+              {
+                "success": "false",
+                "errors.0.code": 602
+              },
+              {
+                "success": "false",
+                "errors.0.code": 604
+              },
+              {
+                "success": "false",
+                "errors.0.code": 606
+              },
+              {
+                "success": "false",
+                "errors.0.code": 607
+              },
+              {
+                "success": "false",
+                "errors.0.code": 608
+              },
+              {
+                "success": "false",
+                "errors.0.code": 611
+              }
             ],
             "abortable": [
-              { "success": "false", "errors.0.code": 603 },
-              { "success": "false", "errors.0.code": 605 },
-              { "success": "false", "errors.0.code": 609 },
-              { "success": "false", "errors.0.code": 610 }
+              {
+                "success": "false",
+                "errors.0.code": 603
+              },
+              {
+                "success": "false",
+                "errors.0.code": 605
+              },
+              {
+                "success": "false",
+                "errors.0.code": 609
+              },
+              {
+                "success": "false",
+                "errors.0.code": 610
+              }
             ]
           }
         },
@@ -249,7 +357,154 @@
       {
         "jobId": 3
       }
-    ]
+    ],
+    "destination": {
+      "Config": {
+        "accountId": "valid_account_broken_event",
+        "clientId": "504300cd-76b2-a7l4-bhle-90a07420nx73",
+        "clientSecret": "3l3gJpzRsZagD6gu7tnTeKXz0bomLGnd",
+        "trackAnonymousEvents": false,
+        "createIfNotExist": true,
+        "customActivityEventMap": [
+          {
+            "from": "acq_signup_completed",
+            "to": "100026"
+          },
+          {
+            "from": "act_createwebinarform_submit",
+            "to": "100025"
+          },
+          {
+            "from": "act_presentation_style",
+            "to": "100025"
+          },
+          {
+            "from": "act_webinar_view",
+            "to": "100025"
+          },
+          {
+            "from": "act_webinar_join",
+            "to": "100025"
+          },
+          {
+            "from": "act_presentation_addteammember",
+            "to": "100025"
+          },
+          {
+            "from": "act_engagement_discussions_savediscussion",
+            "to": "100025"
+          },
+          {
+            "to": "100025",
+            "from": "act_engagement_networking_savetime"
+          }
+        ]
+      },
+      "destinationDefinition": {
+        "config": {
+          "destConfig": {
+            "defaultConfig": [
+              "accountId",
+              "clientId",
+              "clientSecret",
+              "trackAnonymousEvents",
+              "customActivityEventMap",
+              "customActivityPropertyMap",
+              "customActivityPrimaryKeyMap",
+              "leadTraitMapping"
+            ]
+          },
+          "secretKeys": [
+            "clientSecret"
+          ],
+          "excludeKeys": [],
+          "includeKeys": [],
+          "routerTransform": true,
+          "supportedSourceTypes": [
+            "android",
+            "ios",
+            "web",
+            "unity",
+            "amp",
+            "cloud",
+            "reactnative"
+          ]
+        },
+        "responseRules": {
+          "responseType": "JSON",
+          "rules": {
+            "retryable": [
+              {
+                "success": "false",
+                "errors.0.code": 600
+              },
+              {
+                "success": "false",
+                "errors.0.code": 601
+              },
+              {
+                "success": "false",
+                "errors.0.code": 602
+              },
+              {
+                "success": "false",
+                "errors.0.code": 604
+              },
+              {
+                "success": "false",
+                "errors.0.code": 606
+              },
+              {
+                "success": "false",
+                "errors.0.code": 607
+              },
+              {
+                "success": "false",
+                "errors.0.code": 608
+              },
+              {
+                "success": "false",
+                "errors.0.code": 611
+              }
+            ],
+            "abortable": [
+              {
+                "success": "false",
+                "errors.0.code": 603
+              },
+              {
+                "success": "false",
+                "errors.0.code": 605
+              },
+              {
+                "success": "false",
+                "errors.0.code": 609
+              },
+              {
+                "success": "false",
+                "errors.0.code": 610
+              }
+            ]
+          }
+        },
+        "id": "1aIXqM806xAVm92nx07YwKbRrO9",
+        "name": "MARKETO",
+        "displayName": "Marketo",
+        "createdAt": "2020-04-09T09:24:31.794Z",
+        "updatedAt": "2021-01-11T11:03:28.103Z"
+      },
+      "secretConfig": {},
+      "ID": "1mMy5cqbtfuaKZv1IhVQKnBdVke",
+      "name": "Marketo",
+      "enabled": true,
+      "workspaceId": "1TSN08muJTZwH8iCDmnnRt1pmMd",
+      "deleted": false,
+      "createdAt": "2022-02-10T08:39:32.005Z",
+      "updatedAt": "2022-09-03T16:22:31.374Z",
+      "transformations": [],
+      "isConnectionEnabled": true,
+      "isProcessorEnabled": true
+    }
   },
   {
     "batched": false,
@@ -259,6 +514,153 @@
       "errorCategory": "network",
       "errorType": "aborted",
       "meta": "unhandledStatusCode"
+    },
+    "destination": {
+      "Config": {
+        "accountId": "unhandled_status_code",
+        "clientId": "504300cd-76b2-a7l4-bhle-90a07420nx73",
+        "clientSecret": "3l3gJpzRsZagD6gu7tnTeKXz0bomLGnd",
+        "trackAnonymousEvents": false,
+        "createIfNotExist": true,
+        "customActivityEventMap": [
+          {
+            "from": "acq_signup_completed",
+            "to": "100026"
+          },
+          {
+            "from": "act_createwebinarform_submit",
+            "to": "100025"
+          },
+          {
+            "from": "act_presentation_style",
+            "to": "100025"
+          },
+          {
+            "from": "act_webinar_view",
+            "to": "100025"
+          },
+          {
+            "from": "act_webinar_join",
+            "to": "100025"
+          },
+          {
+            "from": "act_presentation_addteammember",
+            "to": "100025"
+          },
+          {
+            "from": "act_engagement_discussions_savediscussion",
+            "to": "100025"
+          },
+          {
+            "to": "100025",
+            "from": "act_engagement_networking_savetime"
+          }
+        ]
+      },
+      "destinationDefinition": {
+        "config": {
+          "destConfig": {
+            "defaultConfig": [
+              "accountId",
+              "clientId",
+              "clientSecret",
+              "trackAnonymousEvents",
+              "customActivityEventMap",
+              "customActivityPropertyMap",
+              "customActivityPrimaryKeyMap",
+              "leadTraitMapping"
+            ]
+          },
+          "secretKeys": [
+            "clientSecret"
+          ],
+          "excludeKeys": [],
+          "includeKeys": [],
+          "routerTransform": true,
+          "supportedSourceTypes": [
+            "android",
+            "ios",
+            "web",
+            "unity",
+            "amp",
+            "cloud",
+            "reactnative"
+          ]
+        },
+        "responseRules": {
+          "responseType": "JSON",
+          "rules": {
+            "retryable": [
+              {
+                "success": "false",
+                "errors.0.code": 600
+              },
+              {
+                "success": "false",
+                "errors.0.code": 601
+              },
+              {
+                "success": "false",
+                "errors.0.code": 602
+              },
+              {
+                "success": "false",
+                "errors.0.code": 604
+              },
+              {
+                "success": "false",
+                "errors.0.code": 606
+              },
+              {
+                "success": "false",
+                "errors.0.code": 607
+              },
+              {
+                "success": "false",
+                "errors.0.code": 608
+              },
+              {
+                "success": "false",
+                "errors.0.code": 611
+              }
+            ],
+            "abortable": [
+              {
+                "success": "false",
+                "errors.0.code": 603
+              },
+              {
+                "success": "false",
+                "errors.0.code": 605
+              },
+              {
+                "success": "false",
+                "errors.0.code": 609
+              },
+              {
+                "success": "false",
+                "errors.0.code": 610
+              }
+            ]
+          }
+        },
+        "id": "1aIXqM806xAVm92nx07YwKbRrO9",
+        "name": "MARKETO",
+        "displayName": "Marketo",
+        "createdAt": "2020-04-09T09:24:31.794Z",
+        "updatedAt": "2021-01-11T11:03:28.103Z"
+      },
+      "secretConfig": {},
+      "ID": "1mMy5cqbtfuaKZv1IhVQKnBdVke",
+      "name": "Marketo",
+      "enabled": true,
+      "workspaceId": "1TSN08muJTZwH8iCDmnnRt1pmMd",
+      "deleted": false,
+      "createdAt": "2022-02-10T08:39:32.005Z",
+      "updatedAt": "2022-09-03T16:22:31.374Z",
+      "transformations": [],
+      "isConnectionEnabled": true,
+      "isProcessorEnabled": true
     },
     "metadata": [
       {
@@ -360,7 +762,9 @@
               "leadTraitMapping"
             ]
           },
-          "secretKeys": ["clientSecret"],
+          "secretKeys": [
+            "clientSecret"
+          ],
           "excludeKeys": [],
           "includeKeys": [],
           "routerTransform": true,

--- a/test/__tests__/data/marketo_static_list_router_output.json
+++ b/test/__tests__/data/marketo_static_list_router_output.json
@@ -139,6 +139,26 @@
         "jobId": 3
       }
     ],
+    "destination": {
+      "ID": "1zia9wKshXt80YksLmUdJnr7IHI",
+      "Name": "test_marketo",
+      "DestinationDefinition": {
+        "ID": "1iVQvTRMsPPyJzwol0ifH93QTQ6",
+        "Name": "MARKETO",
+        "DisplayName": "Marketo",
+        "transformAt": "processor",
+        "transformAtV1": "processor"
+      },
+      "Config": {
+        "clientId": "marketo_client_id_success",
+        "clientSecret": "marketo_client_secret_success",
+        "accountId": "marketo_acct_id_success",
+        "staticListId": 1234
+      },
+      "Enabled": true,
+      "Transformations": [],
+      "IsProcessorEnabled": true
+    },
     "batched": false,
     "statusCode": 400,
     "error": "Event type track is not supported",

--- a/test/__tests__/data/mautic_router_output.json
+++ b/test/__tests__/data/mautic_router_output.json
@@ -62,6 +62,14 @@
       "errorCategory": "dataValidation",
       "errorType": "configuration"
     },
+    "destination": {
+      "Config": {
+        "lookUpField": "email",
+        "password": "abcdefghij1234",
+        "subDomainName": "testapi3",
+        "userName": "abcdef"
+      }
+    },
     "batched": false,
     "statusCode": 500,
     "error": "Invalid user name provided in the destination configuration"

--- a/test/__tests__/data/pagerduty_router.json
+++ b/test/__tests__/data/pagerduty_router.json
@@ -273,6 +273,12 @@
         "statTags": {
           "errorCategory": "dataValidation",
           "errorType": "instrumentation"
+        },
+        "destination": {
+          "Config": {
+            "routingKey": "9552b56325dc490bd0139be85f7b8fac",
+            "dedupKeyFieldIdentifier": "properties.dedupKey"
+          }
         }
       }
     ]

--- a/test/__tests__/data/pardot_router_output.json
+++ b/test/__tests__/data/pardot_router_output.json
@@ -320,6 +320,50 @@
     }
   },
   {
+    "destination": {
+      "Config": {
+        "rudderAccountId": "1z8LpaSAuFR9TPWL6fECZfjmRa-",
+        "businessUnitId": "0Uv2v000000k9tHCAQ",
+        "campaignId": 42213,
+        "authStatus": "active",
+        "eventDelivery": true,
+        "eventDeliveryTS": 1636965406397
+      },
+      "DestinationDefinition": {
+        "name": "PARDOT",
+        "displayName": "Pardot",
+        "config": {
+          "auth": {
+            "type": "OAuth"
+          },
+          "transformAt": "router",
+          "transformAtV1": "router",
+          "saveDestinationResponse": true,
+          "includeKeys": [],
+          "excludeKeys": [],
+          "supportedSourceTypes": [
+            "android",
+            "ios",
+            "web",
+            "unity",
+            "amp",
+            "cloud",
+            "warehouse",
+            "reactnative",
+            "flutter",
+            "cordova"
+          ],
+          "destConfig": {
+            "defaultConfig": ["rudderAccountId", "businessUnitId", "campaignId"]
+          },
+          "secretKeys": ["businessUnitId"]
+        }
+      },
+      "Enabled": true,
+      "ID": "1WXjIHpu7ETXgjfiGPW3kCUgZFR",
+      "Name": "test destination",
+      "Transformations": []
+    },
     "metadata": [
       {
         "secret": null

--- a/test/__tests__/data/persistiq_router.json
+++ b/test/__tests__/data/persistiq_router.json
@@ -177,6 +177,17 @@
         "statusCode": 200
       },
       {
+        "destination": {
+          "Config": {
+            "apiKey": "2c646069cc5ae3f22cc0dab36cd060ad",
+            "persistIqAttributesMapping": [
+              {
+                "from": "useroccupation",
+                "to": "occupation"
+              }
+            ]
+          }
+        },
         "metadata": [
           {
             "jobId": 3

--- a/test/__tests__/data/pinterest_tag_router_batch_output.json
+++ b/test/__tests__/data/pinterest_tag_router_batch_output.json
@@ -307,7 +307,9 @@
                   "value": 27.5,
                   "order_id": "50314b8e9bcf000000000000",
                   "num_items": 2,
-                  "content_ids": ["123"],
+                  "content_ids": [
+                    "123"
+                  ],
                   "contents": [
                     {
                       "quantity": 2,
@@ -635,6 +637,47 @@
       "statTags": {
         "errorCategory": "dataValidation",
         "errorType": "instrumentation"
+      },
+      "destination": {
+        "ID": "1pYpzzvcn7AQ2W9GGIAZSsN6Mfq",
+        "Name": "PINTEREST_TAG",
+        "Config": {
+          "tagId": "123456789",
+          "advertiserId": "429047995",
+          "appId": "429047995",
+          "sendingUnHashedData": true,
+          "enableDeduplication": true,
+          "deduplicationKey": "messageId",
+          "enhancedMatch": true,
+          "customProperties": [
+            {
+              "properties": "presentclass"
+            },
+            {
+              "properties": "presentgrade"
+            }
+          ],
+          "eventsMapping": [
+            {
+              "from": "ABC Searched",
+              "to": "Watch Video"
+            },
+            {
+              "from": "ABC Searched",
+              "to": "Signup"
+            },
+            {
+              "from": "User Signup",
+              "to": "Signup"
+            },
+            {
+              "from": "User Created",
+              "to": "Signup"
+            }
+          ]
+        },
+        "Enabled": true,
+        "Transformations": []
       }
     }
   ]

--- a/test/__tests__/data/pinterest_tag_router_error_output.json
+++ b/test/__tests__/data/pinterest_tag_router_error_output.json
@@ -11,6 +11,47 @@
     "statTags": {
       "errorCategory": "dataValidation",
       "errorType": "instrumentation"
+    },
+    "destination": {
+      "ID": "1pYpzzvcn7AQ2W9GGIAZSsN6Mfq",
+      "Name": "PINTEREST_TAG",
+      "Config": {
+        "tagId": "123456789",
+        "advertiserId": "429047995",
+        "appId": "429047995",
+        "sendingUnHashedData": true,
+        "enableDeduplication": true,
+        "deduplicationKey": "messageId",
+        "enhancedMatch": true,
+        "customProperties": [
+          {
+            "properties": "presentclass"
+          },
+          {
+            "properties": "presentgrade"
+          }
+        ],
+        "eventsMapping": [
+          {
+            "from": "ABC Searched",
+            "to": "Watch Video"
+          },
+          {
+            "from": "ABC Searched",
+            "to": "Signup"
+          },
+          {
+            "from": "User Signup",
+            "to": "Signup"
+          },
+          {
+            "from": "User Created",
+            "to": "Signup"
+          }
+        ]
+      },
+      "Enabled": true,
+      "Transformations": []
     }
   }
 ]

--- a/test/__tests__/data/pinterest_tag_router_output.json
+++ b/test/__tests__/data/pinterest_tag_router_output.json
@@ -501,7 +501,48 @@
       },
       "batched": false,
       "statusCode": 400,
-      "error": "message type identify is not supported"
+      "error": "message type identify is not supported",
+      "destination": {
+        "ID": "1pYpzzvcn7AQ2W9GGIAZSsN6Mfq",
+        "Name": "PINTEREST_TAG",
+        "Config": {
+          "tagId": "123456789",
+          "advertiserId": "429047995",
+          "appId": "429047995",
+          "sendingUnHashedData": true,
+          "enableDeduplication": true,
+          "deduplicationKey": "messageId",
+          "enhancedMatch": true,
+          "customProperties": [
+            {
+              "properties": "presentclass"
+            },
+            {
+              "properties": "presentgrade"
+            }
+          ],
+          "eventsMapping": [
+            {
+              "from": "ABC Searched",
+              "to": "Watch Video"
+            },
+            {
+              "from": "ABC Searched",
+              "to": "Signup"
+            },
+            {
+              "from": "User Signup",
+              "to": "Signup"
+            },
+            {
+              "from": "User Created",
+              "to": "Signup"
+            }
+          ]
+        },
+        "Enabled": true,
+        "Transformations": []
+      }
     }
   ]
 ]

--- a/test/__tests__/data/sendinblue_router_output.json
+++ b/test/__tests__/data/sendinblue_router_output.json
@@ -182,6 +182,15 @@
       "errorCategory": "dataValidation",
       "errorType": "instrumentation"
     },
-    "statusCode": 400
+    "statusCode": 400,
+    "destination": {
+      "Config": {
+        "apiKey": "apiKey123",
+        "clientKey": "clientKey123",
+        "templateId": 3,
+        "doi": true,
+        "redirectionUrl": "https://app.sendinblue.com/marketing-dashboard"
+      }
+    }
   }
 ]

--- a/test/__tests__/data/sfmc_router_output.json
+++ b/test/__tests__/data/sfmc_router_output.json
@@ -5,6 +5,36 @@
         "jobId": 2
       }
     ],
+    "destination": {
+      "ID": "1pYpzzvcn7AQ2W9GGIAZSsN6Mfq",
+      "Name": "SFMC",
+      "DestinationDefinition": {
+        "ID": "1pYpYSeQd8OeN6xPdw6VGDzqUd1",
+        "Name": "SFMC",
+        "DisplayName": "Salesforce Marketing Cloud",
+        "Config": {
+          "destConfig": [],
+          "excludeKeys": [],
+          "includeKeys": [],
+          "saveDestinationResponse": true,
+          "supportedSourceTypes": [],
+          "transformAt": "processor"
+        },
+        "ResponseRules": {}
+      },
+      "Config": {
+        "clientId": "vcn7AQ2W9GGIAZSsN6Mfq",
+        "clientSecret": "vcn7AQ2W9GGIAZSsN6Mfq",
+        "createOrUpdateContacts": true,
+        "eventDelivery": true,
+        "eventDeliveryTS": 1615371070621,
+        "eventToUUID": [],
+        "externalKey": "f3ffa19b-e0b3-4967-829f-549b781080e6",
+        "subDomain": "vcn7AQ2W9GGIAZSsN6Mfq"
+      },
+      "Enabled": true,
+      "Transformations": []
+    },
     "batched": false,
     "statusCode": 500,
     "error": "Creating or updating contacts is disabled",

--- a/test/__tests__/data/signl4_router_output.json
+++ b/test/__tests__/data/signl4_router_output.json
@@ -53,6 +53,28 @@
     }
   },
   {
+    "destination": {
+      "Config": {
+        "apiKey": "urissi44sfgs",
+        "s4ServiceValue": "service",
+        "s4ServiceProperty": "",
+        "s4LocationValue": "67.3, 32.3",
+        "s4LocationProperty": "",
+        "s4AlertingScenarioValue": "single_ack",
+        "s4AlertingScenarioProperty": "",
+        "s4ExternalIDValue": "INC493933",
+        "s4ExternalIDProperty": "",
+        "s4StatusValue": "new",
+        "s4StatusProperty": "",
+        "s4Filter": false,
+        "eventToTitleMapping": [
+          {
+            "from": "New Alert",
+            "to": "Alert Created"
+          }
+        ]
+      }
+    },
     "metadata": [
       {
         "jobId": 2

--- a/test/__tests__/data/slack_router_output.json
+++ b/test/__tests__/data/slack_router_output.json
@@ -1,5 +1,62 @@
 [
   {
+    "destination": {
+      "ID": "1ZQVSU9SXNg6KYgZALaqjAO3PIL",
+      "Name": "test-slack",
+      "DestinationDefinition": {
+        "ID": "1ZQUiJVMlmF7lfsdfXg7KXQnlLV",
+        "Name": "SLACK",
+        "DisplayName": "Slack",
+        "Config": {
+          "excludeKeys": [],
+          "includeKeys": []
+        }
+      },
+      "Config": {
+        "eventChannelSettings": [
+          {
+            "eventChannel": "#slack_integration",
+            "eventName": "is",
+            "eventRegex": true
+          },
+          {
+            "eventChannel": "",
+            "eventName": "",
+            "eventRegex": false
+          },
+          {
+            "eventChannel": "",
+            "eventName": "",
+            "eventRegex": false
+          }
+        ],
+        "eventTemplateSettings": [
+          {
+            "eventName": "is",
+            "eventRegex": true,
+            "eventTemplate": "{{name}} performed {{event}} with {{properties.key1}} {{properties.key2}}"
+          },
+          {
+            "eventName": "",
+            "eventRegex": false,
+            "eventTemplate": ""
+          }
+        ],
+        "identifyTemplate": "identified {{name}} with {{traits}}",
+        "webhookUrl": "https://hooks.slack.com/services/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",
+        "whitelistedTraitsSettings": [
+          {
+            "trait": "hiji"
+          },
+          {
+            "trait": ""
+          }
+        ]
+      },
+      "Enabled": true,
+      "Transformations": [],
+      "IsProcessorEnabled": true
+    },
     "metadata": [
       {
         "anonymousId": "4de817fb-7f8e-4e23-b9be-f6736dbda20f",

--- a/test/__tests__/data/snapchat_conversion_router_input.json
+++ b/test/__tests__/data/snapchat_conversion_router_input.json
@@ -300,7 +300,7 @@
       "originalTimestamp": "2022-08-01T15:04:49.266Z"
     },
     "metadata": {
-      "jobId": 1
+      "jobId": 4
     },
     "destination": {
       "Config": {

--- a/test/__tests__/data/snapchat_conversion_router_output.json
+++ b/test/__tests__/data/snapchat_conversion_router_output.json
@@ -43,7 +43,7 @@
   {
     "metadata": [
       {
-        "jobId": 1
+        "jobId": 4
       }
     ],
     "batched": false,
@@ -52,6 +52,21 @@
     "statTags": {
       "errorCategory": "dataValidation",
       "errorType": "configuration"
+    },
+    "destination": {
+      "Config": {
+        "pixelId": "jashdfkjas-3282-49ef1093alsjkdhfjadksf",
+        "apiKey": "eyJhbGciOiJIUzI1NiIsImtpZCI6IkNhbnZhc1MyUlkjhhadfkasdfkhkasdfkj.eyJhdWQiOiJjYW52YXMtY2FudmFzYXBpIiwiaXNzIjoiY2FudmFzLXMyc3Rva2VuIiwibmJmIjoxNjU5MDc3ODA4LCJzdWIiOiJjMmRkMmNkOC02NTQ3LTRiMDAtOTBlZS0xZDZkMzUxN2EwOWN-UFJPRFVDVElPTn45MzZiMTg4My0zNTUyLTQxNTQtOWQyMy00NjZkNGRjN2UxNmIifQ.XdQwpR7qIjH4WMujDWzZSbOIBcZtKwreBWjTPNIiHD.",
+        "appId": "jahsdfjk-5487-asdfa-9957-7c74eb8d3e80",
+        "snapAppId": "",
+        "enableDeduplication": false,
+        "rudderEventsToSnapEvents": [
+          {
+            "from": "Product List Viewed",
+            "to": "product_list_viewed"
+          }
+        ]
+      }
     }
   }
 ]

--- a/test/__tests__/data/tiktok_ads_offline_events_router_output.json
+++ b/test/__tests__/data/tiktok_ads_offline_events_router_output.json
@@ -173,6 +173,12 @@
     "statusCode": 200
   },
   {
+    "destination": {
+      "Config": {
+        "accessToken": "fuwheirujkvjnkrtgkf",
+        "hashUserProperties": true
+      }
+    },
     "batched": false,
     "error": "Event name is required",
     "metadata": [

--- a/test/__tests__/data/versioned_processor_heap_output.json
+++ b/test/__tests__/data/versioned_processor_heap_output.json
@@ -127,25 +127,66 @@
     "statusCode": 200
   },
   {
+    "destination": {
+      "Config": {
+        "appId": "<app id>"
+      },
+      "metadata": {
+        "jobId": 2
+      },
+      "DestinationDefinition": {
+        "DisplayName": "Heap.io",
+        "ID": "1WTbl0l5GjOQKOvfmcGwk0T49kV",
+        "Name": "HEAP",
+        "Config": {
+          "cdkEnabled": true
+        }
+      },
+      "Enabled": true,
+      "ID": "1WTcDSEOE437e4ePH10BJNELXmE",
+      "Name": "heap test",
+      "Transformations": []
+    },
     "statusCode": 400,
-    "error": "message type \"page\" not supported for \"heap\"",
+    "error": "Bad event. Original error: message type \"page\" not supported for \"heap\"",
     "statTags": {
-      "stage": "transform",
-      "scope": "cdk",
-      "meta": "badEvent",
-      "destType": "HEAP",
-      "errorAt": "proc"
+      "errorCategory": "dataValidation",
+      "errorType": "instrumentation",
+      "feature": "processor",
+      "implementation": "cdkV1",
+      "module": "destination",
+      "destType": "HEAP"
     }
   },
   {
+    "destination": {
+      "Config": {
+        "appId": "<app id>"
+      },
+      "metadata": {
+        "jobId": 2
+      },
+      "DestinationDefinition": {
+        "DisplayName": "Heap.io",
+        "ID": "1WTbl0l5GjOQKOvfmcGwk0T49kV",
+        "Name": "HEAP",
+        "Config": {
+          "cdkEnabled": true
+        }
+      },
+      "Enabled": true,
+      "ID": "1WTcDSEOE437e4ePH10BJNELXmE",
+      "Name": "heap test",
+      "Transformations": []
+    },
     "statusCode": 400,
-    "error": "\"type\" is a required field and it must be a string",
+    "error": "Unknown error occurred. Original error: \"type\" is a required field and it must be a string",
     "statTags": {
-      "stage": "transform",
-      "scope": "exception",
-      "meta": "badEvent",
-      "destType": "HEAP",
-      "errorAt": "proc"
+      "errorCategory": "transformation",
+      "feature": "processor",
+      "implementation": "cdkV1",
+      "module": "destination",
+      "destType": "HEAP"
     }
   }
 ]

--- a/test/__tests__/data/versioned_router_heap_input.json
+++ b/test/__tests__/data/versioned_router_heap_input.json
@@ -144,7 +144,7 @@
             "Transformations": []
           },
           "metadata": {
-            "jobId": 2
+            "jobId": 4
           },
           "message": {
             "anonymousId": "sampath",
@@ -203,7 +203,7 @@
             "Transformations": []
           },
           "metadata": {
-            "jobId": 2
+            "jobId": 5
           },
           "message": {
             "anonymousId": "sampath",

--- a/test/__tests__/data/versioned_router_heap_output.json
+++ b/test/__tests__/data/versioned_router_heap_output.json
@@ -101,9 +101,23 @@
       }
     },
     {
+      "destination": {
+        "Config": {
+          "appId": "<app id>"
+        },
+        "DestinationDefinition": {
+          "DisplayName": "Heap.io",
+          "ID": "1WTbl0l5GjOQKOvfmcGwk0T49kV",
+          "Name": "HEAP"
+        },
+        "Enabled": true,
+        "ID": "1WTcDSEOE437e4ePH10BJNELXmE",
+        "Name": "heap test",
+        "Transformations": []
+      },
       "metadata": [
         {
-          "jobId": 2
+          "jobId": 4
         }
       ],
       "batched": false,
@@ -111,15 +125,30 @@
       "error": "invalid message type for heap",
       "statTags": {
         "destType": "HEAP",
-        "scope": "exception",
-        "stage": "transform",
-        "errorAt": "rt"
+        "errorCategory": "dataValidation",
+        "errorType": "instrumentation",
+        "feature": "router",
+        "module": "destination"
       }
     },
     {
+      "destination": {
+        "Config": {
+          "appId": "<app id>"
+        },
+        "DestinationDefinition": {
+          "DisplayName": "Heap.io",
+          "ID": "1WTbl0l5GjOQKOvfmcGwk0T49kV",
+          "Name": "HEAP"
+        },
+        "Enabled": true,
+        "ID": "1WTcDSEOE437e4ePH10BJNELXmE",
+        "Name": "heap test",
+        "Transformations": []
+      },
       "metadata": [
         {
-          "jobId": 2
+          "jobId": 5
         }
       ],
       "batched": false,
@@ -127,9 +156,10 @@
       "error": "message type page not supported for heap",
       "statTags": {
         "destType": "HEAP",
-        "scope": "exception",
-        "stage": "transform",
-        "errorAt": "rt"
+        "errorCategory": "dataValidation",
+        "errorType": "instrumentation",
+        "feature": "router",
+        "module": "destination"
       }
     }
   ]

--- a/test/__tests__/data/woopra_router_output.json
+++ b/test/__tests__/data/woopra_router_output.json
@@ -79,6 +79,11 @@
     "statusCode": 200
   },
   {
+    "destination": {
+      "Config": {
+        "projectName": "int.com"
+      }
+    },
     "metadata": [
       {
         "jobId": 3

--- a/test/__tests__/data/wootric_router_output.json
+++ b/test/__tests__/data/wootric_router_output.json
@@ -136,6 +136,14 @@
     }
   },
   {
+    "destination": {
+      "Config": {
+        "username": "wootricfakeuser@example.com",
+        "password": "password@123",
+        "accountToken": "NPS-1234567"
+      },
+      "ID": "2D7TqLto9tnkBuR1ciMrbiA4cbG"
+    },
     "metadata": [
       {
         "jobId": 5
@@ -150,6 +158,14 @@
     }
   },
   {
+    "destination": {
+      "Config": {
+        "username": "wootricfakeuser@example.com",
+        "password": "password@123",
+        "accountToken": "NPS-1234567"
+      },
+      "ID": "2D7TqLto9tnkBuR1ciMrbiA4cbG"
+    },
     "metadata": [
       {
         "jobId": 6
@@ -333,6 +349,14 @@
         "jobId": 11
       }
     ],
+    "destination": {
+      "Config": {
+        "username": "wootricfakeuser@example.com",
+        "password": "password@123",
+        "accountToken": "NPS-1234567"
+      },
+      "ID": "2D7TqLto9tnkBuR1ciMrbiA4cbG"
+    },
     "batched": false,
     "statusCode": 400,
     "error": "No user found with userId : dummyId2",
@@ -342,6 +366,14 @@
     }
   },
   {
+    "destination": {
+      "Config": {
+        "username": "wootricfakeuser@example.com",
+        "password": "password@123",
+        "accountToken": "NPS-1234567"
+      },
+      "ID": "2D7TqLto9tnkBuR1ciMrbiA4cbG"
+    },
     "metadata": [
       {
         "jobId": 12
@@ -393,6 +425,14 @@
     }
   },
   {
+    "destination": {
+      "Config": {
+        "username": "wootricfakeuser@example.com",
+        "password": "password@123",
+        "accountToken": "NPS-1234567"
+      },
+      "ID": "2D7TqLto9tnkBuR1ciMrbiA4cbG"
+    },
     "metadata": [
       {
         "jobId": 14
@@ -407,6 +447,14 @@
     }
   },
   {
+    "destination": {
+      "Config": {
+        "username": "wootricfakeuser@example.com",
+        "password": "password@123",
+        "accountToken": "NPS-1234567"
+      },
+      "ID": "2D7TqLto9tnkBuR1ciMrbiA4cbG"
+    },
     "metadata": [
       {
         "jobId": 15
@@ -426,6 +474,14 @@
         "jobId": 16
       }
     ],
+    "destination": {
+      "Config": {
+        "username": "wootricfakeuser@example.com",
+        "password": "password@123",
+        "accountToken": "NPS-1234567"
+      },
+      "ID": "2D7TqLto9tnkBuR1ciMrbiA4cbG"
+    },
     "batched": false,
     "statusCode": 400,
     "error": "Event Type is missing from Integration object",

--- a/test/__tests__/data/zendesk_router_output.json
+++ b/test/__tests__/data/zendesk_router_output.json
@@ -119,6 +119,25 @@
     }
   },
   {
+    "destination": {
+      "Config": {
+        "apiToken": "yPJwcLTFSsvIkFhY23SzittHoYADJQ7eKDoxNu4x",
+        "createUsersAsVerified": true,
+        "domain": "rudderlabtest2",
+        "email": "rudderlabtest2@email.com",
+        "removeUsersFromOrganization": false,
+        "sendGroupCallsWithoutUserId": false
+      },
+      "DestinationDefinition": {
+        "DisplayName": "Zendesk",
+        "ID": "1YknZ1ENqB8UurJQJE2VrEA61tr",
+        "Name": "ZENDESK"
+      },
+      "Enabled": true,
+      "ID": "1Z3zFXE6zwvNJBVOUzCuJxeO51P",
+      "Name": "zendesk",
+      "Transformations": []
+    },
     "batched": false,
     "error": "Failed to fetch user with email: testemail2@email due to Couldn't find user: John Wick",
     "metadata": [


### PR DESCRIPTION
## Description of the change

- We need to send `destination` information to fill up the tags of `workspaceId` and `destinationId` for `router_transform_num_jobs` measurement for `router` transform destinations --- ✅ 
- We need to send `destination` information to fill up the tags of `workspaceId` and `destinationId` for `router_transform_num_jobs` measurement for `batch` transform destinations --- ✅ 
- We are following the same convention for `process` transformation --- 🤷🏼‍♂️ 
- For transformer proxy this information is currently not needed --- ❌ 

Without this change for atleast router transformation and batch transformation features, for successfully transformed jobs we would have workspaceId & destinationId rightly bound but if the job has failed, we would not have `workspaceId` and `destinationJob` information as it is not being sent when an error is thrown in transformer

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
