### PR TITLE
fix: bingads audience list data retuns array for single user

### DIFF
--- a/src/cdk/v2/destinations/bingads_audience/procWorkflow.yaml
+++ b/src/cdk/v2/destinations/bingads_audience/procWorkflow.yaml
@@ -25,10 +25,10 @@ steps:
     template: |
       const listArray = .message.properties.listData.add;
       const hashEmail = .destination.Config.hashEmail;
-      list = listArray.({
-          "hashedEmail" :  hashEmail ? $.SHA256(.email) : .email ,
-          "email": .email
-        })[]
+      listArray.({
+        "hashedEmail" :  hashEmail ? $.SHA256(.email) : .email ,
+        "email": .email
+      })[]
 
   - name: payload
     template: |

--- a/src/cdk/v2/destinations/bingads_audience/procWorkflow.yaml
+++ b/src/cdk/v2/destinations/bingads_audience/procWorkflow.yaml
@@ -25,12 +25,10 @@ steps:
     template: |
       const listArray = .message.properties.listData.add;
       const hashEmail = .destination.Config.hashEmail;
-      console.log("fdsfdsf", listArray@prop.listData);
-      console.log("aaa", hashEmail)
       list = listArray.({
           "hashedEmail" :  hashEmail ? $.SHA256(.email) : .email ,
           "email": .email
-        })
+        })[]
 
   - name: payload
     template: |

--- a/test/__tests__/data/bingads_audience.json
+++ b/test/__tests__/data/bingads_audience.json
@@ -20,7 +20,12 @@
             ]
           }
         },
-        "context": { "ip": "14.5.67.21", "library": { "name": "http" } },
+        "context": {
+          "ip": "14.5.67.21",
+          "library": {
+            "name": "http"
+          }
+        },
         "timestamp": "2020-02-02T00:23:09.544Z"
       },
       "destination": {
@@ -84,7 +89,12 @@
             ]
           }
         },
-        "context": { "ip": "14.5.67.21", "library": { "name": "http" } },
+        "context": {
+          "ip": "14.5.67.21",
+          "library": {
+            "name": "http"
+          }
+        },
         "timestamp": "2020-02-02T00:23:09.544Z"
       },
       "destination": {
@@ -148,7 +158,12 @@
             ]
           }
         },
-        "context": { "ip": "14.5.67.21", "library": { "name": "http" } },
+        "context": {
+          "ip": "14.5.67.21",
+          "library": {
+            "name": "http"
+          }
+        },
         "timestamp": "2020-02-02T00:23:09.544Z"
       },
       "destination": {
@@ -185,7 +200,12 @@
             ]
           }
         },
-        "context": { "ip": "14.5.67.21", "library": { "name": "http" } },
+        "context": {
+          "ip": "14.5.67.21",
+          "library": {
+            "name": "http"
+          }
+        },
         "timestamp": "2020-02-02T00:23:09.544Z"
       },
       "destination": {
@@ -207,7 +227,12 @@
       "message": {
         "userId": "user 1",
         "type": "audiencelist",
-        "context": { "ip": "14.5.67.21", "library": { "name": "http" } },
+        "context": {
+          "ip": "14.5.67.21",
+          "library": {
+            "name": "http"
+          }
+        },
         "timestamp": "2020-02-02T00:23:09.544Z"
       },
       "destination": {
@@ -230,7 +255,12 @@
         "userId": "user 1",
         "type": "audiencelist",
         "properties": {},
-        "context": { "ip": "14.5.67.21", "library": { "name": "http" } },
+        "context": {
+          "ip": "14.5.67.21",
+          "library": {
+            "name": "http"
+          }
+        },
         "timestamp": "2020-02-02T00:23:09.544Z"
       },
       "destination": {
@@ -278,7 +308,12 @@
             ]
           }
         },
-        "context": { "ip": "14.5.67.21", "library": { "name": "http" } },
+        "context": {
+          "ip": "14.5.67.21",
+          "library": {
+            "name": "http"
+          }
+        },
         "timestamp": "2020-02-02T00:23:09.544Z"
       },
       "destination": {
@@ -311,6 +346,71 @@
             {
               "email": "2048acfa84a01121060ca2fc8a673a76d427176dc37224d4408c21973bd90e5c",
               "hashedEmail": "2048acfa84a01121060ca2fc8a673a76d427176dc37224d4408c21973bd90e5c"
+            }
+          ]
+        },
+        "JSON_ARRAY": {},
+        "XML": {},
+        "FORM": {}
+      },
+      "files": {}
+    }
+  },
+  {
+    "description": "Only single user data is present",
+    "input": {
+      "message": {
+        "userId": "user 1",
+        "type": "audiencelist",
+        "properties": {
+          "listData": {
+            "add": [
+              {
+                "email": "alex@email.com"
+              }
+            ]
+          }
+        },
+        "context": {
+          "ip": "14.5.67.21",
+          "library": {
+            "name": "http"
+          }
+        },
+        "timestamp": "2020-02-02T00:23:09.544Z"
+      },
+      "metadata": {
+        "sourceType": "",
+        "destinationType": "",
+        "namespace": ""
+      },
+      "destination": {
+        "DestinationDefinition": {
+          "Config": {
+            "cdkV2Enabled": true
+          }
+        },
+        "Config": {
+          "customerAccountId": "89236978",
+          "customerId": "78678678",
+          "audienceId": "564567",
+          "hashEmail": true
+        }
+      }
+    },
+    "output": {
+      "version": "1",
+      "type": "REST",
+      "method": "POST",
+      "endpoint": "",
+      "headers": {},
+      "params": {},
+      "body": {
+        "JSON": {
+          "list": [
+            {
+              "hashedEmail": "ac0f1baec38a9ef3cfcb56db981df7d9bab2568c7f53ef3776d1c059ec58e72b",
+              "email": "alex@email.com"
             }
           ]
         },


### PR DESCRIPTION
## Description of the change

> Previously if we would have sent single user data in list data, it was returning an object. But now, for all conditions it will return array

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
