### PR TITLE
fix(cdkv1): error handling for cdkv1 destinations

### DIFF
--- a/src/cdk/v1/handler.js
+++ b/src/cdk/v1/handler.js
@@ -81,4 +81,5 @@ async function processCdkV1(destType, parsedEvent) {
 
 module.exports = {
   processCdkV1,
+  getErrorInfo,
 };

--- a/test/__tests__/integration/data_scenarios/cdk_v1/failure.json
+++ b/test/__tests__/integration/data_scenarios/cdk_v1/failure.json
@@ -148,8 +148,8 @@
         "sourceDefinitionId": "1b6gJdqOPOCadT3cddw8eidV591",
         "destinationDefinitionId": ""
       },
-      "statusCode": 500,
-      "error": "Unsupported \"channel\": \"offline\". It must be one of: web,server,mobile,sources",
+      "statusCode": 400,
+      "error": "Unknown error occurred. Original error: Unsupported \"channel\": \"offline\". It must be one of: web,server,mobile,sources",
       "statTags": {
         "errorCategory": "transformation",
         "destType": "ZAPIER",


### PR DESCRIPTION
## Description of the change

Currently the error handling is not correct for CDKV1 destinations. Any data-validation or instrumentation errors are getting categorised as transformation errors(that are intended to tell us if the error is unhandled). With this PR, we are looking to fix it.

Task: https://www.notion.so/rudderstacks/Error-Handling-for-CDKV1-destinations-using-new-routes-d01a35e8cc684257a7b92c84cceb1c07?pvs=4

**Note**: This is happening for new routes only. For older routes, things are working well

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [x] Changes have been reviewed by at least one other engineer
- [x] Issue from task tracker has a link to this pull request 
