### PR TITLE
feat(ga4): enable campaign parameters support in cloud mode

### DIFF
--- a/src/v0/destinations/ga4/config.js
+++ b/src/v0/destinations/ga4/config.js
@@ -19,6 +19,7 @@ const DEBUG_ENDPOINT = 'https://www.google-analytics.com/debug/mp/collect';
  */
 const ConfigCategory = {
   COMMON: { name: 'GA4CommonConfig' },
+  CAMPAIGN: { name: 'GA4CampaignDetailsConfig'},
   ITEM_LIST: { name: 'GA4ItemListConfig' },
   ITEM: { name: 'GA4ItemConfig' },
 

--- a/src/v0/destinations/ga4/data/GA4CampaignDetailsConfig.json
+++ b/src/v0/destinations/ga4/data/GA4CampaignDetailsConfig.json
@@ -1,0 +1,50 @@
+[
+    {
+        "destKey": "campaign_id",
+        "sourceKeys": [
+            "context.campaign.id",
+            "properties.campaign.id"
+        ],
+        "required": false
+    },
+    {
+        "destKey": "campaign",
+        "sourceKeys": [
+            "context.campaign.name",
+            "properties.campaign.name"
+        ],
+        "required": false
+    },
+    {
+        "destKey": "source",
+        "sourceKeys": [
+            "context.campaign.source",
+            "properties.campaign.source"
+        ],
+        "required": false
+    },
+    {
+        "destKey": "medium",
+        "sourceKeys": [
+            "context.campaign.medium",
+            "properties.campaign.medium"
+        ],
+        "required": false
+    },
+    {
+        "destKey": "term",
+        "sourceKeys": [
+            "context.campaign.term",
+            "properties.campaign.term"
+        ],
+        "required": false
+    },
+    {
+        "destKey": "content",
+        "sourceKeys": [
+            "context.campaign.content",
+            "properties.campaign.content"
+        ],
+        "required": false
+    }
+]

--- a/src/v0/destinations/ga4/transform.js
+++ b/src/v0/destinations/ga4/transform.js
@@ -235,6 +235,9 @@ const responseBuilder = (message, { Config }) => {
     payload.params.session_number = integrationsObj.sessionNumber;
   }
 
+  // Add campaign parameters
+  payload.params = { ...payload.params, ...constructPayload(message, mappingConfig[ConfigCategory.CAMPAIGN.name]) }
+
   if (payload.params) {
     payload.params = removeUndefinedAndNullValues(payload.params);
   }

--- a/test/__tests__/data/ga4.json
+++ b/test/__tests__/data/ga4.json
@@ -12455,5 +12455,119 @@
         "scope": "exception"
       }
     }
+  },
+  {
+    "description": "(gtag) campaign_details custom event",
+    "input": {
+      "message": {
+        "userId": "user@1",
+        "channel": "web",
+        "anonymousId": "ec5481b6-a926-4d2e-b293-0b3a77c4d3be",
+        "context": {
+          "app": {
+            "build": "1.0.0",
+            "name": "RudderLabs JavaScript SDK",
+            "namespace": "com.rudderlabs.javascript",
+            "version": "1.0.0"
+          },
+          "device": {
+            "adTrackingEnabled": "false",
+            "advertisingId": "T0T0T072-5e28-45a1-9eda-ce22a3e36d1a",
+            "id": "3f034872-5e28-45a1-9eda-ce22a3e36d1a",
+            "manufacturer": "Google",
+            "model": "AOSP on IA Emulator",
+            "name": "generic_x86_arm",
+            "type": "ios",
+            "attTrackingStatus": 3
+          },
+          "ip": "0.0.0.0",
+          "library": {
+            "name": "RudderLabs JavaScript SDK",
+            "version": "1.0.0"
+          },
+          "locale": "en-US",
+          "os": {
+            "name": "iOS",
+            "version": "14.4.1"
+          },
+          "screen": {
+            "density": 2
+          },
+          "campaign": {
+            "id": "google_1234",
+            "name": "Summer_fun",
+            "source": "google",
+            "medium": "cpc",
+            "term": "summer+travel",
+            "content": "logo link"
+          },
+          "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.88 Safari/537.36"
+        },
+        "type": "track",
+        "event": "campaign_details",
+        "properties": {},
+        "integrations": {
+          "All": true
+        }
+      },
+      "destination": {
+        "Config": {
+          "apiSecret": "QyWKGHj8QhG2L4ePAPiXCA",
+          "measurementId": "G-T40PE6BET4",
+          "typesOfClient": "gtag",
+          "eventFilteringOption": "disable",
+          "blacklistedEvents": [
+            {
+              "eventName": ""
+            }
+          ],
+          "whitelistedEvents": [
+            {
+              "eventName": ""
+            }
+          ]
+        },
+        "Enabled": true
+      }
+    },
+    "output": {
+      "body": {
+        "XML": {},
+        "FORM": {},
+        "JSON": {
+          "events": [
+            {
+              "name": "campaign_details",
+              "params": {
+                "campaign_id": "google_1234",
+                "campaign": "Summer_fun",
+                "source": "google",
+                "medium": "cpc",
+                "term": "summer+travel",
+                "content": "logo link",
+                "engagement_time_msec": 1
+              }
+            }
+          ],
+          "user_id": "user@1",
+          "client_id": "ec5481b6-a926-4d2e-b293-0b3a77c4d3be",
+          "non_personalized_ads": true
+        },
+        "JSON_ARRAY": {}
+      },
+      "type": "REST",
+      "files": {},
+      "method": "POST",
+      "params": {
+        "api_secret": "QyWKGHj8QhG2L4ePAPiXCA",
+        "measurement_id": "G-T40PE6BET4"
+      },
+      "headers": {
+        "HOST": "www.google-analytics.com",
+        "Content-Type": "application/json"
+      },
+      "version": "1",
+      "endpoint": "https://www.google-analytics.com/mp/collect"
+    }
   }
 ]


### PR DESCRIPTION
## Description of the change

- This pull request introduces the capability to include campaign parameters in track calls and custom events for GA4 (Google Analytics 4). With this enhancement, campaign parameters associated with a particular event will be sent to GA4 if they are present in the payload.

- The addition of campaign parameters allows for more granular tracking and analysis of marketing campaigns in GA4. By including these parameters, businesses can gain insights into the effectiveness of their marketing efforts and make data-driven decisions to optimize their strategies.

- Furthermore, this PR ensures that campaign parameters can also be sent to GA4 using the `campaign_details` custom event. This provides flexibility for users to include campaign-related information in custom events for better campaign analysis and attribution.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
