### PR TITLE
feat(customerio): allow for transactional messageid in incoming messages

### DIFF
--- a/src/v0/sources/customerio/mapping.json
+++ b/src/v0/sources/customerio/mapping.json
@@ -25,5 +25,6 @@
   "data.device_platform": "properties.devicePlatform",
   "data.recipients": "properties.recipients",
   "data.event_type": "properties.type",
-  "data.newsletter_id": "properties.newsletterId"
+  "data.newsletter_id": "properties.newsletterId",
+  "data.transactional_message_id": "properties.transactionalMessageId"
 }

--- a/test/__tests__/data/customerio_source_input.json
+++ b/test/__tests__/data/customerio_source_input.json
@@ -100,6 +100,23 @@
   },
   {
     "data": {
+      "customer_id": "user-123",
+      "delivery_id": "REAC4wUAAYYJgQgkyRqwwEPeOA6Nfv==",
+      "identifiers": {
+        "cio_id": "7ef807109981",
+        "id": "user-123"
+      },
+      "recipient": "test@example.com",
+      "subject": "Thanks for signing up",
+      "transactional_message_id": 2
+    },
+    "event_id": "01ER4R5WB62QWCNREKFB4DYXGR",
+    "metric": "delivered",
+    "object_type": "email",
+    "timestamp": 1675196819
+  },
+  {
+    "data": {
       "action_id": 38,
       "campaign_id": 6,
       "customer_id": "0200102",

--- a/test/__tests__/data/customerio_source_output.json
+++ b/test/__tests__/data/customerio_source_output.json
@@ -175,6 +175,35 @@
       },
       "integration": {
         "name": "Customer.io"
+      },
+      "traits": {
+        "cioId": "7ef807109981",
+        "email": "test@example.com"
+      }
+    },
+    "integrations": {
+      "Customer.io": false
+    },
+    "type": "track",
+    "event": "Email Delivered",
+    "properties": {
+      "eventId": "01ER4R5WB62QWCNREKFB4DYXGR",
+      "deliveryId": "REAC4wUAAYYJgQgkyRqwwEPeOA6Nfv==",
+      "emailSubject": "Thanks for signing up",
+      "transactionalMessageId": 2
+    },
+    "userId": "user-123",
+    "originalTimestamp": "2023-01-31T20:26:59.000Z",
+    "sentAt": "2023-01-31T20:26:59.000Z"
+  },
+  {
+    "context": {
+      "library": {
+        "name": "unknown",
+        "version": "unknown"
+      },
+      "integration": {
+        "name": "Customer.io"
       }
     },
     "integrations": {


### PR DESCRIPTION

## Description of the change

Like the `campaign_id` for Campaigns, or `newsletter_id` for Broadcasts, the `transactional_message_id` is for messages sent via the Transactional Message API.

See: https://www.customer.io/docs/webhooks/#webhook-attributes

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
