### PR TITLE
feat: suppress errors from unwanted modules to bugsnag

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57,6 +57,7 @@
         "rudder-workflow-engine": "0.4.0",
         "set-value": "^4.1.0",
         "sha256": "^0.2.0",
+        "stacktrace-parser": "^0.1.10",
         "statsd-client": "^0.4.7",
         "truncate-utf8-bytes": "^1.0.2",
         "ua-parser-js": "^1.0.33",
@@ -15950,6 +15951,25 @@
       "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
       "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw=="
     },
+    "node_modules/stacktrace-parser": {
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/stacktrace-parser/-/stacktrace-parser-0.1.10.tgz",
+      "integrity": "sha512-KJP1OCML99+8fhOHxwwzyWrlUuVX5GQ0ZpJTd1DFXhdkrvg1szxfHhawXUZ3g9TkXORQd4/WG68jMlQZ2p8wlg==",
+      "dependencies": {
+        "type-fest": "^0.7.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/stacktrace-parser/node_modules/type-fest": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.7.1.tgz",
+      "integrity": "sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/standard-version": {
       "version": "9.5.0",
       "resolved": "https://registry.npmjs.org/standard-version/-/standard-version-9.5.0.tgz",
@@ -29863,6 +29883,21 @@
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
       "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw=="
+    },
+    "stacktrace-parser": {
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/stacktrace-parser/-/stacktrace-parser-0.1.10.tgz",
+      "integrity": "sha512-KJP1OCML99+8fhOHxwwzyWrlUuVX5GQ0ZpJTd1DFXhdkrvg1szxfHhawXUZ3g9TkXORQd4/WG68jMlQZ2p8wlg==",
+      "requires": {
+        "type-fest": "^0.7.1"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.7.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.7.1.tgz",
+          "integrity": "sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg=="
+        }
+      }
     },
     "standard-version": {
       "version": "9.5.0",

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "rudder-workflow-engine": "0.4.0",
     "set-value": "^4.1.0",
     "sha256": "^0.2.0",
+    "stacktrace-parser": "^0.1.10",
     "statsd-client": "^0.4.7",
     "truncate-utf8-bytes": "^1.0.2",
     "ua-parser-js": "^1.0.33",

--- a/src/util/errorNotifier/bugsnag.js
+++ b/src/util/errorNotifier/bugsnag.js
@@ -48,7 +48,7 @@ const errorTypesDenyList = [
 
 const pathsDenyList = [
   '/src/warehouse/',
-  '/src/util/custom' // User-transformation files
+  '/src/util/custom', // User-transformation files
 ];
 
 let bugsnagClient;
@@ -78,7 +78,9 @@ function notify(err, context, metadata) {
 
     if (isDeniedErrType) return;
 
-    const isDeniedErrPath = pathsDenyList.some((denyPath) => stackTraceParser.parse(err.stack)?.[0]?.file?.includes(denyPath));
+    const isDeniedErrPath = pathsDenyList.some((denyPath) =>
+      stackTraceParser.parse(err.stack)?.[0]?.file?.includes(denyPath),
+    );
 
     if (isDeniedErrPath) return;
 

--- a/src/util/errorNotifier/bugsnag.js
+++ b/src/util/errorNotifier/bugsnag.js
@@ -4,8 +4,10 @@ const {
   CustomError: CDKCustomError,
   DataValidationError,
 } = require('rudder-transformer-cdk/build/error/index');
+const stackTraceParser = require('stacktrace-parser');
 const { logger } = require('../../logger');
 const pkg = require('../../../package.json');
+
 const {
   BaseError,
   TransformationError,
@@ -44,6 +46,11 @@ const errorTypesDenyList = [
   DataValidationError,
 ];
 
+const pathsDenyList = [
+  '/src/warehouse/',
+  '/src/util/custom' // User-transformation files
+];
+
 let bugsnagClient;
 
 function init() {
@@ -70,6 +77,10 @@ function notify(err, context, metadata) {
     const isDeniedErrType = errorTypesDenyList.some((errType) => err instanceof errType);
 
     if (isDeniedErrType) return;
+
+    const isDeniedErrPath = pathsDenyList.some((denyPath) => stackTraceParser.parse(err.stack)?.[0]?.file?.includes(denyPath));
+
+    if (isDeniedErrPath) return;
 
     bugsnagClient.notify(err, (event) => {
       event.addMetadata('metadata', { ...metadata, opContext: context });


### PR DESCRIPTION
## Description of the change

Added deny paths list functionality to Bugsnag notifier to suppress unwanted errors from warehouse, user transformations etc.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

N/A

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
