### PR TITLE
fix(fb pixel): zp mapping and external_id

### DIFF
--- a/src/v0/destinations/facebook_pixel/data/FBPIXELUserDataConfig.json
+++ b/src/v0/destinations/facebook_pixel/data/FBPIXELUserDataConfig.json
@@ -99,7 +99,12 @@
   },
   {
     "destKey": "zp",
-    "sourceKeys": ["traits.address.zip", "context.traits.address.zip"],
+    "sourceKeys": [
+      "traits.address.zip",
+      "context.traits.address.zip",
+      "traits.address.postalCode",
+      "context.traits.address.postalCode"
+    ],
     "required": false,
     "metadata": {
       "type": ["toLower", "hashToSha256"]

--- a/src/v0/destinations/facebook_pixel/transform.js
+++ b/src/v0/destinations/facebook_pixel/transform.js
@@ -222,6 +222,10 @@ const responseBuilderSimple = (message, category, destination, categoryToContent
     MAPPING_CONFIG[CONFIG_CATEGORIES.USERDATA.name],
     'fb_pixel',
   );
+  const { removeExternalId } = Config;
+  if (removeExternalId) {
+    delete userData.external_id;
+  }
   if (userData) {
     const split = userData.name ? userData.name.split(' ') : null;
     if (split !== null && Array.isArray(split) && split.length === 2) {

--- a/src/v0/destinations/facebook_pixel/utils.js
+++ b/src/v0/destinations/facebook_pixel/utils.js
@@ -141,6 +141,7 @@ const transformedPayloadData = (
     'phone',
     'state',
     'zip',
+    'postalCode',
     'birthday',
   ];
   blacklistPiiProperties = blacklistPiiProperties || [];

--- a/test/__tests__/data/facebook_pixel_input.json
+++ b/test/__tests__/data/facebook_pixel_input.json
@@ -64,6 +64,7 @@
             "eventCustomProperties": ""
           }
         ],
+        "removeExternalId":true,
         "valueFieldIdentifier": "",
         "advancedMapping": false,
         "whitelistPiiProperties": [
@@ -1288,6 +1289,7 @@
             "to": "product"
           }
         ],
+        "removeExternalId":true,
         "accessToken": "09876",
         "pixelId": "dfgdfgdgd",
         "eventsToEvents": [

--- a/test/__tests__/data/facebook_pixel_input.json
+++ b/test/__tests__/data/facebook_pixel_input.json
@@ -27,6 +27,9 @@
         },
         "traits": {
           "email": "    aBc@gmail.com   ",
+          "address": {
+            "zip": 1234
+          },
           "anonymousId": "c82cbdff-e5be-4009-ac78-cdeea09ab4b1"
         }
       },
@@ -64,7 +67,7 @@
             "eventCustomProperties": ""
           }
         ],
-        "removeExternalId":true,
+        "removeExternalId": true,
         "valueFieldIdentifier": "",
         "advancedMapping": false,
         "whitelistPiiProperties": [
@@ -313,6 +316,9 @@
           "name": "Ruchira Moitra",
           "email": "abc@gmail.com",
           "phone": 9000000000,
+          "address": {
+            "postalCode": 1234
+          },
           "gender": "female"
         },
         "app": {
@@ -1207,6 +1213,7 @@
         ],
         "accessToken": "09876",
         "pixelId": "dfgdfgdgd",
+        "removeExternalId": false,
         "eventsToEvents": [
           {
             "from": "My product list",
@@ -1289,7 +1296,7 @@
             "to": "product"
           }
         ],
-        "removeExternalId":true,
+        "removeExternalId": true,
         "accessToken": "09876",
         "pixelId": "dfgdfgdgd",
         "eventsToEvents": [
@@ -1369,6 +1376,7 @@
         ],
         "accessToken": "09876",
         "pixelId": "dfgdfgdgd",
