### PR TITLE
fix: rockerbox empty value check

### DIFF
--- a/src/v0/destinations/rockerbox/transform.js
+++ b/src/v0/destinations/rockerbox/transform.js
@@ -5,7 +5,7 @@ const {
   constructPayload,
   simpleProcessRouterDest,
   getHashFromArray,
-  isDefinedAndNotNullAndNotEmpty,
+  isDefinedAndNotNull,
 } = require('../../util');
 const { EventType } = require('../../../constants');
 const { CONFIG_CATEGORIES, MAPPING_CONFIG } = require('./config');
@@ -23,11 +23,11 @@ const responseBuilderSimple = (message, category, destination) => {
   //handle custom properties mapped in the UI
   const customPropsHashMap = getHashFromArray(customPropsMapping);
 
-  if(isDefinedAndNotNullAndNotEmpty(customPropsHashMap)){
+  if (isDefinedAndNotNull(customPropsHashMap)) {
     for (const key in customPropsHashMap) {
       // check if the custom property is passed in event properties
-      if (isDefinedAndNotNullAndNotEmpty(message.properties[key]))
-        payload[customPropsHashMap[key]] = message.properties[key]
+      if (isDefinedAndNotNull(message.properties[key]))
+        payload[customPropsHashMap[key]] = message.properties[key];
     }
   }
 

--- a/test/__tests__/data/rockerbox.json
+++ b/test/__tests__/data/rockerbox.json
@@ -466,8 +466,8 @@
           }
         },
         "properties": {
-          "unit_id": "123",
-          "merch_id": "merchFBoXoX101",
+          "unit_id": 123,
+          "merch_id": false,
           "bounceiD": "fakefake",
           "counce_id": ""
         },
@@ -487,9 +487,9 @@
           "email": "jamesDoe@gmail.com",
           "phone": "92374162212",
           "action": "conv.add_to_cart",
-          "merch_id": "merchFBoXoX101",
+          "merch_id": false,
           "timestamp": 1571043797,
-          "unitID": "123",
+          "unitID": 123,
           "customer_id": "anon_id",
           "conversion_source": "RudderStack"
         },


### PR DESCRIPTION
## Description of the change

Updating `isDefinedAndNotNullAndNotEmpty` to `isDefinedAndNotNull` as integer values were ignored by it.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
