### PR TITLE
feat: add audience id for retl sources from context

### DIFF
--- a/src/v0/destinations/fb_custom_audience/transform.js
+++ b/src/v0/destinations/fb_custom_audience/transform.js
@@ -281,9 +281,6 @@ const processEvent = (message, destination) => {
   const toSendEvents = [];
   let wrappedResponse = {};
 
-  console.log('==============Checking fb custom audience Config=======================');
-  console.log(destination.Config);
-
   let { userSchema } = destination.Config;
   const { isHashRequired, audienceId, maxUserCount } = destination.Config;
   if (!message.type) {
@@ -301,10 +298,8 @@ const processEvent = (message, destination) => {
   const mappedToDestination = get(message, MappedToDestinationKey);
   if (!operationAudienceId && mappedToDestination) {
     const { objectType } = getDestinationExternalIDInfoForRetl(message, 'FB_CUSTOM_AUDIENCE');
-    console.log(objectType);
     operationAudienceId = objectType;
   }
-  console.log(operationAudienceId);
   if (!isDefinedAndNotNullAndNotEmpty(operationAudienceId)) {
     throw new ConfigurationError('Audience ID is a mandatory field');
   }

--- a/src/v0/destinations/fb_custom_audience/transform.js
+++ b/src/v0/destinations/fb_custom_audience/transform.js
@@ -300,10 +300,7 @@ const processEvent = (message, destination) => {
   let operationAudienceId = audienceId;
   const mappedToDestination = get(message, MappedToDestinationKey);
   if (!operationAudienceId && mappedToDestination) {
-    const { objectType } = getDestinationExternalIDInfoForRetl(
-      inputs[0].message,
-      'FB_CUSTOM_AUDIENCE',
-    );
+    const { objectType } = getDestinationExternalIDInfoForRetl(message, 'FB_CUSTOM_AUDIENCE');
     console.log(objectType);
     operationAudienceId = objectType;
   }

--- a/test/__tests__/data/fb_custom_audience_router_rETL_input.json
+++ b/test/__tests__/data/fb_custom_audience_router_rETL_input.json
@@ -1,0 +1,112 @@
+[
+  {
+    "message":  {
+      "sentAt" : "2023-03-30 06:42:55.991938402 +0000 UTC",
+      "userId" : "2MUWghI7u85n91dd1qzGyswpZan-2MUWqbQqvctyfMGqU9QCNadpKNy",
+      "channel" : "sources",
+      "messageId" : "4d906837-031d-4d34-b97a-62fdf51b4d3a",
+      "event" : "Add_Audience",
+      "context" : {
+        "destinationFields" : "EMAIL, FN",
+        "externalId" : [
+          {
+            "type" : "FB_CUSTOM_AUDIENCE-23848494844100489",
+            "identifierType" : "EMAIL"
+          }
+        ],
+        "mappedToDestination" : "true",
+        "sources" : {
+          "job_run_id" : "cgiiurt8um7k7n5dq480",
+          "task_run_id" : "cgiiurt8um7k7n5dq48g",
+          "job_id" : "2MUWghI7u85n91dd1qzGyswpZan",
+          "version" : "895\/merge"
+        }
+      },
+      "recordId" : "725ad989-6750-4839-b46b-0ddb3b8e5aa2\/1\/10",
+      "rudderId" : "85c49666-c628-4835-937b-8f1d9ee7a724",
+      "properties" : {
+        "listData" : {
+          "add" : [
+            {
+              "EMAIL" : "dede@gmail.com",
+              "FN" : "vishwa"
+            },
+            {
+              "EMAIL" : "fchsjjn@gmail.com",
+              "FN" : "hskks"
+            },
+            {
+              "EMAIL" : "fghjnbjk@gmail.com",
+              "FN" : "ghfry"
+            },
+            {
+              "EMAIL" : "gvhjkk@gmail.com",
+              "FN" : "hbcwqe"
+            },
+            {
+              "EMAIL" : "qsdwert@egf.com",
+              "FN" : "dsfds"
+            },
+            {
+              "EMAIL" : "ascscxsaca@com",
+              "FN" : "scadscdvcda"
+            },
+            {
+              "EMAIL" : "abc@gmail.com",
+              "FN" : "subscribed"
+            },
+            {
+              "EMAIL" : "ddwnkl@gmail.com",
+              "FN" : "subscribed"
+            },
+            {
+              "EMAIL" : "subscribed@eewrfrd.com",
+              "FN" : "pending"
+            },
+            {
+              "EMAIL" : "acsdvdf@ddfvf.com",
+              "FN" : "pending"
+            }
+          ]
+        }
+      },
+      "type" : "audienceList",
+      "anonymousId" : "63228b51-394e-4ca2-97a0-427f6187480b"
+    },
+    "destination": {
+      "Config": {
+        "accessToken": "ABC",
+        "disableFormat": false,
+        "isHashRequired": true,
+        "isRaw": false,
+        "maxUserCount": "50",
+        "oneTrustCookieCategories": [],
+        "skipVerify": false,
+        "subType": "NA",
+        "type": "NA",
+        "userSchema": [ "EMAIL" ]
+      },
+      "secretConfig": {},
+      "ID": "1mMy5cqbtfuaKZv1IhVQKnBdVwe",
+      "name": "FB_CUSTOM_AUDIENCE",
+      "enabled": true,
+      "workspaceId": "1TSN08muJTZwH8iCDmnnRt1pmLd",
+      "deleted": false,
+      "createdAt": "2020-12-30T08:39:32.005Z",
+      "updatedAt": "2021-02-03T16:22:31.374Z",
+      "destinationDefinition": {
+        "id": "1aIXqM806xAVm92nx07YwKbRrO9",
+        "name": "FB_CUSTOM_AUDIENCE",
+        "displayName": "FB_CUSTOM_AUDIENCE",
+        "createdAt": "2020-04-09T09:24:31.794Z",
+        "updatedAt": "2021-01-11T11:03:28.103Z"
+      },
+      "transformations": [],
+      "isConnectionEnabled": true,
+      "isProcessorEnabled": true
+    },
+    "metadata": {
+      "jobId": 2
+    }
+  }
+]

--- a/test/__tests__/data/fb_custom_audience_router_rETL_output.json
+++ b/test/__tests__/data/fb_custom_audience_router_rETL_output.json
@@ -1,0 +1,110 @@
+[
+  {
+    "batchedRequest": {
+      "version": "1",
+      "type": "REST",
+      "method": "POST",
+      "endpoint": "https://graph.facebook.com/v16.0/23848494844100489/users",
+      "headers": {},
+      "params": {
+        "access_token": "ABC",
+        "payload": {
+          "schema": [
+            "EMAIL",
+            "FN"
+          ],
+          "data": [
+            [
+              "7625cab24612c37df6d2f724721bb38a25095d0295e29b807238ee188b8aca43",
+              "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+            ],
+            [
+              "b2b4abadd72190af54305c0d3abf1977fec4935016bb13ff28040d5712318dfd",
+              "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+            ],
+            [
+              "c4b007d1c3c9a5d31bd4082237a913e8e0db1767225c2a5ef33be2716df005fa",
+              "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+            ],
+            [
+              "94639be1bd9f17c05820164e9d71ef78558f117a9e8bfab43cf8015e08aa0b27",
+              "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+            ],
+            [
+              "39b456cfb4bb07f9e6bb18698aa173171ca49c731fccc4790e9ecea808d24ae6",
+              "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+            ],
+            [
+              "769f73387add781a481ca08300008a08fb2f1816aaed196137efc2e05976d711",
+              "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+            ],
+            [
+              "48ddb93f0b30c475423fe177832912c5bcdce3cc72872f8051627967ef278e08",
+              "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+            ],
+            [
+              "da2d431121cd10578fd81f8f80344b06db59ea2d05a7b5d27536c8789ddae8f0",
+              "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+            ],
+            [
+              "b100c2ec0718fe6b4805b623aeec6710719d042ceea55f5c8135b010ec1c7b36",
+              "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+            ],
+            [
+              "0c1d1b0ba547a742013366d6fbc8f71dd77f566d94e41ed9f828a74b96928161",
+              "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+            ]
+          ]
+        }
+      },
+      "body": {
+        "JSON": {},
+        "JSON_ARRAY": {},
+        "XML": {},
+        "FORM": {}
+      },
+      "files": {}
+    },
+    "metadata": [
+      {
+        "jobId": 2
+      }
+    ],
+    "batched": false,
+    "statusCode": 200,
+    "destination": {
+      "Config": {
+        "accessToken": "ABC",
+        "disableFormat": false,
+        "isHashRequired": true,
+        "isRaw": false,
+        "maxUserCount": "50",
+        "oneTrustCookieCategories": [],
+        "skipVerify": false,
+        "subType": "NA",
+        "type": "NA",
+        "userSchema": [
+          "EMAIL"
+        ]
+      },
+      "secretConfig": {},
+      "ID": "1mMy5cqbtfuaKZv1IhVQKnBdVwe",
+      "name": "FB_CUSTOM_AUDIENCE",
+      "enabled": true,
+      "workspaceId": "1TSN08muJTZwH8iCDmnnRt1pmLd",
+      "deleted": false,
+      "createdAt": "2020-12-30T08:39:32.005Z",
+      "updatedAt": "2021-02-03T16:22:31.374Z",
+      "destinationDefinition": {
+        "id": "1aIXqM806xAVm92nx07YwKbRrO9",
+        "name": "FB_CUSTOM_AUDIENCE",
+        "displayName": "FB_CUSTOM_AUDIENCE",
+        "createdAt": "2020-04-09T09:24:31.794Z",
+        "updatedAt": "2021-01-11T11:03:28.103Z"
+      },
+      "transformations": [],
+      "isConnectionEnabled": true,
+      "isProcessorEnabled": true
+    }
+  }
+]

--- a/test/__tests__/fb_custom_audience.test.js
+++ b/test/__tests__/fb_custom_audience.test.js
@@ -41,3 +41,27 @@ describe(`${name} Tests`, () => {
     });
   });
 });
+
+describe("Router Tests for rETL sources", () => {
+  it("should send events to dest", async () => {
+    const input = JSON.parse(
+      fs.readFileSync(
+        path.resolve(
+          __dirname,
+          `data/${integration}_router_rETL_input.json`
+        )
+      )
+    );
+    const output = JSON.parse(
+      fs.readFileSync(
+        path.resolve(
+          __dirname,
+          `data/${integration}_router_rETL_output.json`
+        )
+      )
+    );
+    const actualOutput = await transformer.processRouterDest(input);
+   console.log(JSON.stringify(actualOutput))
+    expect(actualOutput).toEqual(output);
+  });
+});


### PR DESCRIPTION
## Description of the change

> Check for rETL vdm sources if audience id not present in destination configs then in context.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
