### PR TITLE
fix: shopify default check for anonymousId

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -7,4 +7,5 @@ CONFIG_BACKEND_URL="https://api.rudderstack.com"
 REDIS_HOST = localhost
 REDIS_PORT = 6379
 REDIS_PASSWORD = 123
+REDIS_USERNAME = abc
 USE_REDIS_DB = true

--- a/src/util/redisConnector.js
+++ b/src/util/redisConnector.js
@@ -16,12 +16,14 @@ const RedisDB = {
       this.host = process.env.REDIS_HOST || 'localhost';
       this.port = parseInt(process.env.REDIS_PORT, 10) || 6379;
       this.password = process.env.REDIS_PASSWORD;
+      this.userName = process.env.REDIS_USERNAME;
       this.maxRetries = parseInt(process.env.REDIS_MAX_RETRIES || 30, 10);
       this.timeAfterRetry = parseInt(process.env.REDIS_TIME_AFTER_RETRY_IN_MS || 10, 10);
       this.client = new Redis({
         host: this.host,
         port: this.port,
         password: this.password,
+        username: this.userName,
         enableReadyCheck: true,
         retryStrategy: (times) => {
           if (times <= this.maxRetries) {
@@ -69,6 +71,10 @@ const RedisDB = {
       }
       return isJsonExpected ? JSON.parse(value) : value;
     } catch (e) {
+      stats.increment('redis_get_val_error', {
+        error: e,
+        timestamp: Date.now()
+      });
       throw new RedisError(`Error getting value from Redis: ${e}`);
     }
   },
@@ -80,16 +86,20 @@ const RedisDB = {
    */
 
   async setVal(key, value, isValJson = true) {
-    const dataExpiry = 60*60; // 1 hour
+    const dataExpiry = 60 * 60; // 1 hour
     try {
       await this.checkAndConnectConnection(); // check if redis is connected and if not, connect
       const valueToStore = isValJson ? JSON.stringify(value) : value;
       const bytes = Buffer.byteLength(valueToStore, "utf-8");
-      await this.client.setex(key,dataExpiry, valueToStore);
+      await this.client.setex(key, dataExpiry, valueToStore);
       stats.gauge('redis_set_val_size', bytes, {
         timestamp: Date.now()
       });
     } catch (e) {
+      stats.increment('redis_set_val_error', {
+        error: e,
+        timestamp: Date.now()
+      });
       throw new RedisError(`Error setting value in Redis due ${e}`);
     }
   },

--- a/src/v0/sources/shopify/util.js
+++ b/src/v0/sources/shopify/util.js
@@ -135,6 +135,7 @@ const setAnonymousIdorUserIdFromDb = async (message, metricMetadata) => {
      */
     case RUDDER_ECOM_MAP.checkouts_create:
     case RUDDER_ECOM_MAP.checkouts_update:
+    case SHOPIFY_TRACK_MAP.checkouts_delete:
     case SHOPIFY_TRACK_MAP.orders_cancelled:
     case SHOPIFY_TRACK_MAP.orders_fulfilled:
     case SHOPIFY_TRACK_MAP.orders_paid:
@@ -153,10 +154,6 @@ const setAnonymousIdorUserIdFromDb = async (message, metricMetadata) => {
       break;
     // https://help.shopify.com/en/manual/orders/edit-orders -> order can be edited through shopify-admin only
     // https://help.shopify.com/en/manual/orders/fulfillment/setting-up-fulfillment -> fullfillments wont include cartToken neither in manual or automatiic
-    case SHOPIFY_TRACK_MAP.orders_edited:
-    case SHOPIFY_TRACK_MAP.orders_delete:
-    case SHOPIFY_TRACK_MAP.fulfillments_create:
-    case SHOPIFY_TRACK_MAP.fulfillments_update:
     default:
   }
   if (!isDefinedAndNotNull(cartToken)) {

--- a/src/v0/sources/shopify/util.js
+++ b/src/v0/sources/shopify/util.js
@@ -122,7 +122,7 @@ const setAnonymousId = (message) => {
 };
 /**
  * This function sets the anonymousId based on cart_token or id from the properties of message.
- * If it's null then we set userId as "ADMIN".
+ * If it's null then we set userId as "shopify-admin".
  * @param {*} message
  * @returns
  */
@@ -172,14 +172,12 @@ const setAnonymousIdorUserIdFromDb = async (message, metricMetadata) => {
       }
       return;
     default:
-      logger.error(`Event ${message.event} not supported`);
+      if (!message.userId) {
+        message.setProperty('userId', "shopify-admin");
+      }
+      return;
   }
-  if(!isDefinedAndNotNull(cartToken)){
-    if (!message.userId) {
-      message.setProperty('userId', "shopify-admin");
-    }
-    return;
-  }
+
   let anonymousIDfromDB;
   const executeStartTime = Date.now();
   const redisVal = await RedisDB.getVal(`${cartToken}`);

--- a/test/__tests__/data/redis/shopify_source.json
+++ b/test/__tests__/data/redis/shopify_source.json
@@ -1,43 +1,5 @@
 [
     {
-        "description": "Track Call -> carts_create with no cartToken",
-        "input": {
-            "query_parameters": {
-                "topic": [
-                    "carts_create"
-                ]
-            },
-            "line_items": [],
-            "note": null,
-            "updated_at": "2023-02-10T12:16:07.251Z",
-            "created_at": "2023-02-10T12:05:04.402Z"
-        },
-        "output": {
-            "userId": "shopify-admin",
-            "context": {
-                "library": {
-                    "name": "RudderStack Shopify Cloud",
-                    "version": "1.0.0"
-                },
-                "integration": {
-                    "name": "SHOPIFY"
-                },
-                "topic": "carts_create"
-            },
-            "event": "Cart Create",
-            "integrations": {
-                "SHOPIFY": true
-            },
-            "type": "track",
-            "properties": {
-                "created_at": "2023-02-10T12:05:04.402Z",
-                "note": null,
-                "products": [],
-                "updated_at": "2023-02-10T12:16:07.251Z"
-            }
-        }
-    },
-    {
         "description": "Track Call -> carts_create with invalid cartToken",
         "input": {
             "id": "shopify_test3",


### PR DESCRIPTION
## Description of the change

> We are changing the behaviour of default case of mapping the `anonymousId` as there are certain events for which `cartToken` is not present and so we are now checking there is `userId` or not present and mapping `userId` as `shopify-admin` if `userId` is not present. 
Added some metrics for data transaction failure between transformer and redis. 
Added `userName` in `redisConnector`

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
