### PR TITLE
fix: allow event names without forced lowercasing, disable lowercasing

### DIFF
--- a/src/v0/destinations/adobe_analytics/config.js
+++ b/src/v0/destinations/adobe_analytics/config.js
@@ -25,19 +25,34 @@ const ECOM_PRODUCT_EVENTS = [
 
 const formatDestinationConfig = (config) => ({
   ...config,
-  eventsToTypes: getHashFromArray(config.eventsToTypes),
-  listMapping: getHashFromArray(config.listMapping),
-  listDelimiter: getHashFromArray(config.listDelimiter),
-  productMerchEvarsMap: getHashFromArray(config.productMerchEvarsMap),
-  productMerchEventToAdobeEvent: getHashFromArray(config.productMerchEventToAdobeEvent),
+  eventsToTypes: getHashFromArray(config.eventsToTypes, 'from', 'to', false),
+  listMapping: getHashFromArray(config.listMapping, 'from', 'to', false),
+  listDelimiter: getHashFromArray(config.listDelimiter, 'from', 'to', false),
+  productMerchEvarsMap: getHashFromArray(config.productMerchEvarsMap, 'from', 'to', false),
+  productMerchEventToAdobeEvent: getHashFromArray(
+    config.productMerchEventToAdobeEvent,
+    'from',
+    'to',
+    false,
+  ),
   eventMerchProperties: config.eventMerchProperties,
-  eventMerchEventToAdobeEvent: getHashFromArray(config.eventMerchEventToAdobeEvent),
-  rudderEventsToAdobeEvents: getHashFromArray(config.rudderEventsToAdobeEvents),
-  customPropsMapping: getHashFromArray(config.customPropsMapping),
-  propsDelimiter: getHashFromArray(config.propsDelimiter),
-  eVarMapping: getHashFromArray(config.eVarMapping),
-  hierMapping: getHashFromArray(config.hierMapping),
-  contextDataMapping: getHashFromArray(config.contextDataMapping),
+  eventMerchEventToAdobeEvent: getHashFromArray(
+    config.eventMerchEventToAdobeEvent,
+    'from',
+    'to',
+    false,
+  ),
+  rudderEventsToAdobeEvents: getHashFromArray(
+    config.rudderEventsToAdobeEvents,
+    'from',
+    'to',
+    false,
+  ),
+  customPropsMapping: getHashFromArray(config.customPropsMapping, 'from', 'to', false),
+  propsDelimiter: getHashFromArray(config.propsDelimiter, 'from', 'to', false),
+  eVarMapping: getHashFromArray(config.eVarMapping, 'from', 'to', false),
+  hierMapping: getHashFromArray(config.hierMapping, 'from', 'to', false),
+  contextDataMapping: getHashFromArray(config.contextDataMapping, 'from', 'to', false),
 });
 
 module.exports = {

--- a/src/v0/destinations/adobe_analytics/transform.js
+++ b/src/v0/destinations/adobe_analytics/transform.js
@@ -183,7 +183,7 @@ const processTrackEvent = (message, adobeEventName, destinationConfig, extras = 
   } = destinationConfig;
   const { event: rawMessageEvent, properties } = message;
   const { overrideEventString, overrideProductString, products } = properties;
-  const event = rawMessageEvent.toLowerCase();
+  const event = rawMessageEvent;
   const adobeEventArr = adobeEventName ? adobeEventName.split(',') : [];
   // adobeEventArr is an array of events which is defined as
   // ["eventName", "mapped Adobe Event=mapped merchproperty's value", "mapped Adobe Event=mapped merchproperty's value", . . .]
@@ -310,8 +310,8 @@ const handleTrack = (message, destinationConfig) => {
   let payload = null;
   // handle ecommerce events separately
   // generic events should go to the default
-  const event = rawEvent?.toLowerCase();
-  switch (event) {
+  const event = rawEvent;
+  switch (event.toLowerCase()) {
     case 'product viewed':
     case 'product list viewed':
       payload = processTrackEvent(message, 'prodView', destinationConfig);
@@ -343,10 +343,10 @@ const handleTrack = (message, destinationConfig) => {
       payload = processTrackEvent(message, 'scOpen', destinationConfig);
       break;
     default:
-      if (destinationConfig.rudderEventsToAdobeEvents[event.toLowerCase()]) {
+      if (destinationConfig.rudderEventsToAdobeEvents[event]) {
         payload = processTrackEvent(
           message,
-          destinationConfig.rudderEventsToAdobeEvents[event.toLowerCase()].trim(),
+          destinationConfig.rudderEventsToAdobeEvents[event].trim(),
           destinationConfig,
         );
       } else {

--- a/test/__tests__/data/adobe_analytics.json
+++ b/test/__tests__/data/adobe_analytics.json
@@ -1982,7 +1982,7 @@
               "to": "event1"
             },
             {
-              "from": "watched video",
+              "from": "Watched Video",
               "to": "event1"
             }
           ],
@@ -2526,7 +2526,7 @@
               "to": "event2"
             },
             {
-              "from": "currency test event",
+              "from": "Currency test event",
               "to": "event6"
             }
           ],


### PR DESCRIPTION
## Description of the change

- allow event names from config without forced lowercasing.
- disable lowercasing explicitly while hashing arrays

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
