### PR TITLE
feat(optimzely_fullstack): removed empty values from common payload

### DIFF
--- a/src/cdk/v2/destinations/optimizely_fullstack/procWorkflow.yaml
+++ b/src/cdk/v2/destinations/optimizely_fullstack/procWorkflow.yaml
@@ -5,6 +5,8 @@ bindings:
     exportAll: true
   - name: removeUndefinedAndNullValues
     path: ../../../../v0/util
+  - name: removeUndefinedNullEmptyExclBoolInt
+    path: ../../../../v0/util
   - name: defaultRequestConfig
     path: ../../../../v0/util
   - name: getIntegrationsObj
@@ -100,7 +102,7 @@ steps:
         "enrich_decisions": .destination.Config.enrichDecisions || true,
         ...$.CLIENT_INFO
       }
-      $.removeUndefinedAndNullValues(commonPayload);
+      $.removeUndefinedNullEmptyExclBoolInt(commonPayload);
 
   - name: getAttributes
     description: Retrieves the attribute mapping from the webapp, obtains the attribute IDs from a data file, and prepares the attributes object based on the mapping and trait values.
@@ -159,6 +161,7 @@ steps:
 
       - name: payload
         template: |
+          console.log("commonpayload: ", $.outputs.commonPayload);
           {
             ...$.outputs.commonPayload,
             "visitors": $.outputs.prepareIdentifyPayload.visitors

--- a/src/cdk/v2/destinations/optimizely_fullstack/procWorkflow.yaml
+++ b/src/cdk/v2/destinations/optimizely_fullstack/procWorkflow.yaml
@@ -161,7 +161,6 @@ steps:
 
       - name: payload
         template: |
-          console.log("commonpayload: ", $.outputs.commonPayload);
           {
             ...$.outputs.commonPayload,
             "visitors": $.outputs.prepareIdentifyPayload.visitors

--- a/test/__tests__/data/optimizely_fullstack.json
+++ b/test/__tests__/data/optimizely_fullstack.json
@@ -607,6 +607,117 @@
     }
   },
   {
+    "description": "Identify call (Decision Event) with projectId is empty",
+    "input": {
+      "message": {
+        "type": "identify",
+        "channel": "web",
+        "properties": {},
+        "context": {
+          "traits": {
+            "organization": "RudderStack",
+            "fullName": "John Doe",
+            "country": "US"
+          },
+          "sessionId": 1685626914716
+        },
+        "rudderId": "8f8fa6b5-8e24-489c-8e22-61f23f2e364f",
+        "messageId": "2116ef8c-efc3-4ca4-851b-02ee60dad6ff",
+        "anonymousId": "97c46c81-3140-456d-b2a9-690d70aaca35",
+        "timestamp": "2023-02-10T12:16:07.251Z",
+        "userId": "userId123",
+        "integrations": {
+          "All": true,
+          "optimizely_fullstack": {
+            "variationId": "test_variation_id_1"
+          }
+        }
+      },
+      "destination": {
+        "Config": {
+          "dataFileUrl": "https://cdn.optimizely.com/datafiles/abc.json",
+          "accountId": "test_account_id",
+          "campaignId": "test_campaign_id",
+          "experimentId": "test_experiment_id",
+          "trackKnownUsers": true,
+          "projectId": "",
+          "attributeMapping": [
+            {
+              "from": "organization",
+              "to": "company"
+            },
+            {
+              "from": "fullName",
+              "to": "name"
+            }
+          ]
+        }
+      }
+    },
+    "output": {
+      "version": "1",
+      "type": "REST",
+      "method": "POST",
+      "endpoint": "https://logx.optimizely.com/v1/events",
+      "headers": {
+        "Content-Type": "application/json"
+      },
+      "params": {},
+      "body": {
+        "JSON": {
+          "account_id": "test_account_id",
+          "anonymize_ip": false,
+          "enrich_decisions": true,
+          "client_name": "RudderStack",
+          "client_version": "1.0.0",
+          "visitors": [
+            {
+              "visitor_id": "userId123",
+              "attributes": [
+                {
+                  "entity_id": "test_attribute_id_5",
+                  "key": "company",
+                  "type": "custom",
+                  "value": "RudderStack"
+                },
+                {
+                  "entity_id": "test_attribute_id_2",
+                  "key": "name",
+                  "type": "custom",
+                  "value": "John Doe"
+                }
+              ],
+              "snapshots": [
+                {
+                  "decisions": [
+                    {
+                      "campaign_id": "test_campaign_id",
+                      "experiment_id": "test_experiment_id",
+                      "variation_id": "test_variation_id_1"
+                    }
+                  ],
+                  "events": [
+                    {
+                      "entity_id": "test_campaign_id",
+                      "type": "campaign_activated",
+                      "timestamp": 1676031367251,
+                      "uuid": "2116ef8c-efc3-4ca4-851b-02ee60dad6ff"
+                    }
+                  ]
+                }
+              ],
+              "session_id": "1685626914716"
+            }
+          ]
+        },
+        "JSON_ARRAY": {},
+        "XML": {},
+        "FORM": {}
+      },
+      "files": {}
+    }
+  },
+  {
     "description": "Track call (Conversion event) with userId",
     "input": {
       "message": {


### PR DESCRIPTION
## Description of the change

> 
- Optimizely drops the event if empty project id sent in payload (e.g. project_id = ""). Project id is optional parameter.
- If empty project id is coming from webapp, `removeUndefinedAndNullValues` is not removing it from the payload sent to optimizely.
- There is one more utility `removeUndefinedNullEmptyExclBoolInt` that will remove empty values from the payload sent to optimizely.


## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
