### PR TITLE
fix: keen bugsnag issue for null context passed

### DIFF
--- a/src/v0/destinations/keen/transform.js
+++ b/src/v0/destinations/keen/transform.js
@@ -95,7 +95,7 @@ function processTrack(message, destination) {
   properties.request_ip = getParsedIP(message);
 
   // add user-agent
-  properties.user_agent = context.userAgent;
+  properties.user_agent = context?.userAgent;
 
   addAddons(properties, destination.Config);
 

--- a/test/__tests__/data/keen_input.json
+++ b/test/__tests__/data/keen_input.json
@@ -2,6 +2,44 @@
   {
     "message": {
       "channel": "web",
+      "type": "page",
+      "context": null,
+      "messageId": "5e10d13a-bf9a-44bf-b884-43a9e591ea71",
+      "session_id": "3049dc4c-5a95-4ccd-a3e7-d74a7e411f22",
+      "originalTimestamp": "2019-10-14T11:15:18.299Z",
+      "anonymousId": "00000000000000000000000000",
+      "userId": "12345",
+      "properties": {
+        "path": "/test",
+        "referrer": "Rudder",
+        "search": "abc",
+        "title": "Test Page",
+        "url": "www.rudderlabs.com"
+      },
+      "traits": {
+        "email": "test@gmail.com",
+        "anonymousId": "anon-id"
+      },
+      "integrations": {
+        "All": true
+      },
+      "name": "ApplicationLoaded",
+      "sentAt": "2019-10-14T11:15:53.296Z"
+    },
+    "destination": {
+      "Config": {
+        "projectID": "abcde",
+        "writeKey": "xyz",
+        "ipAddon": true,
+        "uaAddon": true,
+        "urlAddon": true,
+        "referrerAddon": true
+      }
+    }
+  },
+  {
+    "message": {
+      "channel": "web",
       "context": {
         "app": {
           "build": "1.0.0",
@@ -70,7 +108,6 @@
       }
     }
   },
-
   {
     "message": {
       "channel": "web",

--- a/test/__tests__/data/keen_output.json
+++ b/test/__tests__/data/keen_output.json
@@ -1,5 +1,46 @@
 [
-  { "message": "Event type identify is not supported", "statusCode": 400 },
+  {
+    "body": {
+      "XML": {},
+      "JSON_ARRAY": {},
+      "JSON": {
+        "path": "/test",
+        "referrer": "Rudder",
+        "search": "abc",
+        "title": "Test Page",
+        "url": "www.rudderlabs.com",
+        "userId": "12345",
+        "keen": {
+          "addons": []
+        },
+        "anonymousId": "00000000000000000000000000",
+        "user": {
+          "traits": {
+            "anonymousId": "anon-id",
+            "email": "test@gmail.com"
+          },
+          "userId": "12345"
+        }
+      },
+      "FORM": {}
+    },
+    "files": {},
+    "endpoint": "https://api.keen.io/3.0/projects/abcde/events/Viewed ApplicationLoaded page",
+    "userId": "12345",
+    "headers": {
+      "Content-Type": "application/json",
+      "Authorization": "xyz"
+    },
+    "version": "1",
+    "params": {},
+    "type": "REST",
+    "method": "POST",
+    "statusCode": 200
+  },
+  {
+    "message": "Event type identify is not supported",
+    "statusCode": 400
+  },
   {
     "body": {
       "XML": {},
@@ -14,12 +55,16 @@
         "keen": {
           "addons": [
             {
-              "input": { "ip": "request_ip" },
+              "input": {
+                "ip": "request_ip"
+              },
               "name": "keen:ip_to_geo",
               "output": "ip_geo_info"
             },
             {
-              "input": { "ua_string": "user_agent" },
+              "input": {
+                "ua_string": "user_agent"
+              },
               "name": "keen:ua_parser",
               "output": "parsed_user_agent"
             }
@@ -27,7 +72,10 @@
         },
         "anonymousId": "00000000000000000000000000",
         "user": {
-          "traits": { "anonymousId": "anon-id", "email": "test@gmail.com" },
+          "traits": {
+            "anonymousId": "anon-id",
+            "email": "test@gmail.com"
+          },
           "userId": "12345"
         },
         "path": "/test",
@@ -38,7 +86,10 @@
     "files": {},
     "endpoint": "https://api.keen.io/3.0/projects/abcde/events/Viewed ApplicationLoaded page",
     "userId": "12345",
-    "headers": { "Content-Type": "application/json", "Authorization": "xyz" },
+    "headers": {
+      "Content-Type": "application/json",
+      "Authorization": "xyz"
+    },
     "version": "1",
     "params": {},
     "type": "REST",
@@ -58,12 +109,16 @@
         "keen": {
           "addons": [
             {
-              "input": { "ip": "request_ip" },
+              "input": {
+                "ip": "request_ip"
+              },
               "name": "keen:ip_to_geo",
               "output": "ip_geo_info"
             },
             {
-              "input": { "ua_string": "user_agent" },
+              "input": {
+                "ua_string": "user_agent"
+              },
               "name": "keen:ua_parser",
               "output": "parsed_user_agent"
             }
@@ -71,7 +126,10 @@
         },
         "anonymousId": "00000000000000000000000000",
         "user": {
-          "traits": { "anonymousId": "anon-id", "email": "test@gmail.com" },
+          "traits": {
+            "anonymousId": "anon-id",
+            "email": "test@gmail.com"
+          },
           "userId": "12345"
         },
         "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36"
@@ -81,7 +139,10 @@
     "files": {},
     "endpoint": "https://api.keen.io/3.0/projects/abcde/events/test track event",
     "userId": "12345",
-    "headers": { "Content-Type": "application/json", "Authorization": "xyz" },
+    "headers": {
+      "Content-Type": "application/json",
+      "Authorization": "xyz"
+    },
     "version": "1",
     "params": {},
     "type": "REST",


### PR DESCRIPTION
## Description of the change

> When `context` is passed as null in message we are fetching `context.userAgent` which is throwing error since `context` is **null**.
In this PR we have provided optional chaining when fetching `userAgent`

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
