### PR TITLE
fix(CDK v2): editing CDK v2 for pinterest tag for num_items field

### DIFF
--- a/src/cdk/v2/destinations/pinterest_tag/procWorkflow.yaml
+++ b/src/cdk/v2/destinations/pinterest_tag/procWorkflow.yaml
@@ -8,6 +8,8 @@ bindings:
     path: ../../../../v0/destinations/pinterest_tag/config
   - name: removeUndefinedValues
     path: ../../../../v0/util
+  - name: removeEmptyValues
+    path: ../../../../v0/util
 steps:
   - name: checkIfProcessed
     condition: .message.statusCode
@@ -93,6 +95,7 @@ steps:
         "client_user_agent": .context.userAgent
       });
       userFields = $.removeUndefinedValues(userFields);
+      userFields = $.removeEmptyValues(userFields);
       .destination.Config.sendingUnHashedData ? 
         $.processUserPayload(userFields) :
         $.processHashedUserPayload(userFields, .message)

--- a/src/cdk/v2/destinations/pinterest_tag/procWorkflow.yaml
+++ b/src/cdk/v2/destinations/pinterest_tag/procWorkflow.yaml
@@ -125,7 +125,7 @@ steps:
         template: |
           let products = .message.properties.products;
           {
-            "num_items": $.sum(products.quantity.(Number(.))),
+            "num_items": $.sum(products.quantity.(Number(.))) || 0,
             "content_ids": products.(.product_id ?? .sku ?? .id)[],
             "contents": .message.properties@prop.products.({
               "quantity": Number(.quantity ?? prop.quantity ?? 1),
@@ -137,7 +137,7 @@ steps:
           template: |
             const props = .message.properties;
             const output = {
-              "num_items": Number(props.quantity),
+              "num_items": Number(props.quantity) || 0,
               "content_ids": (props.product_id ?? props.sku ?? props.id)[],
               "contents": {
                 "quantity": Number(props.quantity) || 1,

--- a/src/cdk/v2/destinations/pinterest_tag/procWorkflow.yaml
+++ b/src/cdk/v2/destinations/pinterest_tag/procWorkflow.yaml
@@ -8,7 +8,7 @@ bindings:
     path: ../../../../v0/destinations/pinterest_tag/config
   - name: removeUndefinedValues
     path: ../../../../v0/util
-  - name: removeEmptyValues
+  - name: removeUndefinedAndNullAndEmptyValues
     path: ../../../../v0/util
 steps:
   - name: checkIfProcessed
@@ -94,8 +94,7 @@ steps:
         "client_ip_address": .context.ip ?? .request_ip,
         "client_user_agent": .context.userAgent
       });
-      userFields = $.removeUndefinedValues(userFields);
-      userFields = $.removeEmptyValues(userFields);
+      userFields = $.removeUndefinedAndNullAndEmptyValues(userFields);
       .destination.Config.sendingUnHashedData ? 
         $.processUserPayload(userFields) :
         $.processHashedUserPayload(userFields, .message)

--- a/src/v0/destinations/pinterest_tag/utils.js
+++ b/src/v0/destinations/pinterest_tag/utils.js
@@ -262,7 +262,7 @@ const processHashedUserPayload = (userPayload, message) => {
   });
   // multiKeyMap will works on only specific values like m, male, MALE, f, F, Female
   // if hashed data is sent from the user, it is directly set over here
-  processedHashedUserPayload.ge = [message.traits?.gender || message.context?.traits?.gender];
+  processedHashedUserPayload.ge = [message.traits?.gender || message.context?.traits?.gender || null];
   return processedHashedUserPayload;
 };
 

--- a/src/v0/util/index.js
+++ b/src/v0/util/index.js
@@ -36,7 +36,6 @@ const isNotNull = (x) => x != null;
 const isDefinedAndNotNull = (x) => isDefined(x) && isNotNull(x);
 const isDefinedAndNotNullAndNotEmpty = (x) => isDefined(x) && isNotNull(x) && isNotEmpty(x);
 const removeUndefinedValues = (obj) => _.pickBy(obj, isDefined);
-const removeEmptyValues = (obj) => _.pickBy(obj, isNotEmpty)
 const removeNullValues = (obj) => _.pickBy(obj, isNotNull);
 const removeUndefinedAndNullValues = (obj) => _.pickBy(obj, isDefinedAndNotNull);
 const removeUndefinedAndNullAndEmptyValues = (obj) => _.pickBy(obj, isDefinedAndNotNullAndNotEmpty);
@@ -1784,7 +1783,6 @@ module.exports = {
   isObject,
   isPrimitive,
   isValidUrl,
-  removeEmptyValues,
   removeHyphens,
   removeNullValues,
   removeUndefinedAndNullAndEmptyValues,

--- a/src/v0/util/index.js
+++ b/src/v0/util/index.js
@@ -36,6 +36,7 @@ const isNotNull = (x) => x != null;
 const isDefinedAndNotNull = (x) => isDefined(x) && isNotNull(x);
 const isDefinedAndNotNullAndNotEmpty = (x) => isDefined(x) && isNotNull(x) && isNotEmpty(x);
 const removeUndefinedValues = (obj) => _.pickBy(obj, isDefined);
+const removeEmptyValues = (obj) => _.pickBy(obj, isNotEmpty)
 const removeNullValues = (obj) => _.pickBy(obj, isNotNull);
 const removeUndefinedAndNullValues = (obj) => _.pickBy(obj, isDefinedAndNotNull);
 const removeUndefinedAndNullAndEmptyValues = (obj) => _.pickBy(obj, isDefinedAndNotNullAndNotEmpty);
@@ -1783,6 +1784,7 @@ module.exports = {
   isObject,
   isPrimitive,
   isValidUrl,
+  removeEmptyValues,
   removeHyphens,
   removeNullValues,
   removeUndefinedAndNullAndEmptyValues,

--- a/test/__tests__/data/pinterest_tag_input.json
+++ b/test/__tests__/data/pinterest_tag_input.json
@@ -1410,5 +1410,226 @@
       "Enabled": true,
       "Transformations": []
     }
+  },
+  {
+    "message": {
+        "name": "Test Tool",
+        "type": "page",
+        "sentAt": "2023-02-01T00:00:00.379Z",
+        "userId": "",
+        "channel": "web",
+        "context": {
+            "os": {
+                "name": "",
+                "version": ""
+            },
+            "app": {
+                "name": "RudderLabs JavaScript SDK",
+                "version": "2.22.3",
+                "namespace": "com.rudderlabs.javascript"
+            },
+            "page": {
+                "url": "https://www.abc.com/s598907",
+                "path": "/test-path/s598907",
+                "title": "Test Tool + Reviews | Rudderstack",
+                "search": "",
+                "tab_url": "https://www.abc.com/s598907",
+                "referrer": "$direct",
+                "initial_referrer": "$direct",
+                "referring_domain": "",
+                "initial_referring_domain": ""
+            },
+            "locale": "en-US",
+            "screen": {
+                "width": 1024,
+                "height": 1024,
+                "density": 1,
+                "innerWidth": 1024,
+                "innerHeight": 1024
+            },
+            "traits": {},
+            "library": {
+                "name": "RudderLabs JavaScript SDK",
+                "version": "2.22.3"
+            },
+            "campaign": {},
+            "doNotSell": false,
+            "sessionId": 1675209600203,
+            "userAgent": "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; Googlebot/2.1; +http://www.google.com/bot.html) Chrome/109.0.5414.101 Safari/537.36",
+            "gaClientId": {
+                "integrations": {
+                    "Google Ads": {
+                        "gclid": ""
+                    },
+                    "Google Analytics": {
+                        "clientId": "1518934611.1234569600"
+                    }
+                }
+            },
+            "sessionStart": true
+        },
+        "rudderId": "7291a10f-e7dd-49f9-94ce-0154f53897y6",
+        "messageId": "1c77a616-13a7-4a2e-a8e7-e1a0971897y6",
+        "timestamp": "2023-02-01T12:47:30.030Z",
+        "properties": {
+            "sku": "45790-32",
+            "url": "https://www.abc.com/23rty",
+            "name": "Test Tool",
+            "path": "/test-path/tool",
+            "email": "",
+            "title": "Test Tool + Reviews | Rudderstack",
+            "review": {
+                "reviewCount": 2,
+                "averageReview": 5,
+                "reviewContentID": [
+                    "238300132"
+                ]
+            },
+            "search": "",
+            "tab_url": "https://www.abc/com",
+            "pageInfo": {
+                "pageId": "s592897",
+                "category": {
+                    "pageType": "product",
+                    "subCategory": "Dining & Kitchen Furniture",
+                    "pageTemplate": "product detail grouper",
+                    "primaryCategory": "Furniture"
+                },
+                "brandType": "new brand"
+            },
+            "referrer": "",
+            "subCategory": "Dining & Kitchen Furniture",
+            "primaryCategory": "Furniture",
+            "initial_referrer": "$direct",
+            "referring_domain": "",
+            "initial_referring_domain": ""
+        },
+        "receivedAt": "2023-02-01T12:47:30.038Z",
+        "request_ip": "66.249.72.218",
+        "anonymousId": "a61c77a6-1613-474a-aee8-e7e1a0971047",
+        "integrations": {
+            "All": true
+        },
+        "originalTimestamp": "2023-02-01T00:00:00.371Z"
+    },
+    "destination": {
+        "ID": "1pYpzzvcn7AQ2W9GGIAZSsN6Mfq",
+        "Name": "PINTEREST_TAG",
+        "Config": {
+            "tagId": "123456789",
+            "advertiserId": "123478671210",
+            "sendingUnHashedData": false,
+            "enableDeduplication": false,
+            "eventsMapping": [
+                {
+                    "from": "Product Added",
+                    "to": "AddToCart"
+                },
+                {
+                    "from": "Order Completed",
+                    "to": "Checkout"
+                },
+                {
+                    "from": "Product Viewed",
+                    "to": "PageVisit"
+                },
+                {
+                    "from": "Lead",
+                    "to": "Lead"
+                },
+                {
+                    "from": "Signup",
+                    "to": "Signup"
+                }
+            ],
+            "enhancedMatch": true
+        },
+        "Enabled": true,
+        "Transformations": []
+    }
+},
+{
+  "message": {
+      "type": "track",
+      "event": "custom event",
+      "channel": "web",
+      "sentAt": "2020-08-14T05:30:30.118Z",
+      "context": {
+          "source": "test",
+          "userAgent": "chrome",
+          "traits": {
+              "anonymousId": "50be5c78-6c3f-4b60-be84-97805a316fb1",
+              "email": "abc@gmail.com",
+              "phone": "+1234589947",
+              "ge": "male",
+              "db": "19950715",
+              "lastname": "Ganguly",
+              "firstName": "Shrouti",
+              "address": {
+                  "city": "Kolkata",
+                  "state": "WB",
+                  "zip": "700114",
+                  "country": "IN"
+              }
+          },
+          "device": {
+              "advertisingId": "abc123"
+          },
+          "library": {
+              "name": "rudder-sdk-ruby-sync",
+              "version": "1.0.6"
+          }
+      },
+      "messageId": "7208bbb6-2c4e-45bb-bf5b-ad426f3593e9",
+      "timestamp": "2020-08-14T05:30:30.118Z",
+      "properties": {
+          "sku": "1234",
+          "tax": 2,
+          "total": 27.5,
+          "coupon": "hasbros",
+          "revenue": 48,
+          "currency": "USD",
+          "discount": 2.5,
+          "order_id": "50314b8e9bcf000000000000",
+          "requestIP": "123.0.0.0",
+          "shipping": 3,
+          "subtotal": 22.5,
+          "affiliation": "Google Store",
+          "checkout_id": "fksdjfsdjfisjf9sdfjsd9f"
+      },
+      "anonymousId": "50be5c78-6c3f-4b60-be84-97805a316fb1",
+      "integrations": {
+          "All": true
+      }
+  },
+  "destination": {
+      "ID": "1pYpzzvcn7AQ2W9GGIAZSsN6Mfq",
+      "Name": "PINTEREST_TAG",
+      "Config": {
+          "tagId": "123456789",
+          "advertiserId": "123456",
+          "appId": "429047995",
+          "sendingUnHashedData": true,
+          "enableDeduplication": true,
+          "deduplicationKey": "messageId",
+          "enhancedMatch": true,
+          "customProperties": [
+              {
+                  "properties": "presentclass"
+              },
+              {
+                  "properties": "presentgrade"
+              }
+          ],
+          "eventsMapping": [
+              {
+                  "from": "ABC Searched",
+                  "to": "Watch Video"
+              }
+          ]
+      },
+      "Enabled": true,
+      "Transformations": []
   }
+}
 ]

