### PR TITLE
feat: add override support in clevertap

### DIFF
--- a/src/v0/destinations/clevertap/config.js
+++ b/src/v0/destinations/clevertap/config.js
@@ -40,6 +40,7 @@ const CLEVERTAP_DEFAULT_EXCLUSION = [
   'userId',
   'id',
   'ts',
+  'overrideFields',
 ];
 // ref : https://developer.clevertap.com/docs/disassociate-api
 const DEL_MAX_BATCH_SIZE = 100;

--- a/src/v0/destinations/clevertap/transform.js
+++ b/src/v0/destinations/clevertap/transform.js
@@ -211,7 +211,7 @@ const getClevertapProfile = (message, category) => {
 
   // Add additional properties being passed inside overrideFields in traits
   // to be added to the profile object, to be sent into Clevertap profileData
-  if (message?.traits?.overrideFields) {
+  if (message.traits?.overrideFields) {
     const { overrideFields } = message.traits;
     Object.assign(profile, overrideFields);
   }

--- a/src/v0/destinations/clevertap/transform.js
+++ b/src/v0/destinations/clevertap/transform.js
@@ -208,6 +208,14 @@ const getClevertapProfile = (message, category) => {
     CLEVERTAP_DEFAULT_EXCLUSION,
   );
   profile = convertObjectAndArrayToString(profile);
+
+  // Add additional properties being passed inside overrideFields in traits
+  // to be added to the profile object, to be sent into Clevertap profileData
+  if (message?.traits?.overrideFields) {
+    const { overrideFields } = message.traits;
+    Object.assign(profile, overrideFields);
+  }
+
   return removeUndefinedAndNullValues(profile);
 };
 

--- a/test/__tests__/data/clevertap_input.json
+++ b/test/__tests__/data/clevertap_input.json
@@ -845,8 +845,9 @@
         "All": true
       },
       "sentAt": "2019-10-14T09:03:22.563Z"
-    },
-    {
+    }
+  },
+  {
     "destination": {
       "Config": {
         "passcode": "fbee74a147828e2932c701d19dc1f2dcfa4ac0048be3aa3a88d427090a59dc1c0fa002f1",

--- a/test/__tests__/data/clevertap_input.json
+++ b/test/__tests__/data/clevertap_input.json
@@ -768,5 +768,83 @@
       "messageId": "46c1a69c-cc24-4a49-8079-3fcbabf15eb8",
       "previousId": "1122121"
     }
+  },
+  {
+    "destination": {
+      "Config": {
+        "passcode": "fbee74a147828e2932c701d19dc1f2dcfa4ac0048be3aa3a88d427090a59dc1c0fa002f1",
+        "accountId": "476550467",
+        "trackAnonymous": true,
+        "enableObjectIdMapping": false
+      }
+    },
+    "message": {
+      "channel": "web",
+      "context": {
+        "app": {
+          "build": "1.0.0",
+          "name": "RudderLabs JavaScript SDK",
+          "namespace": "com.rudderlabs.javascript",
+          "version": "1.0.0"
+        },
+        "library": {
+          "name": "RudderLabs JavaScript SDK",
+          "version": "1.0.0"
+        },
+        "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36",
+        "locale": "en-US",
+        "ip": "0.0.0.0",
+        "os": {
+          "name": "",
+          "version": ""
+        },
+        "screen": {
+          "density": 2
+        }
+      },
+      "messageId": "84e26acc-56a5-4835-8233-591137fca468",
+      "session_id": "3049dc4c-5a95-4ccd-a3e7-d74a7e411f22",
+      "originalTimestamp": "2019-10-14T09:03:17.562Z",
+      "anonymousId": "anon_id",
+      "type": "identify",
+      "traits": {
+        "anonymousId": "anon_id",
+        "email": "johnDoe@gmail.com",
+        "first_name": "John",
+        "last_name": "Doe",
+        "overrideFields": {
+          "first_name": "John",
+          "last_name": "Doe"
+        },
+        "phone": "92374162212",
+        "gender": "M",
+        "employed": true,
+        "birthday": "1614775793",
+        "education": "Science",
+        "graduate": true,
+        "married": true,
+        "customerType": "Prime",
+        "msg_push": true,
+        "msgSms": true,
+        "msgemail": true,
+        "msgwhatsapp": false,
+        "custom_tags": ["Test_User", "Interested_User", "DIY_Hobby"],
+        "custom_mappings": {
+          "Office": "Trastkiv",
+          "Country": "Russia"
+        },
+        "address": {
+          "city": "kolkata",
+          "country": "India",
+          "postalCode": 789223,
+          "state": "WB",
+          "street": ""
+        }
+      },
+      "integrations": {
+        "All": true
+      },
+      "sentAt": "2019-10-14T09:03:22.563Z"
+    }
   }
 ]

--- a/test/__tests__/data/clevertap_output.json
+++ b/test/__tests__/data/clevertap_output.json
@@ -571,5 +571,52 @@
     },
     "version": "1",
     "endpoint": "https://api.clevertap.com/1/upload"
+  },
+  {
+    "version": "1",
+    "type": "REST",
+    "method": "POST",
+    "endpoint": "https://api.clevertap.com/1/upload",
+    "headers": {
+      "X-CleverTap-Account-Id": "476550467",
+      "X-CleverTap-Passcode": "fbee74a147828e2932c701d19dc1f2dcfa4ac0048be3aa3a88d427090a59dc1c0fa002f1",
+      "Content-Type": "application/json"
+    },
+    "params": {},
+    "body": {
+      "JSON": {
+        "d": [
+          {
+            "type": "profile",
+            "profileData": {
+              "Email": "johnDoe@gmail.com",
+              "Phone": "92374162212",
+              "Gender": "M",
+              "Employed": true,
+              "DOB": "1614775793",
+              "Education": "Science",
+              "Married": true,
+              "Customer Type": "Prime",
+              "Name": "John Doe",
+              "graduate": true,
+              "msg_push": true,
+              "msgSms": true,
+              "msgemail": true,
+              "msgwhatsapp": false,
+              "custom_tags": "[\"Test_User\",\"Interested_User\",\"DIY_Hobby\"]",
+              "custom_mappings": "{\"Office\":\"Trastkiv\",\"Country\":\"Russia\"}",
+              "address": "{\"city\":\"kolkata\",\"country\":\"India\",\"postalCode\":789223,\"state\":\"WB\",\"street\":\"\"}",
+              "first_name": "John",
+              "last_name": "Doe"
+            },
+            "identity": "anon_id"
+          }
+        ]
+      },
+      "JSON_ARRAY": {},
+      "XML": {},
+      "FORM": {}
+    },
+    "files": {}
   }
 ]


### PR DESCRIPTION
## Description of the change

> Adding support for an `overrideFields` field in traits, to allow any number of fields that are passed in the `overrideFields` object, to pass without destination transformation into Clevertap `profileData`.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
