### PR TITLE
fix: incorrect usage of histogram as counter

### DIFF
--- a/src/services/trackingPlan.ts
+++ b/src/services/trackingPlan.ts
@@ -69,7 +69,7 @@ export default class TrackingPlanservice {
       stats.counter('hv_events_count', events.length, {
         ...metaTags,
       });
-      stats.counter('hv_request_size', requestSize, {
+      stats.histogram('hv_request_size', requestSize, {
         ...metaTags,
       });
       stats.timing('hv_request_latency', requestStartTime, {


### PR DESCRIPTION
## Description of the change

hv_request_size is histogram but used as couter.
Fixes this error: Counter metric hv_request_size failed with error TypeError: metric.inc is not a function. Value: 2223

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues



## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
