### PR TITLE
fix: mixpanel group call

### DIFF
--- a/src/v0/destinations/mp/transform.js
+++ b/src/v0/destinations/mp/transform.js
@@ -344,6 +344,10 @@ const processGroupEvents = (message, type, destination) => {
   } else {
     throw new ConfigurationError('Group Key Settings is not configured');
   }
+
+  if (returnValue.length === 0) {
+    throw new InstrumentationError('Group Key is not present. Aborting message');
+  }
   return returnValue;
 };
 

--- a/src/v0/util/index.js
+++ b/src/v0/util/index.js
@@ -47,7 +47,13 @@ const flattenMap = (collection) => _.flatMap(collection, (x) => x);
 // GENERIC UTLITY
 // ========================================================================
 
-const getEventTime = (message) => new Date(message.timestamp).toISOString();
+const getEventTime = (message) => {
+  try {
+    return new Date(message.timestamp).toISOString();
+  } catch (err) {
+    return new Date(message.originalTimestamp).toISOString();
+  }
+};
 
 const base64Convertor = (string) => Buffer.from(string).toString('base64');
 

--- a/test/__tests__/data/mp_input.json
+++ b/test/__tests__/data/mp_input.json
@@ -4037,5 +4037,76 @@
       "timestamp": "2020-01-24T11:59:02.402+05:30",
       "type": "group"
     }
+  },
+  {
+    "destination": {
+      "Config": {
+        "apiKey": "9432f11f70f8ce386f5110c8c924b3ec4f825256",
+        "token": "9432f11f70f8ce386f5110c8c924b3ec4f825256",
+        "prefixProperties": true,
+        "useNativeSDK": false,
+        "groupKeySettings": [
+          {
+            "groupKey": "company"
+          }
+        ]
+      },
+      "DestinationDefinition": {
+        "DisplayName": "Kiss Metrics",
+        "ID": "1WhbSZ6uA3H5ChVifHpfL2H6sie",
+        "Name": "MIXPANEL"
+      },
+      "Enabled": true,
+      "ID": "1WhcOCGgj9asZu850HvugU2C3Aq",
+      "Name": "Kiss Metrics",
+      "Transformations": []
+    },
+    "message": {
+      "anonymousId": "e6ab2c5e-2cda-44a9-a962-e2f67df78bca",
+      "channel": "mobile",
+      "name": "Contact Us",
+      "context": {
+        "app": {
+          "build": "1.0.0",
+          "name": "RudderLabs Android SDK",
+          "namespace": "com.rudderlabs.javascript",
+          "version": "1.0.5"
+        },
+        "ip": "0.0.0.0",
+        "library": {
+          "name": "RudderLabs JavaScript SDK",
+          "version": "1.0.5"
+        },
+        "locale": "en-GB",
+        "os": {
+          "name": "",
+          "version": ""
+        },
+        "screen": {
+          "density": 2
+        },
+        "traits": {},
+        "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.117 Safari/537.36"
+      },
+      "integrations": {
+        "All": true
+      },
+      "messageId": "dd266c67-9199-4a52-ba32-f46ddde67312",
+      "originalTimestamp": "2020-01-24T06:29:02.358Z",
+      "properties": {
+        "path": "/tests/html/index2.html",
+        "referrer": "",
+        "search": "",
+        "title": "",
+        "url": "http://localhost/tests/html/index2.html"
+      },
+      "traits": {},
+      "receivedAt": "2020-01-24T11:59:02.403+05:30",
+      "request_ip": "[::1]:53708",
+      "sentAt": "2020-01-24T06:29:02.359Z",
+      "timestamp": "2020-01-24T11:59:02.402+05:30",
+      "type": "group",
+      "userId": "hjikl"
+    }
   }
 ]

--- a/test/__tests__/data/mp_input.json
+++ b/test/__tests__/data/mp_input.json
@@ -4108,5 +4108,169 @@
       "type": "group",
       "userId": "hjikl"
     }