+        "removeExternalId": false,
         "eventsToEvents": [
           {
             "from": "",
@@ -1596,7 +1604,13 @@
         }
       },
       "context": {
-        "dataProcessingOptions": [["LDU"], 1, 1000],
+        "dataProcessingOptions": [
+          [
+            "LDU"
+          ],
+          1,
+          1000
+        ],
         "fbc": "fb.1.1554763741205.AbCdEfGhIjKlMnOpQrStUvWxYz1234567890",
         "fbp": "fb.1.1554763741205.234567890",
         "fb_login_id": "fb_id",
@@ -1677,7 +1691,13 @@
         }
       },
       "context": {
-        "dataProcessingOptions": [["LDU"], 1, 1000],
+        "dataProcessingOptions": [
+          [
+            "LDU"
+          ],
+          1,
+          1000
+        ],
         "fbc": "fb.1.1554763741205.AbCdEfGhIjKlMnOpQrStUvWxYz1234567890",
         "fbp": "fb.1.1554763741205.234567890",
         "fb_login_id": "fb_id",
@@ -2506,7 +2526,10 @@
       "userId": "12345",
       "event": "order completed",
       "properties": {
-        "category": ["clothing", "fishing"],
+        "category": [
+          "clothing",
+          "fishing"
+        ],
         "order_id": "ruchiraorder1",
         "total": 99.99,
         "revenue": 12.24,
@@ -3312,7 +3335,9 @@
       "originalTimestamp": "2019-09-01T15:46:51.693229+05:30",
       "anonymousId": "00000000000000000000000000",
       "userId": "12345",
-      "event": { "name": "checkout started" },
+      "event": {
+        "name": "checkout started"
+      },
       "properties": {
         "currency": "CAD",
         "category": "clothing",

--- a/test/__tests__/data/facebook_pixel_output.json
+++ b/test/__tests__/data/facebook_pixel_output.json
@@ -12,7 +12,7 @@
       "JSON_ARRAY": {},
       "FORM": {
         "data": [
-          "{\"user_data\":{\"external_id\":\"6dc8118ec743f5f3b758939714193f547f4a674c68757fa80d7c9564dc093b0a\",\"em\":\"48ddb93f0b30c475423fe177832912c5bcdce3cc72872f8051627967ef278e08\"},\"event_name\":\"spin_result\",\"event_time\":1567333011,\"custom_data\":{\"additional_bet_index\":0,\"value\":400}}"
+          "{\"user_data\":{\"em\":\"48ddb93f0b30c475423fe177832912c5bcdce3cc72872f8051627967ef278e08\"},\"event_name\":\"spin_result\",\"event_time\":1567333011,\"custom_data\":{\"additional_bet_index\":0,\"value\":400}}"
         ]
       }
     },
@@ -275,7 +275,7 @@
       "JSON_ARRAY": {},
       "FORM": {
         "data": [
-          "{\"user_data\":{\"external_id\":\"5994471abb01112afcc18159f6cc74b4f511b99806da59b3caf5a9c173cacfc5\",\"client_user_agent\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36\"},\"event_name\":\"ViewContent\",\"event_time\":1567333011,\"event_id\":\"ec5481b6-a926-4d2e-b293-0b3a77c4d3be\",\"custom_data\":{\"content_ids\":[\"p-298\"],\"content_type\":\"product\",\"content_name\":\"my product 1\",\"content_category\":\"clothing\",\"currency\":\"CAD\",\"value\":24.75,\"contents\":[{\"id\":\"p-298\",\"quantity\":1,\"item_price\":24.75}]}}"
+          "{\"user_data\":{\"client_user_agent\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36\"},\"event_name\":\"ViewContent\",\"event_time\":1567333011,\"event_id\":\"ec5481b6-a926-4d2e-b293-0b3a77c4d3be\",\"custom_data\":{\"content_ids\":[\"p-298\"],\"content_type\":\"product\",\"content_name\":\"my product 1\",\"content_category\":\"clothing\",\"currency\":\"CAD\",\"value\":24.75,\"contents\":[{\"id\":\"p-298\",\"quantity\":1,\"item_price\":24.75}]}}"
         ]
       }
     },

--- a/test/__tests__/data/facebook_pixel_output.json
+++ b/test/__tests__/data/facebook_pixel_output.json
@@ -12,7 +12,7 @@
       "JSON_ARRAY": {},
       "FORM": {
         "data": [
-          "{\"user_data\":{\"em\":\"48ddb93f0b30c475423fe177832912c5bcdce3cc72872f8051627967ef278e08\"},\"event_name\":\"spin_result\",\"event_time\":1567333011,\"custom_data\":{\"additional_bet_index\":0,\"value\":400}}"
+          "{\"user_data\":{\"em\":\"48ddb93f0b30c475423fe177832912c5bcdce3cc72872f8051627967ef278e08\",\"zp\":\"03ac674216f3e15c761ee1a5e255f067953623c8b388b4459e13f978d7c846f4\"},\"event_name\":\"spin_result\",\"event_time\":1567333011,\"custom_data\":{\"additional_bet_index\":0,\"value\":400}}"
         ]
       }
     },
