### PR TITLE
feat(mixpnel): update alias mapping and add validation

### DIFF
--- a/src/v0/destinations/mp/transform.js
+++ b/src/v0/destinations/mp/transform.js
@@ -254,21 +254,22 @@ const processPageOrScreenEvents = (message, type, destination) => {
 };
 
 const processAliasEvents = (message, type, destination) => {
-  if (!(message.previousId || message.anonymousId)) {
+  const aliasId = message.previousId || message.anonymousId;
+  if (!aliasId) {
     throw new InstrumentationError(
       'Either previous id or anonymous id should be present in alias payload',
     );
   }
 
-  if (message.previousId === message.userId) {
-    throw new InstrumentationError('Previous id and user id should not be same');
+  if (aliasId === message.userId) {
+    throw new InstrumentationError('One of previousId/anonymousId is same as userId');
   }
 
   const payload = {
     event: '$create_alias',
     properties: {
       distinct_id: message.userId,
-      alias: message.previousId || message.anonymousId,
+      alias: aliasId,
       token: destination.Config.token,
     },
   };

--- a/src/v0/destinations/mp/transform.js
+++ b/src/v0/destinations/mp/transform.js
@@ -259,11 +259,16 @@ const processAliasEvents = (message, type, destination) => {
       'Either previous id or anonymous id should be present in alias payload',
     );
   }
+
+  if (message.previousId === message.userId) {
+    throw new InstrumentationError('Previous id and user id should not be same');
+  }
+
   const payload = {
     event: '$create_alias',
     properties: {
-      distinct_id: message.previousId || message.anonymousId,
-      alias: message.userId,
+      distinct_id: message.userId,
+      alias: message.previousId || message.anonymousId,
       token: destination.Config.token,
     },
   };

--- a/test/__tests__/data/mp_input.json
+++ b/test/__tests__/data/mp_input.json
@@ -4354,5 +4354,80 @@
       "type": "identify",
       "sentAt": "2020-03-12T09:05:13.042Z"
     }
+  },
+  {
+    "description": "Alias: with same previousId and userId",
+    "destination": {
+      "Config": {
+        "apiKey": "9432f11f70f8ce386f5110c8c924b3ec4f825256",
+        "token": "9432f11f70f8ce386f5110c8c924b3ec4f825256",
+        "prefixProperties": true,
+        "useNativeSDK": false
+      },
+      "DestinationDefinition": {
+        "DisplayName": "Kiss Metrics",
+        "ID": "1WhbSZ6uA3H5ChVifHpfL2H6sie",
+        "Name": "MIXPANEL"
+      },
+      "Enabled": true,
+      "ID": "1WhcOCGgj9asZu850HvugU2C3Aq",
+      "Name": "Kiss Metrics",
+      "Transformations": []
+    },
+    "message": {
+      "anonymousId": "test_anonymous_id",
+      "channel": "web",
+      "context": {
+        "app": {
+          "build": "1.0.0",
+          "name": "RudderLabs JavaScript SDK",
+          "namespace": "com.rudderlabs.javascript",
+          "version": "1.0.5"
+        },
+        "ip": "0.0.0.0",
+        "library": {
+          "name": "RudderLabs JavaScript SDK",
+          "version": "1.0.5"
+        },
+        "locale": "en-GB",
+        "os": {
+          "name": "",
+          "version": ""
+        },
+        "screen": {
+          "density": 2
+        },
+        "traits": {
+          "city": "Disney",
+          "country": "USA",
+          "email": "mickey@disney.com",
+          "lastname": "Mickey",
+          "firstName": "Mouse"
+        },
+        "page": {
+          "path": "/destinations/mixpanel",
+          "referrer": "",
+          "search": "",
+          "title": "",
+          "url": "https://docs.rudderstack.com/destinations/mixpanel",
+          "category": "destination",
+          "initial_referrer": "https://docs.rudderstack.com",
+          "initial_referring_domain": "docs.rudderstack.com"
+        },
+        "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.117 Safari/537.36"
+      },
+      "integrations": {
+        "All": true
+      },
+      "messageId": "79313729-7fe5-4204-963a-dc46f4205e4e",
+      "originalTimestamp": "2020-01-24T06:29:02.366Z",
+      "receivedAt": "2020-01-24T11:59:02.403+05:30",
+      "request_ip": "[::1]:53711",
+      "sentAt": "2020-01-24T06:29:02.366Z",
+      "timestamp": "2020-01-24T11:59:02.403+05:30",
+      "type": "alias",
+      "userId": "test_user_id",
+      "previousId": "test_user_id"
+    }
   }
 ]

--- a/test/__tests__/data/mp_output.json
+++ b/test/__tests__/data/mp_output.json
@@ -157,7 +157,7 @@
     "body": {
       "JSON": {},
       "JSON_ARRAY": {
-        "batch": "[{\"event\":\"$create_alias\",\"properties\":{\"distinct_id\":\"e6ab2c5e-2cda-44a9-a962-e2f67df78bca\",\"alias\":\"1234abc\",\"token\":\"9432f11f70f8ce386f5110c8c924b3ec4f825256\"}}]"
+        "batch": "[{\"event\":\"$create_alias\",\"properties\":{\"distinct_id\":\"1234abc\",\"alias\":\"e6ab2c5e-2cda-44a9-a962-e2f67df78bca\",\"token\":\"9432f11f70f8ce386f5110c8c924b3ec4f825256\"}}]"
       },
       "XML": {},
       "FORM": {}
@@ -564,7 +564,7 @@
     "body": {
       "JSON": {},
       "JSON_ARRAY": {
-        "batch": "[{\"event\":\"$create_alias\",\"properties\":{\"distinct_id\":\"e6ab2c5e-2cda-44a9-a962-e2f67df78bca\",\"alias\":\"1234abc\",\"token\":\"9432f11f70f8ce386f5110c8c924b3ec4f825256\"}}]"
+        "batch": "[{\"event\":\"$create_alias\",\"properties\":{\"distinct_id\":\"1234abc\",\"alias\":\"e6ab2c5e-2cda-44a9-a962-e2f67df78bca\",\"token\":\"9432f11f70f8ce386f5110c8c924b3ec4f825256\"}}]"
       },
       "XML": {},
       "FORM": {}
@@ -1288,5 +1288,9 @@
       "files": {},
       "userId": "test_user_id"
     }
-  ]
+  ],
+  {
+    "statusCode": 400,
+    "message": "Previous id and user id should not be same"
+  }
 ]

--- a/test/__tests__/data/mp_output.json
+++ b/test/__tests__/data/mp_output.json
@@ -1291,6 +1291,6 @@
   ],
   {
     "statusCode": 400,
-    "message": "Previous id and user id should not be same"
+    "message": "One of previousId/anonymousId is same as userId"
   }
 ]


### PR DESCRIPTION
## Description of the change

> 
- Add the validation when previousId and userId are the same
- Mapping userId with `distinctId` and (previousId or anonymousId) with `alias` property


## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
