### PR TITLE
fix: batch metatdata count

### DIFF
--- a/src/v0/destinations/braze/util.js
+++ b/src/v0/destinations/braze/util.js
@@ -318,7 +318,7 @@ const processBatch = (transformedEvents) => {
   const attributesArray = [];
   const eventsArray = [];
   const purchaseArray = [];
-  const successMetadata = [];
+  const metadata = [];
   const failureResponses = [];
   for (const transformedEvent of transformedEvents) {
     if (!isHttpStatusSuccess(transformedEvent?.statusCode)) {
@@ -334,8 +334,9 @@ const processBatch = (transformedEvents) => {
       if (Array.isArray(purchases)) {
         purchaseArray.push(...purchases);
       }
-      successMetadata.push(...transformedEvent.metadata);
+      
     }
+    metadata.push(...transformedEvent.metadata);
   }
   const attributeArrayChunks = _.chunk(attributesArray, 75);
   const eventsArrayChunks = _.chunk(eventsArray, 75);
@@ -373,7 +374,7 @@ const processBatch = (transformedEvents) => {
   return [
     {
       batchedRequest: responseArray,
-      metadata: successMetadata,
+      metadata,
       batched: true,
       statusCode: 200,
       destination,

--- a/src/v0/destinations/braze/util.js
+++ b/src/v0/destinations/braze/util.js
@@ -370,16 +370,21 @@ const processBatch = (transformedEvents) => {
       headers,
     });
   }
-  return [
-    {
+  const finalResponse = [];
+  if (successMetadata.length > 0) {
+    finalResponse.push({
       batchedRequest: responseArray,
       metadata: successMetadata,
       batched: true,
       statusCode: 200,
       destination,
-    },
-    ...failureResponses,
-  ];
+    });
+  }
+  if (failureResponses.length > 0) {
+    finalResponse.push(...failureResponses);
+  }
+
+  return finalResponse;
 };
 
 module.exports = {

--- a/src/v0/destinations/braze/util.js
+++ b/src/v0/destinations/braze/util.js
@@ -318,7 +318,7 @@ const processBatch = (transformedEvents) => {
   const attributesArray = [];
   const eventsArray = [];
   const purchaseArray = [];
-  const metadata = [];
+  const successMetadata = [];
   const failureResponses = [];
   for (const transformedEvent of transformedEvents) {
     if (!isHttpStatusSuccess(transformedEvent?.statusCode)) {
@@ -334,9 +334,8 @@ const processBatch = (transformedEvents) => {
       if (Array.isArray(purchases)) {
         purchaseArray.push(...purchases);
       }
-      
+      successMetadata.push(...transformedEvent.metadata);
     }
-    metadata.push(...transformedEvent.metadata);
   }
   const attributeArrayChunks = _.chunk(attributesArray, 75);
   const eventsArrayChunks = _.chunk(eventsArray, 75);
@@ -374,7 +373,7 @@ const processBatch = (transformedEvents) => {
   return [
     {
       batchedRequest: responseArray,
-      metadata,
+      metadata: successMetadata,
       batched: true,
       statusCode: 200,
       destination,


### PR DESCRIPTION
## Description of the change
Fix for router transform batching logic to correctly add metadata array to router response from transformer

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
