### PR TITLE
fix: error extraction migrated to typescript

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -63,6 +63,7 @@ module.exports = {
   //     diagnostics: false
   //   },
   // },
+  preset: 'ts-jest/presets/js-with-ts-esm',
 
   // The maximum amount of workers used to run your tests. Can be specified as % or a number. E.g. maxWorkers: 10% will use 10% of your CPU amount + 1 as the maximum worker number. maxWorkers: 2 will use a maximum of 2 workers.
   // maxWorkers: "50%",

--- a/src/util/error-extractor/index.js
+++ b/src/util/error-extractor/index.js
@@ -1,6 +1,0 @@
-function ErrorDetailsExtractor(builder) {
-  this.status = builder.getStatus();
-  this.messageDetails = builder.getMessageDetails();
-}
-
-module.exports = ErrorDetailsExtractor;

--- a/src/util/error-extractor/index.ts
+++ b/src/util/error-extractor/index.ts
@@ -1,13 +1,29 @@
-const ErrorDetailsExtractor = require(".");
+/* eslint-disable max-classes-per-file */
+import { MessageDetails, StatusCode } from "./types";
 
-class ErrorDetailsExtractorBuilder {
+export class ErrorDetailsExtractor {
+  status: StatusCode;
+
+  messageDetails: MessageDetails;
+
+  constructor (builder: ErrorDetailsExtractorBuilder) {
+    this.status = builder.getStatus();
+    this.messageDetails = builder.getMessageDetails();
+  }
+
+}
+
+export class ErrorDetailsExtractorBuilder {
+  status: StatusCode;
+
+  messageDetails: MessageDetails;
 
   constructor() {
     this.status = 0;
     this.messageDetails = {};
   }
   
-  setStatus(status) {
+  setStatus(status: number): ErrorDetailsExtractorBuilder {
     this.status = status;
     return this;
   }
@@ -18,7 +34,7 @@ class ErrorDetailsExtractorBuilder {
    * @param {string} fieldPath -- Path of the field which should be set as "error message"
    * @returns 
    */
-  setMessageField(fieldPath) {
+  setMessageField(fieldPath: string): ErrorDetailsExtractorBuilder {
     if (this.messageDetails?.message) {
       // This check basically ensures that "setMessage" was not already before
       return this;
@@ -35,7 +51,7 @@ class ErrorDetailsExtractorBuilder {
    * @param {string} msg - error message
    * @returns 
    */
-  setMessage(msg) {
+  setMessage(msg: string): ErrorDetailsExtractorBuilder {
     if (this.messageDetails?.field) {
       // This check basically ensures that "setMessageField" was not already called before
       return this;
@@ -46,17 +62,17 @@ class ErrorDetailsExtractorBuilder {
     return this;
   }
 
-  build() {
+  build(): ErrorDetailsExtractor {
     return new ErrorDetailsExtractor(this)
   }
 
-  getStatus() {
+  getStatus(): number {
     return this.status;
   }
   
-  getMessageDetails() {
+  getMessageDetails(): Record<string, string> {
     return this.messageDetails;
   }
 }
 
-module.exports = ErrorDetailsExtractorBuilder
+

--- a/src/util/error-extractor/types.ts
+++ b/src/util/error-extractor/types.ts
@@ -1,0 +1,2 @@
+export type MessageDetails = Record<string, string>;
+export type StatusCode = number;

--- a/src/util/redis/redisConnector.test.js
+++ b/src/util/redis/redisConnector.test.js
@@ -69,6 +69,7 @@ describe(`Redis Class Get Tests`, () => {
   const data = JSON.parse(testDataFile);
   data.forEach((dataPoint, index) => {
     it(`${index}. Redis Get- ${dataPoint.description}`, async () => {
+      let isObjExpected;
       try {
         const output = await RedisDB.getVal(dataPoint.input.value, (isObjExpected = false));
         expect(output).toEqual(dataPoint.output);

--- a/test/__mocks__/data/facebook_pixel/proxy_response.json
+++ b/test/__mocks__/data/facebook_pixel/proxy_response.json
@@ -64,6 +64,20 @@
       "status": 400
     }
   },
+  "https://graph.facebook.com/v16.0/1234567891234572/events?access_token=valid_access_token_unhandled_response": {
+    "response": {
+      "data": {
+        "error": {
+          "message": "Unhandled random error",
+          "type": "RandomException",
+          "code": 5,
+          "error_subcode": 12,
+          "fbtrace_id": "facebook_px_trace_id_10"
+        }
+      },
+      "status": 412
+    }
+  },
   "https://graph.facebook.com/v16.0/1234567891234570/events?access_token=valid_access_token": {
     "response": {
       "data": {

--- a/test/__tests__/azure_synapse.test.js
+++ b/test/__tests__/azure_synapse.test.js
@@ -39,7 +39,7 @@ var testCases = [
 ];
 
 describe("Azure Synapse data types testing", () => {
-  options = {};
+  let options = {};
   options.getDataTypeOverride = getDataTypeOverride;
   testCases.forEach(testCase => {
     it(`should return data type ${testCase.type} for this input data ${testCase.data} everytime`, () => {

--- a/test/__tests__/bq.test.js
+++ b/test/__tests__/bq.test.js
@@ -39,7 +39,7 @@ var testCases = [
 ];
 
 describe("Big Query data types testing", () => {
-  options = {};
+  let options = {};
   options.getDataTypeOverride = getDataTypeOverride;
   testCases.forEach(testCase => {
     it(`should return data type ${testCase.type} for this input data ${testCase.data} everytime`, () => {

--- a/test/__tests__/clickhouse.test.js
+++ b/test/__tests__/clickhouse.test.js
@@ -115,7 +115,7 @@ var testCases = [
 ];
 
 describe("ClickHouse data types testing", () => {
-  options = {};
+  let options = {};
   options.getDataTypeOverride = getDataTypeOverride;
   testCases.forEach(testCase => {
     it(`should return data type ${testCase.type} for this input data ${testCase.data} everytime`, () => {

--- a/test/__tests__/data/facebook_pixel_proxy_input.json
+++ b/test/__tests__/data/facebook_pixel_proxy_input.json
@@ -191,5 +191,29 @@
         "endpoint": "https://graph.facebook.com/v16.0/1234567891234571/events?access_token=valid_access_token"
       }
     }
+  },
+  {
+    "request": {
+      "body": {
+        "body": {
+          "XML": {},
+          "FORM": {
+            "data": [
+              "{\"user_data\":{\"external_id\":\"c58f05b5e3cc4796f3181cf07349d306547c00b20841a175b179c6860e6a34ab\",\"client_ip_address\":\"32.122.223.26\",\"client_user_agent\":\"Mozilla/5.0 (iPhone; CPU iPhone OS 15_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.5 Mobile/15E148 Safari/604.1\"},\"event_name\":\"Checkout Step Viewed\",\"event_time\":1654772112,\"event_source_url\":\"https://www.my.kaiser.com/checkout\",\"event_id\":\"4f002656-a7b2-4c17-b9bd-8caa5a29190a\",\"custom_data\":{\"checkout_id\":\"26SF29B\",\"site\":\"www.my.kaiser.com\",\"step\":1}}"
+            ]
+          },
+          "JSON": {},
+          "JSON_ARRAY": {}
+        },
+        "type": "REST",
+        "files": {},
+        "method": "POST",
+        "params": {},
+        "userId": "",
+        "headers": {},
+        "version": "1",
+        "endpoint": "https://graph.facebook.com/v16.0/1234567891234572/events?access_token=valid_access_token_unhandled_response"
+      }
+    }
   }
 ]

--- a/test/__tests__/data/facebook_pixel_proxy_output.json
+++ b/test/__tests__/data/facebook_pixel_proxy_output.json
@@ -178,5 +178,30 @@
         "module": "destination"
       }
     }
+  },
+  {
+    "output": {
+      "status": 500,
+      "message": "Unhandled random error",
+      "destinationResponse": {
+        "error": {
+          "message": "Unhandled random error",
+          "type": "RandomException",
+          "code": 5,
+          "error_subcode": 12,
+          "fbtrace_id": "facebook_px_trace_id_10"
+        },
+        "status": 412
+      },
+      "statTags": {
+        "destType": "FACEBOOK_PIXEL",
+        "errorCategory": "network",
+        "errorType": "retryable",
+        "feature": "dataDelivery",
+        "implementation": "native",
+        "module": "destination",
+        "meta": "unhandledStatusCode"
+      }
+    }
   }
 ]

--- a/test/__tests__/marketo_bulk_upload.test.js
+++ b/test/__tests__/marketo_bulk_upload.test.js
@@ -7,6 +7,14 @@ const integration = "marketo_bulk_upload";
 const transformer = require(`../../src/${version}/destinations/${integration}/transform`);
 
 jest.mock("axios");
+let reqTransformBody;
+let respTransformBody;
+let respFileUploadBody;
+let reqFileUploadBody;
+let reqPollBody;
+let respPollBody;
+let reqJobStatusBody;
+let respJobStatusBody;
 
 try {
   reqTransformBody = JSON.parse(

--- a/test/__tests__/mssql.test.js
+++ b/test/__tests__/mssql.test.js
@@ -39,7 +39,7 @@ var testCases = [
 ];
 
 describe("MSSQL data types testing", () => {
-  options = {};
+  let options = {};
   options.getDataTypeOverride = getDataTypeOverride;
   testCases.forEach(testCase => {
     it(`should return data type ${testCase.type} for this input data ${testCase.data} everytime`, () => {

--- a/test/__tests__/postgres.test.js
+++ b/test/__tests__/postgres.test.js
@@ -39,7 +39,7 @@ var testCases = [
 ];
 
 describe("Postgres data types testing", () => {
-  options = {};
+  let options = {};
   options.getDataTypeOverride = getDataTypeOverride;
   testCases.forEach(testCase => {
     it(`should return data type ${testCase.type} for this input data ${testCase.data} everytime`, () => {

--- a/test/__tests__/rs.test.js
+++ b/test/__tests__/rs.test.js
@@ -39,7 +39,7 @@ var testCases = [
 ];
 
 describe("Redshift data types testing", () => {
-  options = {};
+  let options = {};
   options.getDataTypeOverride = getDataTypeOverride;
   testCases.forEach(testCase => {
     it(`should return data type ${testCase.type} for this input data ${testCase.data} everytime`, () => {

--- a/test/__tests__/s3_datalake.test.js
+++ b/test/__tests__/s3_datalake.test.js
@@ -39,7 +39,7 @@ var testCases = [
 ];
 
 describe("S3 Datalake data types testing", () => {
-  options = {};
+  let options = {};
   options.getDataTypeOverride = getDataTypeOverride;
   testCases.forEach(testCase => {
     it(`should return data type ${testCase.type} for this input data ${testCase.data} everytime`, () => {

--- a/test/__tests__/snowflake.test.js
+++ b/test/__tests__/snowflake.test.js
@@ -39,7 +39,7 @@ var testCases = [
 ];
 
 describe("Snowflake data types testing", () => {
-  options = {};
+  let options = {};
   options.getDataTypeOverride = getDataTypeOverride;
   testCases.forEach(testCase => {
     it(`should return data type ${testCase.type} for this input data ${testCase.data} everytime`, () => {

--- a/test/__tests__/warehouse.test.js
+++ b/test/__tests__/warehouse.test.js
@@ -363,7 +363,7 @@ describe("handle reserved words", () => {
         Object.keys(reserverdKeywordsMap).forEach(k => {
           expect(out.metadata.columns).not.toHaveProperty(k.toLowerCase());
           expect(out.metadata.columns).not.toHaveProperty(k.toUpperCase());
-          snakeCasedKey = _.snakeCase(k).toUpperCase();
+          let snakeCasedKey = _.snakeCase(k).toUpperCase();
           if (k === snakeCasedKey) {
             k = `_${k}`;
           } else {


### PR DESCRIPTION
## Description of the change

- made use of the typescript error extraction class
- updated logic to throw unhandled status code error(in a different way without using `UnHandledStatusCodeError` class)
- added test-cases for the unhandled status code case

- updated the jest configuration to support typescript in javascript
- updated couple of test-files to move from implicit declaration to explicit declaration

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