@@ -66,7 +66,7 @@
       "JSON_ARRAY": {},
       "FORM": {
         "data": [
-          "{\"user_data\":{\"external_id\":\"8d969eef6ecad3c29a3a629280e686cf0c3f5d5a86aff3ca12020c923adc6c92\",\"em\":\"48ddb93f0b30c475423fe177832912c5bcdce3cc72872f8051627967ef278e08\",\"ph\":\"593a6d58f34eb5c3de4f47e38d1faaa7d389fafe332a85400b1e54498391c579\",\"ge\":\"252f10c83610ebca1a059c0bae8255eba2f95be4d1d7bcfa89d7248a82d9f111\",\"client_ip_address\":\"0.0.0.0\",\"client_user_agent\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36\",\"fn\":\"d5c853a578ee28b6152606785eb8e2eb10a369b2903e8f8ee1ce761eaf9acd0c\",\"ln\":\"6c535a187517963217c07cbdb552cb8991987d6c33cbaecbe2fc7bc4199e156e\"},\"event_name\":\"identify\",\"event_time\":1567333011,\"event_id\":\"84e26acc-56a5-4835-8233-591137fca468\"}"
+          "{\"user_data\":{\"external_id\":\"8d969eef6ecad3c29a3a629280e686cf0c3f5d5a86aff3ca12020c923adc6c92\",\"em\":\"48ddb93f0b30c475423fe177832912c5bcdce3cc72872f8051627967ef278e08\",\"ph\":\"593a6d58f34eb5c3de4f47e38d1faaa7d389fafe332a85400b1e54498391c579\",\"ge\":\"252f10c83610ebca1a059c0bae8255eba2f95be4d1d7bcfa89d7248a82d9f111\",\"zp\":\"03ac674216f3e15c761ee1a5e255f067953623c8b388b4459e13f978d7c846f4\",\"client_ip_address\":\"0.0.0.0\",\"client_user_agent\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36\",\"fn\":\"d5c853a578ee28b6152606785eb8e2eb10a369b2903e8f8ee1ce761eaf9acd0c\",\"ln\":\"6c535a187517963217c07cbdb552cb8991987d6c33cbaecbe2fc7bc4199e156e\"},\"event_name\":\"identify\",\"event_time\":1567333011,\"event_id\":\"84e26acc-56a5-4835-8233-591137fca468\"}"
         ]
       }
     },

--- a/test/__tests__/data/facebook_pixel_router_input.json
+++ b/test/__tests__/data/facebook_pixel_router_input.json
@@ -54,6 +54,7 @@
             "blacklistPiiHash": false
           }
         ],
+        "removeExternalId":true,
         "accessToken": "09876",
         "pixelId": "dfgdfgdgd",
         "eventsToEvents": [

--- a/test/__tests__/data/facebook_pixel_router_output.json
+++ b/test/__tests__/data/facebook_pixel_router_output.json
@@ -35,6 +35,7 @@
             "blacklistPiiHash": false
           }
         ],
+        "removeExternalId":true,
         "accessToken": "09876",
         "pixelId": "dfgdfgdgd",
         "eventsToEvents": [

--- a/test/__tests__/data/facebook_pixel_router_output.json
+++ b/test/__tests__/data/facebook_pixel_router_output.json
@@ -13,7 +13,7 @@
         "JSON_ARRAY": {},
         "FORM": {
           "data": [
-            "{\"user_data\":{\"external_id\":\"6dc8118ec743f5f3b758939714193f547f4a674c68757fa80d7c9564dc093b0a\",\"em\":\"48ddb93f0b30c475423fe177832912c5bcdce3cc72872f8051627967ef278e08\"},\"event_name\":\"spin_result\",\"event_time\":1567333011,\"custom_data\":{\"additional_bet_index\":0,\"value\":400}}"
+            "{\"user_data\":{\"em\":\"48ddb93f0b30c475423fe177832912c5bcdce3cc72872f8051627967ef278e08\"},\"event_name\":\"spin_result\",\"event_time\":1567333011,\"custom_data\":{\"additional_bet_index\":0,\"value\":400}}"
           ]
         }
       },


### PR DESCRIPTION
## Description of the change

> Supporting `postCode` mapping to be in parity with standard Identify spec.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
