### PR TITLE
fix: valid cart_update event extra check

### DIFF
--- a/src/v0/sources/shopify/config.js
+++ b/src/v0/sources/shopify/config.js
@@ -101,6 +101,8 @@ const SUPPORTED_TRACK_EVENTS = [
   'orders_paid',
   'orders_partially_fullfilled',
 ];
+
+const maxTimeToIdentifyRSGeneratedCall = 10000; // in ms
 const useRedisDatabase = process.env.USE_REDIS_DB === 'true' || false;
 
 module.exports = {
@@ -117,4 +119,5 @@ module.exports = {
   SHOPIFY_TRACK_MAP,
   useRedisDatabase,
   SHOPIFY_ADMIN_ONLY_EVENTS,
+  maxTimeToIdentifyRSGeneratedCall
 };

--- a/src/v0/sources/shopify/shopify_redis.util.test.js
+++ b/src/v0/sources/shopify/shopify_redis.util.test.js
@@ -3,6 +3,23 @@ jest.mock('ioredis', () => require('../../../../test/__mocks__/redis'));
 describe('Shopify Utils Test', () => {
 
     describe('Check for valid cart update event test cases', () => {
+        it('Event containing token and nothing is retreived from redis and less than req. time difference between created_at and uadated_at', async () => {
+            const input = {
+                "query_parameters": {
+                    "topic": [
+                        "carts_update"
+                    ]
+                },
+                "id": "cartTokenTest1",
+                "line_items": [],
+                "note": null,
+                "updated_at": "2023-02-10T12:05:07.251Z",
+                "created_at": "2023-02-10T12:05:04.402Z"
+            };
+            const expectedOutput = false;
+            const output = await checkAndUpdateCartItems(input);
+            expect(output).toEqual(expectedOutput);
+        });
         it('Event containing token and nothing is retreived from redis', async () => {
             const input = {
                 token: 'token_not_in_redis',

--- a/src/v0/sources/shopify/util.js
+++ b/src/v0/sources/shopify/util.js
@@ -229,7 +229,11 @@ const checkAndUpdateCartItems = async (inputEvent, redisData, metricMetadata) =>
     await updateCartItemsInRedis(cartToken, newCartItemsHash, metricMetadata);
   } else {
     const { created_at, updated_at } = inputEvent;
-    if (Date.parse(updated_at) - Date.parse(created_at) < maxTimeToIdentifyRSGeneratedCall && inputEvent?.line_items?.length === 0) {
+    const timeDifference = Date.parse(updated_at) - Date.parse(created_at);
+    const isTimeWithinThreshold = timeDifference < maxTimeToIdentifyRSGeneratedCall;
+    const isLineItemsEmpty = inputEvent?.line_items?.length === 0;
+
+    if (isTimeWithinThreshold && isLineItemsEmpty) {
       return false;
     }
   }

--- a/src/v0/sources/shopify/util.js
+++ b/src/v0/sources/shopify/util.js
@@ -13,6 +13,7 @@ const {
   SHOPIFY_TRACK_MAP,
   SHOPIFY_ADMIN_ONLY_EVENTS,
   useRedisDatabase,
+  maxTimeToIdentifyRSGeneratedCall
 } = require('./config');
 const { TransformationError } = require('../../util/errorTypes');
 
@@ -226,6 +227,11 @@ const checkAndUpdateCartItems = async (inputEvent, redisData, metricMetadata) =>
       return false;
     }
     await updateCartItemsInRedis(cartToken, newCartItemsHash, metricMetadata);
+  } else {
+    const { created_at, updated_at } = inputEvent;
+    if (Date.parse(updated_at) - Date.parse(created_at) < maxTimeToIdentifyRSGeneratedCall && inputEvent?.line_items?.length === 0) {
+      return false;
+    }
   }
   return true;
 };


### PR DESCRIPTION
## Description of the change

> Resolves INT-164
We are receiving `cart_update` event generated by rudderstack tracker before `rudderIdentifier` could reach us from tracker which is resulting in no redis mapping and we are assuming the event to be valid but since it is a rudderstack generated event it should not be a valid event and we should drop it.
To deal with such scenarios we are introducing some more check which will basically check the following conditions and if all true then will drop the `cart_update` event.

1. Nothing is retrieved from redis for particular cart_token.
2. `line_items` array is empty
3.  Difference between cart `updated_at` and `created_at` less than decided time limit ( currently 10 sec)

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
