### PR TITLE
fix(am): remove os fields mapping to browser values

### DIFF
--- a/src/v0/destinations/am/utils.js
+++ b/src/v0/destinations/am/utils.js
@@ -21,18 +21,11 @@ function getInfoFromUA(path, payload, defaultVal) {
 
 function getOSName(payload, sourceKey) {
   const payloadVal = get(payload, sourceKey);
-  if (payload.channel && payload.channel.toLowerCase() === 'web') {
-    return getInfoFromUA('browser.name', payload, payloadVal);
-  }
   return payloadVal;
 }
 
 function getOSVersion(payload, sourceKey) {
   const payloadVal = get(payload, sourceKey);
-
-  if (payload.channel && payload.channel.toLowerCase() === 'web') {
-    return getInfoFromUA('browser.version', payload, payloadVal);
-  }
   return payloadVal;
 }
 

--- a/test/__tests__/data/am_input.json
+++ b/test/__tests__/data/am_input.json
@@ -38,8 +38,8 @@
         "locale": "en-US",
         "ip": "0.0.0.0",
         "os": {
-          "name": "",
-          "version": ""
+          "name": "iOS",
+          "version": "10"
         },
         "screen": {
           "density": 2
@@ -135,8 +135,8 @@
         "locale": "en-US",
         "ip": "0.0.0.0",
         "os": {
-          "name": "",
-          "version": ""
+          "name": "iOS",
+          "version": "10"
         },
         "screen": {
           "density": 2
@@ -219,8 +219,8 @@
         "locale": "en-US",
         "ip": "0.0.0.0",
         "os": {
-          "name": "",
-          "version": ""
+          "name": "iOS",
+          "version": "10"
         },
         "screen": {
           "density": 2
@@ -276,8 +276,8 @@
         "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36",
         "locale": "en-US",
         "os": {
-          "name": "",
-          "version": ""
+          "name": "iOS",
+          "version": "10"
         },
         "screen": {
           "density": 2
@@ -343,8 +343,8 @@
         "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36",
         "locale": "en-US",
         "os": {
-          "name": "",
-          "version": ""
+          "name": "iOS",
+          "version": "10"
         },
         "screen": {
           "density": 2
@@ -416,8 +416,8 @@
         "locale": "en-US",
         "ip": "0.0.0.0",
         "os": {
-          "name": "",
-          "version": ""
+          "name": "iOS",
+          "version": "10"
         },
         "screen": {
           "density": 2
@@ -483,8 +483,8 @@
         "locale": "en-US",
         "ip": "0.0.0.0",
         "os": {
-          "name": "",
-          "version": ""
+          "name": "iOS",
+          "version": "10"
         },
         "screen": {
           "density": 2
@@ -654,8 +654,8 @@
         "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.121 Safari/537.36",
         "locale": "en-US",
         "os": {
-          "name": "",
-          "version": ""
+          "name": "iOS",
+          "version": "10"
         },
         "screen": {
           "density": 0.8999999761581421
@@ -1752,8 +1752,8 @@
       "channel": "web",
       "context": {
         "os": {
-          "name": "",
-          "version": ""
+          "name": "iOS",
+          "version": "10"
         },
         "app": {
           "name": "RudderLabs JavaScript SDK",
@@ -1823,8 +1823,8 @@
       "channel": "web",
       "context": {
         "os": {
-          "name": "",
-          "version": ""
+          "name": "iOS",
+          "version": "10"
         },
         "app": {
           "name": "RudderLabs JavaScript SDK",
@@ -1891,8 +1891,8 @@
       "channel": "web",
       "context": {
         "os": {
-          "name": "",
-          "version": ""
+          "name": "iOS",
+          "version": "10"
         },
         "app": {
           "name": "RudderLabs JavaScript SDK",
@@ -1959,8 +1959,8 @@
       "channel": "web",
       "context": {
         "os": {
-          "name": "",
-          "version": ""
+          "name": "iOS",
+          "version": "10"
         },
         "app": {
           "name": "RudderLabs JavaScript SDK",
@@ -2027,8 +2027,8 @@
       "channel": "web",
       "context": {
         "os": {
-          "name": "",
-          "version": ""
+          "name": "iOS",
+          "version": "10"
         },
         "app": {
           "name": "RudderLabs JavaScript SDK",
@@ -2377,8 +2377,8 @@
       "channel": "web",
       "context": {
         "os": {
-          "name": "",
-          "version": ""
+          "name": "iOS",
+          "version": "10"
         },
         "app": {
           "name": "RudderLabs JavaScript SDK",
@@ -2873,8 +2873,8 @@
         "locale": "en-US",
         "ip": "0.0.0.0",
         "os": {
-          "name": "",
-          "version": ""
+          "name": "iOS",
+          "version": "10"
         },
         "screen": {
           "density": 2
@@ -3050,8 +3050,8 @@
         "locale": "en-US",
         "ip": "0.0.0.0",
         "os": {
-          "name": "",
-          "version": ""
+          "name": "iOS",
+          "version": "10"
         },
         "screen": {
           "density": 2
@@ -3129,8 +3129,8 @@
         "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.121 Safari/537.36",
         "locale": "en-US",
         "os": {
-          "name": "",
-          "version": ""
+          "name": "iOS",
+          "version": "10"
         },
         "screen": {
           "density": 0.8999999761581421
@@ -3497,8 +3497,8 @@
         "locale": "en-US",
         "ip": "0.0.0.0",
         "os": {
-          "name": "",
-          "version": ""
+          "name": "iOS",
+          "version": "10"
         },
         "screen": {
           "density": 2
@@ -3591,8 +3591,8 @@
         "locale": "en-US",
         "ip": "0.0.0.0",
         "os": {
-          "name": "",
-          "version": ""
+          "name": "iOS",
+          "version": "10"
         },
         "screen": {
           "density": 2
@@ -3671,8 +3671,8 @@
         "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.121 Safari/537.36",
         "locale": "en-US",
         "os": {
-          "name": "",
-          "version": ""
+          "name": "iOS",
+          "version": "10"
         },
         "screen": {
           "density": 0.8999999761581421
@@ -3781,8 +3781,8 @@
         "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36",
         "locale": "en-US",
         "os": {
-          "name": "",
-          "version": ""
+          "name": "iOS",
+          "version": "10"
         },
         "screen": {
           "density": 2
@@ -4004,8 +4004,8 @@
         "locale": "en-US",
         "ip": "0.0.0.0",
         "os": {
-          "name": "",
-          "version": ""
+          "name": "iOS",
+          "version": "10"
         },
         "screen": {
           "density": 2

--- a/test/__tests__/data/am_output.json
+++ b/test/__tests__/data/am_output.json
@@ -13,7 +13,7 @@
         "api_key": "abcde",
         "events": [
           {
-            "os_name": "Chrome",
+            "os_name": "iOS",
             "os_version": "test os",
             "device_model": "Mac",
             "platform": "Web",
@@ -69,7 +69,7 @@
         "api_key": "abcde",
         "events": [
           {
-            "os_name": "Chrome",
+            "os_name": "iOS",
             "os_version": "test os",
             "device_model": "Mac",
             "platform": "Web",
@@ -125,8 +125,8 @@
         "api_key": "abcde",
         "events": [
           {
-            "os_name": "Chrome",
-            "os_version": "77.0.3865.90",
+            "os_name": "iOS",
+            "os_version": "10",
             "city": "kolkata",
             "country": "India",
             "platform": "Web",
@@ -180,8 +180,8 @@
         "api_key": "abcde",
         "events": [
           {
-            "os_name": "Chrome",
-            "os_version": "77.0.3865.90",
+            "os_name": "iOS",
+            "os_version": "10",
             "platform": "Web",
             "library": "rudderstack",
             "device_model": "Mac",
@@ -239,8 +239,8 @@
         "api_key": "abcde",
         "events": [
           {
-            "os_name": "Chrome",
-            "os_version": "77.0.3865.90",
+            "os_name": "iOS",
+            "os_version": "10",
             "platform": "Web",
             "library": "rudderstack",
             "device_model": "Mac",
@@ -301,8 +301,8 @@
         "api_key": "abcde",
         "events": [
           {
-            "os_name": "Chrome",
-            "os_version": "77.0.3865.90",
+            "os_name": "iOS",
+            "os_version": "10",
             "platform": "Web",
             "library": "rudderstack",
             "device_model": "Mac",
@@ -354,8 +354,8 @@
         "api_key": "abcde",
         "events": [
           {
-            "os_name": "Chrome",
-            "os_version": "77.0.3865.90",
+            "os_name": "iOS",
+            "os_version": "10",
             "city": "kolkata",
             "country": "India",
             "platform": "Web",
@@ -570,8 +570,8 @@
           "api_key": "abcde",
           "events": [
             {
-              "os_name": "Chrome",
-              "os_version": "85.0.4183.121",
+              "os_name": "iOS",
+              "os_version": "10",
               "platform": "Web",
               "library": "rudderstack",
               "device_model": "Mac",
@@ -1721,8 +1721,8 @@
         "api_key": "abcde",
         "events": [
           {
-            "os_name": "Chrome",
-            "os_version": "86.0.4240.198",
+            "os_name": "iOS",
+            "os_version": "10",
             "library": "rudderstack",
             "device_model": "Mac",
             "platform": "Web",
@@ -1774,8 +1774,8 @@
         "api_key": "abcde",
         "events": [
           {
-            "os_name": "Chrome",
-            "os_version": "86.0.4240.198",
+            "os_name": "iOS",
+            "os_version": "10",
             "device_model": "Mac",
             "library": "rudderstack",
             "platform": "Web",
@@ -1825,8 +1825,8 @@
         "api_key": "abcde",
         "events": [
           {
-            "os_name": "Chrome",
-            "os_version": "86.0.4240.198",
+            "os_name": "iOS",
+            "os_version": "10",
             "device_model": "Mac",
             "library": "rudderstack",
             "platform": "Web",
@@ -1876,8 +1876,8 @@
         "api_key": "abcde",
         "events": [
           {
-            "os_name": "Chrome",
-            "os_version": "86.0.4240.198",
+            "os_name": "iOS",
+            "os_version": "10",
             "device_model": "Mac",
             "library": "rudderstack",
             "platform": "Web",
@@ -1927,8 +1927,8 @@
         "api_key": "abcde",
         "events": [
           {
-            "os_name": "Chrome",
-            "os_version": "86.0.4240.198",
+            "os_name": "iOS",
+            "os_version": "10",
             "device_model": "Mac",
             "library": "rudderstack",
             "platform": "Web",
@@ -2342,8 +2342,8 @@
             "device_id": "2f8b0ba7-d76e-4b91-9577-d1b6ebd68946",
             "device_model": "Mac",
             "event_type": "$identify",
-            "os_name": "Chrome",
-            "os_version": "86.0.4240.198",
+            "os_name": "iOS",
+            "os_version": "10",
             "platform": "Web",
             "insert_id": "6f08cc45-95c3-40c1-90f2-2f44a92947ef",
             "language": "en-GB",
@@ -2874,8 +2874,8 @@
         "api_key": "abcde",
         "events": [
           {
-            "os_name": "Chrome",
-            "os_version": "77.0.3865.90",
+            "os_name": "iOS",
+            "os_version": "10",
             "city": "kolkata",
             "country": "India",
             "platform": "Web",
@@ -3023,7 +3023,7 @@
         "api_key": "abcde",
         "events": [
           {
-            "os_name": "Chrome",
+            "os_name": "iOS",
             "os_version": "test os",
             "device_model": "Mac",
             "platform": "Web",
@@ -3080,8 +3080,8 @@
           "api_key": "abcde",
           "events": [
             {
-              "os_name": "Chrome",
-              "os_version": "85.0.4183.121",
+              "os_name": "iOS",
+              "os_version": "10",
               "platform": "Web",
               "library": "rudderstack",
               "device_model": "Mac",
@@ -3350,7 +3350,7 @@
         "api_key": "abcde",
         "events": [
           {
-            "os_name": "Chrome",
+            "os_name": "iOS",
             "os_version": "test os",
             "device_model": "Mac",
             "platform": "Web",
@@ -3407,7 +3407,7 @@
         "api_key": "abcde",
         "events": [
           {
-            "os_name": "Chrome",
+            "os_name": "iOS",
             "os_version": "test os",
             "device_model": "Mac",
             "platform": "Web",
@@ -3465,8 +3465,8 @@
           "api_key": "abcde",
           "events": [
             {
-              "os_name": "Chrome",
-              "os_version": "85.0.4183.121",
+              "os_name": "iOS",
+              "os_version": "10",
               "device_model": "Mac",
               "platform": "Web",
               "event_id": 3,
@@ -3583,8 +3583,8 @@
         "api_key": "abcde",
         "events": [
           {
-            "os_name": "Chrome",
-            "os_version": "77.0.3865.90",
+            "os_name": "iOS",
+            "os_version": "10",
             "device_model": "Mac",
             "platform": "Web",
             "device_id": "00000000000000000000000000",
@@ -3716,7 +3716,7 @@
         "api_key": "abcde",
         "events": [
           {
-            "os_name": "Chrome",
+            "os_name": "iOS",
             "os_version": "test os",
             "device_model": "Mac",
             "platform": "Web",

--- a/test/__tests__/data/am_router_input.json
+++ b/test/__tests__/data/am_router_input.json
@@ -30,8 +30,8 @@
         "locale": "en-US",
         "ip": "0.0.0.0",
         "os": {
-          "name": "",
-          "version": ""
+          "name": "iOS",
+          "version": "10"
         },
         "screen": {
           "density": 2
@@ -90,8 +90,8 @@
         "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36",
         "locale": "en-US",
         "os": {
-          "name": "",
-          "version": ""
+          "name": "iOS",
+          "version": "10"
         },
         "screen": {
           "density": 2

--- a/test/__tests__/data/am_router_output.json
+++ b/test/__tests__/data/am_router_output.json
@@ -15,8 +15,8 @@
             "api_key": "abcde",
             "events": [
               {
-                "os_name": "Chrome",
-                "os_version": "77.0.3865.90",
+                "os_name": "iOS",
+                "os_version": "10",
                 "device_model": "Mac",
                 "library": "rudderstack",
                 "platform": "Web",
@@ -88,8 +88,8 @@
             "api_key": "abcde",
             "events": [
               {
-                "os_name": "Chrome",
-                "os_version": "77.0.3865.90",
+                "os_name": "iOS",
+                "os_version": "10",
                 "device_model": "Mac",
                 "library": "rudderstack",
                 "platform": "Web",


### PR DESCRIPTION
## Description of the change

- This PR removes mapping of browser name and version to `os_name` and `os_version` respectively.
- `os_name` and `os_version` will be mapped only from `context.os.name` and `context.os.version` if these fields 
   (`os_name` and `os_version`) are not already present in the payload.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
