### PR TITLE
chore: send redis failure metric always

### DIFF
--- a/src/util/prometheus.js
+++ b/src/util/prometheus.js
@@ -94,7 +94,7 @@ class Prometheus {
         logger.warn(
           `Prometheus: Summary metric ${name} not found in the registry. Creating a new one`,
         );
-        metric = this.newSummaryStat(name, '', Object.keys(tags));
+        metric = this.newSummaryStat(name, name, Object.keys(tags));
       }
       metric.observe(tags, value);
     } catch (e) {
@@ -109,7 +109,7 @@ class Prometheus {
         logger.warn(
           `Prometheus: Timing metric ${name} not found in the registry. Creating a new one`,
         );
-        metric = this.newHistogramStat(name, '', Object.keys(tags));
+        metric = this.newHistogramStat(name, name, Object.keys(tags));
       }
       metric.observe(tags, (new Date() - start) / 1000);
     } catch (e) {
@@ -124,7 +124,7 @@ class Prometheus {
         logger.warn(
           `Prometheus: Histogram metric ${name} not found in the registry. Creating a new one`,
         );
-        metric = this.newHistogramStat(name, '', Object.keys(tags));
+        metric = this.newHistogramStat(name, name, Object.keys(tags));
       }
       metric.observe(tags, value);
     } catch (e) {
@@ -143,7 +143,7 @@ class Prometheus {
         logger.warn(
           `Prometheus: Counter metric ${name} not found in the registry. Creating a new one`,
         );
-        metric = this.newCounterStat(name, '', Object.keys(tags));
+        metric = this.newCounterStat(name, name, Object.keys(tags));
       }
       metric.inc(tags, delta);
     } catch (e) {
@@ -158,7 +158,7 @@ class Prometheus {
         logger.warn(
           `Prometheus: Gauge metric ${name} not found in the registry. Creating a new one`,
         );
-        metric = this.newGaugeStat(name, '', Object.keys(tags));
+        metric = this.newGaugeStat(name, name, Object.keys(tags));
       }
       metric.set(tags, value);
     } catch (e) {


### PR DESCRIPTION
## Description of the change

Sending redis failure alert always. 
Reason: For redis failure alerts to work properly, we need to init the metric on server start. Instead of initing, sending the metric always. There shouldn't be any impact as such.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
