### PR TITLE
fix: added missed stats to dest transform controllers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 node_modules
 npm-debug.log
 reports/*
+dist

--- a/src/services/source/nativeIntegration.ts
+++ b/src/services/source/nativeIntegration.ts
@@ -8,6 +8,7 @@ import {
 import PostTransformationServiceSource from './postTransformation';
 import FetchHandler from '../../helpers/fetchHandlers';
 import tags from '../../v0/util/tags';
+import stats from '../../util/stats';
 
 export default class NativeIntegrationSourceService implements IntegrationSourceService {
   public getTags(): MetaTransferObject {
@@ -37,6 +38,10 @@ export default class NativeIntegrationSourceService implements IntegrationSource
           return PostTransformationServiceSource.handleSuccessEventsSource(respEvents);
         } catch (error: any) {
           const metaTO = this.getTags();
+          stats.increment('source_transform_errors', {
+            sourceType,
+            version,
+          });
           return PostTransformationServiceSource.handleFailureEventsSource(error, metaTO);
         }
       }),


### PR DESCRIPTION
Added missed stats to dest transformer controller also added stats for source transform failure
event counts, onboarded dist to .gitignore
