### PR TITLE
fix: missing type for page and group calls

### DIFF
--- a/src/v0/destinations/factorsai/transform.js
+++ b/src/v0/destinations/factorsai/transform.js
@@ -44,6 +44,7 @@ function processTrack(message, factorsAIApiKey) {
 // process Page Call
 function processPageAndGroup(message, factorsAIApiKey, category) {
   const requestJson = constructPayload(message, mappingConfig[category]);
+  requestJson.type = message.type;
   return buildResponse(requestJson, factorsAIApiKey);
 }
 

--- a/test/integrations/destinations/factorsai/data.ts
+++ b/test/integrations/destinations/factorsai/data.ts
@@ -381,6 +381,7 @@ export const data = [
                 XML: {},
                 FORM: {},
                 JSON: {
+                  type: 'group',
                   traits: {
                     company: '5055077684',
                     type: 'IT',
@@ -482,6 +483,7 @@ export const data = [
                 XML: {},
                 FORM: {},
                 JSON: {
+                  type: 'page',
                   name: 'ApplicationLoaded',
                   userId: '12345',
                   context: {


### PR DESCRIPTION
## Description of the change

> Resolves INT-463
FactorsAI expect to see a type property in the JSON with the value page for all page events and currently our integration is not sending this value. We are fixing this here.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
