### PR TITLE
fix: faas pods creation failure due to caching

### DIFF
--- a/src/util/openfaas/index.js
+++ b/src/util/openfaas/index.js
@@ -92,8 +92,18 @@ const isFunctionDeployed = (functionName) => {
 
 const setFunctionInCache = (functionName) => {
   const funcList = functionListCache.get(FUNC_LIST_KEY) || [];
-  funcList.push(functionName);
-  functionListCache.set(FUNC_LIST_KEY, funcList);
+  const funcListSet = new Set(funcList);
+  if (funcListSet.has(functionName)) return;
+  funcListSet.add(functionName);
+  functionListCache.set(FUNC_LIST_KEY, Array.from(funcListSet));
+};
+
+const removeFunctionFromCache = (functionName) => {
+  const funcList = functionListCache.get(FUNC_LIST_KEY) || [];
+  const funcListSet = new Set(funcList);
+  if (!funcListSet.has(functionName)) return;
+  funcListSet.delete(functionName);
+  functionListCache.set(FUNC_LIST_KEY, Array.from(funcListSet));
 };
 
 const invalidateFnCache = () => {
@@ -150,7 +160,10 @@ const deployFaasFunction = async (functionName, code, versionId, libraryVersionI
     logger.error(`[Faas] Error while deploying ${functionName}: ${error.message}`);
     // To handle concurrent create requests,
     // throw retry error if deployment or service already exists so that request can be retried
-    if ((error.statusCode === 500 || error.statusCode === 400) && error.message.includes('already exists')) {
+    if (
+      (error.statusCode === 500 || error.statusCode === 400) &&
+      error.message.includes('already exists')
+    ) {
       setFunctionInCache(functionName);
       throw new RetryRequestError(`${functionName} already exists`);
     }
@@ -199,6 +212,7 @@ const executeFaasFunction = async (
       error.statusCode === 404 &&
       error.message.includes(`error finding function ${functionName}`)
     ) {
+      removeFunctionFromCache(functionName);
       await setupFaasFunction(functionName, null, versionId, libraryVersionIDs, testMode);
       throw new RetryRequestError(`${functionName} not found`);
     }


### PR DESCRIPTION
## Description of the change

https://linear.app/rudderstack/issue/DAT-326/fix-faas-pods-deployment-creation-failure
## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
