### PR TITLE
chore(cicd): replace local with gha cache in build steps

### DIFF
--- a/.github/workflows/build-pr-artifacts.yml
+++ b/.github/workflows/build-pr-artifacts.yml
@@ -7,172 +7,57 @@ on:
       - reopened
       - synchronize
 
-env:
-  REPO_NAME_OLD: rudderlabs/develop-rudder-transformer
-  REPO_NAME: rudderstack/develop-rudder-transformer
-  DOCKERHUB_USERNAME: rudderlabs
-
 jobs:
-  generate-tag-name:
-    name: Generate Tag Name
+  generate-tag-names:
     runs-on: ubuntu-latest
+    name: Generate Tag Names
+    # Skip for the release pull requests as staging artifacts will be generated
+    if: startsWith(github.event.pull_request.head.ref, 'release/') != true && startsWith(github.event.pull_request.head.ref, 'hotfix-release/') != true && github.event.pull_request.head.ref != 'main'
     outputs:
-      tag_name: ${{ steps.gen_tag_name.outputs.tag_name }}
+      tag_name: ${{ steps.gen_tag_names.outputs.tag_name }}
+      tag_name_ut: ${{ steps.gen_tag_names.outputs.tag_name_ut }}
     steps:
       # Replace problematic characters in branch name (like '/') with safe characters (like '.')
-      - name: Generate Tag Name
-        id: gen_tag_name
-        shell: bash
+      - name: Generate Tag Names
+        id: gen_tag_names
         run: |
-          echo "tag_name=$(echo ${{ github.head_ref }} | tr "/" .)" >> $GITHUB_OUTPUT
+          tag_name=$(echo ${{ github.head_ref }} | tr "/" .)
+          echo "Tag Name: $tag_name"
+          echo "tag_name=$tag_name" >> $GITHUB_OUTPUT
+
+          tag_name_ut="ut-$tag_name"
+          echo "UT Tag Name: $tag_name_ut"
+          echo "tag_name_ut=$tag_name_ut" >> $GITHUB_OUTPUT
 
   build-transformer-image:
     name: Build Transformer Docker Image - PR
