### PR TITLE
fix(INT-339): marketo response handler to handle static list removed and skipped statuses

### DIFF
--- a/test/__mocks__/data/marketo_static_list/proxy_response.json
+++ b/test/__mocks__/data/marketo_static_list/proxy_response.json
@@ -1,4 +1,31 @@
 {
+  "https://marketo_acct_id_success.mktorest.com/rest/v1/lists/1234/leads.json?id=110&id=111&id=112": {
+    "data": {
+      "requestId": "b6d1#18a8d2c10e7",
+      "result": [
+        {
+          "id": 110,
+          "status": "skipped",
+          "reasons": [
+            {
+              "code": "1015",
+              "message": "Lead not in list"
+            }
+          ]
+        },
+        {
+          "id": 111,
+          "status": "removed"
+        },
+        {
+          "id": 112,
+          "status": "removed"
+        }
+      ],
+      "success": true
+    },
+    "status": 200
+  },
   "https://marketo_acct_id_success.mktorest.com/rest/v1/lists/1234/leads.json?id=1&id=2&id=3": {
     "data": {
       "requestId": "68d8#1846058ee27",
@@ -60,12 +87,11 @@
         "status": "skipped",
         "reasons": [
           {
-            "code": "1004",
-            "message": "Lead not found"
+            "code": "1015",
+            "message": "Lead not in list"
           }
         ]
       },
-
       "success": true
     },
     "status": 200

--- a/test/__tests__/data/marketo_static_list_proxy_input.json
+++ b/test/__tests__/data/marketo_static_list_proxy_input.json
@@ -1,6 +1,26 @@
 [
   {
     "type": "REST",
+    "endpoint": "https://marketo_acct_id_success.mktorest.com/rest/v1/lists/1234/leads.json?id=110&id=111&id=112",
+    "method": "POST",
+    "userId": "",
+    "headers": {
+      "Authorization": "Bearer Incorrect_token",
+      "Content-Type": "application/json"
+    },
+    "body": {
+      "FORM": {},
+      "JSON": {},
+      "JSON_ARRAY": {},
+      "XML": {}
+    },
+    "files": {},
+    "params": {
+      "destination": "marketo_static_list"
+    }
+  },
+  {
+    "type": "REST",
     "endpoint": "https://marketo_acct_id_success.mktorest.com/rest/v1/lists/1234/leads.json?id=1&id=2&id=3",
     "method": "POST",
     "userId": "",

--- a/test/__tests__/data/marketo_static_list_proxy_output.json
+++ b/test/__tests__/data/marketo_static_list_proxy_output.json
@@ -1,6 +1,39 @@
 [
   {
     "output": {
+      "message": "Request Processed Successfully",
+      "destinationResponse": {
+        "response": {
+          "requestId": "b6d1#18a8d2c10e7",
+          "result": [
+            {
+              "id": 110,
+              "status": "skipped",
+              "reasons": [
+                {
+                  "code": "1015",
+                  "message": "Lead not in list"
+                }
+              ]
+            },
+            {
+              "id": 111,
+              "status": "removed"
+            },
+            {
+              "id": 112,
+              "status": "removed"
+            }
+          ],
+          "success": true
+        },
+        "status": 200
+      },
+      "status": 200
+    }
+  },
+  {
+    "output": {
       "status": 500,
       "message": "Request Failed for Marketo Static List, Access token invalid (Retryable).during Marketo Static List Response Handling",
       "destinationResponse": {
@@ -72,21 +105,25 @@
   },
   {
     "output": {
-      "destinationResponse": "",
-      "message": "Request failed during: during Marketo Static List Response Handling, error: [{\"code\":\"1004\",\"message\":\"Lead not found\"}]",
-      "statTags": {
-        "destType": "MARKETO_STATIC_LIST",
-        "errorCategory": "dataValidation",
-        "destinationId": "Non-determininable",
-        "workspaceId": "Non-determininable",
-        "errorType": "instrumentation",
-        "feature": "dataDelivery",
-        "implementation": "native",
-        "destinationId": "Non-determininable",
-        "workspaceId": "Non-determininable",
-        "module": "destination"
-      },
-      "status": 400
+      "status": 200,
+      "message": "Request Processed Successfully",
+      "destinationResponse": {
+        "response": {
+          "requestId": "12d3c#1846057dce2",
+          "result": {
+            "id": 5,
+            "status": "skipped",
+            "reasons": [
+              {
+                "code": "1015",
+                "message": "Lead not in list"
+              }
+            ]
+          },
+          "success": true
+        },
+        "status": 200
+      }
     }
   }
 ]


### PR DESCRIPTION
## Description of the change

> We are not handling the `skipped` (code: 1015) and `removed` statuses properly due which for these even if the calls are successful we are returning as error 

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
