### PR TITLE
fix: handle marketo auth token response when expires_in is 0 sec 

### DIFF
--- a/src/v0/destinations/marketo/util.js
+++ b/src/v0/destinations/marketo/util.js
@@ -175,20 +175,20 @@ const marketoResponseHandler = (
   }
   if (isHttpStatusSuccess(status)) {
     // for authentication requests
-    if (response && response.access_token && response.expires_in) {
-      return response;
-    }
-    /* This scenario will handle the case when we get the foloowing response
+    if (response && response.access_token) {
+        /* This scenario will handle the case when we get the foloowing response
     status: 200  
     respnse: {"access_token":"86e6c440-1c2e-4a67-8b0d-53496bfaa510:sj","token_type":"bearer","expires_in":0,"scope":"CDP@cvent.com"}
     wherein "expires_in":0 denotes that we should refresh the accessToken but its not expired yet. 
     */
-    if (response && response.access_token && response.expires_in === 0) {
+      if(response.expires_in === 0) {
       throw new RetryableError(
         `Request Failed for ${destination}, Access Token Expired (Retryable).${sourceMessage}`,
         500,
         response,
       );
+      }
+      return response;
     }
     // marketo application level success
     if (response && response.success) {

--- a/src/v0/destinations/marketo/util.js
+++ b/src/v0/destinations/marketo/util.js
@@ -178,6 +178,18 @@ const marketoResponseHandler = (
     if (response && response.access_token && response.expires_in) {
       return response;
     }
+    /* This scenario will handle the case when we get the foloowing response
+    status: 200  
+    respnse: {"access_token":"86e6c440-1c2e-4a67-8b0d-53496bfaa510:sj","token_type":"bearer","expires_in":0,"scope":"CDP@cvent.com"}
+    wherein "expires_in":0 denotes that we should refresh the accessToken but its not expired yet. 
+    */
+    if (response && response.access_token && response.expires_in === 0) {
+      throw new RetryableError(
+        `Request Failed for ${destination}, Access Token Expired (Retryable).${sourceMessage}`,
+        500,
+        response,
+      );
+    }
     // marketo application level success
     if (response && response.success) {
       nestedResponseHandler(response, sourceMessage);

--- a/test/__mocks__/data/marketo/response.json
+++ b/test/__mocks__/data/marketo/response.json
@@ -5,6 +5,12 @@
     "scope": "integrations@rudderstack.com",
     "token_type": "bearer"
   },
+  "https://marketo_acct_id_token_failure.mktorest.com/identity/oauth/token": {
+    "access_token": "access_token_expired",
+    "expires_in": 0,
+    "scope": "integrations@rudderstack.com",
+    "token_type": "bearer"
+  },
   "https://marketo_acct_id_success.mktorest.com/rest/v1/leads.json": {
     "requestId": "7ab2#17672a46a99",
     "result": [

--- a/test/__tests__/data/marketo_input.json
+++ b/test/__tests__/data/marketo_input.json
@@ -372,6 +372,64 @@
       "anonymousId": "anon_id_success",
       "channel": "mobile",
       "context": {
+        "traits": {
+          "anonymousId": "anon_id_success"
+        },
+        "userAgent": "Dalvik/2.1.0 (Linux; U; Android 8.1.0; Android SDK built for x86 Build/OSM1.180201.007)"
+      },
+      "event": "Product Clicked",
+      "integrations": {
+        "All": true
+      },
+      "messageId": "id1",
+      "properties": {
+        "name": "Test Product"
+      },
+      "originalTimestamp": "2020-12-17T21:00:59.176Z",
+      "userId": "user_id_success",
+      "type": "track",
+      "sentAt": "2020-03-12T09:05:03.421Z"
+    },
+    "destination": {
+      "ID": "1mMy5cqbtfuaKZv1IhVQKnBerte",
+      "Config": {
+        "accountId": "marketo_acct_id_token_failure",
+        "clientId": "marketo_acct_id_token_failure",
+        "clientSecret": "marketo_acct_id_token_failure",
+        "trackAnonymousEvents": false,
+        "customActivityEventMap": [
+          {
+            "from": "Product Clicked",
+            "to": "100001"
+          }
+        ],
+        "customActivityPropertyMap": [
+          {
+            "from": "name",
+            "to": "productName"
+          }
+        ],
+        "customActivityPrimaryKeyMap": [
+          {
+            "from": "Product Clicked",
+            "to": "name"
+          }
+        ],
+        "leadTraitMapping": [
+          {
+            "from": "leadScore",
+            "to": "customLeadScore"
+          }
+        ],
+        "createIfNotExist": true
+      }
+    }
+  },
+  {
+    "message": {
+      "anonymousId": "anon_id_success",
+      "channel": "mobile",
+      "context": {
         "app": {
           "build": "1",
           "name": "TestAppName",

--- a/test/__tests__/data/marketo_output.json
+++ b/test/__tests__/data/marketo_output.json
@@ -125,6 +125,10 @@
     "error": "Request Failed for marketo, Access Token Expired (Retryable).During fetching auth token"
   },
   {
+    "statusCode": 500,
+    "error": "Request Failed for marketo, Access Token Expired (Retryable).During fetching auth token"
+  },
+  {
     "statusCode": 400,
     "error": "Invalid traits value for Marketo"
   },


### PR DESCRIPTION
## Description of the change

> Solution for #2422 in which when `expires_in = 0` sec for get `auth_token` request

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
