### PR TITLE
fix(intercom): flatten metadata and custom attributes

### DIFF
--- a/src/v0/destinations/intercom/config.js
+++ b/src/v0/destinations/intercom/config.js
@@ -41,9 +41,13 @@ const ReservedTraitsProperties = [
 
 const ReservedCompanyProperties = ['id', 'name', 'industry'];
 
+// ref:- https://developers.intercom.com/intercom-api-reference/v1.4/reference/event-metadata-types
+const MetadataTypes = { richLink: ['url', 'value'], monetaryAmount: ['amount', 'currency'] };
+
 module.exports = {
   ConfigCategory,
   MappingConfig,
   ReservedCompanyProperties,
   ReservedTraitsProperties,
+  MetadataTypes,
 };

--- a/src/v0/destinations/intercom/data/INTERCOMTrackConfig.json
+++ b/src/v0/destinations/intercom/data/INTERCOMTrackConfig.json
@@ -28,5 +28,9 @@
     "metadata": {
       "type": "secondTimestamp"
     }
+  },
+  {
+    "destKey": "metadata",
+    "sourceKeys": "properties"
   }
 ]

--- a/src/v0/destinations/intercom/util.js
+++ b/src/v0/destinations/intercom/util.js
@@ -1,0 +1,32 @@
+const { MetadataTypes } = require('./config');
+
+/**
+ * Separates reserved metadata from rest of the metadata based on the metadata types
+ * ref:- https://developers.intercom.com/intercom-api-reference/v1.4/reference/event-metadata-types
+ * @param {*} metadata
+ * @returns
+ */
+function separateReservedAndRestMetadata(metadata) {
+  const reservedMetadata = {};
+  const restMetadata = {};
+  if (metadata) {
+    Object.entries(metadata).forEach(([key, value]) => {
+      if (value && typeof value === 'object') {
+        const hasMonetaryAmountKeys = MetadataTypes.monetaryAmount.every((type) => type in value);
+        const hasRichLinkKeys = MetadataTypes.richLink.every((type) => type in value);
+        if (hasMonetaryAmountKeys || hasRichLinkKeys) {
+          reservedMetadata[key] = value;
+        } else {
+          restMetadata[key] = value;
+        }
+      } else {
+        restMetadata[key] = value;
+      }
+    });
+  }
+
+  // Return the separated metadata objects
+  return { reservedMetadata, restMetadata };
+}
+
+module.exports = { separateReservedAndRestMetadata };

