### PR TITLE
fix: add optional chaining for phone in tiktok_ads_offline_events

### DIFF
--- a/src/v0/destinations/tiktok_ads_offline_events/transform.js
+++ b/src/v0/destinations/tiktok_ads_offline_events/transform.js
@@ -56,7 +56,7 @@ const getTrackResponse = (message, category, Config, event) => {
     set(payload, 'properties.contents', contents);
   }
 
-  const email = message?.traits?.email || message?.context?.traits?.email;
+  const email = message.traits?.email || message.context?.traits?.email;
   if (isDefinedAndNotNullAndNotEmpty(email)) {
     const emails = hashUserProperties
       ? [SHA256(email.trim().toLowerCase()).toString()]
@@ -64,7 +64,7 @@ const getTrackResponse = (message, category, Config, event) => {
     set(payload, 'context.user.emails', emails);
   }
 
-  const phoneNumber = message?.traits?.phone || message?.context?.traits.phone;
+  const phoneNumber = message.traits?.phone || message.context?.traits?.phone;
   if (isDefinedAndNotNullAndNotEmpty(phoneNumber)) {
     const phoneNumbers = hashUserProperties
       ? [SHA256(phoneNumber.trim()).toString()]


### PR DESCRIPTION
## Description of the change

We are adding optional chaining for phones from user traits.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
