### PR TITLE
fix(facebook_pixel): name conversion to string

### DIFF
--- a/src/v0/destinations/facebook_pixel/data/FBPIXELUserDataConfig.json
+++ b/src/v0/destinations/facebook_pixel/data/FBPIXELUserDataConfig.json
@@ -79,7 +79,10 @@
   {
     "destKey": "name",
     "sourceKeys": ["traits.name", "context.traits.name"],
-    "required": false
+    "required": false,
+    "metadata": {
+      "type": "toString"
+    }
   },
   {
     "destKey": "ct",

--- a/test/__tests__/data/facebook_pixel_input.json
+++ b/test/__tests__/data/facebook_pixel_input.json
@@ -3965,5 +3965,128 @@
       },
       "Enabled": true
     }
+  },
+  {
+    "metadata": {
+      "jobId": 12
+    },
+    "destination": {
+      "secretConfig": {},
+      "Config": {
+        "blacklistPiiProperties": [
+          {
+            "blacklistPiiProperties": "",
+            "blacklistPiiHash": false
+          }
+        ],
+        "pixelId": "12345555566",
+        "eventsToEvents": [
+          {
+            "from": "",
+            "to": ""
+          }
+        ],
+        "valueFieldIdentifier": "properties.price",
+        "advancedMapping": false,
+        "whitelistPiiProperties": [],
+        "limitedDataUSage": false,
+        "accessToken": "Asdkjhbriufkjrvknkjfkjhkjf",
+        "testDestination": false,
+        "testEventCode": "",
+        "standardPageCall": false,
+        "blacklistedEvents": [],
+        "whitelistedEvents": [],
+        "eventFilteringOption": "disable",
+        "removeExternalId": false,
+        "useUpdatedMapping": false,
+        "oneTrustCookieCategories": [],
+        "useNativeSDK": false,
+        "eventDelivery": false,
+        "eventDeliveryTS": 1686748039135
+      },
+      "liveEventsConfig": {
+        "eventDelivery": false,
+        "eventDeliveryTS": 1686748039135
+      },
+      "id": "destId1",
+      "workspaceId": "wsp2",
+      "transformations": [],
+      "isConnectionEnabled": true,
+      "isProcessorEnabled": true,
+      "name": "san-fb_pixel",
+      "enabled": true,
+      "deleted": false,
+      "createdAt": "2023-06-06T13:36:08.579Z",
+      "updatedAt": "2023-06-14T13:07:19.136Z",
+      "revisionId": "revId2",
+      "secretVersion": 3
+    },
+    "message": {
+      "type": "page",
+      "sentAt": "2019-09-01T15:46:51.000Z",
+      "userId": "user@19",
+      "channel": "web",
+      "context": {
+        "os": {
+          "name": "",
+          "version": ""
+        },
+        "app": {
+          "name": "RudderLabs JavaScript SDK",
+          "version": "dev-snapshot",
+          "namespace": "com.rudderlabs.javascript"
+        },
+        "page": {
+          "url": "http://127.0.0.1:8888/",
+          "path": "/",
+          "title": "Document",
+          "search": "",
+          "tab_url": "http://127.0.0.1:8888/",
+          "referrer": "http://127.0.0.1:8888/",
+          "initial_referrer": "$direct",
+          "referring_domain": "127.0.0.1:8888",
+          "initial_referring_domain": ""
+        },
+        "locale": "en-GB",
+        "screen": {
+          "width": 1728,
+          "height": 1117,
+          "density": 2,
+          "innerWidth": 547,
+          "innerHeight": 915
+        },
+        "traits": {
+          "name": false,
+          "source": "rudderstack"
+        },
+        "library": {
+          "name": "RudderLabs JavaScript SDK",
+          "version": "dev-snapshot"
+        },
+        "campaign": {},
+        "sessionId": 1687769234506,
+        "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36"
+      },
+      "rudderId": "6bbfd003-c074-4ee9-8674-c132ded9ff04",
+      "timestamp": "2019-09-01T15:46:51.000Z",
+      "properties": {
+        "url": "http://127.0.0.1:8888/",
+        "path": "/",
+        "title": "Document",
+        "search": "",
+        "tab_url": "http://127.0.0.1:8888/",
+        "referrer": "http://127.0.0.1:8888/",
+        "initial_referrer": "$direct",
+        "referring_domain": "127.0.0.1:8888",
+        "initial_referring_domain": ""
+      },
+      "receivedAt": "2019-09-01T15:46:51.000Z",
+      "request_ip": "49.206.54.243",
+      "anonymousId": "700ab220-faad-4cdf-8484-63e4c6bce6fe",
+      "integrations": {
+        "All": true
+      },
+      "originalTimestamp": "2019-09-01T15:46:51.000Z"
+    }
   }
 ]

--- a/test/__tests__/data/facebook_pixel_output.json
+++ b/test/__tests__/data/facebook_pixel_output.json
@@ -749,5 +749,24 @@
       "errorCategory": "dataValidation",
       "errorType": "configuration"
     }
+  },
+  {
+    "body": {
+      "FORM": {
+        "data": [
+          "{\"user_data\":{\"external_id\":\"72fd46c9ecb386f6747664a3e1d524294a3d7a2c8ae4aeb22b1e578b75093635\",\"client_ip_address\":\"49.206.54.243\",\"client_user_agent\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36\"},\"event_name\":\"PageView\",\"event_time\":1567352811,\"event_source_url\":\"http://127.0.0.1:8888/\",\"action_source\":\"website\",\"custom_data\":{\"url\":\"http://127.0.0.1:8888/\",\"path\":\"/\",\"title\":\"Document\",\"search\":\"\",\"tab_url\":\"http://127.0.0.1:8888/\",\"referrer\":\"http://127.0.0.1:8888/\",\"initial_referrer\":\"$direct\",\"referring_domain\":\"127.0.0.1:8888\",\"initial_referring_domain\":\"\"}}"
+        ]
+      },
+      "JSON": {},
+      "JSON_ARRAY": {},
+      "XML": {}
+    },
+    "endpoint": "https://graph.facebook.com/v16.0/12345555566/events?access_token=Asdkjhbriufkjrvknkjfkjhkjf",
+    "files": {},
+    "headers": {},
+    "method": "POST",
+    "params": {},
+    "type": "REST",
+    "version": "1"
   }
 ]


### PR DESCRIPTION
## Description of the change

For some reason the name property is being sent as false (boolean). That data-type does not have split method defined in Javascript. Which is causing this issue

Bugsnag: https://app.squadcast.com/incident/64991c6372ca037dfb591a1a
Notion: https://www.notion.so/rudderstacks/Bugsnag-Facebook-Pixel-name-is-sent-as-boolean-but-expected-to-be-string-4f3ce02a094c4996865c7d00d7b4a956?pvs=4

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