-    runs-on: ubuntu-latest
-    needs: [generate-tag-name]
-    env:
-      TAG_NAME: ${{ needs.generate-tag-name.outputs.tag_name }}
-
     # Skip for the release pull requests as staging artifacts will be generated
     # Skip main to develop sync pull requests
     if: startsWith(github.event.pull_request.head.ref, 'release/') != true && startsWith(github.event.pull_request.head.ref, 'hotfix-release/') != true && github.event.pull_request.head.ref != 'main'
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3.5.0
-        with:
-          fetch-depth: 1
-
-      - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v2.5.0
-
-      - name: Login to DockerHub
-        uses: docker/login-action@v2.1.0
-        with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PROD_TOKEN }}
-
-      - name: Cache Docker Layers
-        uses: actions/cache@v3.3.1
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
-
-      - name: Build Docker Image for Tests
-        uses: docker/build-push-action@v4.0.0
-        with:
-          context: .
-          file: Dockerfile
-          target: development
-          load: true
-          tags: |
-            ${{ env.REPO_NAME }}:${{ env.TAG_NAME }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
-
-      - name: Run Tests
-        run: |
-          docker run ${{ env.REPO_NAME }}:${{ env.TAG_NAME }} npm run test:ci
-          docker run ${{ env.REPO_NAME }}:${{ env.TAG_NAME }} npm run test:integration
-
-      - name: Build and Push Multi-platform Images
-        uses: docker/build-push-action@v4.0.0
-        with:
-          context: .
-          push: true
-          target: production
-          tags: |
-            ${{ env.REPO_NAME_OLD }}:${{ env.TAG_NAME }}
-            ${{ env.REPO_NAME }}:${{ env.TAG_NAME }}
-          platforms: |
-            linux/amd64
-            linux/arm64
-          build-args: |
-            version=${{ env.TAG_NAME }}
-            GIT_COMMIT_SHA=${{ github.sha }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
-
-        # Temp fix
-        # https://github.com/docker/build-push-action/issues/252
-        # https://github.com/moby/buildkit/issues/1896
-      - name: Move Cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+    needs: [generate-tag-names]
+    uses: ./.github/workflows/build-push-docker-image.yml
+    with:
+      build_tag: rudderstack/develop-rudder-transformer:${{ needs.generate-tag-names.outputs.tag_name }}
+      push_tags: rudderstack/develop-rudder-transformer:${{ needs.generate-tag-names.outputs.tag_name }},rudderlabs/develop-rudder-transformer:${{ needs.generate-tag-names.outputs.tag_name }}
+      img_tag: ${{ needs.generate-tag-names.outputs.tag_name }}
+      dockerfile: Dockerfile
+      load_target: development
+      push_target: production
+    secrets:
+      DOCKERHUB_PROD_TOKEN: ${{ secrets.DOCKERHUB_PROD_TOKEN }}
 
   build-user-transformer-image:
     name: Build User Transformer Docker Image - PR
-    runs-on: ubuntu-latest
-    needs: [generate-tag-name]
-    env:
-      TAG_NAME: ut-${{ needs.generate-tag-name.outputs.tag_name }}
-
     # Skip for the release pull requests as staging artifacts will be generated
     if: startsWith(github.event.pull_request.head.ref, 'release/') != true && startsWith(github.event.pull_request.head.ref, 'hotfix-release/') != true && github.event.pull_request.head.ref != 'main'
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3.5.0
-        with:
-          fetch-depth: 1
-
-      - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v2.5.0
-
-      - name: Login to DockerHub
-        uses: docker/login-action@v2.1.0
-        with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PROD_TOKEN }}
-
-      - name: Cache Docker Layers
-        uses: actions/cache@v3.3.1
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
-
-      - name: Build Docker Image for Tests
-        uses: docker/build-push-action@v4.0.0
-        with:
-          context: .
-          file: Dockerfile-ut-func
-          target: development
-          load: true
-          tags: |
-            ${{ env.REPO_NAME }}:${{ env.TAG_NAME }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
-
-      - name: Run Tests
-        run: |
-          docker run ${{ env.REPO_NAME }}:${{ env.TAG_NAME }} npm run test:ci
-
-      - name: Build and Push Multi-platform Images
-        uses: docker/build-push-action@v4.0.0
-        with:
-          context: .
-          file: Dockerfile-ut-func
-          target: development
-          push: true
-          tags: |
-            ${{ env.REPO_NAME_OLD }}:${{ env.TAG_NAME }}
-            ${{ env.REPO_NAME }}:${{ env.TAG_NAME }}
-          platforms: |
-            linux/amd64
-            linux/arm64
-          build-args: |
-            version=${{ env.TAG_NAME }}
-            GIT_COMMIT_SHA=${{ github.sha }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
-
-        # Temp fix
-        # https://github.com/docker/build-push-action/issues/252
-        # https://github.com/moby/buildkit/issues/1896
-      - name: Move Cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+    needs: [generate-tag-names]
+    uses: ./.github/workflows/build-push-docker-image.yml
+    with:
+      build_tag: rudderstack/develop-rudder-transformer:${{ needs.generate-tag-names.outputs.tag_name_ut }}
+      push_tags: rudderstack/develop-rudder-transformer:${{ needs.generate-tag-names.outputs.tag_name_ut }},rudderlabs/develop-rudder-transformer:${{ needs.generate-tag-names.outputs.tag_name_ut }}
+      img_tag: ${{ needs.generate-tag-names.outputs.tag_name_ut }}
+      dockerfile: Dockerfile-ut-func
+      load_target: development
+      push_target: development
+    secrets:
+      DOCKERHUB_PROD_TOKEN: ${{ secrets.DOCKERHUB_PROD_TOKEN }}

--- a/.github/workflows/build-push-docker-image.yml
+++ b/.github/workflows/build-push-docker-image.yml
@@ -1,0 +1,81 @@
+name: Build Transformer Docker Image
+
+on:
+  workflow_call:
+    inputs:
+      build_tag:
+        required: true
+        type: string
+      push_tags:
+        required: true
+        type: string
+      img_tag:
+        required: true
+        type: string
+      dockerfile:
+        required: true
+        type: string
+      load_target:
+        required: true
+        type: string
+      push_target:
+        required: true
+        type: string
+    secrets:
+      DOCKERHUB_PROD_TOKEN:
+        required: true
+
+env:
+  DOCKERHUB_USERNAME: rudderlabs
+
+jobs:
+  build-transformer-image:
+    name: Build Transformer Docker Image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3.5.0
+        with:
+          fetch-depth: 1
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v2.5.0
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v2.1.0
+        with:
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PROD_TOKEN }}
+
+      - name: Build Docker Image
+        uses: docker/build-push-action@v4.0.0
+        with:
+          context: .
+          file: ${{ inputs.dockerfile }}
+          target: ${{ inputs.load_target }}
+          load: true
+          tags: ${{ inputs.build_tag }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Run Tests
+        run: |
+          docker run ${{ inputs.build_tag }} npm run test:ci
+          docker run ${{ inputs.build_tag }} npm run test:integration
+
+      - name: Build and Push Multi-platform Images
+        uses: docker/build-push-action@v4.0.0
+        with:
+          context: .
+          file: ${{ inputs.dockerfile }}
+          target: ${{ inputs.push_target }}
+          push: true
+          tags: ${{ inputs.push_tags }}
+          platforms: |
+            linux/amd64
+            linux/arm64
+          build-args: |
+            version=${{ inputs.img_tag }}
+            GIT_COMMIT_SHA=${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/build-push-docker-image.yml
+++ b/.github/workflows/build-push-docker-image.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.5.0
+        uses: actions/checkout@v3.5.2
         with:
           fetch-depth: 1
 

--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -11,7 +11,7 @@ jobs:
     if: (github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/heads/hotfix/')) && (github.actor == 'ItsSudip' || github.actor == 'krishna2020' || github.actor == 'saikumarrs' || github.actor == 'sandeepdsvs' || github.actor == 'shrouti1507') &&  (github.triggering_actor == 'ItsSudip' || github.triggering_actor == 'krishna2020' || github.triggering_actor == 'saikumarrs' || github.triggering_actor == 'sandeepdsvs' || github.triggering_actor == 'shrouti1507')
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.5.0
+        uses: actions/checkout@v3.5.2
         with:
           fetch-depth: 0
 

--- a/.github/workflows/housekeeping.yml
+++ b/.github/workflows/housekeeping.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.5.0
+        uses: actions/checkout@v3.5.2
 
       - name: Delete Old Branches
         uses: beatlabs/delete-old-branches-action@v0.0.9

--- a/.github/workflows/prepare-for-dev-deploy.yml
+++ b/.github/workflows/prepare-for-dev-deploy.yml
@@ -10,140 +10,60 @@ on:
     branches:
       - develop
 
-env:
-  REPO_NAME_OLD: rudderlabs/develop-rudder-transformer
-  REPO_NAME: rudderstack/develop-rudder-transformer
-  DOCKERHUB_USERNAME: rudderlabs
-
 jobs:
   report-coverage:
     name: Report Code Coverage
     if: github.event_name == 'push'
     uses: ./.github/workflows/report-code-coverage.yml
 
-  build-transformer-image:
-    name: Build Transformer Docker Image - Dev
+  generate-tag-names:
     runs-on: ubuntu-latest
+    name: Generate Tag Names
     # Only merged pull requests must trigger
     if: github.event.pull_request.merged == true
     outputs:
-      tag_name: ${{ steps.gen_tag_name.outputs.tag_name }}
+      tag_name: ${{ steps.gen_tag_names.outputs.tag_name }}
+      tag_name_ut: ${{ steps.gen_tag_names.outputs.tag_name_ut }}
     steps:
-      - name: Generate Tag Name
-        id: gen_tag_name
+      - name: Generate Tag Names
+        id: gen_tag_names
         run: |
           tag_name="latest"
+          echo "Tag Name: $tag_name"
           echo "tag_name=$tag_name" >> $GITHUB_OUTPUT
 
-      - name: Checkout
-        uses: actions/checkout@v3.5.0
-        with:
-          fetch-depth: 1
+          tag_name_ut="ut-$tag_name"
+          echo "UT Tag Name: $tag_name_ut"
+          echo "tag_name_ut=$tag_name_ut" >> $GITHUB_OUTPUT
 
-      - name: Login to DockerHub
-        uses: docker/login-action@v2.1.0
-        with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PROD_TOKEN }}
-
-      - name: Build Docker Image
-        uses: docker/build-push-action@v4.0.0
-        with:
-          context: .
-          file: Dockerfile
-          target: development
-          load: true
-          tags: |
-            ${{ env.REPO_NAME }}:${{ steps.gen_tag_name.outputs.tag_name }}
-
-      - name: Run Tests
-        run: |
-          docker run ${{ env.REPO_NAME }}:${{ steps.gen_tag_name.outputs.tag_name }} npm run test:ci
-          docker run ${{ env.REPO_NAME }}:${{ steps.gen_tag_name.outputs.tag_name }} npm run test:integration
-
-      - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v2.5.0
-        with:
-          platforms: |
-            linux/amd64
-            linux/arm64
-
-      - name: Build and Push Multi-platform Images
-        uses: docker/build-push-action@v4.0.0
-        with:
-          context: .
-          file: Dockerfile
-          target: production
-          push: true
-          tags: |
-            ${{ env.REPO_NAME_OLD }}:${{ steps.gen_tag_name.outputs.tag_name }}
-            ${{ env.REPO_NAME }}:${{ steps.gen_tag_name.outputs.tag_name }}
-          platforms: |
-            linux/amd64
-            linux/arm64
-          build-args: |
-            version=${{ steps.gen_tag_name.outputs.tag_name }}
-            GIT_COMMIT_SHA=${{ github.sha }}
+  build-transformer-image:
+    name: Build Transformer Docker Image - Dev
+    # Only merged pull requests must trigger
+    if: github.event.pull_request.merged == true
+    needs: [generate-tag-names]
+    uses: ./.github/workflows/build-push-docker-image.yml
+    with:
+      build_tag: rudderstack/develop-rudder-transformer:${{ needs.generate-tag-names.outputs.tag_name }}
+      push_tags: rudderstack/develop-rudder-transformer:${{ needs.generate-tag-names.outputs.tag_name }},rudderlabs/develop-rudder-transformer:${{ needs.generate-tag-names.outputs.tag_name }}
+      img_tag: ${{ needs.generate-tag-names.outputs.tag_name }}
+      dockerfile: Dockerfile
+      load_target: development
+      push_target: production
+    secrets:
+      DOCKERHUB_PROD_TOKEN: ${{ secrets.DOCKERHUB_PROD_TOKEN }}
 
   build-user-transformer-image:
     name: Build User Transformer Docker Image - Dev
-    runs-on: ubuntu-latest
     # Only merged pull requests must trigger
     if: github.event.pull_request.merged == true
-    outputs:
-      tag_name: ${{ steps.gen_tag_name.outputs.tag_name }}
-    steps:
-      - name: Generate Tag Name
-        id: gen_tag_name
-        run: |
-          tag_name="ut-latest"
-          echo "tag_name=$tag_name" >> $GITHUB_OUTPUT
-
-      - name: Checkout
-        uses: actions/checkout@v3.5.0
-        with:
-          fetch-depth: 1
-
-      - name: Login to DockerHub
-        uses: docker/login-action@v2.1.0
-        with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PROD_TOKEN }}
-
-      - name: Build Docker Image
-        uses: docker/build-push-action@v4.0.0
-        with:
-          context: .
-          file: Dockerfile-ut-func
-          target: development
-          load: true
-          tags: |
-            ${{ env.REPO_NAME }}:${{ steps.gen_tag_name.outputs.tag_name }}
-
-      - name: Run Tests
-        run: |
-          docker run ${{ env.REPO_NAME }}:${{ steps.gen_tag_name.outputs.tag_name }} npm run test:ci
-
-      - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v2.5.0
-        with:
-          platforms: |
-            linux/amd64
-            linux/arm64
-
-      - name: Build and Push Multi-platform Images
-        uses: docker/build-push-action@v4.0.0
-        with:
-          context: .
-          file: Dockerfile-ut-func
-          target: development
-          push: true
-          tags: |
-            ${{ env.REPO_NAME_OLD }}:${{ steps.gen_tag_name.outputs.tag_name }}
-            ${{ env.REPO_NAME }}:${{ steps.gen_tag_name.outputs.tag_name }}
-          platforms: |
-            linux/amd64
-            linux/arm64
-          build-args: |
-            version=${{ steps.gen_tag_name.outputs.tag_name }}
-            GIT_COMMIT_SHA=${{ github.sha }}
+    needs: [generate-tag-names]
+    uses: ./.github/workflows/build-push-docker-image.yml
+    with:
+      build_tag: rudderstack/develop-rudder-transformer:${{ needs.generate-tag-names.outputs.tag_name_ut }}
+      push_tags: rudderstack/develop-rudder-transformer:${{ needs.generate-tag-names.outputs.tag_name_ut }},rudderlabs/develop-rudder-transformer:${{ needs.generate-tag-names.outputs.tag_name_ut }}
+      img_tag: ${{ needs.generate-tag-names.outputs.tag_name_ut }}
+      dockerfile: Dockerfile-ut-func
+      load_target: development
+      push_target: development
+    secrets:
+      DOCKERHUB_PROD_TOKEN: ${{ secrets.DOCKERHUB_PROD_TOKEN }}

