### PR TITLE
feat(INT-162): adding email as fallback to userId

### DIFF
--- a/src/v0/destinations/customerio/util.js
+++ b/src/v0/destinations/customerio/util.js
@@ -11,7 +11,6 @@ const {
   defaultDeleteRequestConfig,
   isAppleFamily,
   validateEmail,
-  isDefinedAndNotNull,
 } = require('../../util');
 
 const { EventType, SpecedTraits, TraitsMapping } = require('../../../constants');
@@ -104,7 +103,7 @@ const identifyResponseBuilder = (userId, message) => {
   const rawPayload = {};
   // if userId is not there simply drop the payload
   const id = userId || getFieldValueFromMessage(message, "email");
-  if (!isDefinedAndNotNull(id)) {
+  if (!id) {
     throw new InstrumentationError('userId or email is not present');
   }
 
@@ -169,7 +168,7 @@ const identifyResponseBuilder = (userId, message) => {
 
 const aliasResponseBuilder = (message, userId) => {
   // ref : https://customer.io/docs/api/#operation/merge
-  if (!isDefinedAndNotNull(userId) && !isDefinedAndNotNull(message.previousId)) {
+  if (!userId && !message.previousId) {
     throw new InstrumentationError('Both userId and previousId is mandatory for merge operation');
   }
   const endpoint = MERGE_USER_ENDPOINT;
@@ -214,7 +213,7 @@ const groupResponseBuilder = (message) => {
   if (validateEmail(id)) {
     cioProperty = 'email';
   }
-  if (isDefinedAndNotNull(id)) {
+  if (id) {
     rawPayload.cio_relationships.push({ identifiers: { [cioProperty]: id } });
   }
   const requestConfig = defaultPostRequestConfig;
@@ -236,7 +235,7 @@ const defaultResponseBuilder = (message, evName, userId, evType, destination, me
   const isDeviceDeleteEvent = deviceDeleteRelatedEventName === evName;
   if (isDeviceDeleteEvent) {
 
-    if (!isDefinedAndNotNull(id) || !isDefinedAndNotNull(token)) {
+    if (!id || !token) {
       throw new InstrumentationError('userId/email or device_token not present');
     }
     endpoint = DEVICE_DELETE_ENDPOINT.replace(':id', id).replace(':device_id', token);
@@ -277,7 +276,7 @@ const defaultResponseBuilder = (message, evName, userId, evType, destination, me
     }
   }
 
-  if (isDefinedAndNotNull(id)) {
+  if (id) {
     endpoint =
       isDeviceRelatedEvent && token
         ? DEVICE_REGISTER_ENDPOINT.replace(':id', id)
@@ -310,7 +309,7 @@ const defaultResponseBuilder = (message, evName, userId, evType, destination, me
 const validateConfigFields = destination => {
   const { Config } = destination;
   configFieldsToCheck.forEach(configProperty => {
-    if (!isDefinedAndNotNull(Config[configProperty])) {
+    if (!Config[configProperty]) {
       throw new ConfigurationError(`${configProperty} not found in Configs`);
     }
   });

--- a/src/v0/destinations/customerio/util.test.js
+++ b/src/v0/destinations/customerio/util.test.js
@@ -119,6 +119,14 @@ describe('Unit test cases for customerio identifyResponseBuilder', () => {
       expect(error.message).toEqual(expectedOutput);
     }
   });
+  it('No Identifier to send for Identify Call', async () => {
+    let expectedOutput = "userId or email is not present";
+    try {
+      identifyResponseBuilder('', getIdentifyTestMessage())
+    } catch (error) {
+      expect(error.message).toEqual(expectedOutput);
+    }
+  });
 });
 
 describe('Unit test cases for customerio aliasResponseBuilder', () => {

--- a/src/v0/destinations/customerio/util.test.js
+++ b/src/v0/destinations/customerio/util.test.js
@@ -21,6 +21,21 @@ const getTestMessage = () => {
   };
   return message;
 };
+const getIdentifyTestMessage = () => {
+  let message = {
+    anonymousId: 'anonId',
+    traits: {
+      name: 'rudder',
+      address: {
+        city: 'kolkata',
+        country: 'India',
+      },
+      createdAt: '2014-05-21T15:54:20Z',
+      timestamp: '2014-05-21T15:54:20Z',
+    },
+  };
+  return message;
+};
 
 const getGroupTestMessage = () => {
   let message = {
@@ -95,6 +110,14 @@ describe('Unit test cases for customerio identifyResponseBuilder', () => {
       requestConfig: { requestFormat: 'JSON', requestMethod: 'PUT' },
     };
     expect(identifyResponseBuilder('user1', getTestMessage())).toEqual(expectedOutput);
+  });
+  it('No Identifier to send for Identify Call', async () => {
+    let expectedOutput = "userId or email is not present";
+    try {
+      identifyResponseBuilder(null, getIdentifyTestMessage())
+    } catch (error) {
+      expect(error.message).toEqual(expectedOutput);
+    }
   });
 });
 

--- a/src/v0/destinations/customerio/util.test.js
+++ b/src/v0/destinations/customerio/util.test.js
@@ -115,6 +115,22 @@ describe('Unit test cases for customerio aliasResponseBuilder', () => {
     };
     expect(aliasResponseBuilder({ previousId: "abc@test.com" }, "user1")).toEqual(expectedOutput);
   });
+  it('Merging happending with userId as email and present one as id', async () => {
+    let expectedOutput = {
+      endpoint: 'https://track.customer.io/api/v1/merge_customers',
+      rawPayload: { secondary: { id: 'user1' }, primary: { email: "abc@test.com" } },
+      requestConfig: { requestFormat: 'JSON', requestMethod: 'POST' },
+    };
+    expect(aliasResponseBuilder({ previousId: "user1" }, "abc@test.com")).toEqual(expectedOutput);
+  });
+  it('Merging happending with userId as email and present one as id', async () => {
+    let expectedOutput = {
+      endpoint: 'https://track.customer.io/api/v1/merge_customers',
+      rawPayload: { secondary: { email: 'user1@test.com' }, primary: { email: "abc@test.com" } },
+      requestConfig: { requestFormat: 'JSON', requestMethod: 'POST' },
+    };
+    expect(aliasResponseBuilder({ previousId: "user1@test.com" }, "abc@test.com")).toEqual(expectedOutput);
+  });
 });
 
 describe('Unit test cases for customerio groupResponseBuilder', () => {

--- a/src/v0/destinations/customerio/util.test.js
+++ b/src/v0/destinations/customerio/util.test.js
@@ -107,6 +107,14 @@ describe('Unit test cases for customerio aliasResponseBuilder', () => {
     };
     expect(aliasResponseBuilder(getTestMessage(), 'user1')).toEqual(expectedOutput);
   });
+  it('Merging happending with previous_id as email and present one as id', async () => {
+    let expectedOutput = {
+      endpoint: 'https://track.customer.io/api/v1/merge_customers',
+      rawPayload: { primary: { id: 'user1' }, secondary: { email: "abc@test.com" } },
+      requestConfig: { requestFormat: 'JSON', requestMethod: 'POST' },
+    };
+    expect(aliasResponseBuilder({ previousId: "abc@test.com" }, "user1")).toEqual(expectedOutput);
+  });
 });
 
 describe('Unit test cases for customerio groupResponseBuilder', () => {

--- a/test/__tests__/data/customerio_input.json
+++ b/test/__tests__/data/customerio_input.json
@@ -154,6 +154,75 @@
         },
         "traits": {
           "anonymousId": "123456",
+          "address": {
+            "city": "kolkata",
+            "country": "India",
+            "postalCode": 712136,
+            "state": "WB",
+            "street": ""
+          },
+          "ip": "0.0.0.0",
+          "age": 26
+        },
+        "library": {
+          "name": "RudderLabs JavaScript SDK",
+          "version": "1.0.0"
+        },
+        "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36",
+        "locale": "en-US",
+        "ip": "0.0.0.0",
+        "os": {
+          "name": "",
+          "version": ""
+        },
+        "screen": {
+          "density": 2
+        }
+      },
+      "user_properties": {
+        "prop1": "val1",
+        "prop2": "val2"
+      },
+      "type": "identify",
+      "messageId": "84e26acc-56a5-4835-8233-591137fca468",
+      "originalTimestamp": "2019-10-14T09:03:17.562Z",
+      "anonymousId": "123456",
+      "integrations": {
+        "All": true
+      },
+      "traits": {
+        "anonymousId": "anon-id",
+        "dot.name": "Arnab Pal",
+        "address": {
+          "city": "NY",
+          "country": "USA",
+          "postalCode": 712136,
+          "state": "CA",
+          "street": ""
+        }
+      },
+      "sentAt": "2019-10-14T09:03:22.563Z"
+    },
+    "destination": {
+      "Config": {
+        "datacenterEU": false,
+        "siteID": "46be54768e7d49ab2628",
+        "apiKey": "19f0f734e3bb87a44596"
+      }
+    }
+  },
+  {
+    "message": {
+      "channel": "web",
+      "context": {
+        "app": {
+          "build": "1.0.0",
+          "name": "RudderLabs JavaScript SDK",
+          "namespace": "com.rudderlabs.javascript",
+          "version": "1.0.0"
+        },
+        "traits": {
+          "anonymousId": "123456",
           "email": "sayan@gmail.com",
           "address": {
             "city": "kolkata",
@@ -333,6 +402,58 @@
         },
         "traits": {
           "email": "sayan@gmail.com",
+          "anonymousId": "12345"
+        },
+        "library": {
+          "name": "RudderLabs JavaScript SDK",
+          "version": "1.0.0"
+        },
+        "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36",
+        "locale": "en-US",
+        "ip": "0.0.0.0",
+        "os": {
+          "name": "",
+          "version": ""
+        },
+        "screen": {
+          "density": 2
+        }
+      },
+      "type": "track",
+      "messageId": "ec5481b6-a926-4d2e-b293-0b3a77c4d3be",
+      "originalTimestamp": "2019-10-14T11:15:18.300Z",
+      "anonymousId": "c82cbdff-e5be-4009-ac78-cdeea09ab4b1",
+      "userId": "",
+      "event": "test track event",
+      "properties": {
+        "user_actual_role": "system_admin",
+        "user_actual_id": 12345,
+        "user_time_spent": 50000
+      },
+      "integrations": {
+        "All": true
+      },
+      "sentAt": "2019-10-14T11:15:53.296Z"
+    },
+    "destination": {
+      "Config": {
+        "datacenterEU": false,
+        "siteID": "46be54768e7d49ab2628",
+        "apiKey": "19f0f734e3bb87a44596"
+      }
+    }
+  },
+  {
+    "message": {
+      "channel": "web",
+      "context": {
+        "app": {
+          "build": "1.0.0",
+          "name": "RudderLabs JavaScript SDK",
+          "namespace": "com.rudderlabs.javascript",
+          "version": "1.0.0"
+        },
+        "traits": {
           "anonymousId": "12345"
         },
         "library": {
@@ -649,7 +770,123 @@
           "version": "1.0.0"
         },
         "traits": {
+          "anonymousId": "12345"
+        },
+        "library": {
+          "name": "RudderLabs JavaScript SDK",
+          "version": "1.0.0"
+        },
+        "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36",
+        "locale": "en-US",
+        "ip": "0.0.0.0",
+        "os": {
+          "name": "",
+          "version": ""
+        },
+        "screen": {
+          "density": 2
+        }
+      },
+      "type": "track",
+      "messageId": "ec5481b6-a926-4d2e-b293-0b3a77c4d3be",
+      "originalTimestamp": "2019-10-14T11:15:18.300Z",
+      "anonymousId": "c82cbdff-e5be-4009-ac78-cdeea09ab4b1",
+      "event": "Application Uninstalled",
+      "properties": {
+        "user_actual_role": "system_admin",
+        "user_actual_id": 12345,
+        "user_time_spent": 50000
+      },
+      "integrations": {
+        "All": true
+      },
+      "sentAt": "2019-10-14T11:15:53.296Z"
+    },
+    "destination": {
+      "Config": {
+        "datacenterEU": false,
+        "siteID": "46be54768e7d49ab2628",
+        "apiKey": "19f0f734e3bb87a44596"
+      }
+    }
+  },
+  {
+    "message": {
+      "channel": "mobile",
+      "context": {
+        "device": {
+          "name": "test android",
+          "id": "sample_device_id",
+          "model": "some_model_device",
+          "type": "mobile",
+          "token": "somel"
+        },
+        "app": {
+          "build": "1.0.0",
+          "name": "RudderLabs JavaScript SDK",
+          "namespace": "com.rudderlabs.javascript",
+          "version": "1.0.0"
+        },
+        "traits": {
           "email": "sayan@gmail.com",
+          "anonymousId": "12345"
+        },
+        "library": {
+          "name": "RudderLabs JavaScript SDK",
+          "version": "1.0.0"
+        },
+        "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36",
+        "locale": "en-US",
+        "ip": "0.0.0.0",
+        "os": {
+          "name": "",
+          "version": ""
+        },
+        "screen": {
+          "density": 2
+        }
+      },
+      "type": "track",
+      "messageId": "ec5481b6-a926-4d2e-b293-0b3a77c4d3be",
+      "originalTimestamp": "2019-10-14T11:15:18.300Z",
+      "anonymousId": "c82cbdff-e5be-4009-ac78-cdeea09ab4b1",
+      "event": "Application Installed",
+      "properties": {
+        "user_actual_role": "system_admin",
+        "user_actual_id": 12345,
+        "user_time_spent": 50000
+      },
+      "integrations": {
+        "All": true
+      },
+      "sentAt": "2019-10-14T11:15:53.296Z"
+    },
+    "destination": {
+      "Config": {
+        "datacenterEU": false,
+        "siteID": "46be54768e7d49ab2628",
+        "apiKey": "19f0f734e3bb87a44596"
+      }
+    }
+  },
+  {
+    "message": {
+      "channel": "mobile",
+      "context": {
+        "device": {
+          "name": "test android",
+          "id": "sample_device_id",
+          "model": "some_model_device",
+          "type": "mobile",
+          "token": "somel"
+        },
+        "app": {
+          "build": "1.0.0",
+          "name": "RudderLabs JavaScript SDK",
+          "namespace": "com.rudderlabs.javascript",
+          "version": "1.0.0"
+        },
+        "traits": {
           "anonymousId": "12345"
         },
         "library": {
@@ -1222,6 +1459,58 @@
   },
   {
     "message": {
+      "channel": "web",
+      "context": {
+        "app": {
+          "build": "1.0.0",
+          "name": "RudderLabs JavaScript SDK",
+          "namespace": "com.rudderlabs.javascript",
+          "version": "1.0.0"
+        },
+        "traits": {
+          "anonymousId": "12345"
+        },
+        "library": {
+          "name": "RudderLabs JavaScript SDK",
+          "version": "1.0.0"
+        },
+        "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36",
+        "locale": "en-US",
+        "ip": "0.0.0.0",
+        "os": {
+          "name": "",
+          "version": ""
+        },
+        "screen": {
+          "density": 2
+        }
+      },
+      "type": "track",
+      "messageId": "ec5481b6-a926-4d2e-b293-0b3a77c4d3be",
+      "originalTimestamp": "2019-10-14T11:15:18.300Z",
+      "anonymousId": "c82cbdff-e5be-4009-ac78-cdeea09ab4b1",
+      "userId": "",
+      "event": "test track event",
+      "properties": {
+        "user_actual_role": "system_admin",
+        "user_actual_id": 12345,
+        "user_time_spent": 50000
+      },
+      "integrations": {
+        "All": true
+      },
+      "sentAt": "2019-10-14T11:15:53.296Z"
+    },
+    "destination": {
+      "Config": {
+        "datacenterEU": true,
+        "siteID": "46be54768e7d49ab2628",
+        "apiKey": "19f0f734e3bb87a44596"
+      }
+    }
+  },
+  {
+    "message": {
       "anonymousId": "7e32188a4dab669f",
       "channel": "mobile",
       "context": {
@@ -1436,7 +1725,6 @@
           "version": "1.0.0"
         },
         "traits": {
-          "email": "sayan@gmail.com",
           "anonymousId": "12345"
         },
         "library": {
@@ -1496,6 +1784,64 @@
         },
         "traits": {
           "email": "sayan@gmail.com",
+          "anonymousId": "12345"
+        },
+        "library": {
+          "name": "RudderLabs JavaScript SDK",
+          "version": "1.0.0"
+        },
+        "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36",
+        "locale": "en-US",
+        "ip": "0.0.0.0",
+        "os": {
+          "name": "",
+          "version": ""
+        },
+        "screen": {
+          "density": 2
+        }
+      },
+      "type": "track",
+      "messageId": "ec5481b6-a926-4d2e-b293-0b3a77c4d3be",
+      "originalTimestamp": "2019-10-14T11:15:18.300Z",
+      "anonymousId": "c82cbdff-e5be-4009-ac78-cdeea09ab4b1",
+      "event": "Application Installed",
+      "properties": {
+        "user_actual_role": "system_admin",
+        "user_actual_id": 12345,
+        "user_time_spent": 50000
+      },
+      "integrations": {
+        "All": true
+      },
+      "sentAt": "2019-10-14T11:15:53.296Z"
+    },
+    "destination": {
+      "Config": {
+        "datacenterEU": true,
+        "siteID": "46be54768e7d49ab2628",
+        "apiKey": "19f0f734e3bb87a44596"
+      }
+    }
+  },
+  {
+    "message": {
+      "channel": "mobile",
+      "context": {
+        "device": {
+          "name": "test android",
+          "id": "sample_device_id",
+          "model": "some_model_device",
+          "type": "mobile",
+          "token": "somel"
+        },
+        "app": {
+          "build": "1.0.0",
+          "name": "RudderLabs JavaScript SDK",
+          "namespace": "com.rudderlabs.javascript",
+          "version": "1.0.0"
+        },
+        "traits": {
           "anonymousId": "12345"
         },
         "library": {
@@ -1845,6 +2191,57 @@
           "version": "1.0.0"
         },
         "traits": {
+          "anonymousId": "12345"
+        },
+        "library": {
+          "name": "RudderLabs JavaScript SDK",
+          "version": "1.0.0"
+        },
+        "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36",
+        "locale": "en-US",
+        "ip": "0.0.0.0",
+        "os": {
+          "name": "",
+          "version": ""
+        },
+        "screen": {
+          "density": 2
+        }
+      },
+      "type": "track",
+      "messageId": "ec5481b6-a926-4d2e-b293-0b3a77c4d3be",
+      "originalTimestamp": "2019-10-14T11:15:18.300Z",
+      "anonymousId": "c82cbdff-e5be-4009-ac78-cdeea09ab4b1",
+      "event": "https://www.stoodi.com.br/exershgcios/upe/2019/questao/gregorio-de-matos-poeta-baiano-que-viveu-no-seculo-xvi/",
+      "properties": {
+        "user_actual_role": "system_admin",
+        "user_actual_id": 12345,
+        "user_time_spent": 50
+      },
+      "integrations": {
+        "All": true
+      },
+      "sentAt": "2019-10-14T11:15:53.296Z"
+    },
+    "destination": {
+      "Config": {
+        "datacenterEU": false,
+        "siteID": "46be54768e7d49ab2628",
+        "apiKey": "19f0f734e3bb87a44596"
+      }
+    }
+  },
+  {
+    "message": {
+      "channel": "web",
+      "context": {
+        "app": {
+          "build": "1.0.0",
+          "name": "RudderLabs JavaScript SDK",
+          "namespace": "com.rudderlabs.javascript",
+          "version": "1.0.0"
+        },
+        "traits": {
           "email": "sayan@gmail.com",
           "anonymousId": "12345"
         },
@@ -1872,6 +2269,57 @@
         "user_actual_role": "system_admin",
         "user_actual_id": 12345,
         "user_time_spent": 50
+      },
+      "integrations": {
+        "All": true
+      },
+      "sentAt": "2019-10-14T11:15:53.296Z"
+    },
+    "destination": {
+      "Config": {
+        "datacenterEU": false,
+        "siteID": "46be54768e7d49ab2628",
+        "apiKey": "19f0f734e3bb87a44596"
+      }
+    }
+  },
+  {
+    "message": {
+      "channel": "web",
+      "context": {
+        "app": {
+          "build": "1.0.0",
+          "name": "RudderLabs JavaScript SDK",
+          "namespace": "com.rudderlabs.javascript",
+          "version": "1.0.0"
+        },
+        "traits": {
+          "anonymousId": "12345"
+        },
+        "library": {
+          "name": "RudderLabs JavaScript SDK",
+          "version": "1.0.0"
+        },
+        "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36",
+        "locale": "en-US",
+        "ip": "0.0.0.0",
+        "os": {
+          "name": "",
+          "version": ""
+        },
+        "screen": {
+          "density": 2
+        }
+      },
+      "type": "screen",
+      "messageId": "ec5481b6-a926-4d2e-b293-0b3a77c4d3be",
+      "originalTimestamp": "2019-10-14T11:15:18.300Z",
+      "anonymousId": "c82cbdff-e5be-4009-ac78-cdeea09ab4b1",
+      "event": "https://www.stoodi.com.br/exercicios/upe/2016/questao/gregorio-de-matos-poeta-baiano-que-viveu-no-seculo-xvi/",
+      "properties": {
+        "user_actual_role": "system_admin",
+        "user_actual_id": 12345,
+        "user_time_spent": 50000
       },
       "integrations": {
         "All": true

--- a/test/__tests__/data/customerio_input.json
+++ b/test/__tests__/data/customerio_input.json
@@ -2,6 +2,28 @@
   {
     "message": {
       "channel": "web",
+      "type": "identify",
+      "userId": "cio_1234",
+      "integrations": {
+        "All": true
+      },
+      "traits": {
+        "email": "updated_email@example.com",
+        "id": "updated-id-value"
+      },
+      "sentAt": "2019-10-14T09:03:22.563Z"
+    },
+    "destination": {
+      "Config": {
+        "datacenterEU": false,
+        "siteID": "46be54768e7d49ab2628",
+        "apiKey": "19f0f734e3bb87a44596"
+      }
+    }
+  },
+  {
+    "message": {
+      "channel": "web",
       "context": {
         "app": {
           "build": "1.0.0",

--- a/test/__tests__/data/customerio_output.json
+++ b/test/__tests__/data/customerio_output.json
@@ -34,8 +34,39 @@
     "statusCode": 200
   },
   {
-    "message": "userId not present",
+    "message": "userId or email is not present",
     "statusCode": 400
+  },
+  {
+    "body": {
+      "XML": {},
+      "JSON_ARRAY": {},
+      "JSON": {
+        "_timestamp": 1571043797,
+        "anonymous_id": "123456",
+        "city": "NY",
+        "country": "USA",
+        "dot.name": "Arnab Pal",
+        "email": "test@gmail.com",
+        "postalCode": 712136,
+        "prop1": "val1",
+        "prop2": "val2",
+        "state": "CA",
+        "street": ""
+      },
+      "FORM": {}
+    },
+    "files": {},
+    "endpoint": "https://track.customer.io/api/v1/customers/test@gmail.com",
+    "userId": "123456",
+    "headers": {
+      "Authorization": "Basic NDZiZTU0NzY4ZTdkNDlhYjI2Mjg6MTlmMGY3MzRlM2JiODdhNDQ1OTY="
+    },
+    "version": "1",
+    "params": {},
+    "type": "REST",
+    "method": "PUT",
+    "statusCode": 200
   },
   {
     "body": {
@@ -86,6 +117,34 @@
     "files": {},
     "endpoint": "https://track.customer.io/api/v1/customers/12345/events",
     "userId": "12345",
+    "headers": {
+      "Authorization": "Basic NDZiZTU0NzY4ZTdkNDlhYjI2Mjg6MTlmMGY3MzRlM2JiODdhNDQ1OTY="
+    },
+    "version": "1",
+    "params": {},
+    "type": "REST",
+    "method": "POST",
+    "statusCode": 200
+  },
+  {
+    "body": {
+      "XML": {},
+      "JSON_ARRAY": {},
+      "JSON": {
+        "type": "event",
+        "data": {
+          "user_actual_id": 12345,
+          "user_actual_role": "system_admin",
+          "user_time_spent": 50000
+        },
+        "timestamp": 1571051718,
+        "name": "test track event"
+      },
+      "FORM": {}
+    },
+    "files": {},
+    "endpoint": "https://track.customer.io/api/v1/customers/sayan@gmail.com/events",
+    "userId": "c82cbdff-e5be-4009-ac78-cdeea09ab4b1",
     "headers": {
       "Authorization": "Basic NDZiZTU0NzY4ZTdkNDlhYjI2Mjg6MTlmMGY3MzRlM2JiODdhNDQ1OTY="
     },
@@ -192,8 +251,55 @@
     "statusCode": 200
   },
   {
-    "message": "userId or device_token not present",
+    "body": {
+      "XML": {},
+      "JSON_ARRAY": {},
+      "JSON": {},
+      "FORM": {}
+    },
+    "files": {},
+    "endpoint": "https://track.customer.io/api/v1/customers/sayan@gmail.com/devices/somel",
+    "userId": "c82cbdff-e5be-4009-ac78-cdeea09ab4b1",
+    "headers": {
+      "Authorization": "Basic NDZiZTU0NzY4ZTdkNDlhYjI2Mjg6MTlmMGY3MzRlM2JiODdhNDQ1OTY="
+    },
+    "version": "1",
+    "params": {},
+    "type": "REST",
+    "method": "DELETE",
+    "statusCode": 200
+  },
+  {
+    "message": "userId/email or device_token not present",
     "statusCode": 400
+  },
+  {
+    "body": {
+      "XML": {},
+      "JSON_ARRAY": {},
+      "JSON": {
+        "device": {
+          "id": "somel",
+          "last_used": 1571051718,
+          "platform": "mobile",
+          "user_actual_id": 12345,
+          "user_actual_role": "system_admin",
+          "user_time_spent": 50000
+        }
+      },
+      "FORM": {}
+    },
+    "files": {},
+    "endpoint": "https://track.customer.io/api/v1/customers/sayan@gmail.com/devices",
+    "userId": "c82cbdff-e5be-4009-ac78-cdeea09ab4b1",
+    "headers": {
+      "Authorization": "Basic NDZiZTU0NzY4ZTdkNDlhYjI2Mjg6MTlmMGY3MzRlM2JiODdhNDQ1OTY="
+    },
+    "version": "1",
+    "params": {},
+    "type": "REST",
+    "method": "PUT",
+    "statusCode": 200
   },
   {
     "body": {
@@ -449,6 +555,34 @@
       "JSON_ARRAY": {},
       "JSON": {
         "type": "event",
+        "data": {
+          "user_actual_id": 12345,
+          "user_actual_role": "system_admin",
+          "user_time_spent": 50000
+        },
+        "timestamp": 1571051718,
+        "name": "test track event"
+      },
+      "FORM": {}
+    },
+    "files": {},
+    "endpoint": "https://track-eu.customer.io/api/v1/customers/sayan@gmail.com/events",
+    "userId": "c82cbdff-e5be-4009-ac78-cdeea09ab4b1",
+    "headers": {
+      "Authorization": "Basic NDZiZTU0NzY4ZTdkNDlhYjI2Mjg6MTlmMGY3MzRlM2JiODdhNDQ1OTY="
+    },
+    "version": "1",
+    "params": {},
+    "type": "REST",
+    "method": "POST",
+    "statusCode": 200
+  },
+  {
+    "body": {
+      "XML": {},
+      "JSON_ARRAY": {},
+      "JSON": {
+        "type": "event",
         "anonymous_id": "c82cbdff-e5be-4009-ac78-cdeea09ab4b1",
         "data": {
           "user_actual_id": 12345,
@@ -540,8 +674,36 @@
     "statusCode": 200
   },
   {
-    "message": "userId or device_token not present",
+    "message": "userId/email or device_token not present",
     "statusCode": 400
+  },
+  {
+    "body": {
+      "XML": {},
+      "JSON_ARRAY": {},
+      "JSON": {
+        "device": {
+          "id": "somel",
+          "last_used": 1571051718,
+          "platform": "mobile",
+          "user_actual_role": "system_admin",
+          "user_actual_id": 12345,
+          "user_time_spent": 50000
+        }
+      },
+      "FORM": {}
+    },
+    "files": {},
+    "endpoint": "https://track-eu.customer.io/api/v1/customers/sayan@gmail.com/devices",
+    "userId": "c82cbdff-e5be-4009-ac78-cdeea09ab4b1",
+    "headers": {
+      "Authorization": "Basic NDZiZTU0NzY4ZTdkNDlhYjI2Mjg6MTlmMGY3MzRlM2JiODdhNDQ1OTY="
+    },
+    "version": "1",
+    "params": {},
+    "type": "REST",
+    "method": "PUT",
+    "statusCode": 200
   },
   {
     "body": {
@@ -736,6 +898,34 @@
     "version": "1",
     "type": "REST",
     "method": "POST",
+    "endpoint": "https://track.customer.io/api/v1/customers/sayan@gmail.com/events",
+    "headers": {
+      "Authorization": "Basic NDZiZTU0NzY4ZTdkNDlhYjI2Mjg6MTlmMGY3MzRlM2JiODdhNDQ1OTY="
+    },
+    "params": {},
+    "body": {
+      "JSON": {
+        "data": {
+          "user_actual_role": "system_admin",
+          "user_actual_id": 12345,
+          "user_time_spent": 50
+        },
+        "name": "https://www.stoodi.com.br/exershgcios/upe/2019/questao/gregorio-de-matos-poeta-baiano-que-viveu-no-seculo-xvi/",
+        "type": "event",
+        "timestamp": 1571051718
+      },
+      "XML": {},
+      "JSON_ARRAY": {},
+      "FORM": {}
+    },
+    "files": {},
+    "userId": "c82cbdff-e5be-4009-ac78-cdeea09ab4b1",
+    "statusCode": 200
+  },
+  {
+    "version": "1",
+    "type": "REST",
+    "method": "POST",
     "endpoint": "https://track.customer.io/api/v1/events",
     "headers": {
       "Authorization": "Basic NDZiZTU0NzY4ZTdkNDlhYjI2Mjg6MTlmMGY3MzRlM2JiODdhNDQ1OTY="
@@ -750,6 +940,34 @@
         },
         "anonymous_id": "c82cbdff-e5be-4009-ac78-cdeea09ab4b1",
         "name": "Viewed https://www.stoodi.com.br/exercicios/upe/2016/questao/gregorio-de-matos-poeta-baiano-q Screen",
+        "type": "event",
+        "timestamp": 1571051718
+      },
+      "XML": {},
+      "JSON_ARRAY": {},
+      "FORM": {}
+    },
+    "files": {},
+    "userId": "c82cbdff-e5be-4009-ac78-cdeea09ab4b1",
+    "statusCode": 200
+  },
+  {
+    "version": "1",
+    "type": "REST",
+    "method": "POST",
+    "endpoint": "https://track.customer.io/api/v1/customers/sayan@gmail.com/events",
+    "headers": {
+      "Authorization": "Basic NDZiZTU0NzY4ZTdkNDlhYjI2Mjg6MTlmMGY3MzRlM2JiODdhNDQ1OTY="
+    },
+    "params": {},
+    "body": {
+      "JSON": {
+        "data": {
+          "user_actual_role": "system_admin",
+          "user_actual_id": 12345,
+          "user_time_spent": 50000
+        },
+        "name": "Viewed https://www.stoodi.com.br/exercicios/upe/2016/questao/gregorio-de-matos-poeta-baiano-que-viveu-no-seculo-xvi/ Screen",
         "type": "event",
         "timestamp": 1571051718
       },

--- a/test/__tests__/data/customerio_output.json
+++ b/test/__tests__/data/customerio_output.json
@@ -1,5 +1,27 @@
 [
   {
+    "body": {
+      "XML": {},
+      "JSON_ARRAY": {},
+      "JSON": {
+        "email": "updated_email@example.com",
+        "id": "updated-id-value"
+      },
+      "FORM": {}
+    },
+    "files": {},
+    "endpoint": "https://track.customer.io/api/v1/customers/cio_1234",
+    "userId": "cio_1234",
+    "headers": {
+      "Authorization": "Basic NDZiZTU0NzY4ZTdkNDlhYjI2Mjg6MTlmMGY3MzRlM2JiODdhNDQ1OTY="
+    },
+    "version": "1",
+    "params": {},
+    "type": "REST",
+    "method": "PUT",
+    "statusCode": 200
+  },
+  {
     "message": "apiKey not found in Configs"
   },
   {


### PR DESCRIPTION
## Description of the change
> CustomerIo accepts either `id`, `email` or `cio_id` as identifiers but currently we were only sending `id` mapped to `userId` but now we are looking for `email` as well and if its available we are using it as identifier instead of dropping the event. 
> This is done for identify and merge calls and identified track and device events.
> Extended support to update identifiers using `cio_id` fetched from CustomerIO dashboard

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
