### PR TITLE
fix(transformation): release isolate in case of error while creating

### DIFF
--- a/src/util/ivmFactory.js
+++ b/src/util/ivmFactory.js
@@ -259,10 +259,12 @@ async function createIvm(code, libraryVersionIds, versionId, testMode) {
   const bootstrapScriptResult = await bootstrap.run(context);
   // const customScript = await isolate.compileScript(`${library} ;\n; ${code}`);
   const customScriptModule = await isolate.compileModule(`${codeWithWrapper}`);
-  await customScriptModule.instantiate(context, (spec) => {
+  await customScriptModule.instantiate(context, async (spec) => {
     if (librariesMap[spec]) {
       return compiledModules[spec].module;
     }
+    // Release the isolate context before throwing an error
+    await context.release();
     console.log(`import from ${spec} failed. Module not found.`);
     throw new Error(`import from ${spec} failed. Module not found.`);
   });


### PR DESCRIPTION
## Description of the change

> while creation of isolate, make sure to release context in case of error

https://www.notion.so/rudderstacks/Debug-why-transformer-crashes-on-import-error-b35d693b74c6406f920a3c7ce0e48d21

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
