### PR TITLE
Add Vitally destination

### DIFF
--- a/src/cdk/v1/vitally/config.yaml
+++ b/src/cdk/v1/vitally/config.yaml
@@ -1,0 +1,15 @@
+message:
+  supportedMessageTypes:
+    - identify
+    - track
+    - group
+  default:
+    transformation:
+      spreadMessage: true
+      response:
+        format: JSON
+        method: POST
+        endpoint: "https://{{ destConfig.workspace}}.vitally.io/rudderstack"
+        headers:
+          authorization: "Basic {{ destConfig.apiKey }}"
+          content-type: "application/json"

--- a/src/cdk/v1/vitally/config.yaml
+++ b/src/cdk/v1/vitally/config.yaml
@@ -9,7 +9,7 @@ message:
       response:
         format: JSON
         method: POST
-        endpoint: "https://{{ destConfig.workspace}}.vitally.io/rudderstack"
+        endpoint: "https://api.vitally.io/rudderstack"
         headers:
           authorization: "Basic {{ destConfig.apiKey }}"
           content-type: "application/json"

--- a/src/constants/destinationCanonicalNames.js
+++ b/src/constants/destinationCanonicalNames.js
@@ -87,6 +87,7 @@ const DestCanonicalNames = {
   ga4: ['GA4', 'ga4', 'Ga4', 'Google Analytics 4', 'googleAnalytics4'],
   pipedream: ['Pipedream', 'PipeDream', 'pipedream', 'PIPEDREAM'],
   pagerduty: ['pagerduty', 'PAGERDUTY', 'PagerDuty', 'Pagerduty', 'pagerDuty'],
+  vitally: ["vitally", "VITALLY", "Vitally"]
 };
 
 module.exports = { DestHandlerMap, DestCanonicalNames };

--- a/test/__tests__/data/vitally_input.json
+++ b/test/__tests__/data/vitally_input.json
@@ -1,0 +1,85 @@
+[
+    {
+        "message": {
+            "userId": "0220c056-934e-11ed-a1eb-0242ac120002",
+            "event": "this is a track event",
+            "type": "track",
+            "properties": {
+                "thing": "amazing!"
+            },
+            "originalTimestamp": "2023-01-13T09:03:17.562Z",
+            "sentAt": "2023-01-13T09:03:17.562Z"
+        },
+        "destination": {
+            "Config": {
+              "workspace": "wonderbits",
+              "apiKey": "abc123"
+            },
+            "DestinationDefinition": {
+                "Config": {
+                    "cdkEnabled": true
+                }
+            }
+        }
+    },
+    {
+        "message": {
+            "userId": "0220c056-934e-11ed-a1eb-0242ac120002",
+            "type": "identify",
+            "traits": {
+                "name": "Johnny Appleseed"
+            },
+            "originalTimestamp": "2023-01-13T09:03:17.562Z",
+            "sentAt": "2023-01-13T09:03:17.562Z"
+        },
+        "destination": {
+            "Config": {
+              "workspace": "wonderbits",
+              "apiKey": "abc123"
+            },
+            "DestinationDefinition": {
+                "Config": {
+                    "cdkEnabled": true
+                }
+            }
+        }
+    },
+    {
+        "message": {
+            "userId": "0220c056-934e-11ed-a1eb-0242ac120002",
+            "type": "group",
+            "groupId": "5de17322-934e-11ed-a1eb-0242ac120002",
+            "originalTimestamp": "2023-01-13T09:03:17.562Z",
+            "sentAt": "2023-01-13T09:03:17.562Z"
+        },
+        "destination": {
+            "Config": {
+              "workspace": "wonderbits",
+              "apiKey": "abc123"
+            },
+            "DestinationDefinition": {
+                "Config": {
+                    "cdkEnabled": true
+                }
+            }
+        }
+    },
+    {
+        "message": {
+            "type": "page",
+            "originalTimestamp": "2023-01-13T09:03:17.562Z",
+            "sentAt": "2023-01-13T09:03:17.562Z"
+        },
+        "destination": {
+            "Config": {
+              "workspace": "wonderbits",
+              "apiKey": "abc123"
+            },
+            "DestinationDefinition": {
+                "Config": {
+                    "cdkEnabled": true
+                }
+            }
+        }
+    }
+  ]