--- a/src/v0/destinations/intercom/util.test.js
+++ b/src/v0/destinations/intercom/util.test.js
@@ -1,0 +1,176 @@
+const { separateReservedAndRestMetadata } = require('./util');
+
+describe('separateReservedAndRestMetadata utility test', () => {
+  it('separate reserved and rest metadata', () => {
+    const metadata = {
+      property1: 1,
+      property2: 'test',
+      property3: true,
+      property4: {
+        property1: 1,
+        property2: 'test',
+        property3: {
+          subProp1: {
+            a: 'a',
+            b: 'b',
+          },
+          subProp2: ['a', 'b'],
+        },
+      },
+      property5: {},
+      property6: [],
+      property7: null,
+      property8: undefined,
+      revenue: {
+        amount: 1232,
+        currency: 'inr',
+        test: 123,
+      },
+      price: {
+        amount: 3000,
+        currency: 'USD',
+      },
+      article: {
+        url: 'https://example.org/ab1de.html',
+        value: 'the dude abides',
+      },
+    };
+    const expectedReservedMetadata = {
+      revenue: {
+        amount: 1232,
+        currency: 'inr',
+        test: 123,
+      },
+      price: {
+        amount: 3000,
+        currency: 'USD',
+      },
+      article: {
+        url: 'https://example.org/ab1de.html',
+        value: 'the dude abides',
+      },
+    };
+    const expectedRestMetadata = {
+      property1: 1,
+      property2: 'test',
+      property3: true,
+      property4: {
+        property1: 1,
+        property2: 'test',
+        property3: {
+          subProp1: {
+            a: 'a',
+            b: 'b',
+          },
+          subProp2: ['a', 'b'],
+        },
+      },
+      property5: {},
+      property6: [],
+      property7: null,
+      property8: undefined,
+    };
+    const { reservedMetadata, restMetadata } = separateReservedAndRestMetadata(metadata);
+
+    expect(expectedReservedMetadata).toEqual(reservedMetadata);
+    expect(expectedRestMetadata).toEqual(restMetadata);
+  });
+
+  it('reserved metadata types not present in input metadata', () => {
+    const metadata = {
+      property1: 1,
+      property2: 'test',
+      property3: true,
+      property4: {
+        property1: 1,
+        property2: 'test',
+        property3: {
+          subProp1: {
+            a: 'a',
+            b: 'b',
+          },
+          subProp2: ['a', 'b'],
+        },
+      },
+      property5: {},
+      property6: [],
+      property7: null,
+      property8: undefined,
+    };
+    const expectedRestMetadata = {
+      property1: 1,
+      property2: 'test',
+      property3: true,
+      property4: {
+        property1: 1,
+        property2: 'test',
+        property3: {
+          subProp1: {
+            a: 'a',
+            b: 'b',
+          },
+          subProp2: ['a', 'b'],
+        },
+      },
+      property5: {},
+      property6: [],
+      property7: null,
+      property8: undefined,
+    };
+    const { reservedMetadata, restMetadata } = separateReservedAndRestMetadata(metadata);
+
+    expect({}).toEqual(reservedMetadata);
+    expect(expectedRestMetadata).toEqual(restMetadata);
+  });
+
+  it('metadata input contains only reserved metadata types', () => {
+    const metadata = {
+      revenue: {
+        amount: 1232,
+        currency: 'inr',
+        test: 123,
+      },
+      price: {
+        amount: 3000,
+        currency: 'USD',
+      },
+      article: {
+        url: 'https://example.org/ab1de.html',
+        value: 'the dude abides',
+      },
+    };
+    const expectedReservedMetadata = {
+      revenue: {
+        amount: 1232,
+        currency: 'inr',
+        test: 123,
+      },
+      price: {
+        amount: 3000,
+        currency: 'USD',
+      },
+      article: {
+        url: 'https://example.org/ab1de.html',
+        value: 'the dude abides',
+      },
+    };
+    const { reservedMetadata, restMetadata } = separateReservedAndRestMetadata(metadata);
+
+    expect(expectedReservedMetadata).toEqual(reservedMetadata);
+    expect({}).toEqual(restMetadata);
+  });
+
+  it('empty metadata object', () => {
+    const metadata = {};
+    const { reservedMetadata, restMetadata } = separateReservedAndRestMetadata(metadata);
+    expect({}).toEqual(reservedMetadata);
+    expect({}).toEqual(restMetadata);
+  });
+
+  it('null/undefined metadata', () => {
+    const metadata = null;
+    const { reservedMetadata, restMetadata } = separateReservedAndRestMetadata(metadata);
+    expect({}).toEqual(reservedMetadata);
+    expect({}).toEqual(restMetadata);
+  });
+});

--- a/test/__tests__/data/intercom_input.json
+++ b/test/__tests__/data/intercom_input.json
@@ -47,7 +47,24 @@
           "userId": "test_user_id_1",
           "email": "test_1@test.com",
           "phone": "9876543210",
-          "key1": "value1"
+          "key1": "value1",
+          "address": {
+            "city": "Kolkata",
+            "state": "West Bengal"
+          },
+          "originalArray": [
+            {
+              "nested_field": "nested value",
+              "tags": ["tag_1", "tag_2", "tag_3"]
+            },
+            {
+              "nested_field": "nested value",
+              "tags": ["tag_1"]
+            },
+            {
+              "nested_field": "nested value"
+            }
+          ]
         },
         "userAgent": "unknown"
       },
