### PR TITLE
fix: remove secure environment for datafile call

### DIFF
--- a/src/cdk/v2/destinations/optimizely_fullstack/procWorkflow.yaml
+++ b/src/cdk/v2/destinations/optimizely_fullstack/procWorkflow.yaml
@@ -37,7 +37,6 @@ steps:
       $.assertConfig(.destination.Config.experimentId, "Experiment ID is not present. Aborting");
       $.assertConfig(!(.destination.Config.trackKnownUsers && !(.message.userId)), "UserId is required for event tracking when the 'Track Known Users' setting is enabled. Please include a 'userId' in your event payload");
       $.assertConfig(!(!.destination.Config.trackKnownUsers && !(.message.anonymousId)), "AnonymousId is required when 'Track Known Users' setting is disabled");
-      $.assertConfig(!(.destination.Config.secureEnvironment && !(.destination.Config.dataFileAccessToken)), "Data File Access Token is not present for secure environment. Aborting");
 
   - name: messageType
     template: |
@@ -60,12 +59,7 @@ steps:
     description: Fetch the data file from the data file url
     template: |
       const dataFileUrl = .destination.Config.dataFileUrl;
-      const options = .destination.Config.secureEnvironment ? {
-        headers: {
-         "Authorization": "Bearer " + .destination.Config.dataFileAccessToken
-        }
-      };
-      const rawResponse = await $.handleHttpRequest("get", dataFileUrl, options);
+      const rawResponse = await $.handleHttpRequest("get", dataFileUrl);
       const processedResponse = rawResponse.processedResponse;
       $.assertHttpResp(processedResponse, "Data File Lookup Failed");
       processedResponse.response

--- a/test/__tests__/data/optimizely_fullstack.json
+++ b/test/__tests__/data/optimizely_fullstack.json
@@ -27,39 +27,6 @@
     }
   },
   {
-    "description": "Missing Data File Access Token for Secure Environment",
-    "input": {
-      "message": {
-        "type": "identify",
-        "channel": "web",
-        "properties": {},
-        "context": {},
-        "rudderId": "8f8fa6b5-8e24-489c-8e22-61f23f2e364f",
-        "messageId": "2116ef8c-efc3-4ca4-851b-02ee60dad6ff",
-        "anonymousId": "97c46c81-3140-456d-b2a9-690d70aaca35",
-        "integrations": {
-          "All": true,
-          "optimizely_fullstack": {
-            "variationId": "123"
-          }
-        }
-      },
-      "destination": {
-        "Config": {
-          "accountId": "test_account_id",
-          "campaignId": "test_campaign_id",
-          "experimentId": "test_experiment_id",
-          "dataFileUrl": "https://cdn.optimizely.com/datafiles/abc.json",
-          "secureEnvironment": true,
-          "dataFileAccessToken": ""
-        }
-      }
-    },
-    "output": {
-      "error": "Data File Access Token is not present for secure environment. Aborting"
-    }
-  },
-  {
     "description": "Identify call: Missing Variation ID in integration object",
     "input": {
       "message": {


### PR DESCRIPTION
## Description of the change

> Resolves INT-556
Fetching the datafile for secure environment with access token is supported using SDK only in optimizley. Removing the handling of secure environment in transformer

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
