### PR TITLE
fix.batching with multiplexing

### DIFF
--- a/src/v0/destinations/fb_custom_audience/transform.js
+++ b/src/v0/destinations/fb_custom_audience/transform.js
@@ -378,10 +378,7 @@ const processRouterDest = (inputs, reqMetadata) => {
         return getSuccessRespEvents(input.message, [input.metadata], input.destination);
       }
       const transformedList = process(input);
-      const responseList = transformedList.map((transformedPayload) =>
-        getSuccessRespEvents(transformedPayload, [input.metadata], input.destination),
-      );
-      return responseList;
+      return getSuccessRespEvents(transformedList, [input.metadata], input.destination);
     } catch (error) {
       return handleRtTfSingleEventError(input, error, reqMetadata);
     }

--- a/src/v0/destinations/iterable/transform.js
+++ b/src/v0/destinations/iterable/transform.js
@@ -422,30 +422,33 @@ function getEventChunks(event, identifyEventChunks, trackEventChunks, eventRespo
     event.message.operation === 'catalogs'
   ) {
     identifyEventChunks.push(event);
-  } else if (event.message.endpoint.includes('api/events/track')) {
+  } else if (event.message?.endpoint?.includes('api/events/track')) {
     // Checking if it is track type of event
     trackEventChunks.push(event);
   } else {
     // any other type of event
     const { message, metadata, destination } = event;
     const endpoint = get(message, 'endpoint');
+    if (Array.isArray(message)) {
+      eventResponseList.push(getSuccessRespEvents(message, metadata, destination));
+    } else {
+      const batchedResponse = defaultBatchRequestConfig();
+      batchedResponse.batchedRequest.headers = message.headers;
+      batchedResponse.batchedRequest.endpoint = endpoint;
+      batchedResponse.batchedRequest.body = message.body;
+      batchedResponse.batchedRequest.params = message.params;
+      batchedResponse.batchedRequest.method = defaultPostRequestConfig.requestMethod;
+      batchedResponse.metadata = [metadata];
+      batchedResponse.destination = destination;
 
-    const batchedResponse = defaultBatchRequestConfig();
-    batchedResponse.batchedRequest.headers = message.headers;
-    batchedResponse.batchedRequest.endpoint = endpoint;
-    batchedResponse.batchedRequest.body = message.body;
-    batchedResponse.batchedRequest.params = message.params;
-    batchedResponse.batchedRequest.method = defaultPostRequestConfig.requestMethod;
-    batchedResponse.metadata = [metadata];
-    batchedResponse.destination = destination;
-
-    eventResponseList.push(
-      getSuccessRespEvents(
-        batchedResponse.batchedRequest,
-        batchedResponse.metadata,
-        batchedResponse.destination,
-      ),
-    );
+      eventResponseList.push(
+        getSuccessRespEvents(
+          batchedResponse.batchedRequest,
+          batchedResponse.metadata,
+          batchedResponse.destination,
+        ),
+      );
+    }
   }
 }
 

