### PR TITLE
fix(braze): enable merge behaviour to stitch user data

### DIFF
--- a/src/v0/destinations/braze/transform.js
+++ b/src/v0/destinations/braze/transform.js
@@ -80,7 +80,7 @@ function getIdentifyPayload(message) {
   let payload = {};
   payload = setAliasObjectWithAnonId(payload, message);
   payload = setExternalId(payload, message);
-  return { aliases_to_identify: [payload] };
+  return { aliases_to_identify: [payload], merge_behavior: "merge" };
 }
 
 function populateCustomAttributesWithOperation(


### PR DESCRIPTION
## Description of the change

- enable merge_user behaviour to merge anonymous user fields to the identified user.
- for more info refer [here](https://www.braze.com/docs/api/endpoints/user_data/post_user_identify/#request-parameters)

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
