### PR TITLE
fix(klaviyo): skip profile lookup call for rETL events

### DIFF
--- a/src/v0/destinations/klaviyo/transform.js
+++ b/src/v0/destinations/klaviyo/transform.js
@@ -57,7 +57,7 @@ const identifyRequestHandler = async (message, category, destination) => {
   const traitsInfo = getFieldValueFromMessage(message, 'traits');
   const response = defaultRequestConfig();
   let personId;
-  if (!mappedToDestination) {
+  if (message.channel !== 'sources') {
     personId = await isProfileExist(message, destination);
   }
   let propertyPayload = constructPayload(message, MAPPING_CONFIG[category.name]);

--- a/src/v0/destinations/klaviyo/transform.js
+++ b/src/v0/destinations/klaviyo/transform.js
@@ -56,7 +56,10 @@ const identifyRequestHandler = async (message, category, destination) => {
   }
   const traitsInfo = getFieldValueFromMessage(message, 'traits');
   const response = defaultRequestConfig();
-  const personId = await isProfileExist(message, destination);
+  let personId;
+  if (!mappedToDestination) {
+    personId = await isProfileExist(message, destination);
+  }
   let propertyPayload = constructPayload(message, MAPPING_CONFIG[category.name]);
   // Extract other K-V property from traits about user custom properties
   propertyPayload = extractCustomFields(

--- a/test/__tests__/data/klaviyo.json
+++ b/test/__tests__/data/klaviyo.json
@@ -1158,7 +1158,7 @@
     }
   },
   {
-    "description": "Throwing error if list Id is not in the payload",
+    "description": "Identify call for existing profile details when mappedToDestination key is true",
     "input": {
       "destination": {
         "Config": {
@@ -1211,21 +1211,24 @@
       {
         "version": "1",
         "type": "REST",
-        "method": "PUT",
-        "endpoint": "https://a.klaviyo.com/api/v1/person/01G79MV4XVPABNP8G5FSK40QES",
+        "method": "POST",
+        "endpoint": "https://a.klaviyo.com/api/identify",
         "headers": {
-          "Accept": "application/json"
+          "Content-Type": "application/json",
+          "Accept": "text/html"
         },
-        "params": {
-          "$id": "utsab@rudderstack.com",
-          "$email": "utsab@rudderstack.com",
-          "api_key": "pk_b68c7b5163d98807fcb57e6f921216629d",
-          "$first_name": "Utsab",
-          "$last_name": "Chowdhury",
-          "omega": "omegashenron"
-        },
+        "params": {},
         "body": {
-          "JSON": {},
+          "JSON": {
+            "token": "WJqij9",
+            "properties": {
+              "$email": "utsab@rudderstack.com",
+              "omega": "omegashenron",
+              "$last_name": "Chowdhury",
+              "$first_name": "Utsab",
+              "$id": "utsab@rudderstack.com"
+            }
+          },
           "JSON_ARRAY": {},
           "XML": {},
           "FORM": {}

--- a/test/__tests__/data/klaviyo.json
+++ b/test/__tests__/data/klaviyo.json
@@ -1158,7 +1158,7 @@
     }
   },
   {
-    "description": "Identify call for existing profile details when mappedToDestination key is true",
+    "description": "Identify call for existing profile details when channel === 'sources'",
     "input": {
       "destination": {
         "Config": {
@@ -1170,9 +1170,8 @@
         "type": "identify",
         "sentAt": "2021-01-03T17:02:53.195Z",
         "userId": "utsabc",
-        "channel": "web",
+        "channel": "sources",
         "context": {
-          "mappedToDestination": true,
           "externalId": [
             {
               "identifierType": "$email",
@@ -1226,7 +1225,7 @@
               "omega": "omegashenron",
               "$last_name": "Chowdhury",
               "$first_name": "Utsab",
-              "$id": "utsab@rudderstack.com"
+              "$id": "utsabc"
             }
           },
           "JSON_ARRAY": {},


### PR DESCRIPTION
## Description of the change

Skip profile lookup call to check for existing user for rETL events

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