--- a/src/v0/destinations/snapchat_conversion/util.js
+++ b/src/v0/destinations/snapchat_conversion/util.js
@@ -111,39 +111,31 @@ function getPriceSum(message) {
  * @param {*} events
  * @returns
  */
-function generateBatchedPayloadForArray(events) {
+function generateBatchedPayloadForArray(events, destination) {
   const batchResponseList = [];
-  const metadata = [];
 
   // extracting destination
   // from the first event in a batch
-  const { destination } = events[0];
   const { apiKey } = destination.Config;
 
-  let batchEventResponse = defaultBatchRequestConfig();
+  const { batchedRequest } = defaultBatchRequestConfig();
 
   // Batch event into dest batch structure
   events.forEach((ev) => {
-    batchResponseList.push(ev.message.body.JSON);
-    metadata.push(ev.metadata);
+    batchResponseList.push(ev.body.JSON);
   });
 
-  batchEventResponse.batchedRequest.body.JSON_ARRAY = {
+  batchedRequest.body.JSON_ARRAY = {
     batch: JSON.stringify(batchResponseList),
   };
 
-  batchEventResponse.batchedRequest.endpoint = ENDPOINT;
-  batchEventResponse.batchedRequest.headers = {
+  batchedRequest.endpoint = ENDPOINT;
+  batchedRequest.headers = {
     'Content-Type': 'application/json',
     Authorization: `Bearer ${apiKey}`,
   };
-  batchEventResponse = {
-    ...batchEventResponse,
-    metadata,
-    destination,
-  };
 
-  return batchEventResponse;
+  return batchedRequest;
 }
 
 module.exports = {

--- a/test/__tests__/data/fb_custom_audience_router.json
+++ b/test/__tests__/data/fb_custom_audience_router.json
@@ -51,7 +51,7 @@
           "timestamp": "2020-02-02T00:23:09.544Z"
         },
         "metadata": {
-          "jobId": 2
+          "jobId": 1
         },
         "destination": {
           "Config": {
@@ -169,61 +169,115 @@
     ],
     "output": [
       {
-        "batchedRequest": {
-          "version": "1",
-          "type": "REST",
-          "method": "DELETE",
-          "endpoint": "https://graph.facebook.com/v15.0/aud1/users",
-          "headers": {},
-          "params": {
-            "access_token": "ABC",
-            "payload": {
-              "is_raw": true,
-              "data_source": {
-                "type": "UNKNOWN",
-                "sub_type": "ANYTHING"
-              },
-              "schema": [
-                "EMAIL",
-                "DOBM",
-                "DOBD",
-                "DOBY",
-                "PHONE",
-                "GEN",
-                "FI",
-                "MADID",
-                "ZIP",
-                "ST",
-                "COUNTRY"
-              ],
-              "data": [
-                [
-                  "shrouti@abc.com",
-                  "2",
-                  "13",
-                  "2013",
-                  "@09432457768",
-                  "f",
-                  "Ms.",
-                  "ABC",
-                  "ZIP ",
-                  "123abc ",
-                  "IN"
+        "batchedRequest": [
+          {
+            "version": "1",
+            "type": "REST",
+            "method": "DELETE",
+            "endpoint": "https://graph.facebook.com/v15.0/aud1/users",
+            "headers": {},
+            "params": {
+              "access_token": "ABC",
+              "payload": {
+                "is_raw": true,
+                "data_source": {
+                  "type": "UNKNOWN",
+                  "sub_type": "ANYTHING"
+                },
+                "schema": [
+                  "EMAIL",
+                  "DOBM",
+                  "DOBD",
+                  "DOBY",
+                  "PHONE",
+                  "GEN",
+                  "FI",
+                  "MADID",
+                  "ZIP",
+                  "ST",
+                  "COUNTRY"
+                ],
+                "data": [
+                  [
+                    "shrouti@abc.com",
+                    "2",
+                    "13",
+                    "2013",
+                    "@09432457768",
+                    "f",
+                    "Ms.",
+                    "ABC",
+                    "ZIP ",
+                    "123abc ",
+                    "IN"
+                  ]
                 ]
-              ]
-            }
+              }
+            },
+            "body": {
+              "JSON": {},
+              "JSON_ARRAY": {},
+              "XML": {},
+              "FORM": {}
+            },
+            "files": {}
           },
-          "body": {
-            "JSON": {},
-            "XML": {},
-            "JSON_ARRAY": {},
-            "FORM": {}
-          },
-          "files": {}
-        },
+          {
+            "version": "1",
+            "type": "REST",
+            "method": "POST",
+            "endpoint": "https://graph.facebook.com/v15.0/aud1/users",
+            "headers": {},
+            "params": {
+              "access_token": "ABC",
+              "payload": {
+                "is_raw": true,
+                "data_source": {
+                  "type": "UNKNOWN",
+                  "sub_type": "ANYTHING"
+                },
+                "schema": [
+                  "EMAIL",
+                  "DOBM",
+                  "DOBD",
+                  "DOBY",
+                  "PHONE",
+                  "GEN",
+                  "FI",
+                  "MADID",
+                  "ZIP",
+                  "ST",
+                  "COUNTRY"
+                ],
+                "data": [
+                  [
+                    "shrouti@abc.com",
+                    "2",
+                    "13",
+                    "2013",
+                    "@09432457768",
+                    "f",
+                    "Ms.",
+                    "ABC",
+                    "ZIP ",
+                    "123abc ",
+                    "IN"
+                  ]
+                ]
+              }
+            },
+            "body": {
+              "JSON": {},
+              "JSON_ARRAY": {},
+              "XML": {},
+              "FORM": {}
+            },
+            "files": {}
+          }
+        ],
         "metadata": [
           {
-            "jobId": 2
+            "jobId": 1
           }
         ],
         "batched": false,
@@ -258,234 +312,110 @@
         }
       },
       {
-        "batchedRequest": {
-          "version": "1",
-          "type": "REST",
-          "method": "POST",
-          "endpoint": "https://graph.facebook.com/v15.0/aud1/users",
-          "headers": {},
-          "params": {
-            "access_token": "ABC",
-            "payload": {
-              "is_raw": true,
-              "data_source": {
-                "type": "UNKNOWN",
-                "sub_type": "ANYTHING"
-              },
-              "schema": [
-                "EMAIL",
-                "DOBM",
-                "DOBD",
-                "DOBY",
-                "PHONE",
-                "GEN",
-                "FI",
-                "MADID",
-                "ZIP",
-                "ST",
-                "COUNTRY"
-              ],
-              "data": [
-                [
-                  "shrouti@abc.com",
-                  "2",
-                  "13",
-                  "2013",
-                  "@09432457768",
-                  "f",
-                  "Ms.",
-                  "ABC",
-                  "ZIP ",
-                  "123abc ",
-                  "IN"
-                ]
-              ]
-            }
-          },
-          "body": {
-            "JSON": {},
-            "XML": {},
-            "JSON_ARRAY": {},
-            "FORM": {}
-          },
-          "files": {}
-        },
-        "metadata": [
+        "batchedRequest": [
           {
-            "jobId": 2
+            "version": "1",
+            "type": "REST",
+            "method": "DELETE",
+            "endpoint": "https://graph.facebook.com/v15.0/aud1/users",
+            "headers": {},
+            "params": {
+              "access_token": "ABC",
+              "payload": {
+                "is_raw": true,
+                "data_source": {
+                  "sub_type": "ANYTHING"
+                },
+                "schema": [
+                  "EMAIL",
+                  "DOBM",
+                  "DOBD",
+                  "DOBY",
+                  "PHONE",
+                  "GEN",
+                  "FI",
+                  "MADID",
+                  "ZIP",
+                  "ST",
+                  "COUNTRY"
+                ],
+                "data": [
+                  [
+                    "shrouti@abc.com",
+                    "2",
+                    "13",
+                    "2013",
+                    "@09432457768",
+                    "f",
+                    "Ms.",
+                    "ABC",
+                    "ZIP ",
+                    "123abc ",
+                    "IN"
+                  ]
+                ]
+              }
+            },
+            "body": {
+              "JSON": {},
+              "JSON_ARRAY": {},
+              "XML": {},
+              "FORM": {}
+            },
+            "files": {}
+          },
+          {
+            "version": "1",
+            "type": "REST",
+            "method": "POST",
+            "endpoint": "https://graph.facebook.com/v15.0/aud1/users",
+            "headers": {},
+            "params": {
+              "access_token": "ABC",
+              "payload": {
+                "is_raw": true,
+                "data_source": {
+                  "sub_type": "ANYTHING"
+                },
+                "schema": [
+                  "EMAIL",
+                  "DOBM",
+                  "DOBD",
+                  "DOBY",
+                  "PHONE",
+                  "GEN",
+                  "FI",
+                  "MADID",
+                  "ZIP",
+                  "ST",
+                  "COUNTRY"
+                ],
+                "data": [
+                  [
+                    "shrouti@abc.com",
+                    "2",
+                    "13",
+                    "2013",
+                    "@09432457768",
+                    "f",
+                    "Ms.",
+                    "ABC",
+                    "ZIP ",
+                    "123abc ",
+                    "IN"
+                  ]
+                ]
+              }
+            },
+            "body": {
+              "JSON": {},
+              "JSON_ARRAY": {},
+              "XML": {},
+              "FORM": {}
+            },
+            "files": {}
           }
         ],
-        "batched": false,
-        "statusCode": 200,
-        "destination": {
-          "Config": {
-            "accessToken": "ABC",
-            "userSchema": [
-              "EMAIL",
-              "DOBM",
-              "DOBD",
-              "DOBY",
-              "PHONE",
-              "GEN",
-              "FI",
-              "MADID",
-              "ZIP",
-              "ST",
-              "COUNTRY"
-            ],
-            "isHashRequired": false,
-            "disableFormat": false,
-            "audienceId": "aud1",
-            "isRaw": true,
-            "type": "UNKNOWN",
-            "subType": "ANYTHING",
-            "maxUserCount": "50"
-          },
-          "Enabled": true,
-          "Transformations": [],
-          "IsProcessorEnabled": true
-        }
-      },
-      {
-        "batchedRequest": {
-          "version": "1",
-          "type": "REST",
-          "method": "DELETE",
-          "endpoint": "https://graph.facebook.com/v15.0/aud1/users",
-          "headers": {},
-          "params": {
-            "access_token": "ABC",
-            "payload": {
-              "is_raw": true,
-              "data_source": {
-                "sub_type": "ANYTHING"
-              },
-              "schema": [
-                "EMAIL",
-                "DOBM",
-                "DOBD",
-                "DOBY",
-                "PHONE",
-                "GEN",
-                "FI",
-                "MADID",
-                "ZIP",
-                "ST",
-                "COUNTRY"
-              ],
-              "data": [
-                [
-                  "shrouti@abc.com",
-                  "2",
-                  "13",
-                  "2013",
-                  "@09432457768",
-                  "f",
-                  "Ms.",
-                  "ABC",
-                  "ZIP ",
-                  "123abc ",
-                  "IN"
-                ]
-              ]
-            }
-          },
-          "body": {
-            "JSON": {},
-            "XML": {},
-            "JSON_ARRAY": {},
-            "FORM": {}
-          },
-          "files": {}
-        },
-        "metadata": [
-          {
-            "jobId": 2
-          }
-        ],
-        "batched": false,
-        "statusCode": 200,
-        "destination": {
-          "Config": {
-            "accessToken": "ABC",
-            "userSchema": [
-              "EMAIL",
-              "DOBM",
-              "DOBD",
-              "DOBY",
-              "PHONE",
-              "GEN",
-              "FI",
-              "MADID",
-              "ZIP",
-              "ST",
-              "COUNTRY"
-            ],
-            "isHashRequired": false,
-            "disableFormat": false,
-            "audienceId": "aud1",
-            "isRaw": true,
-            "type": "NA",
-            "subType": "ANYTHING",
-            "maxUserCount": "50"
-          },
-          "Enabled": true,
-          "Transformations": [],
-          "IsProcessorEnabled": true
-        }
-      },
-      {
-        "batchedRequest": {
-          "version": "1",
-          "type": "REST",
-          "method": "POST",
-          "endpoint": "https://graph.facebook.com/v15.0/aud1/users",
-          "headers": {},
-          "params": {
-            "access_token": "ABC",
-            "payload": {
-              "is_raw": true,
-              "data_source": {
-                "sub_type": "ANYTHING"
-              },
-              "schema": [
-                "EMAIL",
-                "DOBM",
-                "DOBD",
-                "DOBY",
-                "PHONE",
-                "GEN",
-                "FI",
-                "MADID",
-                "ZIP",
-                "ST",
-                "COUNTRY"
-              ],
-              "data": [
-                [
-                  "shrouti@abc.com",
-                  "2",
-                  "13",
-                  "2013",
-                  "@09432457768",
-                  "f",
-                  "Ms.",
-                  "ABC",
-                  "ZIP ",
-                  "123abc ",
-                  "IN"
-                ]
-              ]
-            }
-          },
-          "body": {
-            "JSON": {},
-            "XML": {},
-            "JSON_ARRAY": {},
-            "FORM": {}
-          },
-          "files": {}
-        },
         "metadata": [
           {
             "jobId": 2


### PR DESCRIPTION
## Description of the change

If we are doing batching and multiplexing in one destination then metadata is getting duplicate data and server is getting confused with the duplicate jobIds so here we are updating the batching logic to update them accordingly to send one metadata only for multiplexed events.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
