### PR TITLE
fix: add missing implementation stat tag for router transformation

### DIFF
--- a/src/versionedRouter.js
+++ b/src/versionedRouter.js
@@ -464,7 +464,8 @@ async function routerHandleDest(ctx) {
     defTags = {
       [tags.TAG_NAMES.DEST_TYPE]: destType.toUpperCase(),
       [tags.TAG_NAMES.MODULE]: tags.MODULES.DESTINATION,
-      [tags.TAG_NAMES.FEATURE]: tags.FEATURES.ROUTER
+      [tags.TAG_NAMES.FEATURE]: tags.FEATURES.ROUTER,
+      [tags.TAG_NAMES.IMPLEMENTATION]: tags.IMPLEMENTATIONS.NATIVE
     };
 
     const routerDestHandler = getDestHandler("v0", destType);


### PR DESCRIPTION
## Description of the change

The default stat tag `implementation` was missing in the router transformation handler. Hence, added, and it defaults to `native`.
In the case of CDK v2, the tag is taken care of in its handler module.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

N/A

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