--- a/test/__tests__/data/vitally_input.json
+++ b/test/__tests__/data/vitally_input.json
@@ -12,7 +12,6 @@
         },
         "destination": {
             "Config": {
-              "workspace": "wonderbits",
               "apiKey": "abc123"
             },
             "DestinationDefinition": {
@@ -34,7 +33,6 @@
         },
         "destination": {
             "Config": {
-              "workspace": "wonderbits",
               "apiKey": "abc123"
             },
             "DestinationDefinition": {
@@ -54,7 +52,6 @@
         },
         "destination": {
             "Config": {
-              "workspace": "wonderbits",
               "apiKey": "abc123"
             },
             "DestinationDefinition": {
@@ -72,7 +69,6 @@
         },
         "destination": {
             "Config": {
-              "workspace": "wonderbits",
               "apiKey": "abc123"
             },
             "DestinationDefinition": {

--- a/test/__tests__/data/vitally_output.json
+++ b/test/__tests__/data/vitally_output.json
@@ -15,7 +15,7 @@
                 "sentAt": "2023-01-13T09:03:17.562Z"
             }
         },
-        "endpoint": "https://wonderbits.vitally.io/rudderstack",
+        "endpoint": "https://api.vitally.io/rudderstack",
         "files": {},
         "params": {},
         "type": "REST",
@@ -41,7 +41,7 @@
                 "sentAt": "2023-01-13T09:03:17.562Z"
             }
         },
-        "endpoint": "https://wonderbits.vitally.io/rudderstack",
+        "endpoint": "https://api.vitally.io/rudderstack",
         "files": {},
         "params": {},
         "type": "REST",
@@ -65,7 +65,7 @@
                 "sentAt": "2023-01-13T09:03:17.562Z"
             }
         },
-        "endpoint": "https://wonderbits.vitally.io/rudderstack",
+        "endpoint": "https://api.vitally.io/rudderstack",
         "files": {},
         "params": {},
         "type": "REST",

--- a/test/__tests__/data/vitally_output.json
+++ b/test/__tests__/data/vitally_output.json
@@ -1,0 +1,83 @@
+[
+    {
+        "body": {
+            "FORM": {},
+            "JSON_ARRAY": {},
+            "XML": {},
+            "JSON": {
+                "userId": "0220c056-934e-11ed-a1eb-0242ac120002",
+                "event": "this is a track event",
+                "type": "track",
+                "properties": {
+                    "thing": "amazing!"
+                },
+                "originalTimestamp": "2023-01-13T09:03:17.562Z",
+                "sentAt": "2023-01-13T09:03:17.562Z"
+            }
+        },
+        "endpoint": "https://wonderbits.vitally.io/rudderstack",
+        "files": {},
+        "params": {},
+        "type": "REST",
+        "version": "1",
+        "method": "POST",
+        "headers": {
+            "authorization": "Basic abc123",
+            "content-type": "application/json"
+        }
+    },
+    {
+        "body": {
+            "FORM": {},
+            "JSON_ARRAY": {},
+            "XML": {},
+            "JSON": {
+                "userId": "0220c056-934e-11ed-a1eb-0242ac120002",
+                "type": "identify",
+                "traits": {
+                    "name": "Johnny Appleseed"
+                },
+                "originalTimestamp": "2023-01-13T09:03:17.562Z",
+                "sentAt": "2023-01-13T09:03:17.562Z"
+            }
+        },
+        "endpoint": "https://wonderbits.vitally.io/rudderstack",
+        "files": {},
+        "params": {},
+        "type": "REST",
+        "version": "1",
+        "method": "POST",
+        "headers": {
+            "authorization": "Basic abc123",
+            "content-type": "application/json"
+        }
+    },
+    {
+        "body": {
+            "FORM": {},
+            "JSON_ARRAY": {},
+            "XML": {},
+            "JSON": {
+                "userId": "0220c056-934e-11ed-a1eb-0242ac120002",
+                "type": "group",
+                "groupId": "5de17322-934e-11ed-a1eb-0242ac120002",
+                "originalTimestamp": "2023-01-13T09:03:17.562Z",
+                "sentAt": "2023-01-13T09:03:17.562Z"
+            }
+        },
+        "endpoint": "https://wonderbits.vitally.io/rudderstack",
+        "files": {},
+        "params": {},
+        "type": "REST",
+        "version": "1",
+        "method": "POST",
+        "headers": {
+            "authorization": "Basic abc123",
+            "content-type": "application/json"
+        }
+    },
+    {
+        "statusCode": 400,
+        "error": "message type \"page\" not supported for \"vitally\""
+    }
+  ]

--- a/test/__tests__/vitally.test.js
+++ b/test/__tests__/vitally.test.js
@@ -1,0 +1,6 @@
+const {
+  getDestFromTestFile,
+  executeTransformationTest
+} = require("./utilities/test-utils");
+
+executeTransformationTest(getDestFromTestFile(__filename), "processor");


### PR DESCRIPTION
## Description of the change

Adds [Vitally](https://www.vitally.io/) as a new destination. The only transformation needed is:
* attach API key to the authorization header
* drop events that aren't group, identify and track

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

[config-generator](https://github.com/rudderlabs/config-generator/pull/47)
[transformer](https://github.com/rudderlabs/rudder-transformer/pull/1795)
[rudderstack-docs](https://github.com/rudderlabs/rudderstack-docs/pull/1113)


### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