@@ -397,7 +414,11 @@
             "name": "Test Comp",
             "id": "company_id",
             "industry": "test industry",
-            "key1": "value1"
+            "key1": "value1",
+            "key2": {
+              "a": "a"
+            },
+            "key3": [1, 2, 3]
           }
         },
         "userAgent": "unknown"
@@ -474,7 +495,9 @@
             "key1": "value1",
             "key2": null,
             "key3": ["value1", "value2"],
-            "key4": { "foo": "bar" }
+            "key4": {
+              "foo": "bar"
+            }
           }
         },
         "userAgent": "unknown"
@@ -634,12 +657,28 @@
         "property5": {
           "property1": 1,
           "property2": "test",
-          "property3": true,
-          "property4": "test",
-          "property5": true,
-          "property6": true
+          "property3": {
+            "subProp1": {
+              "a": "a",
+              "b": "b"
+            },
+            "subProp2": ["a", "b"]
+          }
         },
-        "property6": null
+        "properties6": null,
+        "revenue": {
+          "amount": 1232,
+          "currency": "inr",
+          "test": 123
+        },
+        "price": {
+          "amount": 3000,
+          "currency": "USD"
+        },
+        "article": {
+          "url": "https://example.org/ab1de.html",
+          "value": "the dude abides"
+        }
       },
       "event": "Test Event 2",
       "integrations": {

--- a/test/__tests__/data/intercom_output.json
+++ b/test/__tests__/data/intercom_output.json
@@ -22,7 +22,16 @@
         "user_id": "test_user_id_1",
         "custom_attributes": {
           "anonymousId": "58b21c2d-f8d5-4410-a2d0-b268a26b7e33",
-          "key1": "value1"
+          "key1": "value1",
+          "address.city": "Kolkata",
+          "address.state": "West Bengal",
+          "originalArray[0].nested_field": "nested value",
+          "originalArray[0].tags[0]": "tag_1",
+          "originalArray[0].tags[1]": "tag_2",
+          "originalArray[0].tags[2]": "tag_3",
+          "originalArray[1].nested_field": "nested value",
+          "originalArray[1].tags[0]": "tag_1",
+          "originalArray[2].nested_field": "nested value"
         }
       },
       "XML": {},
@@ -160,7 +169,9 @@
           {
             "company_id": "company_id",
             "custom_attributes": {
-              "key1": "value1"
+              "key1": "value1",
+              "key2": "{\"a\":\"a\"}",
+              "key3": "[1,2,3]"
             },
             "name": "Test Comp",
             "industry": "test industry"
@@ -273,7 +284,27 @@
           "property1": 1,
           "property2": "test",
           "property3": true,
-          "property4": "2020-10-05T09:09:03.731Z"
+          "property4": "2020-10-05T09:09:03.731Z",
+          "property5.property1": 1,
+          "property5.property2": "test",
+          "property5.property3.subProp1.a": "a",
+          "property5.property3.subProp1.b": "b",
+          "property5.property3.subProp2[0]": "a",
+          "property5.property3.subProp2[1]": "b",
+          "properties6": null,
+          "revenue": {
+            "amount": 1232,
+            "currency": "inr",
+            "test": 123
+          },
+          "price": {
+            "amount": 3000,
+            "currency": "USD"
+          },
+          "article": {
+            "url": "https://example.org/ab1de.html",
+            "value": "the dude abides"
+          }
         }
       },
       "XML": {},
@@ -299,8 +330,7 @@
       "JSON": {
         "email": "test_1@test.com",
         "event_name": "Test Event 2",
-        "created": 1601493061,
-        "metadata": {}
+        "created": 1601493061
       },
       "XML": {},
       "JSON_ARRAY": {},


### PR DESCRIPTION
## Description of the change

> Resolves INT-266

- Add flatten json utility for `metadata` in track call and `custom attributes` in identify call.
- Excludes the flattening of event metadata types such as **richLink** and **monetaryAmount**. Which are supported as JSON object in intercom
- properties are mapped with metadata and traits are mapped with custom attributes

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
