### PR TITLE
feat(mixpanel): add strict parameter and send unencoded data

### DIFF
--- a/src/v0/destinations/mp/transform.js
+++ b/src/v0/destinations/mp/transform.js
@@ -36,8 +36,10 @@ const mPEventPropertiesConfigJson = mappingConfig[ConfigCategory.EVENT_PROPERTIE
  */
 const createUser = async (response) => {
   const url = response.endpoint;
-  const { payload } = response.body.JSON_ARRAY.batch;
-  const axiosResponse = await httpPOST(url, payload);
+  const { batch: payload } = response.body.JSON_ARRAY;
+  const axiosResponse = await httpPOST(url, payload, {
+    headers: { 'Content-Type': 'application/json' },
+  });
   return processAxiosResponse(axiosResponse);
 };
 

--- a/src/v0/destinations/mp/transform.js
+++ b/src/v0/destinations/mp/transform.js
@@ -40,6 +40,9 @@ const createUser = async (response) => {
   const axiosResponse = await httpPOST(url, payload, {
     headers: { 'Content-Type': 'application/json' },
   });
+  if (!axiosResponse.success) {
+    console.log("[MP] Raw HTTP response(for error):", axiosResponse.response);
+  }
   return processAxiosResponse(axiosResponse);
 };
 

--- a/src/v0/destinations/mp/transform.js
+++ b/src/v0/destinations/mp/transform.js
@@ -40,9 +40,7 @@ const createUser = async (response) => {
   const axiosResponse = await httpPOST(url, payload, {
     headers: { 'Content-Type': 'application/json' },
   });
-  if (!axiosResponse.success) {
-    console.log("[MP] Raw HTTP response(for error):", axiosResponse.response);
-  }
+  console.error(`[MP] Success:${axiosResponse.success} Raw HTTP response(for error):`, axiosResponse.response);
   return processAxiosResponse(axiosResponse);
 };
 

--- a/src/v0/destinations/mp/transform.js
+++ b/src/v0/destinations/mp/transform.js
@@ -40,7 +40,6 @@ const createUser = async (response) => {
   const axiosResponse = await httpPOST(url, payload, {
     headers: { 'Content-Type': 'application/json' },
   });
-  console.error(`[MP] Success:${axiosResponse.success} Raw HTTP response(for error):`, axiosResponse.response);
   return processAxiosResponse(axiosResponse);
 };
 

--- a/src/v0/destinations/mp/util.js
+++ b/src/v0/destinations/mp/util.js
@@ -99,7 +99,7 @@ const createIdentifyResponse = (message, type, destination, responseBuilderSimpl
   // user payload created
   const properties = getTransformedJSON(message, mPIdentifyConfigJson, useNewMapping);
 
-  const parameters = {
+  const payload = {
     $set: properties,
     $token: token,
     $distinct_id: message.userId || message.anonymousId,
@@ -108,14 +108,14 @@ const createIdentifyResponse = (message, type, destination, responseBuilderSimpl
   };
 
   if (destination?.Config.identityMergeApi === 'simplified') {
-    parameters.$distinct_id = message.userId || `$device:${message.anonymousId}`;
+    payload.$distinct_id = message.userId || `$device:${message.anonymousId}`;
   }
 
   if (message.context?.active === false) {
-    parameters.$ignore_time = true;
+    payload.$ignore_time = true;
   }
   // Creating the response to create user
-  return responseBuilderSimple(parameters, message, type, destination.Config);
+  return responseBuilderSimple(payload, message, type, destination.Config);
 };
 
 /**

--- a/test/__tests__/data/mp_input.json
+++ b/test/__tests__/data/mp_input.json
@@ -4272,5 +4272,87 @@
       "Name": "Kiss Metrics",
       "Transformations": []
     }
+  },
+  {
+    "description": "Track: with strict mode enabled",
+    "destination": {
+      "Config": {
+        "apiKey": "9432f11f70f8ce386f5110c8c924b3ec4f825256",
+        "token": "9432f11f70f8ce386f5110c8c924b3ec4f825256",
+        "apiSecret": "some_api_secret",
+        "prefixProperties": true,
+        "dataResidency": "eu",
+        "useNativeSDK": false,
+        "strictMode": true
+      },
+      "DestinationDefinition": {
+        "DisplayName": "Mixpanel",
+        "ID": "1WhbSZ6uA3H5ChVifHpfL2H6sie",
+        "Name": "MP"
+      },
+      "Enabled": true,
+      "ID": "1WhcOCGgj9asZu850HvugU2C3Aq",
+      "Name": "Mixpanel",
+      "Transformations": []
+    },
+    "message": {
+      "anonymousId": "5094f5704b9cf2b3",
+      "channel": "mobile",
+      "context": {
+        "app": {
+          "build": "1",
+          "name": "LeanPlumIntegrationAndroid",
+          "namespace": "com.android.SampleLeanPlum",
+          "version": "1.0"
+        },
+        "device": {
+          "id": "5094f5704b9cf2b3",
+          "manufacturer": "Google",
+          "model": "Android SDK built for x86",
+          "name": "generic_x86",
+          "type": "ios",
+          "token": "test_device_token"
+        },
+        "library": {
+          "name": "com.rudderstack.android.sdk.core",
+          "version": "1.0.1-beta.1"
+        },
+        "locale": "en-US",
+        "network": {
+          "carrier": "Android",
+          "bluetooth": false,
+          "cellular": true,
+          "wifi": true
+        },
+        "os": {
+          "name": "iOS",
+          "version": "8.1.0"
+        },
+        "screen": {
+          "density": 420,
+          "height": 1794,
+          "width": 1080
+        },
+        "timezone": "Asia/Kolkata",
+        "traits": {
+          "anonymousId": "5094f5704b9cf2b3",
+          "userId": "test_user_id"
+        },
+        "userAgent": "Dalvik/2.1.0 (Linux; U; Android 8.1.0; Android SDK built for x86 Build/OSM1.180201.007)"
+      },
+      "event": "MainActivity",
+      "integrations": {
+        "All": true
+      },
+      "userId": "test_user_id",
+      "messageId": "id2",
+      "properties": {
+        "name": "MainActivity",
+        "automatic": true
+      },
+      "originalTimestamp": "2020-03-12T09:05:03.421Z",
+      "type": "identify",
+      "sentAt": "2020-03-12T09:05:13.042Z"
+    }
   }
 ]

--- a/test/__tests__/data/mp_output.json
+++ b/test/__tests__/data/mp_output.json
@@ -5,30 +5,12 @@
     "method": "POST",
     "endpoint": "https://api.mixpanel.com/track/",
     "headers": {},
-    "params": {
-      "data": {
-        "event": "Loaded a Page",
-        "properties": {
-          "ip": "0.0.0.0",
-          "$user_id": "hjikl",
-          "$current_url": "https://docs.rudderstack.com/destinations/mixpanel",
-          "$screen_dpi": 2,
-          "mp_lib": "RudderLabs JavaScript SDK",
-          "$app_build_number": "1.0.0",
-          "$app_version_string": "1.0.5",
-          "$insert_id": "dd266c67-9199-4a52-ba32-f46ddde67312",
-          "token": "9432f11f70f8ce386f5110c8c924b3ec4f825256",
-          "distinct_id": "hjikl",
-          "time": 1579847342,
-          "name": "Contact Us",
-          "$browser": "Chrome",
-          "$browser_version": "79.0.3945.117"
-        }
-      }
-    },
+    "params": {},
     "body": {
       "JSON": {},
-      "JSON_ARRAY": {},
+      "JSON_ARRAY": {
+        "batch": "[{\"event\":\"Loaded a Page\",\"properties\":{\"ip\":\"0.0.0.0\",\"$user_id\":\"hjikl\",\"$current_url\":\"https://docs.rudderstack.com/destinations/mixpanel\",\"$screen_dpi\":2,\"mp_lib\":\"RudderLabs JavaScript SDK\",\"$app_build_number\":\"1.0.0\",\"$app_version_string\":\"1.0.5\",\"$insert_id\":\"dd266c67-9199-4a52-ba32-f46ddde67312\",\"token\":\"9432f11f70f8ce386f5110c8c924b3ec4f825256\",\"distinct_id\":\"hjikl\",\"time\":1579847342,\"name\":\"Contact Us\",\"$browser\":\"Chrome\",\"$browser_version\":\"79.0.3945.117\"}}]"
+      },
       "XML": {},
       "FORM": {}
     },
@@ -41,31 +23,12 @@
     "method": "POST",
     "endpoint": "https://api.mixpanel.com/track/",
     "headers": {},
-    "params": {
-      "data": {
-        "event": "Loaded a Page",
-        "properties": {
-          "ip": "0.0.0.0",
-          "$user_id": "hjikl",
-          "$current_url": "https://docs.rudderstack.com/destinations/mixpanel",
-          "$screen_dpi": 2,
-          "mp_lib": "RudderLabs JavaScript SDK",
-          "$app_build_number": "1.0.0",
-          "$app_version_string": "1.0.5",
-          "$insert_id": "dd266c67-9199-4a52-ba32-f46ddde67312",
-          "token": "9432f11f70f8ce386f5110c8c924b3ec4f825256",
-          "distinct_id": "hjikl",
-          "time": 1579847342,
-          "name": "Contact Us",
-          "category": "Contact",
-          "$browser": "Chrome",
-          "$browser_version": "79.0.3945.117"
-        }
-      }
-    },
+    "params": {},
     "body": {
       "JSON": {},
-      "JSON_ARRAY": {},
+      "JSON_ARRAY": {
+        "batch": "[{\"event\":\"Loaded a Page\",\"properties\":{\"ip\":\"0.0.0.0\",\"$user_id\":\"hjikl\",\"$current_url\":\"https://docs.rudderstack.com/destinations/mixpanel\",\"$screen_dpi\":2,\"mp_lib\":\"RudderLabs JavaScript SDK\",\"$app_build_number\":\"1.0.0\",\"$app_version_string\":\"1.0.5\",\"$insert_id\":\"dd266c67-9199-4a52-ba32-f46ddde67312\",\"token\":\"9432f11f70f8ce386f5110c8c924b3ec4f825256\",\"distinct_id\":\"hjikl\",\"time\":1579847342,\"name\":\"Contact Us\",\"category\":\"Contact\",\"$browser\":\"Chrome\",\"$browser_version\":\"79.0.3945.117\"}}]"
+      },
       "XML": {},
       "FORM": {}
     },
@@ -78,28 +41,12 @@
     "method": "POST",
     "endpoint": "https://api.mixpanel.com/track/",
     "headers": {},
-    "params": {
-      "data": {
-        "event": "Loaded a Screen",
-        "properties": {
-          "category": "communication",
-          "ip": "0.0.0.0",
-          "$user_id": "hjikl",
-          "$screen_dpi": 2,
-          "mp_lib": "RudderLabs JavaScript SDK",
-          "$app_build_number": "1.0.0",
-          "$app_version_string": "1.0.5",
-          "$insert_id": "dd266c67-9199-4a52-ba32-f46ddde67312",
-          "token": "9432f11f70f8ce386f5110c8c924b3ec4f825256",
-          "distinct_id": "hjikl",
-          "time": 1579847342,
-          "name": "Contact Us"
-        }
-      }
-    },
+    "params": {},
     "body": {
       "JSON": {},
-      "JSON_ARRAY": {},
+      "JSON_ARRAY": {
+        "batch": "[{\"event\":\"Loaded a Screen\",\"properties\":{\"category\":\"communication\",\"ip\":\"0.0.0.0\",\"$user_id\":\"hjikl\",\"$screen_dpi\":2,\"mp_lib\":\"RudderLabs JavaScript SDK\",\"$app_build_number\":\"1.0.0\",\"$app_version_string\":\"1.0.5\",\"$insert_id\":\"dd266c67-9199-4a52-ba32-f46ddde67312\",\"token\":\"9432f11f70f8ce386f5110c8c924b3ec4f825256\",\"distinct_id\":\"hjikl\",\"time\":1579847342,\"name\":\"Contact Us\"}}]"
+      },
       "XML": {},
       "FORM": {}
     },
@@ -112,33 +59,12 @@
     "method": "POST",
     "endpoint": "https://api.mixpanel.com/track/",
     "headers": {},
-    "params": {
-      "data": {
-        "event": "Loaded a Screen",
-        "properties": {
-          "path": "/tests/html/index2.html",
-          "referrer": "",
-          "search": "",
-          "title": "",
-          "url": "http://localhost/tests/html/index2.html",
-          "ip": "0.0.0.0",
-          "$user_id": "hjiklmk",
-          "$screen_dpi": 2,
-          "mp_lib": "RudderLabs Android SDK",
-          "$app_build_number": "1.0.0",
-          "$app_version_string": "1.0.5",
-          "$insert_id": "dd266c67-9199-4a52-ba32-f46ddde67312",
-          "token": "9432f11f70f8ce386f5110c8c924b3ec4f825256",
-          "distinct_id": "hjiklmk",
-          "time": 1579847342,
-          "name": "Contact Us",
-          "category": "Contact"
-        }
-      }
-    },
+    "params": {},
     "body": {
       "JSON": {},
-      "JSON_ARRAY": {},
+      "JSON_ARRAY": {
+        "batch": "[{\"event\":\"Loaded a Screen\",\"properties\":{\"path\":\"/tests/html/index2.html\",\"referrer\":\"\",\"search\":\"\",\"title\":\"\",\"url\":\"http://localhost/tests/html/index2.html\",\"ip\":\"0.0.0.0\",\"$user_id\":\"hjiklmk\",\"$screen_dpi\":2,\"mp_lib\":\"RudderLabs Android SDK\",\"$app_build_number\":\"1.0.0\",\"$app_version_string\":\"1.0.5\",\"$insert_id\":\"dd266c67-9199-4a52-ba32-f46ddde67312\",\"token\":\"9432f11f70f8ce386f5110c8c924b3ec4f825256\",\"distinct_id\":\"hjiklmk\",\"time\":1579847342,\"name\":\"Contact Us\",\"category\":\"Contact\"}}]"
+      },
       "XML": {},
       "FORM": {}
     },
@@ -151,27 +77,12 @@
     "method": "POST",
     "endpoint": "https://api.mixpanel.com/track/",
     "headers": {},
-    "params": {
-      "data": {
-        "event": "Loaded a Screen",
-        "properties": {
-          "ip": "0.0.0.0",
-          "$user_id": "hjikl",
-          "$screen_dpi": 2,
-          "mp_lib": "RudderLabs JavaScript SDK",
-          "$app_build_number": "1.0.0",
-          "$app_version_string": "1.0.5",
-          "$insert_id": "dd266c67-9199-4a52-ba32-f46ddde67312",
-          "token": "9432f11f70f8ce386f5110c8c924b3ec4f825256",
-          "distinct_id": "hjikl",
-          "time": 1579847342,
-          "name": "Contact Us"
-        }
-      }
-    },
+    "params": {},
     "body": {
       "JSON": {},
-      "JSON_ARRAY": {},
+      "JSON_ARRAY": {
+        "batch": "[{\"event\":\"Loaded a Screen\",\"properties\":{\"ip\":\"0.0.0.0\",\"$user_id\":\"hjikl\",\"$screen_dpi\":2,\"mp_lib\":\"RudderLabs JavaScript SDK\",\"$app_build_number\":\"1.0.0\",\"$app_version_string\":\"1.0.5\",\"$insert_id\":\"dd266c67-9199-4a52-ba32-f46ddde67312\",\"token\":\"9432f11f70f8ce386f5110c8c924b3ec4f825256\",\"distinct_id\":\"hjikl\",\"time\":1579847342,\"name\":\"Contact Us\"}}]"
+      },
       "XML": {},
       "FORM": {}
     },
@@ -184,30 +95,12 @@
     "method": "POST",
     "endpoint": "https://api.mixpanel.com/engage/",
     "headers": {},
-    "params": {
-      "data": {
-        "$set": {
-          "$created": "2020-01-23T08:54:02.362Z",
-          "$email": "mickey@disney.com",
-          "$first_name": "Mickey",
-          "$last_name": "Mouse",
-          "$country_code": "USA",
-          "$city": "Disney",
-          "$initial_referrer": "https://docs.rudderstack.com",
-          "$initial_referring_domain": "docs.rudderstack.com",
-          "$name": "Mickey Mouse",
-          "$browser": "Chrome",
-          "$browser_version": "79.0.3945.117"
-        },
-        "$token": "9432f11f70f8ce386f5110c8c924b3ec4f825256",
-        "$distinct_id": "e6ab2c5e-2cda-44a9-a962-e2f67df78bca",
-        "$ip": "0.0.0.0",
-        "$time": 1579847342
-      }
-    },
+    "params": {},
     "body": {
       "JSON": {},
-      "JSON_ARRAY": {},
+      "JSON_ARRAY": {
+        "batch": "[{\"$set\":{\"$created\":\"2020-01-23T08:54:02.362Z\",\"$email\":\"mickey@disney.com\",\"$first_name\":\"Mickey\",\"$last_name\":\"Mouse\",\"$country_code\":\"USA\",\"$city\":\"Disney\",\"$initial_referrer\":\"https://docs.rudderstack.com\",\"$initial_referring_domain\":\"docs.rudderstack.com\",\"$name\":\"Mickey Mouse\",\"$browser\":\"Chrome\",\"$browser_version\":\"79.0.3945.117\"},\"$token\":\"9432f11f70f8ce386f5110c8c924b3ec4f825256\",\"$distinct_id\":\"e6ab2c5e-2cda-44a9-a962-e2f67df78bca\",\"$ip\":\"0.0.0.0\",\"$time\":1579847342}]"
+      },
       "XML": {},
       "FORM": {}
     },
@@ -221,21 +114,12 @@
       "method": "POST",
       "endpoint": "https://api.mixpanel.com/engage/",
       "headers": {},
-      "params": {
-        "data": {
-          "$append": {
-            "$transactions": {
-              "$time": "2020-01-24T06:29:02.403Z",
-              "$amount": 45.89
-            }
-          },
-          "$token": "9432f11f70f8ce386f5110c8c924b3ec4f825256",
-          "$distinct_id": "e6ab2c5e-2cda-44a9-a962-e2f67df78bca"
-        }
-      },
+      "params": {},
       "body": {
         "JSON": {},
-        "JSON_ARRAY": {},
+        "JSON_ARRAY": {
+          "batch": "[{\"$append\":{\"$transactions\":{\"$time\":\"2020-01-24T06:29:02.403Z\",\"$amount\":45.89}},\"$token\":\"9432f11f70f8ce386f5110c8c924b3ec4f825256\",\"$distinct_id\":\"e6ab2c5e-2cda-44a9-a962-e2f67df78bca\"}]"
+        },
         "XML": {},
         "FORM": {}
       },
@@ -248,34 +132,12 @@
       "method": "POST",
       "endpoint": "https://api.mixpanel.com/track/",
       "headers": {},
-      "params": {
-        "data": {
-          "event": "test revenue MIXPANEL",
-          "properties": {
-            "currency": "USD",
-            "revenue": 45.89,
-            "city": "Disney",
-            "country": "USA",
-            "email": "mickey@disney.com",
-            "firstName": "Mickey",
-            "ip": "0.0.0.0",
-            "$current_url": "https://docs.rudderstack.com/destinations/mixpanel",
-            "$screen_dpi": 2,
-            "mp_lib": "RudderLabs JavaScript SDK",
-            "$app_build_number": "1.0.0",
-            "$app_version_string": "1.0.5",
-            "$insert_id": "a6a0ad5a-bd26-4f19-8f75-38484e580fc7",
-            "token": "9432f11f70f8ce386f5110c8c924b3ec4f825256",
-            "distinct_id": "e6ab2c5e-2cda-44a9-a962-e2f67df78bca",
-            "time": 1579847342,
-            "$browser": "Chrome",
-            "$browser_version": "79.0.3945.117"
-          }
-        }
-      },
+      "params": {},
       "body": {
         "JSON": {},
-        "JSON_ARRAY": {},
+        "JSON_ARRAY": {
+          "batch": "[{\"event\":\"test revenue MIXPANEL\",\"properties\":{\"currency\":\"USD\",\"revenue\":45.89,\"city\":\"Disney\",\"country\":\"USA\",\"email\":\"mickey@disney.com\",\"firstName\":\"Mickey\",\"ip\":\"0.0.0.0\",\"$current_url\":\"https://docs.rudderstack.com/destinations/mixpanel\",\"$screen_dpi\":2,\"mp_lib\":\"RudderLabs JavaScript SDK\",\"$app_build_number\":\"1.0.0\",\"$app_version_string\":\"1.0.5\",\"$insert_id\":\"a6a0ad5a-bd26-4f19-8f75-38484e580fc7\",\"token\":\"9432f11f70f8ce386f5110c8c924b3ec4f825256\",\"distinct_id\":\"e6ab2c5e-2cda-44a9-a962-e2f67df78bca\",\"time\":1579847342,\"$browser\":\"Chrome\",\"$browser_version\":\"79.0.3945.117\"}}]"
+        },
         "XML": {},
         "FORM": {}
       },
@@ -289,19 +151,12 @@
     "method": "POST",
     "endpoint": "https://api.mixpanel.com/track/",
     "headers": {},
-    "params": {
-      "data": {
-        "event": "$create_alias",
-        "properties": {
-          "distinct_id": "e6ab2c5e-2cda-44a9-a962-e2f67df78bca",
-          "alias": "1234abc",
-          "token": "9432f11f70f8ce386f5110c8c924b3ec4f825256"
-        }
-      }
-    },
+    "params": {},
     "body": {
       "JSON": {},
-      "JSON_ARRAY": {},
+      "JSON_ARRAY": {
+        "batch": "[{\"event\":\"$create_alias\",\"properties\":{\"distinct_id\":\"e6ab2c5e-2cda-44a9-a962-e2f67df78bca\",\"alias\":\"1234abc\",\"token\":\"9432f11f70f8ce386f5110c8c924b3ec4f825256\"}}]"
+      },
       "XML": {},
       "FORM": {}
     },
@@ -315,21 +170,12 @@
       "method": "POST",
       "endpoint": "https://api.mixpanel.com/engage/",
       "headers": {},
-      "params": {
-        "data": {
-          "$append": {
-            "$transactions": {
-              "$time": "2020-01-24T06:29:02.402Z",
-              "$amount": 25
-            }
-          },
-          "$token": "9432f11f70f8ce386f5110c8c924b3ec4f825256",
-          "$distinct_id": "e6ab2c5e-2cda-44a9-a962-e2f67df78bca"
-        }
-      },
+      "params": {},
       "body": {
         "JSON": {},
-        "JSON_ARRAY": {},
+        "JSON_ARRAY": {
+          "batch": "[{\"$append\":{\"$transactions\":{\"$time\":\"2020-01-24T06:29:02.402Z\",\"$amount\":25}},\"$token\":\"9432f11f70f8ce386f5110c8c924b3ec4f825256\",\"$distinct_id\":\"e6ab2c5e-2cda-44a9-a962-e2f67df78bca\"}]"
+        },
         "XML": {},
         "FORM": {}
       },
@@ -342,63 +188,12 @@
       "method": "POST",
       "endpoint": "https://api.mixpanel.com/track/",
       "headers": {},
-      "params": {
-        "data": {
-          "event": "KM Order Completed",
-          "properties": {
-            "affiliation": "Google Store",
-            "checkout_id": "fksdjfsdjfisjf9sdfjsd9f",
-            "coupon": "hasbros",
-            "currency": "USD",
-            "discount": 2.5,
-            "order_id": "50314b8e9bcf000000000000",
-            "products": [
-              {
-                "category": "Games",
-                "image_url": "https:///www.example.com/product/path.jpg",
-                "name": "Monopoly: 3rd Edition",
-                "price": 19,
-                "product_id": "507f1f77bcf86cd799439011",
-                "quantity": 1,
-                "sku": "45790-32",
-                "url": "https://www.example.com/product/path"
-              },
-              {
-                "category": "Games",
-                "name": "Uno Card Game",
-                "price": 3,
-                "product_id": "505bd76785ebb509fc183733",
-                "quantity": 2,
-                "sku": "46493-32"
-              }
-            ],
-            "revenue": 25,
-            "shipping": 3,
-            "subtotal": 22.5,
-            "tax": 2,
-            "total": 27.5,
-            "city": "Disney",
-            "country": "USA",
-            "email": "mickey@disney.com",
-            "firstName": "Mickey",
-            "ip": "0.0.0.0",
-            "$current_url": "https://docs.rudderstack.com/destinations/mixpanel",
-            "$screen_dpi": 2,
-            "mp_lib": "RudderLabs JavaScript SDK",
-            "$app_build_number": "1.0.0",
-            "$app_version_string": "1.0.5",
-            "$insert_id": "aa5f5e44-8756-40ad-ad1e-b0d3b9fa710a",
-            "token": "9432f11f70f8ce386f5110c8c924b3ec4f825256",
-            "distinct_id": "e6ab2c5e-2cda-44a9-a962-e2f67df78bca",
-            "time": 1579847342,
-            "$browser": "Chrome",
-            "$browser_version": "79.0.3945.117"
-          }
-        }
-      },
+      "params": {},
       "body": {
         "JSON": {},
-        "JSON_ARRAY": {},
+        "JSON_ARRAY": {
+          "batch": "[{\"event\":\"KM Order Completed\",\"properties\":{\"affiliation\":\"Google Store\",\"checkout_id\":\"fksdjfsdjfisjf9sdfjsd9f\",\"coupon\":\"hasbros\",\"currency\":\"USD\",\"discount\":2.5,\"order_id\":\"50314b8e9bcf000000000000\",\"products\":[{\"category\":\"Games\",\"image_url\":\"https:///www.example.com/product/path.jpg\",\"name\":\"Monopoly: 3rd Edition\",\"price\":19,\"product_id\":\"507f1f77bcf86cd799439011\",\"quantity\":1,\"sku\":\"45790-32\",\"url\":\"https://www.example.com/product/path\"},{\"category\":\"Games\",\"name\":\"Uno Card Game\",\"price\":3,\"product_id\":\"505bd76785ebb509fc183733\",\"quantity\":2,\"sku\":\"46493-32\"}],\"revenue\":25,\"shipping\":3,\"subtotal\":22.5,\"tax\":2,\"total\":27.5,\"city\":\"Disney\",\"country\":\"USA\",\"email\":\"mickey@disney.com\",\"firstName\":\"Mickey\",\"ip\":\"0.0.0.0\",\"$current_url\":\"https://docs.rudderstack.com/destinations/mixpanel\",\"$screen_dpi\":2,\"mp_lib\":\"RudderLabs JavaScript SDK\",\"$app_build_number\":\"1.0.0\",\"$app_version_string\":\"1.0.5\",\"$insert_id\":\"aa5f5e44-8756-40ad-ad1e-b0d3b9fa710a\",\"token\":\"9432f11f70f8ce386f5110c8c924b3ec4f825256\",\"distinct_id\":\"e6ab2c5e-2cda-44a9-a962-e2f67df78bca\",\"time\":1579847342,\"$browser\":\"Chrome\",\"$browser_version\":\"79.0.3945.117\"}}]"
+        },
         "XML": {},
         "FORM": {}
       },
@@ -413,21 +208,12 @@
       "method": "POST",
       "endpoint": "https://api.mixpanel.com/engage/",
       "headers": {},
-      "params": {
-        "data": {
-          "$append": {
-            "$transactions": {
-              "$time": "2020-01-24T06:29:02.402Z",
-              "$amount": 34
-            }
-          },
-          "$token": "9432f11f70f8ce386f5110c8c924b3ec4f825256",
-          "$distinct_id": "e6ab2c5e-2cda-44a9-a962-e2f67df78bca"
-        }
-      },
+      "params": {},
       "body": {
         "JSON": {},
-        "JSON_ARRAY": {},
+        "JSON_ARRAY": {
+          "batch": "[{\"$append\":{\"$transactions\":{\"$time\":\"2020-01-24T06:29:02.402Z\",\"$amount\":34}},\"$token\":\"9432f11f70f8ce386f5110c8c924b3ec4f825256\",\"$distinct_id\":\"e6ab2c5e-2cda-44a9-a962-e2f67df78bca\"}]"
+        },
         "XML": {},
         "FORM": {}
       },
@@ -440,72 +226,12 @@
       "method": "POST",
       "endpoint": "https://api.mixpanel.com/track/",
       "headers": {},
-      "params": {
-        "data": {
-          "event": "KM Order Completed",
-          "properties": {
-            "affiliation": "Google Store",
-            "checkout_id": "fksdjfsdjfisjf9sdfjsd9f",
-            "coupon": "hasbros",
-            "currency": "USD",
-            "discount": 2.5,
-            "order_id": "50314b8e9bcf000000000000",
-            "revenue": 34,
-            "key_1": {
-              "child_key1": "child_value1",
-              "child_key2": {
-                "child_key21": "child_value21",
-                "child_key22": "child_value22"
-              }
-            },
-            "products": [
-              {
-                "category": "Games",
-                "image_url": "https:///www.example.com/product/path.jpg",
-                "name": "Monopoly: 3rd Edition",
-                "price": 19,
-                "product_id": "507f1f77bcf86cd799439011",
-                "quantity": 1,
-                "sku": "45790-32",
-                "url": "https://www.example.com/product/path"
-              },
-              {
-                "category": "Games",
-                "name": "Uno Card Game",
-                "price": 3,
-                "product_id": "505bd76785ebb509fc183733",
-                "quantity": 2,
-                "sku": "46493-32"
-              }
-            ],
-            "shipping": 3,
-            "subtotal": 22.5,
-            "tax": 2,
-            "total": 27.5,
-            "city": "Disney",
-            "country": "USA",
-            "email": "mickey@disney.com",
-            "first_name": "Mickey",
-            "lastName": "Mouse",
-            "name": "Mickey Mouse",
-            "ip": "0.0.0.0",
-            "$current_url": "https://docs.rudderstack.com/destinations/mixpanel",
-            "$screen_dpi": 2,
-            "mp_lib": "RudderLabs JavaScript SDK",
-            "$app_build_number": "1.0.0",
-            "$app_version_string": "1.0.5",
-            "$insert_id": "aa5f5e44-8756-40ad-ad1e-b0d3b9fa710a",
-            "token": "9432f11f70f8ce386f5110c8c924b3ec4f825256",
-            "distinct_id": "e6ab2c5e-2cda-44a9-a962-e2f67df78bca",
-            "time": 1579847342,
-            "$browser": "Chrome",
-            "$browser_version": "79.0.3945.117"
-          }
-        }
-      },
+      "params": {},
       "body": {
         "JSON": {},
-        "JSON_ARRAY": {},
+        "JSON_ARRAY": {
+          "batch": "[{\"event\":\"KM Order Completed\",\"properties\":{\"affiliation\":\"Google Store\",\"checkout_id\":\"fksdjfsdjfisjf9sdfjsd9f\",\"coupon\":\"hasbros\",\"currency\":\"USD\",\"discount\":2.5,\"order_id\":\"50314b8e9bcf000000000000\",\"revenue\":34,\"key_1\":{\"child_key1\":\"child_value1\",\"child_key2\":{\"child_key21\":\"child_value21\",\"child_key22\":\"child_value22\"}},\"products\":[{\"category\":\"Games\",\"image_url\":\"https:///www.example.com/product/path.jpg\",\"name\":\"Monopoly: 3rd Edition\",\"price\":19,\"product_id\":\"507f1f77bcf86cd799439011\",\"quantity\":1,\"sku\":\"45790-32\",\"url\":\"https://www.example.com/product/path\"},{\"category\":\"Games\",\"name\":\"Uno Card Game\",\"price\":3,\"product_id\":\"505bd76785ebb509fc183733\",\"quantity\":2,\"sku\":\"46493-32\"}],\"shipping\":3,\"subtotal\":22.5,\"tax\":2,\"total\":27.5,\"city\":\"Disney\",\"country\":\"USA\",\"email\":\"mickey@disney.com\",\"first_name\":\"Mickey\",\"lastName\":\"Mouse\",\"name\":\"Mickey Mouse\",\"ip\":\"0.0.0.0\",\"$current_url\":\"https://docs.rudderstack.com/destinations/mixpanel\",\"$screen_dpi\":2,\"mp_lib\":\"RudderLabs JavaScript SDK\",\"$app_build_number\":\"1.0.0\",\"$app_version_string\":\"1.0.5\",\"$insert_id\":\"aa5f5e44-8756-40ad-ad1e-b0d3b9fa710a\",\"token\":\"9432f11f70f8ce386f5110c8c924b3ec4f825256\",\"distinct_id\":\"e6ab2c5e-2cda-44a9-a962-e2f67df78bca\",\"time\":1579847342,\"$browser\":\"Chrome\",\"$browser_version\":\"79.0.3945.117\"}}]"
+        },
         "XML": {},
         "FORM": {}
       },
@@ -520,69 +246,12 @@
       "method": "POST",
       "endpoint": "https://api.mixpanel.com/track/",
       "headers": {},
-      "params": {
-        "data": {
-          "event": " new Order Completed totally",
-          "properties": {
-            "affiliation": "Google Store",
-            "checkout_id": "fksdjfsdjfisjf9sdfjsd9f",
-            "coupon": "hasbros",
-            "currency": "USD",
-            "discount": 2.5,
-            "total": 23,
-            "order_id": "50314b8e9bcf000000000000",
-            "key_1": {
-              "child_key1": "child_value1",
-              "child_key2": {
-                "child_key21": "child_value21",
-                "child_key22": "child_value22"
-              }
-            },
-            "products": [
-              {
-                "category": "Games",
-                "image_url": "https:///www.example.com/product/path.jpg",
-                "name": "Monopoly: 3rd Edition",
-                "price": 19,
-                "product_id": "507f1f77bcf86cd799439011",
-                "quantity": 1,
-                "sku": "45790-32",
-                "url": "https://www.example.com/product/path"
-              },
-              {
-                "category": "Games",
-                "name": "Uno Card Game",
-                "price": 3,
-                "product_id": "505bd76785ebb509fc183733",
-                "quantity": 2,
-                "sku": "46493-32"
-              }
-            ],
-            "shipping": 3,
-            "subtotal": 22.5,
-            "tax": 2,
-            "city": "Disney",
-            "country": "USA",
-            "email": "mickey@disney.com",
-            "firstName": "Mickey",
-            "ip": "0.0.0.0",
-            "$current_url": "https://docs.rudderstack.com/destinations/mixpanel",
-            "$screen_dpi": 2,
-            "mp_lib": "RudderLabs JavaScript SDK",
-            "$app_build_number": "1.0.0",
-            "$app_version_string": "1.0.5",
-            "$insert_id": "aa5f5e44-8756-40ad-ad1e-b0d3b9fa710a",
-            "token": "9432f11f70f8ce386f5110c8c924b3ec4f825256",
-            "distinct_id": "e6ab2c5e-2cda-44a9-a962-e2f67df78bca",
-            "time": 1579847342,
-            "$browser": "Chrome",
-            "$browser_version": "79.0.3945.117"
-          }
-        }
-      },
+      "params": {},
       "body": {
         "JSON": {},
-        "JSON_ARRAY": {},
+        "JSON_ARRAY": {
+          "batch": "[{\"event\":\" new Order Completed totally\",\"properties\":{\"affiliation\":\"Google Store\",\"checkout_id\":\"fksdjfsdjfisjf9sdfjsd9f\",\"coupon\":\"hasbros\",\"currency\":\"USD\",\"discount\":2.5,\"total\":23,\"order_id\":\"50314b8e9bcf000000000000\",\"key_1\":{\"child_key1\":\"child_value1\",\"child_key2\":{\"child_key21\":\"child_value21\",\"child_key22\":\"child_value22\"}},\"products\":[{\"category\":\"Games\",\"image_url\":\"https:///www.example.com/product/path.jpg\",\"name\":\"Monopoly: 3rd Edition\",\"price\":19,\"product_id\":\"507f1f77bcf86cd799439011\",\"quantity\":1,\"sku\":\"45790-32\",\"url\":\"https://www.example.com/product/path\"},{\"category\":\"Games\",\"name\":\"Uno Card Game\",\"price\":3,\"product_id\":\"505bd76785ebb509fc183733\",\"quantity\":2,\"sku\":\"46493-32\"}],\"shipping\":3,\"subtotal\":22.5,\"tax\":2,\"city\":\"Disney\",\"country\":\"USA\",\"email\":\"mickey@disney.com\",\"firstName\":\"Mickey\",\"ip\":\"0.0.0.0\",\"$current_url\":\"https://docs.rudderstack.com/destinations/mixpanel\",\"$screen_dpi\":2,\"mp_lib\":\"RudderLabs JavaScript SDK\",\"$app_build_number\":\"1.0.0\",\"$app_version_string\":\"1.0.5\",\"$insert_id\":\"aa5f5e44-8756-40ad-ad1e-b0d3b9fa710a\",\"token\":\"9432f11f70f8ce386f5110c8c924b3ec4f825256\",\"distinct_id\":\"e6ab2c5e-2cda-44a9-a962-e2f67df78bca\",\"time\":1579847342,\"$browser\":\"Chrome\",\"$browser_version\":\"79.0.3945.117\"}}]"
+        },
         "XML": {},
         "FORM": {}
       },
@@ -597,70 +266,12 @@
       "method": "POST",
       "endpoint": "https://api.mixpanel.com/track/",
       "headers": {},
-      "params": {
-        "data": {
-          "event": " Order Completed ",
-          "properties": {
-            "affiliation": "Google Store",
-            "checkout_id": "fksdjfsdjfisjf9sdfjsd9f",
-            "coupon": "hasbros",
-            "currency": "USD",
-            "discount": 2.5,
-            "total": 23,
-            "order_id": "50314b8e9bcf000000000000",
-            "key_1": {
-              "child_key1": "child_value1",
-              "child_key2": {
-                "child_key21": "child_value21",
-                "child_key22": "child_value22"
-              }
-            },
-            "products": [
-              {
-                "category": "Games",
-                "image_url": "https:///www.example.com/product/path.jpg",
-                "name": "Monopoly: 3rd Edition",
-                "price": 19,
-                "product_id": "507f1f77bcf86cd799439011",
-                "quantity": 1,
-                "sku": "45790-32",
-                "url": "https://www.example.com/product/path"
-              },
-              {
-                "category": "Games",
-                "name": "Uno Card Game",
-                "price": 3,
-                "product_id": "505bd76785ebb509fc183733",
-                "quantity": 2,
-                "sku": "46493-32"
-              }
-            ],
-            "shipping": 3,
-            "subtotal": 22.5,
-            "tax": 2,
-            "Billing Amount": "77",
-            "city": "Disney",
-            "country": "USA",
-            "email": "mickey@disney.com",
-            "firstName": "Mickey",
-            "ip": "0.0.0.0",
-            "$current_url": "https://docs.rudderstack.com/destinations/mixpanel",
-            "$screen_dpi": 2,
-            "mp_lib": "RudderLabs JavaScript SDK",
-            "$app_build_number": "1.0.0",
-            "$app_version_string": "1.0.5",
-            "$insert_id": "aa5f5e44-8756-40ad-ad1e-b0d3b9fa710a",
-            "token": "9432f11f70f8ce386f5110c8c924b3ec4f825256",
-            "distinct_id": "e6ab2c5e-2cda-44a9-a962-e2f67df78bca",
-            "time": 1579847342,
-            "$browser": "Chrome",
-            "$browser_version": "79.0.3945.117"
-          }
-        }
-      },
+      "params": {},
       "body": {
         "JSON": {},
-        "JSON_ARRAY": {},
+        "JSON_ARRAY": {
+          "batch": "[{\"event\":\" Order Completed \",\"properties\":{\"affiliation\":\"Google Store\",\"checkout_id\":\"fksdjfsdjfisjf9sdfjsd9f\",\"coupon\":\"hasbros\",\"currency\":\"USD\",\"discount\":2.5,\"total\":23,\"order_id\":\"50314b8e9bcf000000000000\",\"key_1\":{\"child_key1\":\"child_value1\",\"child_key2\":{\"child_key21\":\"child_value21\",\"child_key22\":\"child_value22\"}},\"products\":[{\"category\":\"Games\",\"image_url\":\"https:///www.example.com/product/path.jpg\",\"name\":\"Monopoly: 3rd Edition\",\"price\":19,\"product_id\":\"507f1f77bcf86cd799439011\",\"quantity\":1,\"sku\":\"45790-32\",\"url\":\"https://www.example.com/product/path\"},{\"category\":\"Games\",\"name\":\"Uno Card Game\",\"price\":3,\"product_id\":\"505bd76785ebb509fc183733\",\"quantity\":2,\"sku\":\"46493-32\"}],\"shipping\":3,\"subtotal\":22.5,\"tax\":2,\"Billing Amount\":\"77\",\"city\":\"Disney\",\"country\":\"USA\",\"email\":\"mickey@disney.com\",\"firstName\":\"Mickey\",\"ip\":\"0.0.0.0\",\"$current_url\":\"https://docs.rudderstack.com/destinations/mixpanel\",\"$screen_dpi\":2,\"mp_lib\":\"RudderLabs JavaScript SDK\",\"$app_build_number\":\"1.0.0\",\"$app_version_string\":\"1.0.5\",\"$insert_id\":\"aa5f5e44-8756-40ad-ad1e-b0d3b9fa710a\",\"token\":\"9432f11f70f8ce386f5110c8c924b3ec4f825256\",\"distinct_id\":\"e6ab2c5e-2cda-44a9-a962-e2f67df78bca\",\"time\":1579847342,\"$browser\":\"Chrome\",\"$browser_version\":\"79.0.3945.117\"}}]"
+        },
         "XML": {},
         "FORM": {}
       },
@@ -678,27 +289,12 @@
     "method": "POST",
     "endpoint": "https://api.mixpanel.com/engage/",
     "headers": {},
-    "params": {
-      "data": {
-        "$set": {
-          "$email": "mickey@disney.com",
-          "$country_code": "USA",
-          "$city": "Disney",
-          "$initial_referrer": "https://docs.rudderstack.com",
-          "$initial_referring_domain": "docs.rudderstack.com",
-          "$firstName": "Mickey",
-          "$browser": "Chrome",
-          "$browser_version": "79.0.3945.117"
-        },
-        "$token": "9432f11f70f8ce386f5110c8c924b3ec4f825256",
-        "$distinct_id": "e6ab2c5e-2cda-44a9-a962-e2f67df78bca",
-        "$ip": "0.0.0.0",
-        "$time": 1579847342
-      }
-    },
+    "params": {},
     "body": {
       "JSON": {},
-      "JSON_ARRAY": {},
+      "JSON_ARRAY": {
+        "batch": "[{\"$set\":{\"$email\":\"mickey@disney.com\",\"$country_code\":\"USA\",\"$city\":\"Disney\",\"$initial_referrer\":\"https://docs.rudderstack.com\",\"$initial_referring_domain\":\"docs.rudderstack.com\",\"$firstName\":\"Mickey\",\"$browser\":\"Chrome\",\"$browser_version\":\"79.0.3945.117\"},\"$token\":\"9432f11f70f8ce386f5110c8c924b3ec4f825256\",\"$distinct_id\":\"e6ab2c5e-2cda-44a9-a962-e2f67df78bca\",\"$ip\":\"0.0.0.0\",\"$time\":1579847342}]"
+      },
       "XML": {},
       "FORM": {}
     },
@@ -712,19 +308,12 @@
       "method": "POST",
       "endpoint": "https://api.mixpanel.com/engage/",
       "headers": {},
-      "params": {
-        "data": {
-          "$token": "9432f11f70f8ce386f5110c8c924b3ec4f825256",
-          "$distinct_id": "hjikl",
-          "$set": {
-            "company": ["testComp"]
-          },
-          "$ip": "0.0.0.0"
-        }
-      },
+      "params": {},
       "body": {
         "JSON": {},
-        "JSON_ARRAY": {},
+        "JSON_ARRAY": {
+          "batch": "[{\"$token\":\"9432f11f70f8ce386f5110c8c924b3ec4f825256\",\"$distinct_id\":\"hjikl\",\"$set\":{\"company\":[\"testComp\"]},\"$ip\":\"0.0.0.0\"}]"
+        },
         "XML": {},
         "FORM": {}
       },
@@ -737,19 +326,12 @@
       "method": "POST",
       "endpoint": "https://api.mixpanel.com/groups/",
       "headers": {},
-      "params": {
-        "data": {
-          "$token": "9432f11f70f8ce386f5110c8c924b3ec4f825256",
-          "$group_key": "company",
-          "$group_id": "testComp",
-          "$set": {
-            "company": "testComp"
-          }
-        }
-      },
+      "params": {},
       "body": {
         "JSON": {},
-        "JSON_ARRAY": {},
+        "JSON_ARRAY": {
+          "batch": "[{\"$token\":\"9432f11f70f8ce386f5110c8c924b3ec4f825256\",\"$group_key\":\"company\",\"$group_id\":\"testComp\",\"$set\":{\"company\":\"testComp\"}}]"
+        },
         "XML": {},
         "FORM": {}
       },
@@ -764,19 +346,12 @@
       "method": "POST",
       "endpoint": "https://api.mixpanel.com/engage/",
       "headers": {},
-      "params": {
-        "data": {
-          "$token": "9432f11f70f8ce386f5110c8c924b3ec4f825256",
-          "$distinct_id": "hjikl",
-          "$set": {
-            "company": ["testComp", "testComp1"]
-          },
-          "$ip": "0.0.0.0"
-        }
-      },
+      "params": {},
       "body": {
         "JSON": {},
-        "JSON_ARRAY": {},
+        "JSON_ARRAY": {
+          "batch": "[{\"$token\":\"9432f11f70f8ce386f5110c8c924b3ec4f825256\",\"$distinct_id\":\"hjikl\",\"$set\":{\"company\":[\"testComp\",\"testComp1\"]},\"$ip\":\"0.0.0.0\"}]"
+        },
         "XML": {},
         "FORM": {}
       },
@@ -789,19 +364,12 @@
       "method": "POST",
       "endpoint": "https://api.mixpanel.com/groups/",
       "headers": {},
-      "params": {
-        "data": {
-          "$token": "9432f11f70f8ce386f5110c8c924b3ec4f825256",
-          "$group_key": "company",
-          "$group_id": "testComp",
-          "$set": {
-            "company": ["testComp", "testComp1"]
-          }
-        }
-      },
+      "params": {},
       "body": {
         "JSON": {},
-        "JSON_ARRAY": {},
+        "JSON_ARRAY": {
+          "batch": "[{\"$token\":\"9432f11f70f8ce386f5110c8c924b3ec4f825256\",\"$group_key\":\"company\",\"$group_id\":\"testComp\",\"$set\":{\"company\":[\"testComp\",\"testComp1\"]}}]"
+        },
         "XML": {},
         "FORM": {}
       },
@@ -814,19 +382,12 @@
       "method": "POST",
       "endpoint": "https://api.mixpanel.com/groups/",
       "headers": {},
-      "params": {
-        "data": {
-          "$token": "9432f11f70f8ce386f5110c8c924b3ec4f825256",
-          "$group_key": "company",
-          "$group_id": "testComp1",
-          "$set": {
-            "company": ["testComp", "testComp1"]
-          }
-        }
-      },
+      "params": {},
       "body": {
         "JSON": {},
-        "JSON_ARRAY": {},
+        "JSON_ARRAY": {
+          "batch": "[{\"$token\":\"9432f11f70f8ce386f5110c8c924b3ec4f825256\",\"$group_key\":\"company\",\"$group_id\":\"testComp1\",\"$set\":{\"company\":[\"testComp\",\"testComp1\"]}}]"
+        },
         "XML": {},
         "FORM": {}
       },
@@ -841,19 +402,12 @@
       "method": "POST",
       "endpoint": "https://api-eu.mixpanel.com/engage/",
       "headers": {},
-      "params": {
-        "data": {
-          "$token": "9432f11f70f8ce386f5110c8c924b3ec4f825256",
-          "$distinct_id": "hjikl",
-          "$set": {
-            "company": ["testComp"]
-          },
-          "$ip": "0.0.0.0"
-        }
-      },
+      "params": {},
       "body": {
         "JSON": {},
-        "JSON_ARRAY": {},
+        "JSON_ARRAY": {
+          "batch": "[{\"$token\":\"9432f11f70f8ce386f5110c8c924b3ec4f825256\",\"$distinct_id\":\"hjikl\",\"$set\":{\"company\":[\"testComp\"]},\"$ip\":\"0.0.0.0\"}]"
+        },
         "XML": {},
         "FORM": {}
       },
@@ -866,19 +420,12 @@
       "method": "POST",
       "endpoint": "https://api-eu.mixpanel.com/groups/",
       "headers": {},
-      "params": {
-        "data": {
-          "$token": "9432f11f70f8ce386f5110c8c924b3ec4f825256",
-          "$group_key": "company",
-          "$group_id": "testComp",
-          "$set": {
-            "company": "testComp"
-          }
-        }
-      },
+      "params": {},
       "body": {
         "JSON": {},
-        "JSON_ARRAY": {},
+        "JSON_ARRAY": {
+          "batch": "[{\"$token\":\"9432f11f70f8ce386f5110c8c924b3ec4f825256\",\"$group_key\":\"company\",\"$group_id\":\"testComp\",\"$set\":{\"company\":\"testComp\"}}]"
+        },
         "XML": {},
         "FORM": {}
       },
@@ -893,21 +440,12 @@
       "method": "POST",
       "endpoint": "https://api-eu.mixpanel.com/engage/",
       "headers": {},
-      "params": {
-        "data": {
-          "$append": {
-            "$transactions": {
-              "$time": "2020-01-24T06:29:02.402Z",
-              "$amount": 25
-            }
-          },
-          "$token": "9432f11f70f8ce386f5110c8c924b3ec4f825256",
-          "$distinct_id": "e6ab2c5e-2cda-44a9-a962-e2f67df78bca"
-        }
-      },
+      "params": {},
       "body": {
         "JSON": {},
-        "JSON_ARRAY": {},
+        "JSON_ARRAY": {
+          "batch": "[{\"$append\":{\"$transactions\":{\"$time\":\"2020-01-24T06:29:02.402Z\",\"$amount\":25}},\"$token\":\"9432f11f70f8ce386f5110c8c924b3ec4f825256\",\"$distinct_id\":\"e6ab2c5e-2cda-44a9-a962-e2f67df78bca\"}]"
+        },
         "XML": {},
         "FORM": {}
       },
@@ -920,64 +458,12 @@
       "method": "POST",
       "endpoint": "https://api-eu.mixpanel.com/track/",
       "headers": {},
-      "params": {
-        "data": {
-          "event": "KM Order Completed",
-          "properties": {
-            "affiliation": "Google Store",
-            "checkout_id": "fksdjfsdjfisjf9sdfjsd9f",
-            "coupon": "hasbros",
-            "currency": "USD",
-            "discount": 2.5,
-            "order_id": "50314b8e9bcf000000000000",
-            "products": [
-              {
-                "category": "Games",
-                "image_url": "https:///www.example.com/product/path.jpg",
-                "name": "Monopoly: 3rd Edition",
-                "price": 19,
-                "product_id": "507f1f77bcf86cd799439011",
-                "quantity": 1,
-                "sku": "45790-32",
-                "url": "https://www.example.com/product/path"
-              },
-              {
-                "category": "Games",
-                "name": "Uno Card Game",
-                "price": 3,
-                "product_id": "505bd76785ebb509fc183733",
-                "quantity": 2,
-                "sku": "46493-32"
-              }
-            ],
-            "revenue": 25,
-            "shipping": 3,
-            "subtotal": 22.5,
-            "tax": 2,
-            "total": 27.5,
-            "city": "Disney",
-            "country": "USA",
-            "email": "mickey@disney.com",
-            "firstname": "Mickey",
-            "lastname": "Mouse",
-            "ip": "0.0.0.0",
-            "$current_url": "https://docs.rudderstack.com/destinations/mixpanel",
-            "$screen_dpi": 2,
-            "mp_lib": "RudderLabs JavaScript SDK",
-            "$app_build_number": "1.0.0",
-            "$app_version_string": "1.0.5",
-            "$insert_id": "aa5f5e44-8756-40ad-ad1e-b0d3b9fa710a",
-            "token": "9432f11f70f8ce386f5110c8c924b3ec4f825256",
-            "distinct_id": "e6ab2c5e-2cda-44a9-a962-e2f67df78bca",
-            "time": 1579847342,
-            "$browser": "Chrome",
-            "$browser_version": "79.0.3945.117"
-          }
-        }
-      },
+      "params": {},
       "body": {
         "JSON": {},
-        "JSON_ARRAY": {},
+        "JSON_ARRAY": {
+          "batch": "[{\"event\":\"KM Order Completed\",\"properties\":{\"affiliation\":\"Google Store\",\"checkout_id\":\"fksdjfsdjfisjf9sdfjsd9f\",\"coupon\":\"hasbros\",\"currency\":\"USD\",\"discount\":2.5,\"order_id\":\"50314b8e9bcf000000000000\",\"products\":[{\"category\":\"Games\",\"image_url\":\"https:///www.example.com/product/path.jpg\",\"name\":\"Monopoly: 3rd Edition\",\"price\":19,\"product_id\":\"507f1f77bcf86cd799439011\",\"quantity\":1,\"sku\":\"45790-32\",\"url\":\"https://www.example.com/product/path\"},{\"category\":\"Games\",\"name\":\"Uno Card Game\",\"price\":3,\"product_id\":\"505bd76785ebb509fc183733\",\"quantity\":2,\"sku\":\"46493-32\"}],\"revenue\":25,\"shipping\":3,\"subtotal\":22.5,\"tax\":2,\"total\":27.5,\"city\":\"Disney\",\"country\":\"USA\",\"email\":\"mickey@disney.com\",\"firstname\":\"Mickey\",\"lastname\":\"Mouse\",\"ip\":\"0.0.0.0\",\"$current_url\":\"https://docs.rudderstack.com/destinations/mixpanel\",\"$screen_dpi\":2,\"mp_lib\":\"RudderLabs JavaScript SDK\",\"$app_build_number\":\"1.0.0\",\"$app_version_string\":\"1.0.5\",\"$insert_id\":\"aa5f5e44-8756-40ad-ad1e-b0d3b9fa710a\",\"token\":\"9432f11f70f8ce386f5110c8c924b3ec4f825256\",\"distinct_id\":\"e6ab2c5e-2cda-44a9-a962-e2f67df78bca\",\"time\":1579847342,\"$browser\":\"Chrome\",\"$browser_version\":\"79.0.3945.117\"}}]"
+        },
         "XML": {},
         "FORM": {}
       },
@@ -991,33 +477,12 @@
     "method": "POST",
     "endpoint": "https://api-eu.mixpanel.com/engage/",
     "headers": {},
-    "params": {
-      "data": {
-        "$set": {
-          "$carrier": "Android",
-          "$manufacturer": "Google",
-          "$model": "Android SDK built for x86",
-          "$screen_height": 1794,
-          "$screen_width": 1080,
-          "$wifi": true,
-          "anonymousId": "5094f5704b9cf2b3",
-          "$android_devices": ["test_device_token"],
-          "$os": "Android",
-          "$android_model": "Android SDK built for x86",
-          "$android_os_version": "8.1.0",
-          "$android_manufacturer": "Google",
-          "$android_app_version": "1.0",
-          "$android_app_version_code": "1.0",
-          "$android_brand": "Google"
-        },
-        "$token": "9432f11f70f8ce386f5110c8c924b3ec4f825256",
-        "$distinct_id": "5094f5704b9cf2b3",
-        "$time": null
-      }
-    },
+    "params": {},
     "body": {
       "JSON": {},
-      "JSON_ARRAY": {},
+      "JSON_ARRAY": {
+        "batch": "[{\"$set\":{\"$carrier\":\"Android\",\"$manufacturer\":\"Google\",\"$model\":\"Android SDK built for x86\",\"$screen_height\":1794,\"$screen_width\":1080,\"$wifi\":true,\"anonymousId\":\"5094f5704b9cf2b3\",\"$android_devices\":[\"test_device_token\"],\"$os\":\"Android\",\"$android_model\":\"Android SDK built for x86\",\"$android_os_version\":\"8.1.0\",\"$android_manufacturer\":\"Google\",\"$android_app_version\":\"1.0\",\"$android_app_version_code\":\"1.0\",\"$android_brand\":\"Google\"},\"$token\":\"9432f11f70f8ce386f5110c8c924b3ec4f825256\",\"$distinct_id\":\"5094f5704b9cf2b3\",\"$time\":null}]"
+      },
       "XML": {},
       "FORM": {}
     },
@@ -1030,20 +495,15 @@
     "method": "POST",
     "endpoint": "https://api-eu.mixpanel.com/import/",
     "headers": {
-      "Authorization": "Basic c29tZV9hcGlfc2VjcmV0Og=="
+      "Authorization": "Basic c29tZV9hcGlfc2VjcmV0Og==",
+      "Content-Type": "application/json"
     },
-    "params": {
-      "data": {
-        "event": "$merge",
-        "properties": {
-          "$distinct_ids": ["test_user_id", "5094f5704b9cf2b3"],
-          "token": "9432f11f70f8ce386f5110c8c924b3ec4f825256"
-        }
-      }
-    },
+    "params": { "strict": 0 },
     "body": {
       "JSON": {},
-      "JSON_ARRAY": {},
+      "JSON_ARRAY": {
+        "batch": "[{\"event\":\"$merge\",\"properties\":{\"$distinct_ids\":[\"test_user_id\",\"5094f5704b9cf2b3\"],\"token\":\"9432f11f70f8ce386f5110c8c924b3ec4f825256\"}}]"
+      },
       "XML": {},
       "FORM": {}
     },
@@ -1056,35 +516,12 @@
     "method": "POST",
     "endpoint": "https://api.mixpanel.com/track/",
     "headers": {},
-    "params": {
-      "data": {
-        "event": "Loaded a Page",
-        "properties": {
-          "path": "/tests/html/index2.html",
-          "referrer": "",
-          "search": "",
-          "title": "",
-          "url": "http://localhost/tests/html/index2.html",
-          "category": "communication",
-          "ip": "0.0.0.0",
-          "$current_url": "https://docs.rudderstack.com/destinations/mixpanel",
-          "$screen_dpi": 2,
-          "mp_lib": "RudderLabs JavaScript SDK",
-          "$app_build_number": "1.0.0",
-          "$app_version_string": "1.0.5",
-          "$insert_id": "dd266c67-9199-4a52-ba32-f46ddde67312",
-          "token": "9432f11f70f8ce386f5110c8c924b3ec4f825256",
-          "distinct_id": "e6ab2c5e-2cda-44a9-a962-e2f67df78bca",
-          "time": 1579847342,
-          "name": "Contact Us",
-          "$browser": "Chrome",
-          "$browser_version": "79.0.3945.117"
-        }
-      }
-    },
+    "params": {},
     "body": {
       "JSON": {},
-      "JSON_ARRAY": {},
+      "JSON_ARRAY": {
+        "batch": "[{\"event\":\"Loaded a Page\",\"properties\":{\"path\":\"/tests/html/index2.html\",\"referrer\":\"\",\"search\":\"\",\"title\":\"\",\"url\":\"http://localhost/tests/html/index2.html\",\"category\":\"communication\",\"ip\":\"0.0.0.0\",\"$current_url\":\"https://docs.rudderstack.com/destinations/mixpanel\",\"$screen_dpi\":2,\"mp_lib\":\"RudderLabs JavaScript SDK\",\"$app_build_number\":\"1.0.0\",\"$app_version_string\":\"1.0.5\",\"$insert_id\":\"dd266c67-9199-4a52-ba32-f46ddde67312\",\"token\":\"9432f11f70f8ce386f5110c8c924b3ec4f825256\",\"distinct_id\":\"e6ab2c5e-2cda-44a9-a962-e2f67df78bca\",\"time\":1579847342,\"name\":\"Contact Us\",\"$browser\":\"Chrome\",\"$browser_version\":\"79.0.3945.117\"}}]"
+      },
       "XML": {},
       "FORM": {}
     },
@@ -1097,19 +534,12 @@
     "method": "POST",
     "endpoint": "https://api.mixpanel.com/track/",
     "headers": {},
-    "params": {
-      "data": {
-        "event": "$create_alias",
-        "properties": {
-          "distinct_id": "e6ab2c5e-2cda-44a9-a962-e2f67df78bca",
-          "alias": "1234abc",
-          "token": "9432f11f70f8ce386f5110c8c924b3ec4f825256"
-        }
-      }
-    },
+    "params": {},
     "body": {
       "JSON": {},
-      "JSON_ARRAY": {},
+      "JSON_ARRAY": {
+        "batch": "[{\"event\":\"$create_alias\",\"properties\":{\"distinct_id\":\"e6ab2c5e-2cda-44a9-a962-e2f67df78bca\",\"alias\":\"1234abc\",\"token\":\"9432f11f70f8ce386f5110c8c924b3ec4f825256\"}}]"
+      },
       "XML": {},
       "FORM": {}
     },
@@ -1122,20 +552,15 @@
     "method": "POST",
     "endpoint": "https://api-eu.mixpanel.com/import/",
     "headers": {
-      "Authorization": "Basic c29tZV9hcGlfc2VjcmV0Og=="
+      "Authorization": "Basic c29tZV9hcGlfc2VjcmV0Og==",
+      "Content-Type": "application/json"
     },
-    "params": {
-      "data": {
-        "event": "$merge",
-        "properties": {
-          "$distinct_ids": ["test_user_id", "5094f5704b9cf2b3"],
-          "token": "9432f11f70f8ce386f5110c8c924b3ec4f825256"
-        }
-      }
-    },
+    "params": { "strict": 0 },
     "body": {
       "JSON": {},
-      "JSON_ARRAY": {},
+      "JSON_ARRAY": {
+        "batch": "[{\"event\":\"$merge\",\"properties\":{\"$distinct_ids\":[\"test_user_id\",\"5094f5704b9cf2b3\"],\"token\":\"9432f11f70f8ce386f5110c8c924b3ec4f825256\"}}]"
+      },
       "XML": {},
       "FORM": {}
     },
@@ -1148,29 +573,12 @@
     "method": "POST",
     "endpoint": "https://api.mixpanel.com/engage/",
     "headers": {},
-    "params": {
-      "data": {
-        "$set": {
-          "$email": "mickey@disney.com",
-          "$country_code": "USA",
-          "$city": "Disney",
-          "$initial_referrer": "https://docs.rudderstack.com",
-          "$initial_referring_domain": "docs.rudderstack.com",
-          "$name": "Mickey Mouse",
-          "$firstName": "Mickey",
-          "$lastName": "Mouse",
-          "$browser": "Chrome",
-          "$browser_version": "79.0.3945.117"
-        },
-        "$token": "9432f11f70f8ce386f5110c8c924b3ec4f825256",
-        "$distinct_id": "e6ab2c5e-2cda-44a9-a962-e2f67df78bca",
-        "$ip": "0.0.0.0",
-        "$time": 1579847342
-      }
-    },
+    "params": {},
     "body": {
       "JSON": {},
-      "JSON_ARRAY": {},
+      "JSON_ARRAY": {
+        "batch": "[{\"$set\":{\"$email\":\"mickey@disney.com\",\"$country_code\":\"USA\",\"$city\":\"Disney\",\"$initial_referrer\":\"https://docs.rudderstack.com\",\"$initial_referring_domain\":\"docs.rudderstack.com\",\"$name\":\"Mickey Mouse\",\"$firstName\":\"Mickey\",\"$lastName\":\"Mouse\",\"$browser\":\"Chrome\",\"$browser_version\":\"79.0.3945.117\"},\"$token\":\"9432f11f70f8ce386f5110c8c924b3ec4f825256\",\"$distinct_id\":\"e6ab2c5e-2cda-44a9-a962-e2f67df78bca\",\"$ip\":\"0.0.0.0\",\"$time\":1579847342}]"
+      },
       "XML": {},
       "FORM": {}
     },
@@ -1183,27 +591,12 @@
     "method": "POST",
     "endpoint": "https://api.mixpanel.com/engage/",
     "headers": {},
-    "params": {
-      "data": {
-        "$set": {
-          "$email": "mickey@disney.com",
-          "$country_code": "USA",
-          "$city": "Disney",
-          "$initial_referrer": "https://docs.rudderstack.com",
-          "$initial_referring_domain": "docs.rudderstack.com",
-          "$firstName": "Mickey",
-          "$browser": "Chrome",
-          "$browser_version": "79.0.3945.117"
-        },
-        "$token": "9432f11f70f8ce386f5110c8c924b3ec4f825256",
-        "$distinct_id": "e6ab2c5e-2cda-44a9-a962-e2f67df78bca",
-        "$ip": "0.0.0.0",
-        "$time": 1579847342
-      }
-    },
+    "params": {},
     "body": {
       "JSON": {},
-      "JSON_ARRAY": {},
+      "JSON_ARRAY": {
+        "batch": "[{\"$set\":{\"$email\":\"mickey@disney.com\",\"$country_code\":\"USA\",\"$city\":\"Disney\",\"$initial_referrer\":\"https://docs.rudderstack.com\",\"$initial_referring_domain\":\"docs.rudderstack.com\",\"$firstName\":\"Mickey\",\"$browser\":\"Chrome\",\"$browser_version\":\"79.0.3945.117\"},\"$token\":\"9432f11f70f8ce386f5110c8c924b3ec4f825256\",\"$distinct_id\":\"e6ab2c5e-2cda-44a9-a962-e2f67df78bca\",\"$ip\":\"0.0.0.0\",\"$time\":1579847342}]"
+      },
       "XML": {},
       "FORM": {}
     },
@@ -1216,30 +609,12 @@
     "method": "POST",
     "endpoint": "https://api.mixpanel.com/engage/",
     "headers": {},
-    "params": {
-      "data": {
-        "$set": {
-          "$email": "mickey@disney.com",
-          "$name": "Mickey Mouse",
-          "$country_code": "USA",
-          "$city": "Disney",
-          "$region": "US",
-          "$initial_referrer": "https://docs.rudderstack.com",
-          "$initial_referring_domain": "docs.rudderstack.com",
-          "$firstName": "Mickey",
-          "$lastName": "Mouse",
-          "$browser": "Chrome",
-          "$browser_version": "79.0.3945.117"
-        },
-        "$token": "9432f11f70f8ce386f5110c8c924b3ec4f825256",
-        "$distinct_id": "e6ab2c5e-2cda-44a9-a962-e2f67df78bca",
-        "$ip": "0.0.0.0",
-        "$time": 1579847342
-      }
-    },
+    "params": {},
     "body": {
       "JSON": {},
-      "JSON_ARRAY": {},
+      "JSON_ARRAY": {
+        "batch": "[{\"$set\":{\"$email\":\"mickey@disney.com\",\"$name\":\"Mickey Mouse\",\"$country_code\":\"USA\",\"$city\":\"Disney\",\"$region\":\"US\",\"$initial_referrer\":\"https://docs.rudderstack.com\",\"$initial_referring_domain\":\"docs.rudderstack.com\",\"$firstName\":\"Mickey\",\"$lastName\":\"Mouse\",\"$browser\":\"Chrome\",\"$browser_version\":\"79.0.3945.117\"},\"$token\":\"9432f11f70f8ce386f5110c8c924b3ec4f825256\",\"$distinct_id\":\"e6ab2c5e-2cda-44a9-a962-e2f67df78bca\",\"$ip\":\"0.0.0.0\",\"$time\":1579847342}]"
+      },
       "XML": {},
       "FORM": {}
     },
@@ -1252,29 +627,12 @@
     "method": "POST",
     "endpoint": "https://api.mixpanel.com/engage/",
     "headers": {},
-    "params": {
-      "data": {
-        "$set": {
-          "$email": "mickey@disney.com",
-          "$country_code": "USA",
-          "$city": "Disney",
-          "$initial_referrer": "https://docs.rudderstack.com",
-          "$initial_referring_domain": "docs.rudderstack.com",
-          "$name": "Mickey Mouse",
-          "$firstName": "Mickey",
-          "$lastName": "Mouse",
-          "$browser": "Chrome",
-          "$browser_version": "79.0.3945.117"
-        },
-        "$token": "9432f11f70f8ce386f5110c8c924b3ec4f825256",
-        "$distinct_id": "e6ab2c5e-2cda-44a9-a962-e2f67df78bca",
-        "$ip": "0.0.0.0",
-        "$time": 1579847342
-      }
-    },
+    "params": {},
     "body": {
       "JSON": {},
-      "JSON_ARRAY": {},
+      "JSON_ARRAY": {
+        "batch": "[{\"$set\":{\"$email\":\"mickey@disney.com\",\"$country_code\":\"USA\",\"$city\":\"Disney\",\"$initial_referrer\":\"https://docs.rudderstack.com\",\"$initial_referring_domain\":\"docs.rudderstack.com\",\"$name\":\"Mickey Mouse\",\"$firstName\":\"Mickey\",\"$lastName\":\"Mouse\",\"$browser\":\"Chrome\",\"$browser_version\":\"79.0.3945.117\"},\"$token\":\"9432f11f70f8ce386f5110c8c924b3ec4f825256\",\"$distinct_id\":\"e6ab2c5e-2cda-44a9-a962-e2f67df78bca\",\"$ip\":\"0.0.0.0\",\"$time\":1579847342}]"
+      },
       "XML": {},
       "FORM": {}
     },
@@ -1287,29 +645,12 @@
     "method": "POST",
     "endpoint": "https://api.mixpanel.com/engage/",
     "headers": {},
-    "params": {
-      "data": {
-        "$set": {
-          "$email": "mickey@disney.com",
-          "$name": "Mouse",
-          "$country_code": "USA",
-          "$city": "Disney",
-          "$initial_referrer": "https://docs.rudderstack.com",
-          "$initial_referring_domain": "docs.rudderstack.com",
-          "$firstName": "Mickey",
-          "$lastName": "Mouse",
-          "$browser": "Chrome",
-          "$browser_version": "79.0.3945.117"
-        },
-        "$token": "9432f11f70f8ce386f5110c8c924b3ec4f825256",
-        "$distinct_id": "e6ab2c5e-2cda-44a9-a962-e2f67df78bca",
-        "$ip": "0.0.0.0",
-        "$time": 1579847342
-      }
-    },
+    "params": {},
     "body": {
       "JSON": {},
-      "JSON_ARRAY": {},
+      "JSON_ARRAY": {
+        "batch": "[{\"$set\":{\"$email\":\"mickey@disney.com\",\"$name\":\"Mouse\",\"$country_code\":\"USA\",\"$city\":\"Disney\",\"$initial_referrer\":\"https://docs.rudderstack.com\",\"$initial_referring_domain\":\"docs.rudderstack.com\",\"$firstName\":\"Mickey\",\"$lastName\":\"Mouse\",\"$browser\":\"Chrome\",\"$browser_version\":\"79.0.3945.117\"},\"$token\":\"9432f11f70f8ce386f5110c8c924b3ec4f825256\",\"$distinct_id\":\"e6ab2c5e-2cda-44a9-a962-e2f67df78bca\",\"$ip\":\"0.0.0.0\",\"$time\":1579847342}]"
+      },
       "XML": {},
       "FORM": {}
     },
@@ -1322,29 +663,12 @@
     "method": "POST",
     "endpoint": "https://api.mixpanel.com/engage/",
     "headers": {},
-    "params": {
-      "data": {
-        "$set": {
-          "$email": "mickey@disney.com",
-          "$first_name": "Mickey",
-          "$last_name": "Mouse",
-          "$country_code": "USA",
-          "$city": "Disney",
-          "$initial_referrer": "https://docs.rudderstack.com",
-          "$initial_referring_domain": "docs.rudderstack.com",
-          "$name": "Mickey Mouse",
-          "$browser": "Chrome",
-          "$browser_version": "79.0.3945.117"
-        },
-        "$token": "9432f11f70f8ce386f5110c8c924b3ec4f825256",
-        "$distinct_id": "e6ab2c5e-2cda-44a9-a962-e2f67df78bca",
-        "$ip": "0.0.0.0",
-        "$time": 1579847342
-      }
-    },
+    "params": {},
     "body": {
       "JSON": {},
-      "JSON_ARRAY": {},
+      "JSON_ARRAY": {
+        "batch": "[{\"$set\":{\"$email\":\"mickey@disney.com\",\"$first_name\":\"Mickey\",\"$last_name\":\"Mouse\",\"$country_code\":\"USA\",\"$city\":\"Disney\",\"$initial_referrer\":\"https://docs.rudderstack.com\",\"$initial_referring_domain\":\"docs.rudderstack.com\",\"$name\":\"Mickey Mouse\",\"$browser\":\"Chrome\",\"$browser_version\":\"79.0.3945.117\"},\"$token\":\"9432f11f70f8ce386f5110c8c924b3ec4f825256\",\"$distinct_id\":\"e6ab2c5e-2cda-44a9-a962-e2f67df78bca\",\"$ip\":\"0.0.0.0\",\"$time\":1579847342}]"
+      },
       "XML": {},
       "FORM": {}
     },
@@ -1357,27 +681,12 @@
     "method": "POST",
     "endpoint": "https://api.mixpanel.com/engage/",
     "headers": {},
-    "params": {
-      "data": {
-        "$set": {
-          "$email": "mickey@disney.com",
-          "$first_name": "Mickey",
-          "$country_code": "USA",
-          "$city": "Disney",
-          "$initial_referrer": "https://docs.rudderstack.com",
-          "$initial_referring_domain": "docs.rudderstack.com",
-          "$browser": "Chrome",
-          "$browser_version": "79.0.3945.117"
-        },
-        "$token": "9432f11f70f8ce386f5110c8c924b3ec4f825256",
-        "$distinct_id": "e6ab2c5e-2cda-44a9-a962-e2f67df78bca",
-        "$ip": "0.0.0.0",
-        "$time": 1579847342
-      }
-    },
+    "params": {},
     "body": {
       "JSON": {},
-      "JSON_ARRAY": {},
+      "JSON_ARRAY": {
+        "batch": "[{\"$set\":{\"$email\":\"mickey@disney.com\",\"$first_name\":\"Mickey\",\"$country_code\":\"USA\",\"$city\":\"Disney\",\"$initial_referrer\":\"https://docs.rudderstack.com\",\"$initial_referring_domain\":\"docs.rudderstack.com\",\"$browser\":\"Chrome\",\"$browser_version\":\"79.0.3945.117\"},\"$token\":\"9432f11f70f8ce386f5110c8c924b3ec4f825256\",\"$distinct_id\":\"e6ab2c5e-2cda-44a9-a962-e2f67df78bca\",\"$ip\":\"0.0.0.0\",\"$time\":1579847342}]"
+      },
       "XML": {},
       "FORM": {}
     },
@@ -1390,30 +699,12 @@
     "method": "POST",
     "endpoint": "https://api.mixpanel.com/engage/",
     "headers": {},
-    "params": {
-      "data": {
-        "$set": {
-          "$email": "mickey@disney.com",
-          "$first_name": "Mickey",
-          "$last_name": "Mouse",
-          "$name": "Mickey Mouse",
-          "$country_code": "USA",
-          "$city": "Disney",
-          "$region": "US",
-          "$initial_referrer": "https://docs.rudderstack.com",
-          "$initial_referring_domain": "docs.rudderstack.com",
-          "$browser": "Chrome",
-          "$browser_version": "79.0.3945.117"
-        },
-        "$token": "9432f11f70f8ce386f5110c8c924b3ec4f825256",
-        "$distinct_id": "e6ab2c5e-2cda-44a9-a962-e2f67df78bca",
-        "$ip": "0.0.0.0",
-        "$time": 1579847342
-      }
-    },
+    "params": {},
     "body": {
       "JSON": {},
-      "JSON_ARRAY": {},
+      "JSON_ARRAY": {
+        "batch": "[{\"$set\":{\"$email\":\"mickey@disney.com\",\"$first_name\":\"Mickey\",\"$last_name\":\"Mouse\",\"$name\":\"Mickey Mouse\",\"$country_code\":\"USA\",\"$city\":\"Disney\",\"$region\":\"US\",\"$initial_referrer\":\"https://docs.rudderstack.com\",\"$initial_referring_domain\":\"docs.rudderstack.com\",\"$browser\":\"Chrome\",\"$browser_version\":\"79.0.3945.117\"},\"$token\":\"9432f11f70f8ce386f5110c8c924b3ec4f825256\",\"$distinct_id\":\"e6ab2c5e-2cda-44a9-a962-e2f67df78bca\",\"$ip\":\"0.0.0.0\",\"$time\":1579847342}]"
+      },
       "XML": {},
       "FORM": {}
     },
@@ -1426,29 +717,12 @@
     "method": "POST",
     "endpoint": "https://api.mixpanel.com/engage/",
     "headers": {},
-    "params": {
-      "data": {
-        "$set": {
-          "$email": "mickey@disney.com",
-          "$first_name": "Mickey",
-          "$last_name": "Mouse",
-          "$country_code": "USA",
-          "$city": "Disney",
-          "$initial_referrer": "https://docs.rudderstack.com",
-          "$initial_referring_domain": "docs.rudderstack.com",
-          "$name": "Mickey Mouse",
-          "$browser": "Chrome",
-          "$browser_version": "79.0.3945.117"
-        },
-        "$token": "9432f11f70f8ce386f5110c8c924b3ec4f825256",
-        "$distinct_id": "e6ab2c5e-2cda-44a9-a962-e2f67df78bca",
-        "$ip": "0.0.0.0",
-        "$time": 1579847342
-      }
-    },
+    "params": {},
     "body": {
       "JSON": {},
-      "JSON_ARRAY": {},
+      "JSON_ARRAY": {
+        "batch": "[{\"$set\":{\"$email\":\"mickey@disney.com\",\"$first_name\":\"Mickey\",\"$last_name\":\"Mouse\",\"$country_code\":\"USA\",\"$city\":\"Disney\",\"$initial_referrer\":\"https://docs.rudderstack.com\",\"$initial_referring_domain\":\"docs.rudderstack.com\",\"$name\":\"Mickey Mouse\",\"$browser\":\"Chrome\",\"$browser_version\":\"79.0.3945.117\"},\"$token\":\"9432f11f70f8ce386f5110c8c924b3ec4f825256\",\"$distinct_id\":\"e6ab2c5e-2cda-44a9-a962-e2f67df78bca\",\"$ip\":\"0.0.0.0\",\"$time\":1579847342}]"
+      },
       "XML": {},
       "FORM": {}
     },
@@ -1470,42 +744,15 @@
       "method": "POST",
       "endpoint": "https://api-eu.mixpanel.com/import/",
       "headers": {
-        "Authorization": "Basic c29tZV9hcGlfc2VjcmV0Og=="
+        "Authorization": "Basic c29tZV9hcGlfc2VjcmV0Og==",
+        "Content-Type": "application/json"
       },
-      "params": {
-        "data": {
-          "event": "MainActivity",
-          "properties": {
-            "name": "MainActivity",
-            "automatic": true,
-            "anonymousId": "5094f5704b9cf2b3",
-            "userId": "test_user_id",
-            "$user_id": "test_user_id",
-            "$os": "iOS",
-            "$screen_height": 1794,
-            "$screen_width": 1080,
-            "$screen_dpi": 420,
-            "$carrier": "Android",
-            "$os_version": "8.1.0",
-            "$device": "generic_x86",
-            "$manufacturer": "Google",
-            "$model": "Android SDK built for x86",
-            "mp_device_model": "Android SDK built for x86",
-            "$wifi": true,
-            "$bluetooth_enabled": false,
-            "mp_lib": "com.rudderstack.android.sdk.core",
-            "$app_build_number": "1",
-            "$app_version_string": "1.0",
-            "$insert_id": "id2",
-            "token": "9432f11f70f8ce386f5110c8c924b3ec4f825256",
-            "distinct_id": "test_user_id",
-            "time": 1520845503
-          }
-        }
-      },
+      "params": { "strict": 0 },
       "body": {
         "JSON": {},
-        "JSON_ARRAY": {},
+        "JSON_ARRAY": {
+          "batch": "[{\"event\":\"MainActivity\",\"properties\":{\"name\":\"MainActivity\",\"automatic\":true,\"anonymousId\":\"5094f5704b9cf2b3\",\"userId\":\"test_user_id\",\"$user_id\":\"test_user_id\",\"$os\":\"iOS\",\"$screen_height\":1794,\"$screen_width\":1080,\"$screen_dpi\":420,\"$carrier\":\"Android\",\"$os_version\":\"8.1.0\",\"$device\":\"generic_x86\",\"$manufacturer\":\"Google\",\"$model\":\"Android SDK built for x86\",\"mp_device_model\":\"Android SDK built for x86\",\"$wifi\":true,\"$bluetooth_enabled\":false,\"mp_lib\":\"com.rudderstack.android.sdk.core\",\"$app_build_number\":\"1\",\"$app_version_string\":\"1.0\",\"$insert_id\":\"id2\",\"token\":\"9432f11f70f8ce386f5110c8c924b3ec4f825256\",\"distinct_id\":\"test_user_id\",\"time\":1520845503}}]"
+        },
         "XML": {},
         "FORM": {}
       },
@@ -1527,31 +774,12 @@
     "method": "POST",
     "endpoint": "https://api.mixpanel.com/engage/",
     "headers": {},
-    "params": {
-      "data": {
-        "$set": {
-          "$created": "2020-01-23T08:54:02.362Z",
-          "$email": "mickey@disney.com",
-          "$first_name": "Mickey",
-          "$last_name": "Mouse",
-          "$country_code": "USA",
-          "$city": "Disney",
-          "$initial_referrer": "https://docs.rudderstack.com",
-          "$initial_referring_domain": "docs.rudderstack.com",
-          "$name": "Mickey Mouse",
-          "$browser": "Chrome",
-          "$browser_version": "79.0.3945.117"
-        },
-        "$token": "9432f11f70f8ce386f5110c8c924b3ec4f825256",
-        "$distinct_id": "e6ab2c5e-2cda-44a9-a962-e2f67df78bca",
-        "$ip": "0.0.0.0",
-        "$time": 1579847342,
-        "$ignore_time": true
-      }
-    },
+    "params": {},
     "body": {
       "JSON": {},
-      "JSON_ARRAY": {},
+      "JSON_ARRAY": {
+        "batch": "[{\"$set\":{\"$created\":\"2020-01-23T08:54:02.362Z\",\"$email\":\"mickey@disney.com\",\"$first_name\":\"Mickey\",\"$last_name\":\"Mouse\",\"$country_code\":\"USA\",\"$city\":\"Disney\",\"$initial_referrer\":\"https://docs.rudderstack.com\",\"$initial_referring_domain\":\"docs.rudderstack.com\",\"$name\":\"Mickey Mouse\",\"$browser\":\"Chrome\",\"$browser_version\":\"79.0.3945.117\"},\"$token\":\"9432f11f70f8ce386f5110c8c924b3ec4f825256\",\"$distinct_id\":\"e6ab2c5e-2cda-44a9-a962-e2f67df78bca\",\"$ip\":\"0.0.0.0\",\"$time\":1579847342,\"$ignore_time\":true}]"
+      },
       "XML": {},
       "FORM": {}
     },
@@ -1564,30 +792,12 @@
     "method": "POST",
     "endpoint": "https://api.mixpanel.com/engage/",
     "headers": {},
-    "params": {
-      "data": {
-        "$set": {
-          "$created": "2020-01-23T08:54:02.362Z",
-          "$email": "mickey@disney.com",
-          "$first_name": "Mickey",
-          "$last_name": "Mouse",
-          "$country_code": "USA",
-          "$city": "Disney",
-          "$initial_referrer": "https://docs.rudderstack.com",
-          "$initial_referring_domain": "docs.rudderstack.com",
-          "$name": "Mickey Mouse",
-          "$browser": "Chrome",
-          "$browser_version": "79.0.3945.117"
-        },
-        "$token": "9432f11f70f8ce386f5110c8c924b3ec4f825256",
-        "$distinct_id": "e6ab2c5e-2cda-44a9-a962-e2f67df78bca",
-        "$ip": "0.0.0.0",
-        "$time": 1579847342
-      }
-    },
+    "params": {},
     "body": {
       "JSON": {},
-      "JSON_ARRAY": {},
+      "JSON_ARRAY": {
+        "batch": "[{\"$set\":{\"$created\":\"2020-01-23T08:54:02.362Z\",\"$email\":\"mickey@disney.com\",\"$first_name\":\"Mickey\",\"$last_name\":\"Mouse\",\"$country_code\":\"USA\",\"$city\":\"Disney\",\"$initial_referrer\":\"https://docs.rudderstack.com\",\"$initial_referring_domain\":\"docs.rudderstack.com\",\"$name\":\"Mickey Mouse\",\"$browser\":\"Chrome\",\"$browser_version\":\"79.0.3945.117\"},\"$token\":\"9432f11f70f8ce386f5110c8c924b3ec4f825256\",\"$distinct_id\":\"e6ab2c5e-2cda-44a9-a962-e2f67df78bca\",\"$ip\":\"0.0.0.0\",\"$time\":1579847342}]"
+      },
       "XML": {},
       "FORM": {}
     },
@@ -1609,41 +819,15 @@
       "method": "POST",
       "endpoint": "https://api.mixpanel.com/import/",
       "headers": {
-        "Authorization": "Basic OTQzMmYxMWY3MGY4Y2UzODZmNTExMGM4YzkyNGIzZWM0ZjgyNTI1Njo="
+        "Authorization": "Basic OTQzMmYxMWY3MGY4Y2UzODZmNTExMGM4YzkyNGIzZWM0ZjgyNTI1Njo=",
+        "Content-Type": "application/json"
       },
-      "params": {
-        "data": {
-          "event": "Application Installed",
-          "properties": {
-            "$app_build_number": "4",
-            "$app_version_string": "1.0",
-            "$bluetooth_enabled": true,
-            "$carrier": "T-Mobile",
-            "$device": "emu64a",
-            "$insert_id": "168cf720-6227-4b56-a98e-c49bdc7279e9",
-            "$manufacturer": "Google",
-            "$model": "sdk_gphone64_arm64",
-            "$os": "Android",
-            "$os_version": "12",
-            "$screen_dpi": 560,
-            "$screen_height": 2984,
-            "$screen_width": 1440,
-            "$session_id": "1662363980",
-            "$wifi": true,
-            "anonymousId": "39da706ec83d0e90",
-            "build": 4,
-            "distinct_id": "39da706ec83d0e90",
-            "mp_device_model": "sdk_gphone64_arm64",
-            "mp_lib": "com.rudderstack.android.sdk.core",
-            "time": null,
-            "token": "9432f11f70f8ce386f5110c8c924b3ec4f825256",
-            "version": "1.0"
-          }
-        }
-      },
+      "params": { "strict": 0 },
       "body": {
         "JSON": {},
-        "JSON_ARRAY": {},
+        "JSON_ARRAY": {
+          "batch": "[{\"event\":\"Application Installed\",\"properties\":{\"build\":4,\"version\":\"1.0\",\"anonymousId\":\"39da706ec83d0e90\",\"$os\":\"Android\",\"$screen_height\":2984,\"$screen_width\":1440,\"$screen_dpi\":560,\"$carrier\":\"T-Mobile\",\"$os_version\":\"12\",\"$device\":\"emu64a\",\"$manufacturer\":\"Google\",\"$model\":\"sdk_gphone64_arm64\",\"mp_device_model\":\"sdk_gphone64_arm64\",\"$wifi\":true,\"$bluetooth_enabled\":true,\"mp_lib\":\"com.rudderstack.android.sdk.core\",\"$app_build_number\":\"4\",\"$app_version_string\":\"1.0\",\"$insert_id\":\"168cf720-6227-4b56-a98e-c49bdc7279e9\",\"$session_id\":\"1662363980\",\"token\":\"9432f11f70f8ce386f5110c8c924b3ec4f825256\",\"distinct_id\":\"39da706ec83d0e90\",\"time\":null}}]"
+        },
         "XML": {},
         "FORM": {}
       },
@@ -1658,41 +842,15 @@
       "method": "POST",
       "endpoint": "https://api.mixpanel.com/import/",
       "headers": {
-        "Authorization": "Basic OTQzMmYxMWY3MGY4Y2UzODZmNTExMGM4YzkyNGIzZWM0ZjgyNTI1Njo="
+        "Authorization": "Basic OTQzMmYxMWY3MGY4Y2UzODZmNTExMGM4YzkyNGIzZWM0ZjgyNTI1Njo=",
+        "Content-Type": "application/json"
       },
-      "params": {
-        "data": {
-          "event": "Application Opened",
-          "properties": {
-            "$app_build_number": "4",
-            "$app_version_string": "1.0",
-            "$bluetooth_enabled": true,
-            "$carrier": "T-Mobile",
-            "$device": "emu64a",
-            "$insert_id": "168cf720-6227-4b56-a98e-c49bdc7279e9",
-            "$manufacturer": "Google",
-            "$model": "sdk_gphone64_arm64",
-            "$os": "Android",
-            "$os_version": "12",
-            "$screen_dpi": 560,
-            "$screen_height": 2984,
-            "$screen_width": 1440,
-            "$session_id": "1662363980",
-            "$wifi": true,
-            "anonymousId": "39da706ec83d0e90",
-            "build": 4,
-            "distinct_id": "39da706ec83d0e90",
-            "mp_device_model": "sdk_gphone64_arm64",
-            "mp_lib": "com.rudderstack.android.sdk.core",
-            "time": null,
-            "token": "9432f11f70f8ce386f5110c8c924b3ec4f825256",
-            "version": "1.0"
-          }
-        }
-      },
+      "params": { "strict": 0 },
       "body": {
         "JSON": {},
-        "JSON_ARRAY": {},
+        "JSON_ARRAY": {
+          "batch": "[{\"event\":\"Application Opened\",\"properties\":{\"build\":4,\"version\":\"1.0\",\"anonymousId\":\"39da706ec83d0e90\",\"$os\":\"Android\",\"$screen_height\":2984,\"$screen_width\":1440,\"$screen_dpi\":560,\"$carrier\":\"T-Mobile\",\"$os_version\":\"12\",\"$device\":\"emu64a\",\"$manufacturer\":\"Google\",\"$model\":\"sdk_gphone64_arm64\",\"mp_device_model\":\"sdk_gphone64_arm64\",\"$wifi\":true,\"$bluetooth_enabled\":true,\"mp_lib\":\"com.rudderstack.android.sdk.core\",\"$app_build_number\":\"4\",\"$app_version_string\":\"1.0\",\"$insert_id\":\"168cf720-6227-4b56-a98e-c49bdc7279e9\",\"$session_id\":\"1662363980\",\"token\":\"9432f11f70f8ce386f5110c8c924b3ec4f825256\",\"distinct_id\":\"39da706ec83d0e90\",\"time\":null}}]"
+        },
         "XML": {},
         "FORM": {}
       },
@@ -1707,19 +865,12 @@
       "method": "POST",
       "endpoint": "https://api.mixpanel.com/engage/",
       "headers": {},
-      "params": {
-        "data": {
-          "$distinct_id": "hjikl",
-          "$set": {
-            "groupId": ["testGroupId"]
-          },
-          "$token": "9432f11f70f8ce386f5110c8c924b3ec4f825256",
-          "$ip": "0.0.0.0"
-        }
-      },
+      "params": {},
       "body": {
         "JSON": {},
-        "JSON_ARRAY": {},
+        "JSON_ARRAY": {
+          "batch": "[{\"$token\":\"9432f11f70f8ce386f5110c8c924b3ec4f825256\",\"$distinct_id\":\"hjikl\",\"$set\":{\"groupId\":[\"testGroupId\"]},\"$ip\":\"0.0.0.0\"}]"
+        },
         "XML": {},
         "FORM": {}
       },
@@ -1732,20 +883,12 @@
       "method": "POST",
       "endpoint": "https://api.mixpanel.com/groups/",
       "headers": {},
-      "params": {
-        "data": {
-          "$group_id": "testGroupId",
-          "$group_key": "groupId",
-          "$set": {
-            "company": "testComp",
-            "groupId": "groupIdInTraits"
-          },
-          "$token": "9432f11f70f8ce386f5110c8c924b3ec4f825256"
-        }
-      },
+      "params": {},
       "body": {
         "JSON": {},
-        "JSON_ARRAY": {},
+        "JSON_ARRAY": {
+          "batch": "[{\"$token\":\"9432f11f70f8ce386f5110c8c924b3ec4f825256\",\"$group_key\":\"groupId\",\"$group_id\":\"testGroupId\",\"$set\":{\"company\":\"testComp\",\"groupId\":\"groupIdInTraits\"}}]"
+        },
         "XML": {},
         "FORM": {}
       },
@@ -1760,38 +903,12 @@
       "method": "POST",
       "endpoint": "https://api.mixpanel.com/track/",
       "headers": {},
-      "params": {
-        "data": {
-          "event": "Product Viewed",
-          "properties": {
-            "name": "T-Shirt",
-            "$user_id": "userId01",
-            "$device_id": "anonId01",
-            "$os": "iOS",
-            "$screen_height": 1794,
-            "$screen_width": 1080,
-            "$screen_dpi": 420,
-            "$carrier": "Android",
-            "$os_version": "8.1.0",
-            "$device": "generic_x86",
-            "$manufacturer": "Google",
-            "$model": "Android SDK built for x86",
-            "mp_device_model": "Android SDK built for x86",
-            "$wifi": true,
-            "$bluetooth_enabled": false,
-            "mp_lib": "com.rudderstack.android.sdk.core",
-            "$app_build_number": "1",
-            "$app_version_string": "1.0",
-            "$insert_id": "id2",
-            "token": "apiToken123",
-            "distinct_id": "userId01",
-            "time": 1579847342
-          }
-        }
-      },
+      "params": {},
       "body": {
         "JSON": {},
-        "JSON_ARRAY": {},
+        "JSON_ARRAY": {
+          "batch": "[{\"event\":\"Product Viewed\",\"properties\":{\"name\":\"T-Shirt\",\"$user_id\":\"userId01\",\"$os\":\"iOS\",\"$screen_height\":1794,\"$screen_width\":1080,\"$screen_dpi\":420,\"$carrier\":\"Android\",\"$os_version\":\"8.1.0\",\"$device\":\"generic_x86\",\"$manufacturer\":\"Google\",\"$model\":\"Android SDK built for x86\",\"mp_device_model\":\"Android SDK built for x86\",\"$wifi\":true,\"$bluetooth_enabled\":false,\"mp_lib\":\"com.rudderstack.android.sdk.core\",\"$app_build_number\":\"1\",\"$app_version_string\":\"1.0\",\"$insert_id\":\"id2\",\"token\":\"apiToken123\",\"distinct_id\":\"userId01\",\"time\":1579847342,\"$device_id\":\"anonId01\"}}]"
+        },
         "XML": {},
         "FORM": {}
       },
@@ -1805,30 +922,12 @@
     "method": "POST",
     "endpoint": "https://api.mixpanel.com/engage/",
     "headers": {},
-    "params": {
-      "data": {
-        "$set": {
-          "$created": "2020-01-23T08:54:02.362Z",
-          "$email": "mickey@disney.com",
-          "$firstName": "Mickey",
-          "$lastName": "Mouse",
-          "$country_code": "USA",
-          "$city": "Disney",
-          "$initial_referrer": "https://docs.rudderstack.com",
-          "$initial_referring_domain": "docs.rudderstack.com",
-          "$name": "Mickey Mouse",
-          "$browser": "Chrome",
-          "$browser_version": "79.0.3945.117"
-        },
-        "$token": "apiToken123",
-        "$distinct_id": "userId01",
-        "$ip": "0.0.0.0",
-        "$time": 1579847342
-      }
-    },
+    "params": {},
     "body": {
       "JSON": {},
-      "JSON_ARRAY": {},
+      "JSON_ARRAY": {
+        "batch": "[{\"$set\":{\"$created\":\"2020-01-23T08:54:02.362Z\",\"$email\":\"mickey@disney.com\",\"$country_code\":\"USA\",\"$city\":\"Disney\",\"$initial_referrer\":\"https://docs.rudderstack.com\",\"$initial_referring_domain\":\"docs.rudderstack.com\",\"$name\":\"Mickey Mouse\",\"$firstName\":\"Mickey\",\"$lastName\":\"Mouse\",\"$browser\":\"Chrome\",\"$browser_version\":\"79.0.3945.117\"},\"$token\":\"apiToken123\",\"$distinct_id\":\"userId01\",\"$ip\":\"0.0.0.0\",\"$time\":1579847342}]"
+      },
       "XML": {},
       "FORM": {}
     },
@@ -1841,30 +940,12 @@
     "method": "POST",
     "endpoint": "https://api.mixpanel.com/engage/",
     "headers": {},
-    "params": {
-      "data": {
-        "$set": {
-          "$created": "2020-01-23T08:54:02.362Z",
-          "$email": "mickey@disney.com",
-          "$firstName": "Mickey",
-          "$lastName": "Mouse",
-          "$country_code": "USA",
-          "$city": "Disney",
-          "$initial_referrer": "https://docs.rudderstack.com",
-          "$initial_referring_domain": "docs.rudderstack.com",
-          "$name": "Mickey Mouse",
-          "$browser": "Chrome",
-          "$browser_version": "79.0.3945.117"
-        },
-        "$token": "apiToken123",
-        "$distinct_id": "$device:anonId01",
-        "$ip": "0.0.0.0",
-        "$time": 1579847342
-      }
-    },
+    "params": {},
     "body": {
       "JSON": {},
-      "JSON_ARRAY": {},
+      "JSON_ARRAY": {
+        "batch": "[{\"$set\":{\"$created\":\"2020-01-23T08:54:02.362Z\",\"$email\":\"mickey@disney.com\",\"$country_code\":\"USA\",\"$city\":\"Disney\",\"$initial_referrer\":\"https://docs.rudderstack.com\",\"$initial_referring_domain\":\"docs.rudderstack.com\",\"$name\":\"Mickey Mouse\",\"$firstName\":\"Mickey\",\"$lastName\":\"Mouse\",\"$browser\":\"Chrome\",\"$browser_version\":\"79.0.3945.117\"},\"$token\":\"apiToken123\",\"$distinct_id\":\"$device:anonId01\",\"$ip\":\"0.0.0.0\",\"$time\":1579847342}]"
+      },
       "XML": {},
       "FORM": {}
     },
@@ -1882,21 +963,12 @@
       "method": "POST",
       "endpoint": "https://api.mixpanel.com/engage/",
       "headers": {},
-      "params": {
-        "data": {
-          "$append": {
-            "$transactions": {
-              "$time": "2020-01-24T06:29:02.403Z",
-              "$amount": 18.9
-            }
-          },
-          "$token": "apiToken123",
-          "$distinct_id": "userId01"
-        }
-      },
+      "params": {},
       "body": {
         "JSON": {},
-        "JSON_ARRAY": {},
+        "JSON_ARRAY": {
+          "batch": "[{\"$append\":{\"$transactions\":{\"$time\":\"2020-01-24T06:29:02.403Z\",\"$amount\":18.9}},\"$token\":\"apiToken123\",\"$distinct_id\":\"userId01\"}]"
+        },
         "XML": {},
         "FORM": {}
       },
@@ -1909,36 +981,12 @@
       "method": "POST",
       "endpoint": "https://api.mixpanel.com/track/",
       "headers": {},
-      "params": {
-        "data": {
-          "event": "test revenue MIXPANEL",
-          "properties": {
-            "currency": "USD",
-            "revenue": 18.9,
-            "city": "Disney",
-            "country": "USA",
-            "email": "mickey@disney.com",
-            "firstName": "Mickey",
-            "ip": "0.0.0.0",
-            "$current_url": "https://docs.rudderstack.com/destinations/mixpanel",
-            "$screen_dpi": 2,
-            "mp_lib": "RudderLabs JavaScript SDK",
-            "$app_build_number": "1.0.0",
-            "$app_version_string": "1.0.5",
-            "$insert_id": "a6a0ad5a-bd26-4f19-8f75-38484e580fc7",
-            "token": "apiToken123",
-            "distinct_id": "userId01",
-            "$device_id": "anonId01",
-            "$user_id": "userId01",
-            "time": 1579847342,
-            "$browser": "Chrome",
-            "$browser_version": "79.0.3945.117"
-          }
-        }
-      },
+      "params": {},
       "body": {
         "JSON": {},
-        "JSON_ARRAY": {},
+        "JSON_ARRAY": {
+          "batch": "[{\"event\":\"test revenue MIXPANEL\",\"properties\":{\"currency\":\"USD\",\"revenue\":18.9,\"city\":\"Disney\",\"country\":\"USA\",\"email\":\"mickey@disney.com\",\"firstName\":\"Mickey\",\"ip\":\"0.0.0.0\",\"$user_id\":\"userId01\",\"$current_url\":\"https://docs.rudderstack.com/destinations/mixpanel\",\"$screen_dpi\":2,\"mp_lib\":\"RudderLabs JavaScript SDK\",\"$app_build_number\":\"1.0.0\",\"$app_version_string\":\"1.0.5\",\"$insert_id\":\"a6a0ad5a-bd26-4f19-8f75-38484e580fc7\",\"token\":\"apiToken123\",\"distinct_id\":\"userId01\",\"time\":1579847342,\"$device_id\":\"anonId01\",\"$browser\":\"Chrome\",\"$browser_version\":\"79.0.3945.117\"}}]"
+        },
         "XML": {},
         "FORM": {}
       },
@@ -1952,30 +1000,12 @@
     "method": "POST",
     "endpoint": "https://api.mixpanel.com/track/",
     "headers": {},
-    "params": {
-      "data": {
-        "event": "Loaded a Page",
-        "properties": {
-          "ip": "0.0.0.0",
-          "$device_id": "anonId01",
-          "$current_url": "https://docs.rudderstack.com/destinations/mixpanel",
-          "$screen_dpi": 2,
-          "mp_lib": "RudderLabs JavaScript SDK",
-          "$app_build_number": "1.0.0",
-          "$app_version_string": "1.0.5",
-          "$insert_id": "dd266c67-9199-4a52-ba32-f46ddde67312",
-          "token": "apiToken123",
-          "distinct_id": "$device:anonId01",
-          "time": 1579847342,
-          "name": "Contact Us",
-          "$browser": "Chrome",
-          "$browser_version": "79.0.3945.117"
-        }
-      }
-    },
+    "params": {},
     "body": {
       "JSON": {},
-      "JSON_ARRAY": {},
+      "JSON_ARRAY": {
+        "batch": "[{\"event\":\"Loaded a Page\",\"properties\":{\"ip\":\"0.0.0.0\",\"$current_url\":\"https://docs.rudderstack.com/destinations/mixpanel\",\"$screen_dpi\":2,\"mp_lib\":\"RudderLabs JavaScript SDK\",\"$app_build_number\":\"1.0.0\",\"$app_version_string\":\"1.0.5\",\"$insert_id\":\"dd266c67-9199-4a52-ba32-f46ddde67312\",\"token\":\"apiToken123\",\"distinct_id\":\"$device:anonId01\",\"time\":1579847342,\"$device_id\":\"anonId01\",\"name\":\"Contact Us\",\"$browser\":\"Chrome\",\"$browser_version\":\"79.0.3945.117\"}}]"
+      },
       "XML": {},
       "FORM": {}
     },
@@ -1989,19 +1019,12 @@
       "method": "POST",
       "endpoint": "https://api.mixpanel.com/engage/",
       "headers": {},
-      "params": {
-        "data": {
-          "$token": "apiToken123",
-          "$distinct_id": "$device:anonId01",
-          "$set": {
-            "company": ["testComp"]
-          },
-          "$ip": "0.0.0.0"
-        }
-      },
+      "params": {},
       "body": {
         "JSON": {},
-        "JSON_ARRAY": {},
+        "JSON_ARRAY": {
+          "batch": "[{\"$token\":\"apiToken123\",\"$distinct_id\":\"$device:anonId01\",\"$set\":{\"company\":[\"testComp\"]},\"$ip\":\"0.0.0.0\"}]"
+        },
         "XML": {},
         "FORM": {}
       },
@@ -2014,19 +1037,12 @@
       "method": "POST",
       "endpoint": "https://api.mixpanel.com/groups/",
       "headers": {},
-      "params": {
-        "data": {
-          "$token": "apiToken123",
-          "$group_key": "company",
-          "$group_id": "testComp",
-          "$set": {
-            "company": "testComp"
-          }
-        }
-      },
+      "params": {},
       "body": {
         "JSON": {},
-        "JSON_ARRAY": {},
+        "JSON_ARRAY": {
+          "batch": "[{\"$token\":\"apiToken123\",\"$group_key\":\"company\",\"$group_id\":\"testComp\",\"$set\":{\"company\":\"testComp\"}}]"
+        },
         "XML": {},
         "FORM": {}
       },

--- a/test/__tests__/data/mp_output.json
+++ b/test/__tests__/data/mp_output.json
@@ -1061,21 +1061,12 @@
       "method": "POST",
       "endpoint": "https://api.mixpanel.com/engage/",
       "headers": {},
-      "params": {
-        "data": {
-          "$append": {
-            "$transactions": {
-              "$amount": 12.13,
-              "$time": "2022-09-05T07:46:20.290Z"
-            }
-          },
-          "$distinct_id": "39da706ec83d0e90",
-          "$token": "9432f11f70f8ce386f5110c8c924b3ec4f825256"
-        }
-      },
+      "params": {},
       "body": {
         "JSON": {},
-        "JSON_ARRAY": {},
+        "JSON_ARRAY": {
+          "batch": "[{\"$append\":{\"$transactions\":{\"$time\":\"2022-09-05T07:46:20.290Z\",\"$amount\":12.13}},\"$token\":\"9432f11f70f8ce386f5110c8c924b3ec4f825256\",\"$distinct_id\":\"39da706ec83d0e90\"}]"
+        },
         "XML": {},
         "FORM": {}
       },
@@ -1088,42 +1079,15 @@
       "method": "POST",
       "endpoint": "https://api.mixpanel.com/import/",
       "headers": {
-        "Authorization": "Basic OTQzMmYxMWY3MGY4Y2UzODZmNTExMGM4YzkyNGIzZWM0ZjgyNTI1Njo="
+        "Authorization": "Basic OTQzMmYxMWY3MGY4Y2UzODZmNTExMGM4YzkyNGIzZWM0ZjgyNTI1Njo=",
+        "Content-Type": "application/json"
       },
-      "params": {
-        "data": {
-          "event": "Application Installed",
-          "properties": {
-            "$app_build_number": "4",
-            "$app_version_string": "1.0",
-            "$bluetooth_enabled": true,
-            "$carrier": "T-Mobile",
-            "$device": "emu64a",
-            "$insert_id": "168cf720-6227-4b56-a98e-c49bdc7279e9",
-            "$manufacturer": "Google",
-            "$model": "sdk_gphone64_arm64",
-            "$os": "Android",
-            "$os_version": "12",
-            "$screen_dpi": 560,
-            "$screen_height": 2984,
-            "$screen_width": 1440,
-            "$session_id": "1662363980",
-            "$wifi": true,
-            "anonymousId": "39da706ec83d0e90",
-            "build": 4,
-            "distinct_id": "39da706ec83d0e90",
-            "mp_device_model": "sdk_gphone64_arm64",
-            "mp_lib": "com.rudderstack.android.sdk.core",
-            "revenue": 12.13,
-            "time": null,
-            "token": "9432f11f70f8ce386f5110c8c924b3ec4f825256",
-            "version": "1.0"
-          }
-        }
-      },
+      "params": { "strict": 0 },
       "body": {
         "JSON": {},
-        "JSON_ARRAY": {},
+        "JSON_ARRAY": {
+          "batch": "[{\"event\":\"Application Installed\",\"properties\":{\"build\":4,\"version\":\"1.0\",\"revenue\":12.13,\"anonymousId\":\"39da706ec83d0e90\",\"$os\":\"Android\",\"$screen_height\":2984,\"$screen_width\":1440,\"$screen_dpi\":560,\"$carrier\":\"T-Mobile\",\"$os_version\":\"12\",\"$device\":\"emu64a\",\"$manufacturer\":\"Google\",\"$model\":\"sdk_gphone64_arm64\",\"mp_device_model\":\"sdk_gphone64_arm64\",\"$wifi\":true,\"$bluetooth_enabled\":true,\"mp_lib\":\"com.rudderstack.android.sdk.core\",\"$app_build_number\":\"4\",\"$app_version_string\":\"1.0\",\"$insert_id\":\"168cf720-6227-4b56-a98e-c49bdc7279e9\",\"$session_id\":\"1662363980\",\"token\":\"9432f11f70f8ce386f5110c8c924b3ec4f825256\",\"distinct_id\":\"39da706ec83d0e90\",\"time\":null}}]"
+        },
         "XML": {},
         "FORM": {}
       },
@@ -1138,21 +1102,12 @@
       "method": "POST",
       "endpoint": "https://api.mixpanel.com/engage/",
       "headers": {},
-      "params": {
-        "data": {
-          "$append": {
-            "$transactions": {
-              "$amount": 23.45,
-              "$time": "2022-09-05T07:46:20.290Z"
-            }
-          },
-          "$distinct_id": "39da706ec83d0e90",
-          "$token": "9432f11f70f8ce386f5110c8c924b3ec4f825256"
-        }
-      },
+      "params": {},
       "body": {
         "JSON": {},
-        "JSON_ARRAY": {},
+        "JSON_ARRAY": {
+          "batch": "[{\"$append\":{\"$transactions\":{\"$time\":\"2022-09-05T07:46:20.290Z\",\"$amount\":23.45}},\"$token\":\"9432f11f70f8ce386f5110c8c924b3ec4f825256\",\"$distinct_id\":\"39da706ec83d0e90\"}]"
+        },
         "XML": {},
         "FORM": {}
       },
@@ -1165,47 +1120,41 @@
       "method": "POST",
       "endpoint": "https://api.mixpanel.com/import/",
       "headers": {
-        "Authorization": "Basic OTQzMmYxMWY3MGY4Y2UzODZmNTExMGM4YzkyNGIzZWM0ZjgyNTI1Njo="
+        "Authorization": "Basic OTQzMmYxMWY3MGY4Y2UzODZmNTExMGM4YzkyNGIzZWM0ZjgyNTI1Njo=",
+        "Content-Type": "application/json"
       },
-      "params": {
-        "data": {
-          "event": "Application Installed",
-          "properties": {
-            "$app_build_number": "4",
-            "$app_version_string": "1.0",
-            "$bluetooth_enabled": true,
-            "$carrier": "T-Mobile",
-            "$device": "emu64a",
-            "$insert_id": "168cf720-6227-4b56-a98e-c49bdc7279e9",
-            "$manufacturer": "Google",
-            "$model": "sdk_gphone64_arm64",
-            "$os": "Android",
-            "$os_version": "12",
-            "$screen_dpi": 560,
-            "$screen_height": 2984,
-            "$screen_width": 1440,
-            "$session_id": "1662363980",
-            "$wifi": true,
-            "anonymousId": "39da706ec83d0e90",
-            "build": 4,
-            "distinct_id": "39da706ec83d0e90",
-            "mp_device_model": "sdk_gphone64_arm64",
-            "mp_lib": "com.rudderstack.android.sdk.core",
-            "time": null,
-            "revenue": 23.45,
-            "token": "9432f11f70f8ce386f5110c8c924b3ec4f825256",
-            "version": "1.0"
-          }
-        }
-      },
+      "params": { "strict": 0 },
       "body": {
         "JSON": {},
-        "JSON_ARRAY": {},
+        "JSON_ARRAY": {
+          "batch": "[{\"event\":\"Application Installed\",\"properties\":{\"build\":4,\"version\":\"1.0\",\"revenue\":23.45,\"anonymousId\":\"39da706ec83d0e90\",\"$os\":\"Android\",\"$screen_height\":2984,\"$screen_width\":1440,\"$screen_dpi\":560,\"$carrier\":\"T-Mobile\",\"$os_version\":\"12\",\"$device\":\"emu64a\",\"$manufacturer\":\"Google\",\"$model\":\"sdk_gphone64_arm64\",\"mp_device_model\":\"sdk_gphone64_arm64\",\"$wifi\":true,\"$bluetooth_enabled\":true,\"mp_lib\":\"com.rudderstack.android.sdk.core\",\"$app_build_number\":\"4\",\"$app_version_string\":\"1.0\",\"$insert_id\":\"168cf720-6227-4b56-a98e-c49bdc7279e9\",\"$session_id\":\"1662363980\",\"token\":\"9432f11f70f8ce386f5110c8c924b3ec4f825256\",\"distinct_id\":\"39da706ec83d0e90\",\"time\":null}}]"
+        },
         "XML": {},
         "FORM": {}
       },
       "files": {},
       "userId": "39da706ec83d0e90"
     }
-  ]
+  ],
+  {
+    "version": "1",
+    "type": "REST",
+    "method": "POST",
+    "endpoint": "https://api-eu.mixpanel.com/import/",
+    "headers": {
+      "Authorization": "Basic c29tZV9hcGlfc2VjcmV0Og==",
+      "Content-Type": "application/json"
+    },
+    "params": { "strict": 1 },
+    "body": {
+      "JSON": {},
+      "JSON_ARRAY": {
+        "batch": "[{\"event\":\"$merge\",\"properties\":{\"$distinct_ids\":[\"test_user_id\",\"5094f5704b9cf2b3\"],\"token\":\"9432f11f70f8ce386f5110c8c924b3ec4f825256\"}}]"
+      },
+      "XML": {},
+      "FORM": {}
+    },
+    "files": {},
+    "userId": "test_user_id"
+  }
 ]

--- a/test/__tests__/data/mp_router_input.json
+++ b/test/__tests__/data/mp_router_input.json
@@ -313,5 +313,89 @@
       "sentAt": "2020-01-24T06:29:02.363Z",
       "timestamp": "2020-01-24T11:59:02.402+05:30"
     }
+  },
+  {
+    "destination": {
+      "Config": {
+        "apiKey": "9432f11f70f8ce386f5110c8c924b3ec4f825256",
+        "token": "9432f11f70f8ce386f5110c8c924b3ec4f825256",
+        "apiSecret": "some_api_secret",
+        "prefixProperties": true,
+        "dataResidency": "eu",
+        "useNativeSDK": false,
+        "strictMode": true
+      },
+      "DestinationDefinition": {
+        "DisplayName": "Mixpanel",
+        "ID": "1WhbSZ6uA3H5ChVifHpfL2H6sie",
+        "Name": "MP"
+      },
+      "Enabled": true,
+      "ID": "1WhcOCGgj9asZu850HvugU2C3Aq",
+      "Name": "Mixpanel",
+      "Transformations": []
+    },
+    "metadata": {
+      "jobId": 2
+    },
+    "message": {
+      "anonymousId": "5094f5704b9cf2b3",
+      "channel": "mobile",
+      "context": {
+        "app": {
+          "build": "1",
+          "name": "LeanPlumIntegrationAndroid",
+          "namespace": "com.android.SampleLeanPlum",
+          "version": "1.0"
+        },
+        "device": {
+          "id": "5094f5704b9cf2b3",
+          "manufacturer": "Google",
+          "model": "Android SDK built for x86",
+          "name": "generic_x86",
+          "type": "ios",
+          "token": "test_device_token"
+        },
+        "library": {
+          "name": "com.rudderstack.android.sdk.core",
+          "version": "1.0.1-beta.1"
+        },
+        "locale": "en-US",
+        "network": {
+          "carrier": "Android",
+          "bluetooth": false,
+          "cellular": true,
+          "wifi": true
+        },
+        "os": {
+          "name": "iOS",
+          "version": "8.1.0"
+        },
+        "screen": {
+          "density": 420,
+          "height": 1794,
+          "width": 1080
+        },
+        "timezone": "Asia/Kolkata",
+        "traits": {
+          "anonymousId": "5094f5704b9cf2b3",
+          "userId": "test_user_id"
+        },
+        "userAgent": "Dalvik/2.1.0 (Linux; U; Android 8.1.0; Android SDK built for x86 Build/OSM1.180201.007)"
+      },
+      "event": "MainActivity",
+      "integrations": {
+        "All": true
+      },
+      "userId": "test_user_id",
+      "messageId": "id2",
+      "properties": {
+        "name": "MainActivity",
+        "automatic": true
+      },
+      "originalTimestamp": "2020-03-12T09:05:03.421Z",
+      "type": "identify",
+      "sentAt": "2020-03-12T09:05:13.042Z"
+    }
   }
 ]

--- a/test/__tests__/data/mp_router_output.json
+++ b/test/__tests__/data/mp_router_output.json
@@ -6,30 +6,12 @@
       "method": "POST",
       "endpoint": "https://api.mixpanel.com/track/",
       "headers": {},
-      "params": {
-        "data": {
-          "event": "Loaded a Page",
-          "properties": {
-            "ip": "0.0.0.0",
-            "$user_id": "hjikl",
-            "$current_url": "https://docs.rudderstack.com/destinations/mixpanel",
-            "$screen_dpi": 2,
-            "mp_lib": "RudderLabs JavaScript SDK",
-            "$app_build_number": "1.0.0",
-            "$app_version_string": "1.0.5",
-            "$insert_id": "dd266c67-9199-4a52-ba32-f46ddde67312",
-            "token": "9432f11f70f8ce386f5110c8c924b3ec4f825256",
-            "distinct_id": "hjikl",
-            "time": 1579847342,
-            "name": "Contact Us",
-            "$browser": "Chrome",
-            "$browser_version": "79.0.3945.117"
-          }
-        }
-      },
+      "params": {},
       "body": {
         "JSON": {},
-        "JSON_ARRAY": {},
+        "JSON_ARRAY": {
+          "batch": "[{\"event\":\"Loaded a Page\",\"properties\":{\"ip\":\"0.0.0.0\",\"$user_id\":\"hjikl\",\"$current_url\":\"https://docs.rudderstack.com/destinations/mixpanel\",\"$screen_dpi\":2,\"mp_lib\":\"RudderLabs JavaScript SDK\",\"$app_build_number\":\"1.0.0\",\"$app_version_string\":\"1.0.5\",\"$insert_id\":\"dd266c67-9199-4a52-ba32-f46ddde67312\",\"token\":\"9432f11f70f8ce386f5110c8c924b3ec4f825256\",\"distinct_id\":\"hjikl\",\"time\":1579847342,\"name\":\"Contact Us\",\"$browser\":\"Chrome\",\"$browser_version\":\"79.0.3945.117\"}}]"
+        },
         "XML": {},
         "FORM": {}
       },
@@ -69,27 +51,12 @@
       "method": "POST",
       "endpoint": "https://api.mixpanel.com/engage/",
       "headers": {},
-      "params": {
-        "data": {
-          "$set": {
-            "$email": "mickey@disney.com",
-            "$country_code": "USA",
-            "$city": "Disney",
-            "$initial_referrer": "https://docs.rudderstack.com",
-            "$initial_referring_domain": "docs.rudderstack.com",
-            "$firstName": "Mickey",
-            "$browser": "Chrome",
-            "$browser_version": "79.0.3945.117"
-          },
-          "$token": "9432f11f70f8ce386f5110c8c924b3ec4f825256",
-          "$distinct_id": "e6ab2c5e-2cda-44a9-a962-e2f67df78bca",
-          "$ip": "0.0.0.0",
-          "$time": 1579847342
-        }
-      },
+      "params": {},
       "body": {
         "JSON": {},
-        "JSON_ARRAY": {},
+        "JSON_ARRAY": {
+          "batch": "[{\"$set\":{\"$email\":\"mickey@disney.com\",\"$country_code\":\"USA\",\"$city\":\"Disney\",\"$initial_referrer\":\"https://docs.rudderstack.com\",\"$initial_referring_domain\":\"docs.rudderstack.com\",\"$firstName\":\"Mickey\",\"$browser\":\"Chrome\",\"$browser_version\":\"79.0.3945.117\"},\"$token\":\"9432f11f70f8ce386f5110c8c924b3ec4f825256\",\"$distinct_id\":\"e6ab2c5e-2cda-44a9-a962-e2f67df78bca\",\"$ip\":\"0.0.0.0\",\"$time\":1579847342}]"
+        },
         "XML": {},
         "FORM": {}
       },
@@ -129,30 +96,12 @@
       "method": "POST",
       "endpoint": "https://api.mixpanel.com/engage/",
       "headers": {},
-      "params": {
-        "data": {
-          "$set": {
-            "$created": "2020-01-23T08:54:02.362Z",
-            "$email": "mickey@disney.com",
-            "$firstName": "Mickey",
-            "$lastName": "Mouse",
-            "$country_code": "USA",
-            "$city": "Disney",
-            "$initial_referrer": "https://docs.rudderstack.com",
-            "$initial_referring_domain": "docs.rudderstack.com",
-            "$name": "Mickey Mouse",
-            "$browser": "Chrome",
-            "$browser_version": "79.0.3945.117"
-          },
-          "$token": "apiToken123",
-          "$distinct_id": "$device:anonId01",
-          "$ip": "0.0.0.0",
-          "$time": 1579847342
-        }
-      },
+      "params": {},
       "body": {
         "JSON": {},
-        "JSON_ARRAY": {},
+        "JSON_ARRAY": {
+          "batch": "[{\"$set\":{\"$created\":\"2020-01-23T08:54:02.362Z\",\"$email\":\"mickey@disney.com\",\"$country_code\":\"USA\",\"$city\":\"Disney\",\"$initial_referrer\":\"https://docs.rudderstack.com\",\"$initial_referring_domain\":\"docs.rudderstack.com\",\"$name\":\"Mickey Mouse\",\"$firstName\":\"Mickey\",\"$lastName\":\"Mouse\",\"$browser\":\"Chrome\",\"$browser_version\":\"79.0.3945.117\"},\"$token\":\"apiToken123\",\"$distinct_id\":\"$device:anonId01\",\"$ip\":\"0.0.0.0\",\"$time\":1579847342}]"
+        },
         "XML": {},
         "FORM": {}
       },
@@ -182,38 +131,12 @@
         "method": "POST",
         "endpoint": "https://api.mixpanel.com/track/",
         "headers": {},
-        "params": {
-          "data": {
-            "event": "Product Viewed",
-            "properties": {
-              "name": "T-Shirt",
-              "$user_id": "userId01",
-              "$device_id": "anonId01",
-              "$os": "iOS",
-              "$screen_height": 1794,
-              "$screen_width": 1080,
-              "$screen_dpi": 420,
-              "$carrier": "Android",
-              "$os_version": "8.1.0",
-              "$device": "generic_x86",
-              "$manufacturer": "Google",
-              "$model": "Android SDK built for x86",
-              "mp_device_model": "Android SDK built for x86",
-              "$wifi": true,
-              "$bluetooth_enabled": false,
-              "mp_lib": "com.rudderstack.android.sdk.core",
-              "$app_build_number": "1",
-              "$app_version_string": "1.0",
-              "$insert_id": "id2",
-              "token": "apiToken123",
-              "distinct_id": "userId01",
-              "time": 1579847342
-            }
-          }
-        },
+        "params": {},
         "body": {
           "JSON": {},
-          "JSON_ARRAY": {},
+          "JSON_ARRAY": {
+            "batch": "[{\"event\":\"Product Viewed\",\"properties\":{\"name\":\"T-Shirt\",\"$user_id\":\"userId01\",\"$os\":\"iOS\",\"$screen_height\":1794,\"$screen_width\":1080,\"$screen_dpi\":420,\"$carrier\":\"Android\",\"$os_version\":\"8.1.0\",\"$device\":\"generic_x86\",\"$manufacturer\":\"Google\",\"$model\":\"Android SDK built for x86\",\"mp_device_model\":\"Android SDK built for x86\",\"$wifi\":true,\"$bluetooth_enabled\":false,\"mp_lib\":\"com.rudderstack.android.sdk.core\",\"$app_build_number\":\"1\",\"$app_version_string\":\"1.0\",\"$insert_id\":\"id2\",\"token\":\"apiToken123\",\"distinct_id\":\"userId01\",\"time\":1579847342,\"$device_id\":\"anonId01\"}}]"
+          },
           "XML": {},
           "FORM": {}
         },
@@ -235,6 +158,56 @@
         "prefixProperties": true,
         "identityMergeApi": "simplified"
       }
+    }
+  },
+  {
+    "batchedRequest": {
+      "version": "1",
+      "type": "REST",
+      "method": "POST",
+      "endpoint": "https://api-eu.mixpanel.com/import/",
+      "headers": {
+        "Authorization": "Basic c29tZV9hcGlfc2VjcmV0Og==",
+        "Content-Type": "application/json"
+      },
+      "params": { "strict": 1 },
+      "body": {
+        "JSON": {},
+        "JSON_ARRAY": {
+          "batch": "[{\"event\":\"$merge\",\"properties\":{\"$distinct_ids\":[\"test_user_id\",\"5094f5704b9cf2b3\"],\"token\":\"9432f11f70f8ce386f5110c8c924b3ec4f825256\"}}]"
+        },
+        "XML": {},
+        "FORM": {}
+      },
+      "files": {},
+      "userId": "test_user_id"
+    },
+    "metadata": [
+      {
+        "jobId": 2
+      }
+    ],
+    "batched": false,
+    "statusCode": 200,
+    "destination": {
+      "Config": {
+        "apiKey": "9432f11f70f8ce386f5110c8c924b3ec4f825256",
+        "token": "9432f11f70f8ce386f5110c8c924b3ec4f825256",
+        "apiSecret": "some_api_secret",
+        "prefixProperties": true,
+        "dataResidency": "eu",
+        "useNativeSDK": false,
+        "strictMode": true
+      },
+      "DestinationDefinition": {
+        "DisplayName": "Mixpanel",
+        "ID": "1WhbSZ6uA3H5ChVifHpfL2H6sie",
+        "Name": "MP"
+      },
+      "Enabled": true,
+      "ID": "1WhcOCGgj9asZu850HvugU2C3Aq",
+      "Name": "Mixpanel",
+      "Transformations": []
     }
   }
 ]

--- a/test/__tests__/mixpanel.test.js
+++ b/test/__tests__/mixpanel.test.js
@@ -16,34 +16,7 @@ const inputData = JSON.parse(inputDataFile);
 const expectedData = JSON.parse(outputDataFile);
 // 2020-01-24T06:29:02.358Z
 Date.now = jest.fn(() => new Date(Date.UTC(2020, 0, 25)).valueOf());
-inputData.forEach((input, index) => {
-  test(`${name} Tests: payload - ${index}`, async () => {
-    let output, expected;
-    try {
-      output = await transformer.process(input);
-      if (Array.isArray(output) && output.length >= 1) {
-        output.forEach(eachPayload => {
-          const decodedPayload = JSON.parse(
-            Buffer.from(
-              JSON.stringify(eachPayload.params.data),
-              "base64"
-            ).toString()
-          );
-          eachPayload.params.data = decodedPayload;
-        });
-      } else {
-        output.params.data = JSON.parse(
-          Buffer.from(JSON.stringify(output.params.data), "base64").toString()
-        );
-      }
-      expected = expectedData[index];
-    } catch (error) {
-      output = error.message;
-      expected = expectedData[index].message;
-    }
-    expect(output).toEqual(expected);
-  });
-});
+
 // Router Test Data
 const inputRouterDataFile = fs.readFileSync(
   path.resolve(__dirname, `./data/${integration}_router_input.json`)
@@ -55,34 +28,22 @@ const inputRouterData = JSON.parse(inputRouterDataFile);
 const expectedRouterData = JSON.parse(outputRouterDataFile);
 
 describe(`${name} Tests`, () => {
-  describe("Router Tests", () => {
-    it("Payload", async () => {
-      const routerOutput = await transformer.processRouterDest(inputRouterData);
-      routerOutput.forEach(eachPayload => {
-        // when batched payload is an array itself
-        if (Array.isArray(eachPayload.batchedRequest)) {
-          const { batchedRequest } = eachPayload;
-          batchedRequest.forEach(request => {
-            const decodedPayload = JSON.parse(
-              Buffer.from(
-                JSON.stringify(request.params.data),
-                "base64"
-              ).toString()
-            );
-            // creating for one single batch array payload
-            request.params.data = decodedPayload;
-          });
-        } else {
-          // where batched request is a simple object
-          const decodedPayload = JSON.parse(
-            Buffer.from(
-              JSON.stringify(eachPayload.batchedRequest.params.data),
-              "base64"
-            ).toString()
-          );
-          eachPayload.batchedRequest.params.data = decodedPayload;
+  describe("Processor Tests", () => {
+    inputData.forEach((input, index) => {
+      it(`${name} - payload: ${index}`, async () => {
+        try {
+          const output = await transformer.process(input);
+          expect(output).toEqual(expectedData[index]);
+        } catch (error) {
+          expect(error.message).toEqual(expectedData[index].message);
         }
       });
+    });
+  });
+
+  describe("Router", () => {
+    it("Payload", async () => {
+      const routerOutput = await transformer.processRouterDest(inputRouterData);
       expect(routerOutput).toEqual(expectedRouterData);
     });
   });


### PR DESCRIPTION
## Description of the change

>

- Added the strict parameter (values = 0/1) to the [/Import](https://developer.mixpanel.com/reference/import-events) endpoint. When the strict parameter is set to 1, Mixpanel will validate the received request.
- Removed the base64 encoding of the payload.
- Removed sending the payload in query parameters.
- Now sending the unencoded payload in the request body.


## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
