### PR TITLE
fix(INT-296): add destType labels for proxy destinations

### DIFF
--- a/src/adapters/network.js
+++ b/src/adapters/network.js
@@ -285,7 +285,7 @@ const prepareProxyRequest = (request) => {
  * @param {*} request
  * @returns
  */
-const proxyRequest = async (request) => {
+const proxyRequest = async (request, destType) => {
   const { endpoint, data, method, params, headers } = prepareProxyRequest(request);
   const requestOptions = {
     url: endpoint,
@@ -294,7 +294,7 @@ const proxyRequest = async (request) => {
     headers,
     method,
   };
-  const response = await httpSend(requestOptions, { feature: 'proxy' });
+  const response = await httpSend(requestOptions, { feature: 'proxy', destType });
   return response;
 };
 

--- a/src/services/destination/nativeIntegration.ts
+++ b/src/services/destination/nativeIntegration.ts
@@ -170,7 +170,7 @@ export default class NativeIntegrationDestinationService implements IntegrationD
   ): Promise<DeliveryResponse> {
     try {
       const networkHandler = networkHandlerFactory.getNetworkHandler(destinationType);
-      const rawProxyResponse = await networkHandler.proxy(destinationRequest);
+      const rawProxyResponse = await networkHandler.proxy(destinationRequest, destinationType);
       const processedProxyResponse = networkHandler.processAxiosResponse(rawProxyResponse);
       return networkHandler.responseHandler(
         {


### PR DESCRIPTION
## Description of the change

The `destType` was coming out to be empty even though we had information about the destination-type

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
