### PR TITLE
fix(intercom): group call

### DIFF
--- a/src/v0/destinations/intercom/transform.js
+++ b/src/v0/destinations/intercom/transform.js
@@ -93,16 +93,23 @@ function validateTrack(payload) {
   return payload;
 }
 
-function checkIfEmailOrUserIdPresent(message) {
-  return !!(message.userId || message.context?.traits?.email);
+function checkIfEmailOrUserIdPresent(message, Config) {
+  let user_id = message.userId;
+  if (Config.sendAnonymousId && !user_id) {
+    user_id = message.anonymousId;
+  }
+  return !!(user_id || message.context?.traits?.email);
 }
 
 function attachUserAndCompany(message, Config) {
   const email = message.context?.traits?.email;
-  const { userId } = message;
+  const { userId, anonymousId } = message;
   const requestBody = {};
   if (userId) {
     requestBody.user_id = userId;
+  }
+  if (Config.sendAnonymousId && !userId) {
+    requestBody.user_id = anonymousId;
   }
   if (email) {
     requestBody.email = email;
@@ -181,7 +188,7 @@ function validateAndBuildResponse(message, payload, category, destination) {
     case EventType.GROUP: {
       response.body.JSON = removeUndefinedAndNullValues(buildCustomAttributes(message, payload));
       respList.push(response);
-      if (checkIfEmailOrUserIdPresent(message)) {
+      if (checkIfEmailOrUserIdPresent(message, destination.Config)) {
         const attachUserAndCompanyResponse = attachUserAndCompany(message, destination.Config);
         attachUserAndCompanyResponse.userId = message.anonymousId;
         respList.push(attachUserAndCompanyResponse);
@@ -225,7 +232,7 @@ function processSingleMessage(message, destination) {
   } else {
     payload = constructPayload(message, MappingConfig[category.name]);
   }
-  if (sendAnonymousId && !payload.user_id) {
+  if (category !== ConfigCategory.GROUP && sendAnonymousId && !payload.user_id) {
     payload.user_id = message.anonymousId;
   }
   return validateAndBuildResponse(message, payload, category, destination);

--- a/test/__tests__/data/intercom_input.json
+++ b/test/__tests__/data/intercom_input.json
@@ -1187,5 +1187,46 @@
         "collectContext": false
       }
     }
+  },
+  {
+    "message": {
+      "groupId": "test_company_id_wdasda",
+      "context": {
+        "traits": {
+          "email": "testUser@test.com"
+        }
+      },
+      "traits": {
+        "employees": 450,
+        "plan": "basic",
+        "email": "test@test.com",
+        "name": "rudderUpdate",
+        "size": "50",
+        "industry": "IT",
+        "website": "url",
+        "monthlySpend": "2131231",
+        "remoteCreatedAt": "1683017572",
+        "key1": "val1",
+        "key2": {
+          "a": "a",
+          "b": "b"
+        },
+        "key3": [1, 2, 3],
+        "key4": null
+      },
+      "anonymousId": "anonId",
+      "integrations": {
+        "All": true
+      },
+      "type": "group"
+    },
+    "destination": {
+      "Config": {
+        "apiKey": "abcd=",
+        "appId": "asdasdasd",
+        "collectContext": false,
+        "sendAnonymousId": true
+      }
+    }
   }
 ]

--- a/test/__tests__/data/intercom_output.json
+++ b/test/__tests__/data/intercom_output.json
@@ -574,5 +574,78 @@
       "version": "1",
       "endpoint": "https://api.intercom.io/users"
     }
+  ],
+  [
+    {
+      "body": {
+        "XML": {},
+        "FORM": {},
+        "JSON": {
+          "name": "rudderUpdate",
+          "plan": "basic",
+          "size": 50,
+          "industry": "IT",
+          "company_id": "test_company_id_wdasda",
+          "monthly_spend": 2131231,
+          "remote_created_at": 1683017572,
+          "website": "url",
+          "custom_attributes": {
+            "key1": "val1",
+            "employees": 450,
+            "email": "test@test.com",
+            "key2.a": "a",
+            "key2.b": "b",
+            "key3[0]": 1,
+            "key3[1]": 2,
+            "key3[2]": 3,
+            "key4": null
+          }
+        },
+        "JSON_ARRAY": {}
+      },
+      "type": "REST",
+      "files": {},
+      "method": "POST",
+      "params": {},
+      "userId": "anonId",
+      "headers": {
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+        "Authorization": "Bearer abcd=",
+        "Intercom-Version": "1.4"
+      },
+      "version": "1",
+      "endpoint": "https://api.intercom.io/companies"
+    },
+    {
+      "body": {
+        "XML": {},
+        "FORM": {},
+        "JSON": {
+          "user_id": "anonId",
+          "email": "testUser@test.com",
+          "companies": [
+            {
+              "name": "rudderUpdate",
+              "company_id": "test_company_id_wdasda"
+            }
+          ]
+        },
+        "JSON_ARRAY": {}
+      },
+      "type": "REST",
+      "files": {},
+      "method": "POST",
+      "params": {},
+      "userId": "anonId",
+      "headers": {
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+        "Authorization": "Bearer abcd=",
+        "Intercom-Version": "1.4"
+      },
+      "version": "1",
+      "endpoint": "https://api.intercom.io/users"
+    }
   ]
 ]


### PR DESCRIPTION
## Description of the change

> Resolves INT-374

- Remove `user_id` parameter from the create/update company payload. Since, this parameter is not supported by Intercom
- Pass anonymousId as user_id to attach the created company to a user in Intercom

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
