### PR TITLE
chore: update docker image repository in deployment yamls on release

### DIFF
--- a/.github/workflows/prepare-for-prod-deploy.yml
+++ b/.github/workflows/prepare-for-prod-deploy.yml
@@ -82,6 +82,7 @@ jobs:
     env:
       TAG_NAME: ${{ needs.generate-tag-names.outputs.tag_name }}
       UT_TAG_NAME: ${{ needs.generate-tag-names.outputs.tag_name_ut }}
+      TF_IMAGE_REPOSITORY: rudderstack/rudder-transformer
     steps:
       - name: Checkout
         uses: actions/checkout@v3.5.2
@@ -111,19 +112,23 @@ jobs:
           cd helm-charts/shared-services/per-az
           yq eval -i ".rudder-transformer.image.tag=\"$TAG_NAME\"" values.blue-release.yaml
           yq eval -i ".user-transformer.image.tag=\"$TAG_NAME\"" values.blue-release.yaml
+          yq eval -i ".rudder-transformer.image.repository=\"$TF_IMAGE_REPOSITORY\"" values.blue-release.yaml
           git add values.blue-release.yaml
-
+          
           yq eval -i ".rudder-transformer.image.tag=\"$TAG_NAME\"" values.enterprise.yaml
           yq eval -i ".user-transformer.image.tag=\"$TAG_NAME\"" values.enterprise.yaml
+          yq eval -i ".rudder-transformer.image.repository=\"$TF_IMAGE_REPOSITORY\"" values.enterprise.yaml
           git add values.enterprise.yaml
 
           yq eval -i ".rudder-transformer.image.tag=\"$TAG_NAME\"" values.multi-tenant.yaml
           yq eval -i ".user-transformer.image.tag=\"$TAG_NAME\"" values.multi-tenant.yaml
+          yq eval -i ".user-transformer.image.repository=\"$TF_IMAGE_REPOSITORY\"" values.multi-tenant.yaml
           git add values.multi-tenant.yaml
 
           cd ../../config-be-rudder-transformer
           yq eval -i ".config-be-rudder-transformer.image.tag=\"$TAG_NAME\"" values.prod.yaml
           yq eval -i ".config-be-user-transformer.image.tag=\"$TAG_NAME\"" values.prod.yaml
+          yq eval -i ".config-be-user-transformer.image.repository=\"$TF_IMAGE_REPOSITORY\"" values.prod.yaml
           git add values.prod.yaml
 
           git commit -m "chore: upgrade shared transformers to $TAG_NAME"


### PR DESCRIPTION
## Description of the change

We are forcefully updating the docker image repository to `rudderstack/rudder-transformer` in deployment files on release

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
