### PR TITLE
fix: error handling for valid timestamp

### DIFF
--- a/src/warehouse/util.js
+++ b/src/warehouse/util.js
@@ -48,7 +48,11 @@ const timestampRegex = new RegExp(
 function validTimestamp(input) {
   if (timestampRegex.test(input)) {
     // check if date value lies in between min time and max time. if not then it's not a valid timestamp
-    const dateInMs = Date.parse(new Date(input).toISOString());
+    const d = new Date(input)
+    if (isNaN(d)) {
+      return false
+    }
+    const dateInMs = Date.parse(d.toISOString());
     if (minTimeInMs <= dateInMs && dateInMs <= maxTimeInMs) {
       return true;
     }

--- a/test/__tests__/warehouse.test.js
+++ b/test/__tests__/warehouse.test.js
@@ -17,6 +17,10 @@ const {
   fullEventColumnTypeByProvider
 } = require("../../src/warehouse/index.js");
 
+const {
+  validTimestamp
+} = require("../../src/warehouse/util.js");
+
 const version = "v0";
 const integrations = [
   "rs",
@@ -1015,4 +1019,59 @@ describe("Integration options", () => {
       });
     });
   });
+});
+
+describe("validTimestamp", () => {
+  const testCases = [
+    {
+      input: undefined,
+      expected: false,
+    },
+    {
+      input: '-0001-11-30T00:00:00+0000',
+      expected: false,
+    },
+    {
+      input: '-2023-06-14T05:23:59.244Z',
+      expected: false,
+    },
+    {
+      input: '+2023-06-14T05:23:59.244Z',
+      expected: false,
+    },
+    {
+      input: '2023-06-14T05:23:59.244Z',
+      expected: true,
+    },
+    {
+      input: '-1900-06-14T05:23:59.244Z',
+      expected: false,
+    },
+    {
+      input: 'abc',
+      expected: false,
+    },
+    {
+      input: '%u002e%u002e%u2216%u002e%u002e%u2216%u002e%u002e%u2216%u002e%u002e%u2216%u002e%u002e%u2216%u002e%u002e%u2216%u002e%u002e%u2216%u002e%u002e%u2216%u002e%u002e%u2216%u002e%u002e%u2216%u002e%u002e%u2216%u002e%u002e%u2216%u002e%u002e%u2216%u002e%u002e%u2216%u002e%u002e%u2216%u002e%u002e%u2216%u002e%u002e%u2216%u002e%u002e%u2216Windows%u2216win%u002ein',
+      expected: false,
+    },
+    {
+      input: '',
+      expected: false,
+    },
+    {
+      input: '2023-06-14',
+      expected: true,
+    },
+    {
+      input: '05:23:59.244Z',
+      expected: false,
+    }
+  ]
+
+  for (const testCase of testCases) {
+    it(`should return ${testCase.expected} for ${testCase.input}`, () => {
+      expect(validTimestamp(testCase.input)).toEqual(testCase.expected);
+    });
+  }
 });


### PR DESCRIPTION
## Description of the change

> Getting for following error `RangeError · Invalid time value` for messagebird when the timestamp is coming as `-0001-11-30T00:00:00+0000`.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