--- a/.github/workflows/prepare-for-prod-deploy.yml
+++ b/.github/workflows/prepare-for-prod-deploy.yml
@@ -77,7 +77,7 @@ jobs:
       UT_TAG_NAME: ${{ needs.generate-tag-names.outputs.tag_name_ut }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.5.0
+        uses: actions/checkout@v3.5.2
         with:
           fetch-depth: 1
 

--- a/.github/workflows/prepare-for-prod-deploy.yml
+++ b/.github/workflows/prepare-for-prod-deploy.yml
@@ -10,11 +10,6 @@ on:
     branches:
       - main
 
-env:
-  REPO_NAME_OLD: rudderlabs/rudder-transformer
-  REPO_NAME: rudderstack/rudder-transformer
-  DOCKERHUB_USERNAME: rudderlabs
-
 jobs:
   report-coverage:
     name: Report Code Coverage

--- a/.github/workflows/prepare-for-prod-deploy.yml
+++ b/.github/workflows/prepare-for-prod-deploy.yml
@@ -21,178 +21,65 @@ jobs:
     if: github.event_name == 'push'
     uses: ./.github/workflows/report-code-coverage.yml
 
-  build-transformer-image:
-    name: Build Transformer Docker Image - Prod
+  generate-tag-names:
     runs-on: ubuntu-latest
+    name: Generate Tag Names
     # Only merged pull requests from release candidate branches must trigger
     if: ((startsWith(github.event.pull_request.head.ref, 'release/') || startsWith(github.event.pull_request.head.ref, 'hotfix-release/')) && github.event.pull_request.merged == true)
     outputs:
-      tag_name: ${{ steps.gen_tag_name.outputs.tag_name }}
+      tag_name: ${{ steps.gen_tag_names.outputs.tag_name }}
+      tag_name_ut: ${{ steps.gen_tag_names.outputs.tag_name_ut }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3.5.0
-        with:
-          fetch-depth: 1
-
-      - name: Generate Tag Name
-        id: gen_tag_name
+      - name: Generate Tag Names
+        id: gen_tag_names
         run: |
           tag_name=$(jq -r .version package.json)
-          echo $tag_name
+          echo "Tag Name: $tag_name"
           echo "tag_name=$tag_name" >> $GITHUB_OUTPUT
 
-      - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v2.5.0
+          tag_name_ut="ut-$tag_name"
+          echo "UT Tag Name: $tag_name_ut"
+          echo "tag_name_ut=$tag_name_ut" >> $GITHUB_OUTPUT
 
-      - name: Login to DockerHub
-        uses: docker/login-action@v2.1.0
-        with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PROD_TOKEN }}
-
-      - name: Cache Docker Layers
-        uses: actions/cache@v3.3.1
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
-
-      - name: Build Docker Image
-        uses: docker/build-push-action@v4.0.0
-        with:
-          context: .
-          file: Dockerfile
-          target: development
-          load: true
-          tags: |
-            ${{ env.REPO_NAME }}:${{ steps.gen_tag_name.outputs.tag_name }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
-
-      - name: Run Tests
-        run: |
-          docker run ${{ env.REPO_NAME }}:${{ steps.gen_tag_name.outputs.tag_name }} npm run test:ci
-          docker run ${{ env.REPO_NAME }}:${{ steps.gen_tag_name.outputs.tag_name }} npm run test:integration
-
-      - name: Build and Push Multi-platform Images
-        uses: docker/build-push-action@v4.0.0
-        with:
-          context: .
-          file: Dockerfile
-          target: production
-          push: true
-          tags: |
-            ${{ env.REPO_NAME_OLD }}:${{ steps.gen_tag_name.outputs.tag_name }}
-            ${{ env.REPO_NAME }}:${{ steps.gen_tag_name.outputs.tag_name }}
-            ${{ env.REPO_NAME_OLD }}:latest
-            ${{ env.REPO_NAME }}:latest
-          platforms: |
-            linux/amd64
-            linux/arm64
-          build-args: |
-            version=${{ steps.gen_tag_name.outputs.tag_name }}
-            GIT_COMMIT_SHA=${{ github.sha }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
-
-        # Temp fix
-        # https://github.com/docker/build-push-action/issues/252
-        # https://github.com/moby/buildkit/issues/1896
-      - name: Move Cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+  build-transformer-image:
+    name: Build Transformer Docker Image - Prod
+    # Only merged pull requests from release candidate branches must trigger
+    if: ((startsWith(github.event.pull_request.head.ref, 'release/') || startsWith(github.event.pull_request.head.ref, 'hotfix-release/')) && github.event.pull_request.merged == true)
+    needs: [generate-tag-names]
+    uses: ./.github/workflows/build-push-docker-image.yml
+    with:
+      build_tag: rudderstack/rudder-transformer:${{ needs.generate-tag-names.outputs.tag_name }}
+      push_tags: rudderstack/rudder-transformer:${{ needs.generate-tag-names.outputs.tag_name }},rudderstack/rudder-transformer:latest,rudderlabs/rudder-transformer:${{ needs.generate-tag-names.outputs.tag_name }},rudderlabs/rudder-transformer:latest
+      img_tag: ${{ needs.generate-tag-names.outputs.tag_name }}
+      dockerfile: Dockerfile
+      load_target: development
+      push_target: production
+    secrets:
+      DOCKERHUB_PROD_TOKEN: ${{ secrets.DOCKERHUB_PROD_TOKEN }}
 
   build-user-transformer-image:
     name: Build User Transformer Docker Image - Prod
-    runs-on: ubuntu-latest
     # Only merged pull requests from release candidate branches must trigger
     if: ((startsWith(github.event.pull_request.head.ref, 'release/') || startsWith(github.event.pull_request.head.ref, 'hotfix-release/')) && github.event.pull_request.merged == true)
-    outputs:
-      tag_name: ${{ steps.gen_tag_name.outputs.tag_name }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3.5.0
-        with:
-          fetch-depth: 1
-
-      - name: Generate Tag Name
-        id: gen_tag_name
-        run: |
-          tag_name="ut-$(jq -r .version package.json)"
-          echo $tag_name
-          echo "tag_name=$tag_name" >> $GITHUB_OUTPUT
-
-      - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v2.5.0
-
-      - name: Login to DockerHub
-        uses: docker/login-action@v2.1.0
-        with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PROD_TOKEN }}
-
-      - name: Cache Docker Layers
-        uses: actions/cache@v3.3.1
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
-
-      - name: Build Docker Image
-        uses: docker/build-push-action@v4.0.0
-        with:
-          context: .
-          file: Dockerfile-ut-func
-          target: development
-          load: true
-          tags: |
-            ${{ env.REPO_NAME }}:${{ steps.gen_tag_name.outputs.tag_name }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
-
-      - name: Run Tests
-        run: |
-          docker run ${{ env.REPO_NAME }}:${{ steps.gen_tag_name.outputs.tag_name }} npm run test:ci
-
-      - name: Build and Push Multi-platform Images
-        uses: docker/build-push-action@v4.0.0
-        with:
-          context: .
-          file: Dockerfile-ut-func
-          target: development
-          push: true
-          tags: |
-            ${{ env.REPO_NAME_OLD }}:${{ steps.gen_tag_name.outputs.tag_name }}
-            ${{ env.REPO_NAME }}:${{ steps.gen_tag_name.outputs.tag_name }}
-            ${{ env.REPO_NAME_OLD }}:ut-latest
-            ${{ env.REPO_NAME }}:ut-latest
-          platforms: |
-            linux/amd64
-            linux/arm64
-          build-args: |
-            version=${{ steps.gen_tag_name.outputs.tag_name }}
-            GIT_COMMIT_SHA=${{ github.sha }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
-
-        # Temp fix
-        # https://github.com/docker/build-push-action/issues/252
-        # https://github.com/moby/buildkit/issues/1896
-      - name: Move Cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+    needs: [generate-tag-names]
+    uses: ./.github/workflows/build-push-docker-image.yml
+    with:
+      build_tag: rudderstack/rudder-transformer:${{ needs.generate-tag-names.outputs.tag_name_ut }}
+      push_tags: rudderstack/rudder-transformer:${{ needs.generate-tag-names.outputs.tag_name_ut }},rudderstack/rudder-transformer:ut-latest,rudderlabs/rudder-transformer:${{ needs.generate-tag-names.outputs.tag_name_ut }},rudderlabs/rudder-transformer:ut-latest
+      img_tag: ${{ needs.generate-tag-names.outputs.tag_name_ut }}
+      dockerfile: Dockerfile-ut-func
+      load_target: development
+      push_target: development
+    secrets:
+      DOCKERHUB_PROD_TOKEN: ${{ secrets.DOCKERHUB_PROD_TOKEN }}
 
   create-pull-request:
     name: Update Helm Charts For Production and Create Pull Request
     runs-on: ubuntu-latest
-    needs: [build-transformer-image, build-user-transformer-image]
+    needs: [generate-tag-names, build-transformer-image, build-user-transformer-image]
     env:
-      TAG_NAME: ${{ needs.build-transformer-image.outputs.tag_name }}
-      UT_TAG_NAME: ${{ needs.build-user-transformer-image.outputs.tag_name }}
+      TAG_NAME: ${{ needs.generate-tag-names.outputs.tag_name }}
+      UT_TAG_NAME: ${{ needs.generate-tag-names.outputs.tag_name_ut }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3.5.0

--- a/.github/workflows/prepare-for-staging-deploy.yml
+++ b/.github/workflows/prepare-for-staging-deploy.yml
@@ -9,11 +9,6 @@ on:
     branches:
       - main
 
-env:
-  REPO_NAME_OLD: rudderlabs/rudder-transformer
-  REPO_NAME: rudderstack/rudder-transformer
-  DOCKERHUB_USERNAME: rudderlabs
-
 jobs:
   generate-tag-names:
     runs-on: ubuntu-latest
@@ -31,7 +26,7 @@ jobs:
           echo "Tag Name: $tag_name"
           echo "tag_name=$tag_name" >> $GITHUB_OUTPUT
 
-          tag_name_ut="ut-staging-$tag_name"
+          tag_name_ut="ut-$tag_name"
           echo "UT Tag Name: $tag_name_ut"
           echo "tag_name_ut=$tag_name_ut" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/prepare-for-staging-deploy.yml
+++ b/.github/workflows/prepare-for-staging-deploy.yml
@@ -72,7 +72,7 @@ jobs:
       UT_TAG_NAME: ${{ needs.generate-tag-names.outputs.tag_name_ut }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.5.0
+        uses: actions/checkout@v3.5.2
         with:
           fetch-depth: 1
 

--- a/.github/workflows/prepare-for-staging-deploy.yml
+++ b/.github/workflows/prepare-for-staging-deploy.yml
@@ -15,176 +15,66 @@ env:
   DOCKERHUB_USERNAME: rudderlabs
 
 jobs:
-  build-transformer-image:
-    name: Build Transformer Docker Image - Staging
+  generate-tag-names:
     runs-on: ubuntu-latest
-    outputs:
-      tag_name: ${{ steps.gen_tag_name.outputs.tag_name }}
-
+    name: Generate Tag Names
     # Only pull requests from release candidate branches must trigger
     if: (startsWith(github.event.pull_request.head.ref, 'release/') || startsWith(github.event.pull_request.head.ref, 'hotfix-release/'))
+    outputs:
+      tag_name: ${{ steps.gen_tag_names.outputs.tag_name }}
+      tag_name_ut: ${{ steps.gen_tag_names.outputs.tag_name_ut }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3.5.0
-        with:
-          fetch-depth: 1
-
-      - name: Generate Tag Name
-        id: gen_tag_name
+      - name: Generate Tag Names
+        id: gen_tag_names
         run: |
           tag_name="staging-$(jq -r .version package.json)"
-          echo $tag_name
+          echo "Tag Name: $tag_name"
           echo "tag_name=$tag_name" >> $GITHUB_OUTPUT
 
-      - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v2.5.0
+          tag_name_ut="ut-staging-$tag_name"
+          echo "UT Tag Name: $tag_name_ut"
+          echo "tag_name_ut=$tag_name_ut" >> $GITHUB_OUTPUT
 
-      - name: Login to DockerHub
-        uses: docker/login-action@v2.1.0
-        with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PROD_TOKEN }}
-
-      - name: Cache Docker Layers
-        uses: actions/cache@v3.3.1
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
-
-      - name: Build Docker Image
-        uses: docker/build-push-action@v4.0.0
-        with:
-          context: .
-          file: Dockerfile
-          target: development
-          load: true
-          tags: |
-            ${{ env.REPO_NAME }}:${{ steps.gen_tag_name.outputs.tag_name }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
-
-      - name: Run Tests
-        run: |
-          docker run ${{ env.REPO_NAME }}:${{ steps.gen_tag_name.outputs.tag_name }} npm run test:ci
-          docker run ${{ env.REPO_NAME }}:${{ steps.gen_tag_name.outputs.tag_name }} npm run test:integration
-
-      - name: Build and Push Multi-platform Images
-        uses: docker/build-push-action@v4.0.0
-        with:
-          context: .
-          file: Dockerfile
-          target: production
-          push: true
-          tags: |
-            ${{ env.REPO_NAME_OLD }}:${{ steps.gen_tag_name.outputs.tag_name }}
-            ${{ env.REPO_NAME }}:${{ steps.gen_tag_name.outputs.tag_name }}
-          platforms: |
-            linux/amd64
-            linux/arm64
-          build-args: |
-            version=${{ steps.gen_tag_name.outputs.tag_name }}
-            GIT_COMMIT_SHA=${{ github.sha }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
-
-        # Temp fix
-        # https://github.com/docker/build-push-action/issues/252
-        # https://github.com/moby/buildkit/issues/1896
-      - name: Move Cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+  build-transformer-image:
+    name: Build Transformer Docker Image - Staging
+    # Only pull requests from release candidate branches must trigger
+    if: (startsWith(github.event.pull_request.head.ref, 'release/') || startsWith(github.event.pull_request.head.ref, 'hotfix-release/'))
+    needs: [generate-tag-names]
+    uses: ./.github/workflows/build-push-docker-image.yml
+    with:
+      build_tag: rudderstack/rudder-transformer:${{ needs.generate-tag-names.outputs.tag_name }}
+      push_tags: rudderstack/rudder-transformer:${{ needs.generate-tag-names.outputs.tag_name }},rudderlabs/rudder-transformer:${{ needs.generate-tag-names.outputs.tag_name }}
+      img_tag: ${{ needs.generate-tag-names.outputs.tag_name }}
+      dockerfile: Dockerfile
+      load_target: development
+      push_target: production
+    secrets:
+      DOCKERHUB_PROD_TOKEN: ${{ secrets.DOCKERHUB_PROD_TOKEN }}
 
   build-user-transformer-image:
     name: Build User Transformer Docker Image - Staging
-    runs-on: ubuntu-latest
-    outputs:
-      tag_name: ${{ steps.gen_tag_name.outputs.tag_name }}
-
     # Only pull requests from release candidate branches must trigger
     if: (startsWith(github.event.pull_request.head.ref, 'release/') || startsWith(github.event.pull_request.head.ref, 'hotfix-release/'))
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3.5.0
-        with:
-          fetch-depth: 1
 
-      - name: Generate Tag Name
-        id: gen_tag_name
-        run: |
-          tag_name="ut-staging-$(jq -r .version package.json)"
-          echo $tag_name
-          echo "tag_name=$tag_name" >> $GITHUB_OUTPUT
-
-      - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v2.5.0
-
-      - name: Login to DockerHub
-        uses: docker/login-action@v2.1.0
-        with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PROD_TOKEN }}
-
-      - name: Cache Docker Layers
-        uses: actions/cache@v3.3.1
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
-
-      - name: Build Docker Image
-        uses: docker/build-push-action@v4.0.0
-        with:
-          context: .
-          file: Dockerfile-ut-func
-          target: development
-          load: true
-          tags: |
-            ${{ env.REPO_NAME }}:${{ steps.gen_tag_name.outputs.tag_name }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
-
-      - name: Run Tests
-        run: |
-          docker run ${{ env.REPO_NAME }}:${{ steps.gen_tag_name.outputs.tag_name }} npm run test:ci
-
-      - name: Build and Push Multi-platform Images
-        uses: docker/build-push-action@v4.0.0
-        with:
-          context: .
-          file: Dockerfile-ut-func
-          target: development
-          push: true
-          tags: |
-            ${{ env.REPO_NAME_OLD }}:${{ steps.gen_tag_name.outputs.tag_name }}
-            ${{ env.REPO_NAME }}:${{ steps.gen_tag_name.outputs.tag_name }}
-          platforms: |
-            linux/amd64
-            linux/arm64
-          build-args: |
-            version=${{ steps.gen_tag_name.outputs.tag_name }}
-            GIT_COMMIT_SHA=${{ github.sha }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
-
-        # Temp fix
-        # https://github.com/docker/build-push-action/issues/252
-        # https://github.com/moby/buildkit/issues/1896
-      - name: Move Cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+    needs: [generate-tag-names]
+    uses: ./.github/workflows/build-push-docker-image.yml
+    with:
+      build_tag: rudderstack/rudder-transformer:${{ needs.generate-tag-names.outputs.tag_name_ut }}
+      push_tags: rudderstack/rudder-transformer:${{ needs.generate-tag-names.outputs.tag_name_ut }},rudderlabs/rudder-transformer:${{ needs.generate-tag-names.outputs.tag_name_ut }}`
+      img_tag: ${{ needs.generate-tag-names.outputs.tag_name_ut }}
+      dockerfile: Dockerfile-ut-func
+      load_target: development
+      push_target: development
+    secrets:
+      DOCKERHUB_PROD_TOKEN: ${{ secrets.DOCKERHUB_PROD_TOKEN }}
 
   create-pull-request:
     name: Update Helm Charts For Staging and Create Pull Request
     runs-on: ubuntu-latest
-    needs: [build-transformer-image, build-user-transformer-image]
+    needs: [generate-tag-names, build-transformer-image, build-user-transformer-image]
     env:
-      TAG_NAME: ${{ needs.build-transformer-image.outputs.tag_name }}
-      UT_TAG_NAME: ${{ needs.build-user-transformer-image.outputs.tag_name }}
+      TAG_NAME: ${{ needs.generate-tag-names.outputs.tag_name }}
+      UT_TAG_NAME: ${{ needs.generate-tag-names.outputs.tag_name_ut }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3.5.0

--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -25,7 +25,7 @@ jobs:
           echo "release_version=$version" >> $GITHUB_OUTPUT
 
       - name: Checkout
-        uses: actions/checkout@v3.5.0
+        uses: actions/checkout@v3.5.2
         with:
           fetch-depth: 0
 

--- a/.github/workflows/report-code-coverage.yml
+++ b/.github/workflows/report-code-coverage.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.5.0
+        uses: actions/checkout@v3.5.2
         with:
           fetch-depth: 1
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.5.0
+        uses: actions/checkout@v3.5.2
         with:
           fetch-depth: 1
 


### PR DESCRIPTION
## Description of the change

Replaced `local` with `gha` (GitHub Actions) cache in Docker build steps.

Also, refactored the workflows to move redundant steps into a workflow.

Additional changes:
- https://github.com/rudderlabs/rudder-transformer/pull/2069

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

N/A

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