+  },
+  {
+    "message": {
+      "type": "track",
+      "event": "Application Installed",
+      "sentAt": "2022-09-05T07:46:26.322Z",
+      "channel": "mobile",
+      "timestamp": "",
+      "context": {
+        "os": {
+          "name": "Android",
+          "version": "12"
+        },
+        "app": {
+          "name": "Sample Kotlin",
+          "build": "4",
+          "version": "1.0",
+          "namespace": "com.example.testapp1mg"
+        },
+        "device": {
+          "id": "39da706ec83d0e90",
+          "name": "emu64a",
+          "type": "Android",
+          "model": "sdk_gphone64_arm64",
+          "manufacturer": "Google"
+        },
+        "locale": "en-US",
+        "screen": {
+          "width": 1440,
+          "height": 2984,
+          "density": 560
+        },
+        "traits": {
+          "anonymousId": "39da706ec83d0e90"
+        },
+        "library": {
+          "name": "com.rudderstack.android.sdk.core",
+          "version": "1.7.0"
+        },
+        "network": {
+          "wifi": true,
+          "carrier": "T-Mobile",
+          "cellular": true,
+          "bluetooth": true
+        },
+        "timezone": "Asia/Kolkata",
+        "sessionId": 1662363980,
+        "userAgent": "Dalvik/2.1.0 (Linux; U; Android Tiramisu Build/TPP2.220218.008)",
+        "sessionStart": true
+      },
+      "rudderId": "3ef1dec3-d729-4830-a394-7b8be6819765",
+      "messageId": "1662363980287-168cf720-6227-4b56-a98e-c49bdc7279e9",
+      "properties": {
+        "build": 4,
+        "version": "1.0",
+        "revenue": 12.13
+      },
+      "anonymousId": "39da706ec83d0e90",
+      "integrations": {
+        "All": true
+      },
+      "originalTimestamp": "2022-09-05T07:46:20.290Z"
+    },
+    "destination": {
+      "Config": {
+        "apiKey": "9432f11f70f8ce386f5110c8c924b3ec4f825256",
+        "apiSecret": "9432f11f70f8ce386f5110c8c924b3ec4f825256",
+        "token": "9432f11f70f8ce386f5110c8c924b3ec4f825256",
+        "prefixProperties": true,
+        "useNativeSDK": false,
+        "useNewMapping": true
+      },
+      "DestinationDefinition": {
+        "DisplayName": "Kiss Metrics",
+        "ID": "1WhbSZ6uA3H5ChVifHpfL2H6sie",
+        "Name": "MIXPANEL"
+      },
+      "Enabled": true,
+      "ID": "1WhcOCGgj9asZu850HvugU2C3Aq",
+      "Name": "Kiss Metrics",
+      "Transformations": []
+    }
+  },
+  {
+    "message": {
+      "type": "track",
+      "event": "Application Installed",
+      "sentAt": "2022-09-05T07:46:26.322Z",
+      "channel": "mobile",
+      "timestamp": "safaff",
+      "context": {
+        "os": {
+          "name": "Android",
+          "version": "12"
+        },
+        "app": {
+          "name": "Sample Kotlin",
+          "build": "4",
+          "version": "1.0",
+          "namespace": "com.example.testapp1mg"
+        },
+        "device": {
+          "id": "39da706ec83d0e90",
+          "name": "emu64a",
+          "type": "Android",
+          "model": "sdk_gphone64_arm64",
+          "manufacturer": "Google"
+        },
+        "locale": "en-US",
+        "screen": {
+          "width": 1440,
+          "height": 2984,
+          "density": 560
+        },
+        "traits": {
+          "anonymousId": "39da706ec83d0e90"
+        },
+        "library": {
+          "name": "com.rudderstack.android.sdk.core",
+          "version": "1.7.0"
+        },
+        "network": {
+          "wifi": true,
+          "carrier": "T-Mobile",
+          "cellular": true,
+          "bluetooth": true
+        },
+        "timezone": "Asia/Kolkata",
+        "sessionId": 1662363980,
+        "userAgent": "Dalvik/2.1.0 (Linux; U; Android Tiramisu Build/TPP2.220218.008)",
+        "sessionStart": true
+      },
+      "rudderId": "3ef1dec3-d729-4830-a394-7b8be6819765",
+      "messageId": "1662363980287-168cf720-6227-4b56-a98e-c49bdc7279e9",
+      "properties": {
+        "build": 4,
+        "version": "1.0",
+        "revenue": 23.45
+      },
+      "anonymousId": "39da706ec83d0e90",
+      "integrations": {
+        "All": true
+      },
+      "originalTimestamp": "2022-09-05T07:46:20.290Z"
+    },
+    "destination": {
+      "Config": {
+        "apiKey": "9432f11f70f8ce386f5110c8c924b3ec4f825256",
+        "apiSecret": "9432f11f70f8ce386f5110c8c924b3ec4f825256",
+        "token": "9432f11f70f8ce386f5110c8c924b3ec4f825256",
+        "prefixProperties": true,
+        "useNativeSDK": false,
+        "useNewMapping": true
+      },
+      "DestinationDefinition": {
+        "DisplayName": "Kiss Metrics",
+        "ID": "1WhbSZ6uA3H5ChVifHpfL2H6sie",
+        "Name": "MIXPANEL"
+      },
+      "Enabled": true,
+      "ID": "1WhcOCGgj9asZu850HvugU2C3Aq",
+      "Name": "Kiss Metrics",
+      "Transformations": []
+    }
   }
 ]

