### PR TITLE
fix: pinterest tag support test event rt flow

### DIFF
--- a/src/cdk/v2/destinations/pinterest_tag/rtWorkflow.yaml
+++ b/src/cdk/v2/destinations/pinterest_tag/rtWorkflow.yaml
@@ -7,6 +7,13 @@ steps:
     template: |
       $.assert(Array.isArray(^) && ^.length > 0, "Invalid event array")
 
+  - name: checkSendTestEventConfig
+    description: |
+      If sendTestEvent is enabled, we send test event to the destination
+      ref: https://help.pinterest.com/en/business/article/track-conversions-with-the-conversions-api
+    template: |
+        ^[0].destination.Config.sendAsTestEvent ? {"test": true} : {}
+
   - name: transform
     externalWorkflow:
       path: ./procWorkflow.yaml
@@ -54,7 +61,7 @@ steps:
           "headers": {
             "Content-Type": "application/json",
           },
-          "params": {},
+          "params": $.outputs.checkSendTestEventConfig,
           "files": {}
         },
         "metadata": ~r batch.metadata,
@@ -83,7 +90,7 @@ steps:
             "Content-Type": "application/json",
               Authorization: "Bearer " + batch.destination.Config.conversionToken,
           },
-          "params": {},
+          "params": $.outputs.checkSendTestEventConfig,
           "files": {}
         },
         "metadata": ~r batch.metadata,


### PR DESCRIPTION
## Description of the change

> We had added support for sending test events in Pinterest. We have fixed the router flow here.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
