### PR TITLE
fix: correcting method name for prepareProxy

### DIFF
--- a/src/v0/destinations/facebook_pixel/networkHandler.js
+++ b/src/v0/destinations/facebook_pixel/networkHandler.js
@@ -117,7 +117,7 @@ const destResponseHandler = (destinationResponse) => {
 
 const networkHandler = function () {
   // The order of execution also happens in this way
-  this.prepareProxyRequest = prepareProxyRequest;
+  this.prepareProxy = prepareProxyRequest;
   this.proxy = proxyRequest;
   this.processAxiosResponse = processAxiosResponse;
   this.responseHandler = destResponseHandler;


### PR DESCRIPTION
## Description of the change

We have a method named `prepareProxy` during handling of `/proxy` request. But here, we are using `prepareProxyRequest` instead of `prepareProxy`. We intend to correct it

**Note**: This will not cause any big-problem for us.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
