### PR TITLE
refactor: combine batch requests with same job ids

### DIFF
--- a/src/v0/destinations/mp/util.test.js
+++ b/src/v0/destinations/mp/util.test.js
@@ -1,4 +1,7 @@
-const { combineBatchRequestsWithSameJobIds } = require('./util');
+const {
+  combineBatchRequestsWithSameJobIds,
+  combineBatchRequestsWithSameJobIds2,
+} = require('./util');
 
 const destinationMock = {
   Config: {
@@ -245,6 +248,283 @@ describe('Mixpanel utils test', () => {
         },
       ];
       expect(combineBatchRequestsWithSameJobIds(input)).toEqual(expectedOutput);
+    });
+  });
+  describe('Unit test cases for combineBatchRequestsWithSameJobIds2', () => {
+    it('Combine batch request with same jobIds', async () => {
+      const input = [
+        {
+          batchedRequest: {
+            endpoint: 'https://api.mixpanel.com/track/',
+          },
+          metadata: [
+            {
+              jobId: 1,
+            },
+            {
+              jobId: 4,
+            },
+          ],
+          batched: true,
+          statusCode: 200,
+          destination: destinationMock,
+        },
+        {
+          batchedRequest: {
+            endpoint: 'https://api.mixpanel.com/import/',
+          },
+          metadata: [
+            {
+              jobId: 3,
+            },
+          ],
+          batched: true,
+          statusCode: 200,
+          destination: destinationMock,
+        },
+        {
+          batchedRequest: {
+            endpoint: 'https://api.mixpanel.com/track/',
+          },
+          metadata: [
+            {
+              jobId: 5,
+            },
+          ],
+          batched: true,
+          statusCode: 200,
+          destination: destinationMock,
+        },
+        {
+          batchedRequest: {
+            endpoint: 'https://api.mixpanel.com/engage/',
+          },
+          metadata: [
+            {
+              jobId: 1,
+            },
+            {
+              jobId: 3,
+            },
+          ],
+          batched: true,
+          statusCode: 200,
+          destination: destinationMock,
+        },
+        {
+          batchedRequest: {
+            endpoint: 'https://api.mixpanel.com/import/',
+          },
+          metadata: [
+            {
+              jobId: 6,
+            },
+          ],
+          batched: true,
+          statusCode: 200,
+          destination: destinationMock,
+        },
+      ];
+
+      const expectedOutput = [
+        {
+          batchedRequest: [
+            { endpoint: 'https://api.mixpanel.com/track/' },
+            { endpoint: 'https://api.mixpanel.com/engage/' },
+            { endpoint: 'https://api.mixpanel.com/engage/' },
+          ],
+          metadata: [{ jobId: 1 }, { jobId: 4 }, { jobId: 3 }],
+          batched: true,
+          statusCode: 200,
+          destination: {
+            Config: {
+              token: 'test_api_token',
+              prefixProperties: true,
+              useNativeSDK: false,
+              useOldMapping: true,
+            },
+            DestinationDefinition: {
+              DisplayName: 'Mixpanel',
+              ID: 'test_destination_definition_id',
+              Name: 'MP',
+            },
+            Enabled: true,
+            ID: 'test_id',
+            Name: 'Mixpanel',
+            Transformations: [],
+          },
+        },
+        {
+          batchedRequest: [{ endpoint: 'https://api.mixpanel.com/import/' }],
+          metadata: [{ jobId: 3 }],
+          batched: true,
+          statusCode: 200,
+          destination: {
+            Config: {
+              token: 'test_api_token',
+              prefixProperties: true,
+              useNativeSDK: false,
+              useOldMapping: true,
+            },
+            DestinationDefinition: {
+              DisplayName: 'Mixpanel',
+              ID: 'test_destination_definition_id',
+              Name: 'MP',
+            },
+            Enabled: true,
+            ID: 'test_id',
+            Name: 'Mixpanel',
+            Transformations: [],
+          },
+        },
+        {
+          batchedRequest: [{ endpoint: 'https://api.mixpanel.com/track/' }],
+          metadata: [{ jobId: 5 }],
+          batched: true,
+          statusCode: 200,
+          destination: {
+            Config: {
+              token: 'test_api_token',
+              prefixProperties: true,
+              useNativeSDK: false,
+              useOldMapping: true,
+            },
+            DestinationDefinition: {
+              DisplayName: 'Mixpanel',
+              ID: 'test_destination_definition_id',
+              Name: 'MP',
+            },
+            Enabled: true,
+            ID: 'test_id',
+            Name: 'Mixpanel',
+            Transformations: [],
+          },
+        },
+        {
+          batchedRequest: [{ endpoint: 'https://api.mixpanel.com/import/' }],
+          metadata: [{ jobId: 6 }],
+          batched: true,
+          statusCode: 200,
+          destination: {
+            Config: {
+              token: 'test_api_token',
+              prefixProperties: true,
+              useNativeSDK: false,
+              useOldMapping: true,
+            },
+            DestinationDefinition: {
+              DisplayName: 'Mixpanel',
+              ID: 'test_destination_definition_id',
+              Name: 'MP',
+            },
+            Enabled: true,
+            ID: 'test_id',
+            Name: 'Mixpanel',
+            Transformations: [],
+          },
+        },
+      ];
+      expect(combineBatchRequestsWithSameJobIds2(input)).toEqual(expectedOutput);
+    });
+
+    it('Each batchRequest contains unique jobIds (no event multiplexing)', async () => {
+      const input = [
+        {
+          batchedRequest: {
+            endpoint: 'https://api.mixpanel.com/track/',
+          },
+          metadata: [
+            {
+              jobId: 1,
+            },
+            {
+              jobId: 4,
+            },
+          ],
+          batched: true,
+          statusCode: 200,
+          destination: destinationMock,
+        },
+        {
+          batchedRequest: {
+            endpoint: 'https://api.mixpanel.com/engage/',
+          },
+          metadata: [
+            {
+              jobId: 2,
+            },
+          ],
+          batched: true,
+          statusCode: 200,
+          destination: destinationMock,
+        },
+        {
+          batchedRequest: {
+            endpoint: 'https://api.mixpanel.com/engage/',
+          },
+          metadata: [
+            {
+              jobId: 5,
+            },
+          ],
+          batched: true,
+          statusCode: 200,
+          destination: destinationMock,
+        },
+      ];
+
+      const expectedOutput = [
+        {
+          batchedRequest: [
+            {
+              endpoint: 'https://api.mixpanel.com/track/',
+            },
+          ],
+
+          metadata: [
+            {
+              jobId: 1,
+            },
+            {
+              jobId: 4,
+            },
+          ],
+          batched: true,
+          statusCode: 200,
+          destination: destinationMock,
+        },
+        {
+          batchedRequest: [
+            {
+              endpoint: 'https://api.mixpanel.com/engage/',
+            },
+          ],
+          metadata: [
+            {
+              jobId: 2,
+            },
+          ],
+          batched: true,
+          statusCode: 200,
+          destination: destinationMock,
+        },
+        {
+          batchedRequest: [
+            {
+              endpoint: 'https://api.mixpanel.com/engage/',
+            },
+          ],
+          metadata: [
+            {
+              jobId: 5,
+            },
+          ],
+          batched: true,
+          statusCode: 200,
+          destination: destinationMock,
+        },
+      ];
+      expect(combineBatchRequestsWithSameJobIds2(input)).toEqual(expectedOutput);
     });
   });
 });


### PR DESCRIPTION
## Description of the change

refactor: combineBatchRequestsWithSameJobIds
    
    implemented as combineBatchRequestsWithSameJobIds2

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