--- a/test/__tests__/data/mp_output.json
+++ b/test/__tests__/data/mp_output.json
@@ -2037,5 +2037,159 @@
   {
     "statusCode": 400,
     "message": "Group Key is not present. Aborting message"
-  }
+  },
+  [
+    {
+      "version": "1",
+      "type": "REST",
+      "method": "POST",
+      "endpoint": "https://api.mixpanel.com/engage/",
+      "headers": {},
+      "params": {
+        "data": {
+          "$append": {
+            "$transactions": {
+              "$amount": 12.13,
+              "$time": "2022-09-05T07:46:20.290Z"
+            }
+          },
+          "$distinct_id": "39da706ec83d0e90",
+          "$token": "9432f11f70f8ce386f5110c8c924b3ec4f825256"
+        }
+      },
+      "body": {
+        "JSON": {},
+        "JSON_ARRAY": {},
+        "XML": {},
+        "FORM": {}
+      },
+      "files": {},
+      "userId": "39da706ec83d0e90"
+    },
+    {
+      "version": "1",
+      "type": "REST",
+      "method": "POST",
+      "endpoint": "https://api.mixpanel.com/import/",
+      "headers": {
+        "Authorization": "Basic OTQzMmYxMWY3MGY4Y2UzODZmNTExMGM4YzkyNGIzZWM0ZjgyNTI1Njo="
+      },
+      "params": {
+        "data": {
+          "event": "Application Installed",
+          "properties": {
+            "$app_build_number": "4",
+            "$app_version_string": "1.0",
+            "$bluetooth_enabled": true,
+            "$carrier": "T-Mobile",
+            "$device": "emu64a",
+            "$insert_id": "168cf720-6227-4b56-a98e-c49bdc7279e9",
+            "$manufacturer": "Google",
+            "$model": "sdk_gphone64_arm64",
+            "$os": "Android",
+            "$os_version": "12",
+            "$screen_dpi": 560,
+            "$screen_height": 2984,
+            "$screen_width": 1440,
+            "$session_id": "1662363980",
+            "$wifi": true,
+            "anonymousId": "39da706ec83d0e90",
+            "build": 4,
+            "distinct_id": "39da706ec83d0e90",
+            "mp_device_model": "sdk_gphone64_arm64",
+            "mp_lib": "com.rudderstack.android.sdk.core",
+            "revenue": 12.13,
+            "time": null,
+            "token": "9432f11f70f8ce386f5110c8c924b3ec4f825256",
+            "version": "1.0"
+          }
+        }
+      },
+      "body": {
+        "JSON": {},
+        "JSON_ARRAY": {},
+        "XML": {},
+        "FORM": {}
+      },
+      "files": {},
+      "userId": "39da706ec83d0e90"
+    }
+  ],
+  [
+    {
+      "version": "1",
+      "type": "REST",
+      "method": "POST",
+      "endpoint": "https://api.mixpanel.com/engage/",
+      "headers": {},
+      "params": {
+        "data": {
+          "$append": {
+            "$transactions": {
+              "$amount": 23.45,
+              "$time": "2022-09-05T07:46:20.290Z"
+            }
+          },
+          "$distinct_id": "39da706ec83d0e90",
+          "$token": "9432f11f70f8ce386f5110c8c924b3ec4f825256"
+        }
+      },
+      "body": {
+        "JSON": {},
+        "JSON_ARRAY": {},
+        "XML": {},
+        "FORM": {}
+      },
+      "files": {},
+      "userId": "39da706ec83d0e90"
+    },
+    {
+      "version": "1",
+      "type": "REST",
+      "method": "POST",
+      "endpoint": "https://api.mixpanel.com/import/",
+      "headers": {
+        "Authorization": "Basic OTQzMmYxMWY3MGY4Y2UzODZmNTExMGM4YzkyNGIzZWM0ZjgyNTI1Njo="
+      },
+      "params": {
+        "data": {
+          "event": "Application Installed",
+          "properties": {
+            "$app_build_number": "4",
+            "$app_version_string": "1.0",
+            "$bluetooth_enabled": true,
+            "$carrier": "T-Mobile",
+            "$device": "emu64a",
+            "$insert_id": "168cf720-6227-4b56-a98e-c49bdc7279e9",
+            "$manufacturer": "Google",
+            "$model": "sdk_gphone64_arm64",
+            "$os": "Android",
+            "$os_version": "12",
+            "$screen_dpi": 560,
+            "$screen_height": 2984,
+            "$screen_width": 1440,
+            "$session_id": "1662363980",
+            "$wifi": true,
+            "anonymousId": "39da706ec83d0e90",
+            "build": 4,
+            "distinct_id": "39da706ec83d0e90",
+            "mp_device_model": "sdk_gphone64_arm64",
+            "mp_lib": "com.rudderstack.android.sdk.core",
+            "time": null,
+            "revenue": 23.45,
+            "token": "9432f11f70f8ce386f5110c8c924b3ec4f825256",
+            "version": "1.0"
+          }
+        }
+      },
+      "body": {
+        "JSON": {},
+        "JSON_ARRAY": {},
+        "XML": {},
+        "FORM": {}
+      },
+      "files": {},
+      "userId": "39da706ec83d0e90"
+    }
+  ]
 ]

--- a/test/__tests__/data/mp_output.json
+++ b/test/__tests__/data/mp_output.json
@@ -2033,5 +2033,9 @@
       "files": {},
       "userId": "anonId01"
     }
-  ]
+  ],
+  {
+    "statusCode": 400,
+    "message": "Group Key is not present. Aborting message"
+  }
 ]


### PR DESCRIPTION
## Description of the change

> For group call in mixpanel if [group key](https://github.com/rudderlabs/rudder-transformer/blob/c91dadc2cf3eaddceefc83e3b9b8f08529a7fd4e/src/v0/destinations/mp/transform.js#L301) is not provided then [processGroupEvents](https://github.com/rudderlabs/rudder-transformer/blob/c91dadc2cf3eaddceefc83e3b9b8f08529a7fd4e/src/v0/destinations/mp/transform.js#L288C7-L288C25) function is returning an empty array to caller function. Which in turn returns a response with "batchedRequest": [] with statusCode: 200 after transformation to server.
Instead of returning empty array, Added a check on group key and failed the event accordingly while doing the transformation.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
