### PR TITLE
fix: remove hashing on twclid for twitter ads

### DIFF
--- a/src/v0/destinations/twitter_ads/transform.js
+++ b/src/v0/destinations/twitter_ads/transform.js
@@ -9,15 +9,15 @@ const {
   simpleProcessRouterDest,
 } = require('../../util');
 const { EventType } = require('../../../constants');
-const {
-  ConfigCategories,
-  mappingConfig,
-  BASE_URL
-} = require('./config');
+const { ConfigCategories, mappingConfig, BASE_URL } = require('./config');
 
-const { InstrumentationError, OAuthSecretError, ConfigurationError } = require('../../util/errorTypes');
+const {
+  InstrumentationError,
+  OAuthSecretError,
+  ConfigurationError,
+} = require('../../util/errorTypes');
 const { JSON_MIME_TYPE } = require('../../util/constant');
-const { getAuthHeaderForRequest } = require("./util");
+const { getAuthHeaderForRequest } = require('./util');
 
 const getOAuthFields = ({ secret }) => {
   if (!secret) {
@@ -27,7 +27,7 @@ const getOAuthFields = ({ secret }) => {
     consumerKey: secret.consumerKey,
     consumerSecret: secret.consumerSecret,
     accessToken: secret.accessToken,
-    accessTokenSecret: secret.accessTokenSecret
+    accessTokenSecret: secret.accessTokenSecret,
   };
   return oAuthObject;
 };
@@ -42,7 +42,7 @@ function buildResponse(message, requestJson, metadata, endpointUrl) {
   const request = {
     url: response.endpoint,
     method: response.method,
-    body: response.body.JSON
+    body: response.body.JSON,
   };
 
   const oAuthObject = getOAuthFields(metadata);
@@ -60,17 +60,20 @@ function prepareUrl(message, destination) {
 }
 
 function populateEventId(event, requestJson, destination) {
-
   const eventNameToIdMappings = destination.Config.twitterAdsEventNames;
-  let eventId = "";
+  let eventId = '';
 
   if (eventNameToIdMappings) {
-    const eventObj = eventNameToIdMappings.find(obj => obj.rudderEventName?.trim().toLowerCase() === event?.toString().toLowerCase());
+    const eventObj = eventNameToIdMappings.find(
+      (obj) => obj.rudderEventName?.trim().toLowerCase() === event?.toString().toLowerCase(),
+    );
     eventId = eventObj?.twitterEventId;
   }
 
-  if(!eventId) {
-    throw new ConfigurationError(`[TWITTER ADS]: Event - '${event}' do not have a corresponding eventId in configuration. Aborting`);
+  if (!eventId) {
+    throw new ConfigurationError(
+      `[TWITTER ADS]: Event - '${event}' do not have a corresponding eventId in configuration. Aborting`,
+    );
   }
 
   return eventId;
@@ -79,14 +82,16 @@ function populateEventId(event, requestJson, destination) {
 function populateContents(requestJson) {
   const reqJson = { ...requestJson };
   if (reqJson.contents) {
-    const transformedContents = requestJson.contents.map(obj => ({
-      ...(obj.id && { content_id: obj.id }),
-      ...(obj.groupId && { content_group_id: obj.groupId }),
-      ...(obj.name && { content_name: obj.name }),
-      ...(obj.price && { content_price: parseFloat(obj.price) }),
-      ...(obj.type && { content_type: obj.type }),
-      ...(obj.quantity && { num_items: parseInt(obj.quantity, 10) })
-    })).filter(tfObj => Object.keys(tfObj).length > 0);
+    const transformedContents = requestJson.contents
+      .map((obj) => ({
+        ...(obj.id && { content_id: obj.id }),
+        ...(obj.groupId && { content_group_id: obj.groupId }),
+        ...(obj.name && { content_name: obj.name }),
+        ...(obj.price && { content_price: parseFloat(obj.price) }),
+        ...(obj.type && { content_type: obj.type }),
+        ...(obj.quantity && { num_items: parseInt(obj.quantity, 10) }),
+      }))
+      .filter((tfObj) => Object.keys(tfObj).length > 0);
     if (transformedContents.length > 0) {
       reqJson.contents = transformedContents;
     }
@@ -96,13 +101,14 @@ function populateContents(requestJson) {
 
 // process track call
 function processTrack(message, metadata, destination) {
-
   let requestJson = constructPayload(message, mappingConfig[ConfigCategories.TRACK.name]);
 
-  requestJson.event_id = requestJson.event_id || populateEventId(message.event, requestJson, destination);
+  requestJson.event_id =
+    requestJson.event_id || populateEventId(message.event, requestJson, destination);
 
   requestJson.conversion_time = isDefinedAndNotNull(requestJson.conversion_time)
-      ? requestJson.conversion_time : message.timestamp;
+    ? requestJson.conversion_time
+    : message.timestamp;
 
   const identifiers = [];
 
@@ -110,19 +116,19 @@ function processTrack(message, metadata, destination) {
     let email = message.properties.email.trim();
     if (email) {
       email = email.toLowerCase();
-      identifiers.push({hashed_email: sha256(email)})
+      identifiers.push({ hashed_email: sha256(email) });
     }
   }
 
   if (message.properties.phone) {
     const phone = message.properties.phone.trim();
     if (phone) {
-      identifiers.push({hashed_phone_number: sha256(phone)})
+      identifiers.push({ hashed_phone_number: sha256(phone) });
     }
   }
 
   if (message.properties.twclid) {
-    identifiers.push({twclid: sha256(message.properties.twclid)});
+    identifiers.push({ twclid: message.properties.twclid });
   }
 
   requestJson = populateContents(requestJson);
@@ -131,33 +137,26 @@ function processTrack(message, metadata, destination) {
 
   const endpointUrl = prepareUrl(message, destination);
 
-  return buildResponse(
-      message,
-      requestJson,
-      metadata,
-      endpointUrl
-  );
+  return buildResponse(message, requestJson, metadata, endpointUrl);
 }
 
 function validateRequest(message) {
-
   const { properties } = message;
 
   if (!properties) {
     throw new InstrumentationError(
-        '[TWITTER ADS]: properties must be present in event. Aborting message',
+      '[TWITTER ADS]: properties must be present in event. Aborting message',
     );
   }
 
   if (!properties.email && !properties.phone && !properties.twclid) {
     throw new InstrumentationError(
-        '[TWITTER ADS]: one of twclid, phone or email must be present in properties.',
+      '[TWITTER ADS]: one of twclid, phone or email must be present in properties.',
     );
   }
 }
 
 function process(event) {
-
   const { message, metadata, destination } = event;
 
   validateRequest(message);
@@ -169,7 +168,6 @@ function process(event) {
   }
 
   throw new InstrumentationError(`Message type ${messageType} not supported`);
-
 }
 
 const processRouterDest = async (inputs, reqMetadata) => {

--- a/test/__tests__/data/twitter_ads.json
+++ b/test/__tests__/data/twitter_ads.json
@@ -136,7 +136,7 @@
                   "hashed_phone_number": "b308962b96b40cce7981493a372db9478edae79f83c2d8ca6cd15a39566f8c56"
                 },
                 {
-                  "twclid": "18beb4813723e788a1d79bcbf80802538ec813aa19ded2e9c21cbf08bed6bee3"
+                  "twclid": "543"
                 }
               ]
             }
@@ -360,7 +360,7 @@
                   "hashed_phone_number": "b308962b96b40cce7981493a372db9478edae79f83c2d8ca6cd15a39566f8c56"
                 },
                 {
-                  "twclid": "18beb4813723e788a1d79bcbf80802538ec813aa19ded2e9c21cbf08bed6bee3"
+                  "twclid": "543"
                 }
               ]
             }
@@ -692,7 +692,7 @@
                   "hashed_phone_number": "b308962b96b40cce7981493a372db9478edae79f83c2d8ca6cd15a39566f8c56"
                 },
                 {
-                  "twclid": "18beb4813723e788a1d79bcbf80802538ec813aa19ded2e9c21cbf08bed6bee3"
+                  "twclid": "543"
                 }
               ]
             }


### PR DESCRIPTION
## Description of the change

> we seem to be hashing `twclid` though the api docs say hashing is not required : [https://developer.twitter.com/en/docs/twitter-ads-api/measurement/web-conversions/conversion-api#:~:text=Preparing%20Iden[…]onversion%20Events%C2%A0](https://developer.twitter.com/en/docs/twitter-ads-api/measurement/web-conversions/conversion-api#:~:text=Preparing%20Identifiers%20for%20Conversion%20Events%C2%A0)

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
