### PR TITLE
fix(integration): pinterest conversion in cdk v2 returns correct num_items for single product array

### DIFF
--- a/src/cdk/v2/destinations/pinterest_tag/procWorkflow.yaml
+++ b/src/cdk/v2/destinations/pinterest_tag/procWorkflow.yaml
@@ -127,7 +127,7 @@ steps:
         template: |
           let products = .message.properties.products;
           {
-            "num_items": $.sum(products.quantity.(Number(.))) || 0,
+            "num_items": $.sum(products.quantity.(Number(.))[]) || 0,
             "content_ids": products.(.product_id ?? .sku ?? .id)[],
             "contents": .message.properties@prop.products.({
               "quantity": Number(.quantity ?? prop.quantity ?? 1),

--- a/test/__tests__/data/pinterest_tag_input.json
+++ b/test/__tests__/data/pinterest_tag_input.json
@@ -1631,5 +1631,102 @@
       "Enabled": true,
       "Transformations": []
   }
+},
+{
+    "message": {
+        "type": "track",
+        "event": "custom event",
+        "channel": "web",
+        "sentAt": "2020-08-14T05:30:30.118Z",
+        "context": {
+            "source": "test",
+            "userAgent": "chrome",
+            "traits": {
+                "anonymousId": "50be5c78-6c3f-4b60-be84-97805a316fb1",
+                "email": "abc@gmail.com",
+                "phone": "+1234589947",
+                "ge": "male",
+                "db": "19950715",
+                "lastname": "Ganguly",
+                "firstName": "Shrouti",
+                "address": {
+                    "city": "Kolkata",
+                    "state": "WB",
+                    "zip": "700114",
+                    "country": "IN"
+                }
+            },
+            "device": {
+                "advertisingId": "abc123"
+            },
+            "library": {
+                "name": "rudder-sdk-ruby-sync",
+                "version": "1.0.6"
+            }
+        },
+        "messageId": "7208bbb6-2c4e-45bb-bf5b-ad426f3593e9",
+        "timestamp": "2020-08-14T05:30:30.118Z",
+        "properties": {
+            "sku": "1234",
+            "tax": 2,
+            "total": 27.5,
+            "coupon": "hasbros",
+            "revenue": 48,
+            "currency": "USD",
+            "discount": 2.5,
+            "order_id": "50314b8e9bcf000000000000",
+            "requestIP": "123.0.0.0",
+            "shipping": 3,
+            "subtotal": 22.5,
+            "affiliation": "Google Store",
+            "checkout_id": "fksdjfsdjfisjf9sdfjsd9f",
+            "products": [
+                {
+                    "sku": "45790-32",
+                    "url": "https://www.example.com/product/path",
+                    "name": "Monopoly: 3rd Edition",
+                    "price": 19,
+                    "category": "Games",
+                    "quantity": 1,
+                    "image_url": "https:///www.example.com/product/path.jpg",
+                    "product_id": "507f1f77bcf86cd799439011"
+                }
+            ]
+        },
+        "anonymousId": "50be5c78-6c3f-4b60-be84-97805a316fb1",
+        "integrations": {
+            "All": true
+        }
+    },
+    "destination": {
+        "ID": "1pYpzzvcn7AQ2W9GGIAZSsN6Mfq",
+        "Name": "PINTEREST_TAG",
+        "Config": {
+            "tagId": "123456789",
+            "advertiserId": "123456",
+            "appId": "429047995",
+            "sendingUnHashedData": true,
+            "enableDeduplication": true,
+            "deduplicationKey": "messageId",
+            "enhancedMatch": true,
+            "customProperties": [
+                {
+                    "properties": "presentclass"
+                },
+                {
+                    "properties": "presentgrade"
+                }
+            ],
+            "eventsMapping": [
+                {
+                    "from": "ABC Searched",
+                    "to": "Watch Video"
+                }
+            ]
+        },
+        "Enabled": true,
+        "Transformations": []
+    }
 }
 ]
+

--- a/test/__tests__/data/pinterest_tag_output.json
+++ b/test/__tests__/data/pinterest_tag_output.json
@@ -782,5 +782,76 @@
       },
       "files": {}
     }
+  ],
+  [
+    {
+      "version": "1",
+      "type": "REST",
+      "method": "POST",
+      "endpoint": "https://ct.pinterest.com/events/v3",
+      "headers": {
+        "Content-Type": "application/json"
+      },
+      "params": {},
+      "body": {
+        "JSON": {
+          "event_name": "custom event",
+          "event_time": 1597383030,
+          "action_source": "web",
+          "event_id": "7208bbb6-2c4e-45bb-bf5b-ad426f3593e9",
+          "app_id": "429047995",
+          "advertiser_id": "123456",
+          "user_data": {
+            "em": [
+              "48ddb93f0b30c475423fe177832912c5bcdce3cc72872f8051627967ef278e08"
+            ],
+            "ph": [
+              "d164bbe036663cb5c96835e9ccc6501e9a521127ea62f6359744928ba932413b"
+            ],
+            "ln": [
+              "bdfdee6414a89d72bfbf5ee90b1f85924467bae1e3980d83c2cd348dc31d5819"
+            ],
+            "fn": [
+              "ee5db3fe0253b651aca3676692e0c59b25909304f5c51d223a02a215d104144b"
+            ],
+            "ct": [
+              "6689106ca7922c30b2fd2c175c85bc7fc2d52cc4941bdd7bb622c6cdc6284a85"
+            ],
+            "st": [
+              "3b45022ab36728cdae12e709e945bba267c50ee8a91e6e4388539a8e03a3fdcd"
+            ],
+            "zp": [
+              "1a4292e00780e18d00e76fde9850aee5344e939ba593333cd5e4b4aa2cd33b0c"
+            ],
+            "country": [
+              "582967534d0f909d196b97f9e6921342777aea87b46fa52df165389db1fb8ccf"
+            ],
+            "hashed_maids": [
+              "6ca13d52ca70c883e0f0bb101e425a89e8624de51db2d2392593af6a84118090"
+            ],
+            "client_user_agent": "chrome"
+          },
+          "custom_data": {
+            "currency": "USD",
+            "value": 27.5,
+            "order_id": "50314b8e9bcf000000000000",
+            "num_items": 1,
+            "content_ids": [
+              "507f1f77bcf86cd799439011"
+            ],
+            "contents": [
+              {
+                "quantity": 1,
+                "item_price": "19"
+              }
+            ]
+          }
+        },
+        "JSON_ARRAY": {},
+        "XML": {},
+        "FORM": {}
+      },
+      "files": {}
+    }
   ]
 ]


### PR DESCRIPTION

## Description of the change

> Pinterest conversion in cdk V2 was not being able to calculate `num_items` for single product elements. `$sum` was not considering product array with single product, as an array. So we had to fix it.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
