### PR TITLE
chore: add instanceName tag to statsd metrics

### DIFF
--- a/src/util/stats.js
+++ b/src/util/stats.js
@@ -3,12 +3,15 @@ const SDC = require('statsd-client');
 const enableStats = process.env.ENABLE_STATS !== 'false';
 const statsServerHost = process.env.STATSD_SERVER_HOST || 'localhost';
 const statsServerPort = parseInt(process.env.STATSD_SERVER_PORT || '8125', 10);
+const instanceID = process.env.INSTANCE_ID || 'localhost';
 
 const statsdClient = new SDC({
   host: statsServerHost,
   port: statsServerPort,
   prefix: 'transformer',
-  tags: {},
+  tags: {
+    instanceName: instanceID,
+  },
 });
 
 // Sends the diff between current time and start as the stat


### PR DESCRIPTION
## Description of the change

Adding instanceName tag to metrics (to have a unique dimension) so as to deploy a common statsd exporter to all transformer pods rather than sidecar to individual pod

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
