### PR TITLE
fix: type issue in lookup via externalid, row lock error as retryable

### DIFF
--- a/src/v0/destinations/salesforce/transform.js
+++ b/src/v0/destinations/salesforce/transform.js
@@ -26,7 +26,6 @@ const {
 const { getAccessToken, salesforceResponseHandler } = require('./utils');
 const { handleHttpRequest } = require('../../../adapters/network');
 const { InstrumentationError, NetworkInstrumentationError } = require('../../util/errorTypes');
-const logger = require('../../../logger');
 const { JSON_MIME_TYPE } = require('../../util/constant');
 
 // Basic response builder
@@ -125,7 +124,7 @@ async function getSaleforceIdForRecord(
     );
   }
   const searchRecord = processedsfSearchResponse.response?.searchRecords?.find(
-    (rec) => rec[identifierType] === identifierValue,
+    (rec) => typeof identifierValue !== 'undefined' && rec[identifierType] === `${identifierValue}`,
   );
 
   return searchRecord?.Id;

--- a/test/__mocks__/data/salesforce/proxy_response.json
+++ b/test/__mocks__/data/salesforce/proxy_response.json
@@ -69,7 +69,7 @@
       "status": 503
     }
   },
-  "https://rudderstack.my.salesforce.com/services/data/v50.0/parameterizedSearch/?q=external_id&sobject=object_name&in=External_ID__c&object_name.fields=id,External_ID__c": {
+  "https://rudderstack.my.salesforce.com/services/data/v50.0/parameterizedSearch/?q=123&sobject=object_name&in=External_ID__c&object_name.fields=id,External_ID__c": {
     "response": {
       "searchRecords": [
         {

--- a/test/__tests__/data/salesforce_proxy_input.json
+++ b/test/__tests__/data/salesforce_proxy_input.json
@@ -233,7 +233,7 @@
   {
     "type": "REST",
     "method": "POST",
-    "endpoint": "https://rudderstack.my.salesforce.com/services/data/v50.0/parameterizedSearch/?q=external_id&sobject=object_name&in=External_ID__c&object_name.fields=id,External_ID__c",
+    "endpoint": "https://rudderstack.my.salesforce.com/services/data/v50.0/parameterizedSearch/?q=123&sobject=object_name&in=External_ID__c&object_name.fields=id,External_ID__c",
     "headers": {
       "Content-Type": "application/json",
       "Authorization": "Bearer token"
@@ -241,7 +241,7 @@
     "body": {
       "JSON": {
         "Planning_Categories__c": "pc",
-        "External_ID__c": "external_id"
+        "External_ID__c": 123
       },
       "JSON_ARRAY": {},
       "XML": {},


### PR DESCRIPTION
## Description of the change

> Fix the type comparison logic of externalId to compare strings, in compliance to the string returned by Salesforce. We are also retrying errors related to row locking now.
 

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
