### PR TITLE
fix: check event properties without making them to lower case

### DIFF
--- a/src/v0/destinations/google_adwords_offline_conversions/networkHandler.js
+++ b/src/v0/destinations/google_adwords_offline_conversions/networkHandler.js
@@ -188,7 +188,7 @@ const ProxyRequest = async (request) => {
     const { properties } = params;
     let { customVariables } = params;
     const resultantCustomVariables = [];
-    customVariables = getHashFromArray(customVariables);
+    customVariables = getHashFromArray(customVariables,"from","to",false);
     Object.keys(customVariables).forEach((key) => {
       if (properties[key] && conversionCustomVariable[customVariables[key]]) {
         // 1. set custom variable name

--- a/test/__tests__/data/google_adwords_offline_conversions_proxy_input.json
+++ b/test/__tests__/data/google_adwords_offline_conversions_proxy_input.json
@@ -325,7 +325,7 @@
           "customerId": "1234567891",
           "customVariables": [
             {
-              "from": "value",
+              "from": "Value",
               "to": "revenue"
             },
             {
@@ -339,7 +339,7 @@
             "externalAttributionCredit": 10,
             "externalAttributionModel": "externalAttributionModel",
             "conversionCustomVariable": "conversionCustomVariable",
-            "value": "value",
+            "Value": "value",
             "merchantId": "9876merchantId",
             "feedCountryCode": "feedCountryCode",
             "feedLanguageCode": "feedLanguageCode",


### PR DESCRIPTION
## Description of the change

In Google ads offline conversion, we are lower casing the custom variable before comparing it with the event properties. We are fixing this with this pr.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
