### PR TITLE
fix(klaviyo): add check for listId for subscribe

### DIFF
--- a/src/v0/destinations/klaviyo/transform.js
+++ b/src/v0/destinations/klaviyo/transform.js
@@ -99,8 +99,11 @@ const identifyRequestHandler = async (message, category, destination) => {
   // Update Profile
   const responseArray = [profileUpdateResponseBuilder(payload, profileId, category, privateApiKey)];
 
-  // check if user wants to subscribe profile or not
-  if (traitsInfo?.properties?.subscribe) {
+  // check if user wants to subscribe profile or not and listId is present or not
+  if (
+    traitsInfo?.properties?.subscribe &&
+    (traitsInfo.properties?.listId || destination.Config?.listId)
+  ) {
     responseArray.push(subscribeUserToList(message, traitsInfo, destination));
     return responseArray;
   }

--- a/src/v0/destinations/klaviyo/util.js
+++ b/src/v0/destinations/klaviyo/util.js
@@ -129,26 +129,6 @@ const subscribeUserToList = (message, traitsInfo, destination) => {
   return response;
 };
 
-/**
- * This function is used to check if the user needs to be subscribed or not.
- * Building and returning response array for subscribe endpoint (for subscribing)
- * @param {*} message
- * @param {*} traitsInfo
- * @param {*} destination
- * @returns
- */
-const checkForSubscribe = (message, traitsInfo, destination) => {
-  const responseArray = [];
-  if (
-    (traitsInfo.properties?.listId || destination.Config?.listId) &&
-    traitsInfo.properties?.subscribe === true
-  ) {
-    const subscribeResponse = subscribeUserToList(message, traitsInfo, destination);
-    responseArray.push(subscribeResponse);
-  }
-  return responseArray;
-};
-
 // This function is used for creating and returning customer properties using mapping json
 const createCustomerProperties = (message) => {
   let customerProperties = constructPayload(
@@ -271,7 +251,6 @@ const batchSubscribeEvents = (subscribeRespList) => {
 
 module.exports = {
   subscribeUserToList,
-  checkForSubscribe,
   createCustomerProperties,
   populateCustomFieldsFromTraits,
   generateBatchedPaylaodForArray,

--- a/test/__tests__/data/klaviyo.json
+++ b/test/__tests__/data/klaviyo.json
@@ -149,6 +149,115 @@
     ]
   },
   {
+    "description": "Profile updation call listId is not provided for subscribing the user",
+    "input": {
+      "destination": {
+        "Config": {
+          "publicApiKey": "WJqij9",
+          "privateApiKey": "pk_b68c7b5163d98807fcb57e6f921216629d"
+        }
+      },
+      "message": {
+        "type": "identify",
+        "sentAt": "2021-01-03T17:02:53.195Z",
+        "userId": "utsabc",
+        "channel": "web",
+        "context": {
+          "os": {
+            "name": "",
+            "version": ""
+          },
+          "app": {
+            "name": "RudderLabs JavaScript SDK",
+            "build": "1.0.0",
+            "version": "1.1.11",
+            "namespace": "com.rudderlabs.javascript"
+          },
+          "traits": {
+            "firstName": "Utsab",
+            "lastName": "Chowdhury",
+            "email": "utsab@rudderstack.com",
+            "phone": "+12 345 578 900",
+            "userId": "utsabc",
+            "title": "Developer",
+            "organization": "Rudder",
+            "city": "Tokyo",
+            "region": "Kanto",
+            "country": "JP",
+            "zip": "100-0001",
+            "Flagged": false,
+            "Residence": "Shibuya",
+            "properties": {
+              "subscribe": false,
+              "consent": ["email", "sms"]
+            }
+          },
+          "locale": "en-US",
+          "screen": {
+            "density": 2
+          },
+          "library": {
+            "name": "RudderLabs JavaScript SDK",
+            "version": "1.1.11"
+          },
+          "campaign": {},
+          "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.16; rv:84.0) Gecko/20100101 Firefox/84.0"
+        },
+        "rudderId": "8f8fa6b5-8e24-489c-8e22-61f23f2e364f",
+        "messageId": "2116ef8c-efc3-4ca4-851b-02ee60dad6ff",
+        "anonymousId": "97c46c81-3140-456d-b2a9-690d70aaca35",
+        "integrations": {
+          "All": true
+        },
+        "originalTimestamp": "2021-01-03T17:02:53.193Z"
+      }
+    },
+    "output": {
+      "version": "1",
+      "type": "REST",
+      "method": "PATCH",
+      "endpoint": "https://a.klaviyo.com/api/profiles/01GW3PHVY0MTCDGS0A1612HARX",
+      "headers": {
+        "Accept": "application/json",
+        "Authorization": "Klaviyo-API-Key pk_b68c7b5163d98807fcb57e6f921216629d",
+        "Content-Type": "application/json",
+        "revision": "2023-02-22"
+      },
+      "params": {},
+      "body": {
+        "JSON": {
+          "data": {
+            "type": "profile",
+            "attributes": {
+              "external_id": "utsabc",
+              "email": "utsab@rudderstack.com",
+              "first_name": "Utsab",
+              "last_name": "Chowdhury",
+              "phone_number": "+12 345 578 900",
+              "title": "Developer",
+              "organization": "Rudder",
+              "location": {
+                "city": "Tokyo",
+                "region": "Kanto",
+                "country": "JP",
+                "zip": "100-0001"
+              }
+            },
+            "properties": {
+              "Flagged": false,
+              "Residence": "Shibuya"
+            },
+            "id": "01GW3PHVY0MTCDGS0A1612HARX"
+          }
+        },
+        "JSON_ARRAY": {},
+        "XML": {},
+        "FORM": {}
+      },
+      "files": {}
+    }
+  },
+  {
     "description": "Identify call with enforceEmailAsPrimary enabled from UI",
     "input": {
       "destination": {


### PR DESCRIPTION
## Description of the change

Add check for `listId` before creating the payload for subscribe endpoint if the subscribe flag is true(user wants to subscribe the profile)

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
