### PR TITLE
fix: salesforce upsert when identifier is not present

### DIFF
--- a/src/v0/destinations/salesforce/transform.js
+++ b/src/v0/destinations/salesforce/transform.js
@@ -127,15 +127,7 @@ async function getSaleforceIdForRecord(
   const searchRecord = processedsfSearchResponse.response?.searchRecords?.find(
     (rec) => rec[identifierType] === identifierValue,
   );
-  if (!searchRecord) {
-    logger.error(
-      `[SALESFORCE] URL for fetching searchRecord: /services/data/v${SF_API_VERSION}/parameterizedSearch/?q=${identifierValue}&sobject=${objectType}&in=${identifierType}&${objectType}.fields=id,${identifierType}`,
-    );
-    throw new InstrumentationError(
-      `:- SALESFORCE SEARCH BY ID: No record found for ${identifierType} ${identifierValue}`,
-      destination.ID,
-    );
-  }
+
   return searchRecord?.Id;
 }
 


### PR DESCRIPTION
## Description of the change

When the external identifier is not present, we are throwing an error instead of inserting it automatically. This PR aims to fix it

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
