### PR TITLE
chore: support for refreshing token during transformation

### DIFF
--- a/src/v0/util/index.js
+++ b/src/v0/util/index.js
@@ -1519,6 +1519,11 @@ const handleRtTfSingleEventError = (input, error, reqMetadata) => {
 
   const resp = getErrorRespEvents([input.metadata], errObj.status, errObj.message, errObj.statTags);
 
+  // Add support for refreshing for OAuth destinations
+  if (error?.authErrorCategory) {
+    resp.authErrorCategory = error.authErrorCategory;
+  }
+
   errNotificationClient.notify(error, 'Router Transformation (event level)', {
     ...resp,
     ...reqMetadata,

--- a/src/versionedRouter.js
+++ b/src/versionedRouter.js
@@ -527,6 +527,11 @@ async function routerHandleDest(ctx) {
       statTags: errObj.statTags,
     };
 
+    // Add support to perform refreshToken action for OAuth destinations
+    if (error?.authErrorCategory) {
+      resp.authErrorCategory = error.authErrorCategory;
+    }
+
     errNotificationClient.notify(error, 'Router Transformation', {
       ...resp,
       ...getCommonMetadata(ctx),


### PR DESCRIPTION
## Description of the change

Previously we used to support refreshing of oauth token during delivery of event data to destination.
Now, we are trying to support refreshing of oauth token even during transformation as well

https://www.notion.so/rudderstacks/OAuth-Token-expiry-during-transformation-doesn-t-refresh-access-token-c2f5f269455248d0b413a60bcc2951c1

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