--- a/test/__tests__/data/pinterest_tag_output.json
+++ b/test/__tests__/data/pinterest_tag_output.json
@@ -18,15 +18,33 @@
           "app_id": "429047995",
           "advertiser_id": "429047995",
           "user_data": {
-            "em": ["48ddb93f0b30c475423fe177832912c5bcdce3cc72872f8051627967ef278e08"],
-            "ph": ["d164bbe036663cb5c96835e9ccc6501e9a521127ea62f6359744928ba932413b"],
-            "ln": ["bdfdee6414a89d72bfbf5ee90b1f85924467bae1e3980d83c2cd348dc31d5819"],
-            "fn": ["ee5db3fe0253b651aca3676692e0c59b25909304f5c51d223a02a215d104144b"],
-            "ct": ["6689106ca7922c30b2fd2c175c85bc7fc2d52cc4941bdd7bb622c6cdc6284a85"],
-            "st": ["3b45022ab36728cdae12e709e945bba267c50ee8a91e6e4388539a8e03a3fdcd"],
-            "zp": ["1a4292e00780e18d00e76fde9850aee5344e939ba593333cd5e4b4aa2cd33b0c"],
-            "country": ["582967534d0f909d196b97f9e6921342777aea87b46fa52df165389db1fb8ccf"],
-            "hashed_maids": ["6ca13d52ca70c883e0f0bb101e425a89e8624de51db2d2392593af6a84118090"],
+            "em": [
+              "48ddb93f0b30c475423fe177832912c5bcdce3cc72872f8051627967ef278e08"
+            ],
+            "ph": [
+              "d164bbe036663cb5c96835e9ccc6501e9a521127ea62f6359744928ba932413b"
+            ],
+            "ln": [
+              "bdfdee6414a89d72bfbf5ee90b1f85924467bae1e3980d83c2cd348dc31d5819"
+            ],
+            "fn": [
+              "ee5db3fe0253b651aca3676692e0c59b25909304f5c51d223a02a215d104144b"
+            ],
+            "ct": [
+              "6689106ca7922c30b2fd2c175c85bc7fc2d52cc4941bdd7bb622c6cdc6284a85"
+            ],
+            "st": [
+              "3b45022ab36728cdae12e709e945bba267c50ee8a91e6e4388539a8e03a3fdcd"
+            ],
+            "zp": [
+              "1a4292e00780e18d00e76fde9850aee5344e939ba593333cd5e4b4aa2cd33b0c"
+            ],
+            "country": [
+              "582967534d0f909d196b97f9e6921342777aea87b46fa52df165389db1fb8ccf"
+            ],
+            "hashed_maids": [
+              "6ca13d52ca70c883e0f0bb101e425a89e8624de51db2d2392593af6a84118090"
+            ],
             "client_user_agent": "chrome"
           },
           "custom_data": {
@@ -35,7 +53,10 @@
             "order_id": "50314b8e9bcf000000000000",
             "opt_out_type": "LDP",
             "num_items": 3,
-            "content_ids": ["507f1f77bcf86cd799439011", "505bd76785ebb509fc183733"],
+            "content_ids": [
+              "507f1f77bcf86cd799439011",
+              "505bd76785ebb509fc183733"
+            ],
             "contents": [
               {
                 "quantity": 1,
@@ -74,15 +95,33 @@
           "app_id": "429047995",
           "advertiser_id": "429047995",
           "user_data": {
-            "em": ["48ddb93f0b30c475423fe177832912c5bcdce3cc72872f8051627967ef278e08"],
-            "ph": ["d164bbe036663cb5c96835e9ccc6501e9a521127ea62f6359744928ba932413b"],
-            "ln": ["bdfdee6414a89d72bfbf5ee90b1f85924467bae1e3980d83c2cd348dc31d5819"],
-            "fn": ["ee5db3fe0253b651aca3676692e0c59b25909304f5c51d223a02a215d104144b"],
-            "ct": ["6689106ca7922c30b2fd2c175c85bc7fc2d52cc4941bdd7bb622c6cdc6284a85"],
-            "st": ["3b45022ab36728cdae12e709e945bba267c50ee8a91e6e4388539a8e03a3fdcd"],
-            "zp": ["1a4292e00780e18d00e76fde9850aee5344e939ba593333cd5e4b4aa2cd33b0c"],
-            "country": ["582967534d0f909d196b97f9e6921342777aea87b46fa52df165389db1fb8ccf"],
-            "hashed_maids": ["6ca13d52ca70c883e0f0bb101e425a89e8624de51db2d2392593af6a84118090"],
+            "em": [
+              "48ddb93f0b30c475423fe177832912c5bcdce3cc72872f8051627967ef278e08"
+            ],
+            "ph": [
+              "d164bbe036663cb5c96835e9ccc6501e9a521127ea62f6359744928ba932413b"
+            ],
+            "ln": [
+              "bdfdee6414a89d72bfbf5ee90b1f85924467bae1e3980d83c2cd348dc31d5819"
+            ],
+            "fn": [
+              "ee5db3fe0253b651aca3676692e0c59b25909304f5c51d223a02a215d104144b"
+            ],
+            "ct": [
+              "6689106ca7922c30b2fd2c175c85bc7fc2d52cc4941bdd7bb622c6cdc6284a85"
+            ],
+            "st": [
+              "3b45022ab36728cdae12e709e945bba267c50ee8a91e6e4388539a8e03a3fdcd"
+            ],
+            "zp": [
+              "1a4292e00780e18d00e76fde9850aee5344e939ba593333cd5e4b4aa2cd33b0c"
+            ],
+            "country": [
+              "582967534d0f909d196b97f9e6921342777aea87b46fa52df165389db1fb8ccf"
+            ],
+            "hashed_maids": [
+              "6ca13d52ca70c883e0f0bb101e425a89e8624de51db2d2392593af6a84118090"
+            ],
             "client_user_agent": "chrome"
           },
           "custom_data": {
@@ -90,7 +129,10 @@
             "value": 27.5,
             "order_id": "50314b8e9bcf000000000000",
             "num_items": 3,
-            "content_ids": ["507f1f77bcf86cd799439011", "505bd76785ebb509fc183733"],
+            "content_ids": [
+              "507f1f77bcf86cd799439011",
+              "505bd76785ebb509fc183733"
+            ],
             "contents": [
               {
                 "quantity": 1,
@@ -129,15 +171,33 @@
           "app_id": "429047995",
           "advertiser_id": "429047995",
           "user_data": {
-            "em": ["48ddb93f0b30c475423fe177832912c5bcdce3cc72872f8051627967ef278e08"],
-            "ph": ["d164bbe036663cb5c96835e9ccc6501e9a521127ea62f6359744928ba932413b"],
-            "ln": ["bdfdee6414a89d72bfbf5ee90b1f85924467bae1e3980d83c2cd348dc31d5819"],
-            "fn": ["ee5db3fe0253b651aca3676692e0c59b25909304f5c51d223a02a215d104144b"],
-            "ct": ["6689106ca7922c30b2fd2c175c85bc7fc2d52cc4941bdd7bb622c6cdc6284a85"],
-            "st": ["3b45022ab36728cdae12e709e945bba267c50ee8a91e6e4388539a8e03a3fdcd"],
-            "zp": ["1a4292e00780e18d00e76fde9850aee5344e939ba593333cd5e4b4aa2cd33b0c"],
-            "country": ["582967534d0f909d196b97f9e6921342777aea87b46fa52df165389db1fb8ccf"],
-            "hashed_maids": ["6ca13d52ca70c883e0f0bb101e425a89e8624de51db2d2392593af6a84118090"],
+            "em": [
+              "48ddb93f0b30c475423fe177832912c5bcdce3cc72872f8051627967ef278e08"
+            ],
+            "ph": [
+              "d164bbe036663cb5c96835e9ccc6501e9a521127ea62f6359744928ba932413b"
+            ],
+            "ln": [
+              "bdfdee6414a89d72bfbf5ee90b1f85924467bae1e3980d83c2cd348dc31d5819"
+            ],
+            "fn": [
+              "ee5db3fe0253b651aca3676692e0c59b25909304f5c51d223a02a215d104144b"
+            ],
+            "ct": [
+              "6689106ca7922c30b2fd2c175c85bc7fc2d52cc4941bdd7bb622c6cdc6284a85"
+            ],
+            "st": [
+              "3b45022ab36728cdae12e709e945bba267c50ee8a91e6e4388539a8e03a3fdcd"
+            ],
+            "zp": [
+              "1a4292e00780e18d00e76fde9850aee5344e939ba593333cd5e4b4aa2cd33b0c"
+            ],
+            "country": [
+              "582967534d0f909d196b97f9e6921342777aea87b46fa52df165389db1fb8ccf"
+            ],
+            "hashed_maids": [
+              "6ca13d52ca70c883e0f0bb101e425a89e8624de51db2d2392593af6a84118090"
+            ],
             "client_user_agent": "chrome"
           },
           "custom_data": {
@@ -145,7 +205,9 @@
             "value": 27.5,
             "order_id": "50314b8e9bcf000000000000",
             "num_items": 2,
-            "content_ids": ["123"],
+            "content_ids": [
+              "123"
+            ],
             "contents": [
               {
                 "quantity": 2,
@@ -188,15 +250,33 @@
           "app_id": "429047995",
           "advertiser_id": "429047995",
           "user_data": {
-            "em": ["48ddb93f0b30c475423fe177832912c5bcdce3cc72872f8051627967ef278e08"],
-            "ph": ["d164bbe036663cb5c96835e9ccc6501e9a521127ea62f6359744928ba932413b"],
-            "ln": ["bdfdee6414a89d72bfbf5ee90b1f85924467bae1e3980d83c2cd348dc31d5819"],
-            "fn": ["ee5db3fe0253b651aca3676692e0c59b25909304f5c51d223a02a215d104144b"],
-            "ct": ["6689106ca7922c30b2fd2c175c85bc7fc2d52cc4941bdd7bb622c6cdc6284a85"],
-            "st": ["3b45022ab36728cdae12e709e945bba267c50ee8a91e6e4388539a8e03a3fdcd"],
-            "zp": ["1a4292e00780e18d00e76fde9850aee5344e939ba593333cd5e4b4aa2cd33b0c"],
-            "country": ["582967534d0f909d196b97f9e6921342777aea87b46fa52df165389db1fb8ccf"],
-            "hashed_maids": ["6ca13d52ca70c883e0f0bb101e425a89e8624de51db2d2392593af6a84118090"],
+            "em": [
+              "48ddb93f0b30c475423fe177832912c5bcdce3cc72872f8051627967ef278e08"
+            ],
+            "ph": [
+              "d164bbe036663cb5c96835e9ccc6501e9a521127ea62f6359744928ba932413b"
+            ],
+            "ln": [
+              "bdfdee6414a89d72bfbf5ee90b1f85924467bae1e3980d83c2cd348dc31d5819"
+            ],
+            "fn": [
+              "ee5db3fe0253b651aca3676692e0c59b25909304f5c51d223a02a215d104144b"
+            ],
+            "ct": [
+              "6689106ca7922c30b2fd2c175c85bc7fc2d52cc4941bdd7bb622c6cdc6284a85"
+            ],
+            "st": [
+              "3b45022ab36728cdae12e709e945bba267c50ee8a91e6e4388539a8e03a3fdcd"
+            ],
+            "zp": [
+              "1a4292e00780e18d00e76fde9850aee5344e939ba593333cd5e4b4aa2cd33b0c"
+            ],
+            "country": [
+              "582967534d0f909d196b97f9e6921342777aea87b46fa52df165389db1fb8ccf"
+            ],
+            "hashed_maids": [
+              "6ca13d52ca70c883e0f0bb101e425a89e8624de51db2d2392593af6a84118090"
+            ],
             "client_user_agent": "chrome"
           },
           "custom_data": {
@@ -204,7 +284,10 @@
             "value": 27.5,
             "num_items": 2,
             "order_id": "50314b8e9bcf000000000000",
-            "content_ids": ["507f1f77bcf86cd799439011", "505bd76785ebb509fc183733"],
+            "content_ids": [
+              "507f1f77bcf86cd799439011",
+              "505bd76785ebb509fc183733"
+            ],
             "contents": [
               {
                 "quantity": 1,
@@ -255,15 +338,33 @@
           "action_source": "web",
           "advertiser_id": "123456",
           "user_data": {
-            "em": ["48ddb93f0b30c475423fe177832912c5bcdce3cc72872f8051627967ef278e08"],
-            "ph": ["d164bbe036663cb5c96835e9ccc6501e9a521127ea62f6359744928ba932413b"],
-            "ln": ["bdfdee6414a89d72bfbf5ee90b1f85924467bae1e3980d83c2cd348dc31d5819"],
-            "fn": ["ee5db3fe0253b651aca3676692e0c59b25909304f5c51d223a02a215d104144b"],
-            "ct": ["6689106ca7922c30b2fd2c175c85bc7fc2d52cc4941bdd7bb622c6cdc6284a85"],
-            "st": ["3b45022ab36728cdae12e709e945bba267c50ee8a91e6e4388539a8e03a3fdcd"],
-            "zp": ["1a4292e00780e18d00e76fde9850aee5344e939ba593333cd5e4b4aa2cd33b0c"],
-            "country": ["582967534d0f909d196b97f9e6921342777aea87b46fa52df165389db1fb8ccf"],
-            "hashed_maids": ["6ca13d52ca70c883e0f0bb101e425a89e8624de51db2d2392593af6a84118090"],
+            "em": [
+              "48ddb93f0b30c475423fe177832912c5bcdce3cc72872f8051627967ef278e08"
+            ],
+            "ph": [
+              "d164bbe036663cb5c96835e9ccc6501e9a521127ea62f6359744928ba932413b"
+            ],
+            "ln": [
+              "bdfdee6414a89d72bfbf5ee90b1f85924467bae1e3980d83c2cd348dc31d5819"
+            ],
+            "fn": [
+              "ee5db3fe0253b651aca3676692e0c59b25909304f5c51d223a02a215d104144b"
+            ],
+            "ct": [
+              "6689106ca7922c30b2fd2c175c85bc7fc2d52cc4941bdd7bb622c6cdc6284a85"
+            ],
+            "st": [
+              "3b45022ab36728cdae12e709e945bba267c50ee8a91e6e4388539a8e03a3fdcd"
+            ],
+            "zp": [
+              "1a4292e00780e18d00e76fde9850aee5344e939ba593333cd5e4b4aa2cd33b0c"
+            ],
+            "country": [
+              "582967534d0f909d196b97f9e6921342777aea87b46fa52df165389db1fb8ccf"
+            ],
+            "hashed_maids": [
+              "6ca13d52ca70c883e0f0bb101e425a89e8624de51db2d2392593af6a84118090"
+            ],
             "client_user_agent": "chrome"
           },
           "custom_data": {
@@ -271,7 +372,10 @@
             "value": 27.5,
             "num_items": 2,
             "order_id": "50314b8e9bcf000000000000",
-            "content_ids": ["507f1f77bcf86cd799439011", "505bd76785ebb509fc183733"],
+            "content_ids": [
+              "507f1f77bcf86cd799439011",
+              "505bd76785ebb509fc183733"
+            ],
             "contents": [
               {
                 "quantity": 1,
@@ -310,15 +414,33 @@
           "app_id": "429047995",
           "advertiser_id": "123456",
           "user_data": {
-            "em": ["48ddb93f0b30c475423fe177832912c5bcdce3cc72872f8051627967ef278e08"],
-            "ph": ["d164bbe036663cb5c96835e9ccc6501e9a521127ea62f6359744928ba932413b"],
-            "ln": ["bdfdee6414a89d72bfbf5ee90b1f85924467bae1e3980d83c2cd348dc31d5819"],
-            "fn": ["ee5db3fe0253b651aca3676692e0c59b25909304f5c51d223a02a215d104144b"],
-            "ct": ["6689106ca7922c30b2fd2c175c85bc7fc2d52cc4941bdd7bb622c6cdc6284a85"],
-            "st": ["3b45022ab36728cdae12e709e945bba267c50ee8a91e6e4388539a8e03a3fdcd"],
-            "zp": ["1a4292e00780e18d00e76fde9850aee5344e939ba593333cd5e4b4aa2cd33b0c"],
-            "country": ["582967534d0f909d196b97f9e6921342777aea87b46fa52df165389db1fb8ccf"],
-            "hashed_maids": ["6ca13d52ca70c883e0f0bb101e425a89e8624de51db2d2392593af6a84118090"],
+            "em": [
+              "48ddb93f0b30c475423fe177832912c5bcdce3cc72872f8051627967ef278e08"
+            ],
+            "ph": [
+              "d164bbe036663cb5c96835e9ccc6501e9a521127ea62f6359744928ba932413b"
+            ],
+            "ln": [
+              "bdfdee6414a89d72bfbf5ee90b1f85924467bae1e3980d83c2cd348dc31d5819"
+            ],
+            "fn": [
+              "ee5db3fe0253b651aca3676692e0c59b25909304f5c51d223a02a215d104144b"
+            ],
+            "ct": [
+              "6689106ca7922c30b2fd2c175c85bc7fc2d52cc4941bdd7bb622c6cdc6284a85"
+            ],
+            "st": [
+              "3b45022ab36728cdae12e709e945bba267c50ee8a91e6e4388539a8e03a3fdcd"
+            ],
+            "zp": [
+              "1a4292e00780e18d00e76fde9850aee5344e939ba593333cd5e4b4aa2cd33b0c"
+            ],
+            "country": [
+              "582967534d0f909d196b97f9e6921342777aea87b46fa52df165389db1fb8ccf"
+            ],
+            "hashed_maids": [
+              "6ca13d52ca70c883e0f0bb101e425a89e8624de51db2d2392593af6a84118090"
+            ],
             "client_user_agent": "chrome"
           }
         },
@@ -348,15 +470,33 @@
           "app_id": "429047995",
           "advertiser_id": "123456",
           "user_data": {
-            "em": ["48ddb93f0b30c475423fe177832912c5bcdce3cc72872f8051627967ef278e08"],
-            "ph": ["d164bbe036663cb5c96835e9ccc6501e9a521127ea62f6359744928ba932413b"],
-            "ln": ["bdfdee6414a89d72bfbf5ee90b1f85924467bae1e3980d83c2cd348dc31d5819"],
-            "fn": ["ee5db3fe0253b651aca3676692e0c59b25909304f5c51d223a02a215d104144b"],
-            "ct": ["6689106ca7922c30b2fd2c175c85bc7fc2d52cc4941bdd7bb622c6cdc6284a85"],
-            "st": ["3b45022ab36728cdae12e709e945bba267c50ee8a91e6e4388539a8e03a3fdcd"],
-            "zp": ["1a4292e00780e18d00e76fde9850aee5344e939ba593333cd5e4b4aa2cd33b0c"],
-            "country": ["582967534d0f909d196b97f9e6921342777aea87b46fa52df165389db1fb8ccf"],
-            "hashed_maids": ["6ca13d52ca70c883e0f0bb101e425a89e8624de51db2d2392593af6a84118090"],
+            "em": [
+              "48ddb93f0b30c475423fe177832912c5bcdce3cc72872f8051627967ef278e08"
+            ],
+            "ph": [
+              "d164bbe036663cb5c96835e9ccc6501e9a521127ea62f6359744928ba932413b"
+            ],
+            "ln": [
+              "bdfdee6414a89d72bfbf5ee90b1f85924467bae1e3980d83c2cd348dc31d5819"
+            ],
+            "fn": [
+              "ee5db3fe0253b651aca3676692e0c59b25909304f5c51d223a02a215d104144b"
+            ],
+            "ct": [
+              "6689106ca7922c30b2fd2c175c85bc7fc2d52cc4941bdd7bb622c6cdc6284a85"
+            ],
+            "st": [
+              "3b45022ab36728cdae12e709e945bba267c50ee8a91e6e4388539a8e03a3fdcd"
+            ],
+            "zp": [
+              "1a4292e00780e18d00e76fde9850aee5344e939ba593333cd5e4b4aa2cd33b0c"
+            ],
+            "country": [
+              "582967534d0f909d196b97f9e6921342777aea87b46fa52df165389db1fb8ccf"
+            ],
+            "hashed_maids": [
+              "6ca13d52ca70c883e0f0bb101e425a89e8624de51db2d2392593af6a84118090"
+            ],
             "client_user_agent": "chrome"
           }
         },
@@ -387,15 +527,33 @@
           "app_id": "429047995",
           "advertiser_id": "123456",
           "user_data": {
-            "em": ["48ddb93f0b30c475423fe177832912c5bcdce3cc72872f8051627967ef278e08"],
-            "ph": ["d164bbe036663cb5c96835e9ccc6501e9a521127ea62f6359744928ba932413b"],
-            "ln": ["bdfdee6414a89d72bfbf5ee90b1f85924467bae1e3980d83c2cd348dc31d5819"],
-            "fn": ["ee5db3fe0253b651aca3676692e0c59b25909304f5c51d223a02a215d104144b"],
-            "ct": ["6689106ca7922c30b2fd2c175c85bc7fc2d52cc4941bdd7bb622c6cdc6284a85"],
-            "st": ["3b45022ab36728cdae12e709e945bba267c50ee8a91e6e4388539a8e03a3fdcd"],
-            "zp": ["1a4292e00780e18d00e76fde9850aee5344e939ba593333cd5e4b4aa2cd33b0c"],
-            "country": ["582967534d0f909d196b97f9e6921342777aea87b46fa52df165389db1fb8ccf"],
-            "hashed_maids": ["6ca13d52ca70c883e0f0bb101e425a89e8624de51db2d2392593af6a84118090"],
+            "em": [
+              "48ddb93f0b30c475423fe177832912c5bcdce3cc72872f8051627967ef278e08"
+            ],
+            "ph": [
+              "d164bbe036663cb5c96835e9ccc6501e9a521127ea62f6359744928ba932413b"
+            ],
+            "ln": [
+              "bdfdee6414a89d72bfbf5ee90b1f85924467bae1e3980d83c2cd348dc31d5819"
+            ],
+            "fn": [
+              "ee5db3fe0253b651aca3676692e0c59b25909304f5c51d223a02a215d104144b"
+            ],
+            "ct": [
+              "6689106ca7922c30b2fd2c175c85bc7fc2d52cc4941bdd7bb622c6cdc6284a85"
+            ],
+            "st": [
+              "3b45022ab36728cdae12e709e945bba267c50ee8a91e6e4388539a8e03a3fdcd"
+            ],
+            "zp": [
+              "1a4292e00780e18d00e76fde9850aee5344e939ba593333cd5e4b4aa2cd33b0c"
+            ],
+            "country": [
+              "582967534d0f909d196b97f9e6921342777aea87b46fa52df165389db1fb8ccf"
+            ],
+            "hashed_maids": [
+              "6ca13d52ca70c883e0f0bb101e425a89e8624de51db2d2392593af6a84118090"
+            ],
             "client_user_agent": "chrome"
           }
         },
@@ -426,13 +584,27 @@
           "app_id": "429047995",
           "advertiser_id": "123456",
           "user_data": {
-            "ph": ["d164bbe036663cb5c96835e9ccc6501e9a521127ea62f6359744928ba932413b"],
-            "ln": ["bdfdee6414a89d72bfbf5ee90b1f85924467bae1e3980d83c2cd348dc31d5819"],
-            "fn": ["ee5db3fe0253b651aca3676692e0c59b25909304f5c51d223a02a215d104144b"],
-            "ct": ["6689106ca7922c30b2fd2c175c85bc7fc2d52cc4941bdd7bb622c6cdc6284a85"],
-            "st": ["3b45022ab36728cdae12e709e945bba267c50ee8a91e6e4388539a8e03a3fdcd"],
-            "zp": ["1a4292e00780e18d00e76fde9850aee5344e939ba593333cd5e4b4aa2cd33b0c"],
-            "country": ["582967534d0f909d196b97f9e6921342777aea87b46fa52df165389db1fb8ccf"],
+            "ph": [
+              "d164bbe036663cb5c96835e9ccc6501e9a521127ea62f6359744928ba932413b"
+            ],
+            "ln": [
+              "bdfdee6414a89d72bfbf5ee90b1f85924467bae1e3980d83c2cd348dc31d5819"
+            ],
+            "fn": [
+              "ee5db3fe0253b651aca3676692e0c59b25909304f5c51d223a02a215d104144b"
+            ],
+            "ct": [
+              "6689106ca7922c30b2fd2c175c85bc7fc2d52cc4941bdd7bb622c6cdc6284a85"
+            ],
+            "st": [
+              "3b45022ab36728cdae12e709e945bba267c50ee8a91e6e4388539a8e03a3fdcd"
+            ],
+            "zp": [
+              "1a4292e00780e18d00e76fde9850aee5344e939ba593333cd5e4b4aa2cd33b0c"
+            ],
+            "country": [
+              "582967534d0f909d196b97f9e6921342777aea87b46fa52df165389db1fb8ccf"
+            ],
             "client_ip_address": "127.0.0.0",
             "client_user_agent": "chrome"
           }
@@ -464,17 +636,144 @@
           "advertiser_id": "123456",
           "event_id": "7208bbb6-2c4e-45bb-bf5b-ad426f3593e9",
           "user_data": {
-            "ph": ["Hashed phone"],
-            "db": ["Hashed DB"],
-            "ln": ["Hashed Lastname"],
-            "fn": ["Hashed FirstName"],
-            "ct": ["hashed city"],
-            "st": ["hashed state"],
-            "zp": ["Hashed Zip"],
-            "country": ["hashed country"],
-            "hashed_maids": ["Hashed maids"],
-            "ge": ["Hashed Gender"],
+            "ph": [
+              "Hashed phone"
+            ],
+            "db": [
+              "Hashed DB"
+            ],
+            "ln": [
+              "Hashed Lastname"
+            ],
+            "fn": [
+              "Hashed FirstName"
+            ],
+            "ct": [
+              "hashed city"
+            ],
+            "st": [
+              "hashed state"
+            ],
+            "zp": [
+              "Hashed Zip"
+            ],
+            "country": [
+              "hashed country"
+            ],
+            "hashed_maids": [
+              "Hashed maids"
+            ],
+            "ge": [
+              "Hashed Gender"
+            ],
             "client_user_agent": "chrome"
+          }
+        },
+        "JSON_ARRAY": {},
+        "XML": {},
+        "FORM": {}
+      },
+      "files": {}
+    }
+  ],
+  [
+    {
+      "body": {
+        "JSON": {
+          "event_time": 1675209600,
+          "event_source_url": "https://www.abc.com/s598907",
+          "action_source": "web",
+          "app_name": "RudderLabs JavaScript SDK",
+          "app_version": "2.22.3",
+          "language": "en-US",
+          "event_id": "1c77a616-13a7-4a2e-a8e7-e1a0971897y6",
+          "advertiser_id": "123478671210",
+          "user_data": {
+            "client_ip_address": "66.249.72.218",
+            "client_user_agent": "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; Googlebot/2.1; +http://www.google.com/bot.html) Chrome/109.0.5414.101 Safari/537.36",
+            "ge": [
+              null
+            ]
+          },
+          "event_name": "PageVisit"
+        },
+        "JSON_ARRAY": {},
+        "XML": {},
+        "FORM": {}
+      },
+      "version": "1",
+      "type": "REST",
+      "method": "POST",
+      "endpoint": "https://ct.pinterest.com/events/v3",
+      "headers": {
+        "Content-Type": "application/json"
+      },
+      "params": {},
+      "files": {}
+    }
+  ],
+  [
+    {
+      "version": "1",
+      "type": "REST",
+      "method": "POST",
+      "endpoint": "https://ct.pinterest.com/events/v3",
+      "headers": {
+        "Content-Type": "application/json"
+      },
+      "params": {},
+      "body": {
+        "JSON": {
+          "event_name": "custom event",
+          "event_time": 1597383030,
+          "action_source": "web",
+          "event_id": "7208bbb6-2c4e-45bb-bf5b-ad426f3593e9",
+          "app_id": "429047995",
+          "advertiser_id": "123456",
+          "user_data": {
+            "em": [
+              "48ddb93f0b30c475423fe177832912c5bcdce3cc72872f8051627967ef278e08"
+            ],
+            "ph": [
+              "d164bbe036663cb5c96835e9ccc6501e9a521127ea62f6359744928ba932413b"
+            ],
+            "ln": [
+              "bdfdee6414a89d72bfbf5ee90b1f85924467bae1e3980d83c2cd348dc31d5819"
+            ],
+            "fn": [
+              "ee5db3fe0253b651aca3676692e0c59b25909304f5c51d223a02a215d104144b"
+            ],
+            "ct": [
+              "6689106ca7922c30b2fd2c175c85bc7fc2d52cc4941bdd7bb622c6cdc6284a85"
+            ],
+            "st": [
+              "3b45022ab36728cdae12e709e945bba267c50ee8a91e6e4388539a8e03a3fdcd"
+            ],
+            "zp": [
+              "1a4292e00780e18d00e76fde9850aee5344e939ba593333cd5e4b4aa2cd33b0c"
+            ],
+            "country": [
+              "582967534d0f909d196b97f9e6921342777aea87b46fa52df165389db1fb8ccf"
+            ],
+            "hashed_maids": [
+              "6ca13d52ca70c883e0f0bb101e425a89e8624de51db2d2392593af6a84118090"
+            ],
+            "client_user_agent": "chrome"
+          },
+          "custom_data": {
+            "currency": "USD",
+            "value": 27.5,
+            "order_id": "50314b8e9bcf000000000000",
+            "num_items": 0,
+            "content_ids": [
+              "1234"
+            ],
+            "contents": [
+              {
+                "quantity": 1,
+                "item_price": "undefined"
+              }
+            ]
           }
         },
         "JSON_ARRAY": {},


### PR DESCRIPTION
## Description of the change

> 
Pinterest implementation in CDK v2, where returning different value for

-  `em`, the value is `""`
-  `num_items` were missing if there was no product array
- in our JS implementation, we also saw that, if no gender parameter is present, it is returning undefined, so fixed that as well.


## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
