### PR TITLE
fix: bqstream event ordering fix

### DIFF
--- a/src/v0/destinations/bqstream/transform.js
+++ b/src/v0/destinations/bqstream/transform.js
@@ -6,10 +6,11 @@ const {
   getSuccessRespEvents,
   checkInvalidRtTfEvents,
   handleRtTfSingleEventError,
+  groupEventsByType,
 } = require('../../util');
 const { MAX_ROWS_PER_REQUEST, DESTINATION } = require('./config');
 const { InstrumentationError } = require('../../util/errorTypes');
-const { getRearrangedEvents, batchEvents } = require('./util');
+const { getRearrangedEvents } = require('./util');
 
 const getInsertIdColValue = (properties, insertIdCol) => {
   if (
@@ -106,7 +107,7 @@ const processRouterDest = (inputs) => {
   }
   const finalResp = [];
   let eachTypeBatchedResponse = [];
-  const batchedEvents = batchEvents(inputs);
+  const batchedEvents = groupEventsByType(inputs);
 
   batchedEvents.forEach((listOfEvents) => {
     const eachTypeSuccessEventList = []; // temporary variable to divide payload into chunks

--- a/src/v0/destinations/bqstream/util.js
+++ b/src/v0/destinations/bqstream/util.js
@@ -1,5 +1,4 @@
 /* eslint-disable no-param-reassign */
-const _ = require('lodash')
 const getValue = require('get-value');
 const {
   getDynamicErrorType,

--- a/src/v0/destinations/bqstream/util.js
+++ b/src/v0/destinations/bqstream/util.js
@@ -1,11 +1,10 @@
 /* eslint-disable no-param-reassign */
-const _ = require('lodash');
 const getValue = require('get-value');
 const {
   getDynamicErrorType,
   processAxiosResponse,
 } = require('../../../adapters/utils/networkUtils');
-const { isHttpStatusSuccess, isDefinedAndNotNull } = require('../../util');
+const { isHttpStatusSuccess } = require('../../util');
 const {
   REFRESH_TOKEN,
   AUTH_STATUS_INACTIVE,
@@ -147,32 +146,6 @@ function networkHandler() {
   this.processAxiosResponse = processAxiosResponse;
 }
 
-const batchEvents = (inputs) => {
-  const batches = [];
-  let currentInputsArray = inputs;
-  while (currentInputsArray.length > 0) {
-    const remainingInputsArray = [];
-    const userOrderTracker = {};
-    const event = currentInputsArray.shift();
-    const messageType = event.message.type;
-    const batch = [event];
-    currentInputsArray.forEach((currentInput) => {
-      const currentMessageType = currentInput.message.type;
-      const currentUser = currentInput.metadata.userId;
-      if (currentMessageType === messageType && !userOrderTracker[currentUser]) {
-        batch.push(currentInput);
-      } else {
-        remainingInputsArray.push(currentInput);
-        userOrderTracker[currentUser] = true;
-      }
-    });
-    batches.push(batch);
-    currentInputsArray = remainingInputsArray;
-  }
-
-  return batches;
-};
-
 /**
  * Optimizes the error response by merging the metadata of the same error type and adding it to the result array.
  *
@@ -231,4 +204,4 @@ const getRearrangedEvents = (eachUserSuccessEventslist, eachUserErrorEventsList)
   return [processedSuccessfulEvents];
 };
 
-module.exports = { networkHandler, getRearrangedEvents, batchEvents };
+module.exports = { networkHandler, getRearrangedEvents };

--- a/src/v0/destinations/bqstream/util.js
+++ b/src/v0/destinations/bqstream/util.js
@@ -1,151 +1,5 @@
 /* eslint-disable no-param-reassign */
-const getValue = require('get-value');
-const {
-  getDynamicErrorType,
-  processAxiosResponse,
-} = require('../../../adapters/utils/networkUtils');
-const { isHttpStatusSuccess, isDefinedAndNotNull } = require('../../util');
-const {
-  REFRESH_TOKEN,
-  AUTH_STATUS_INACTIVE,
-} = require('../../../adapters/networkhandler/authConstants');
-const { proxyRequest } = require('../../../adapters/network');
-const { UnhandledStatusCodeError, NetworkError, AbortedError } = require('../../util/errorTypes');
-const tags = require('../../util/tags');
-
-const DESTINATION_NAME = 'bqstream';
-
-const trimBqStreamResponse = (response) => ({
-  code: getValue(response, 'response.response.data.error.code'), // data.error.status which contains PERMISSION_DENIED
-  status: getValue(response, 'response.response.status'),
-  statusText: getValue(response, 'response.response.statusText'),
-  headers: getValue(response, 'response.response.headers'),
-  data: getValue(response, 'response.response.data'), // Incase of errors, this contains error data
-  success: getValue(response, 'suceess'),
-});
-/**
- * Obtains the Destination OAuth Error Category based on the error code obtained from destination
- *
- * - If an error code is such that the user will not be allowed inside the destination,
- * such error codes fall under AUTH_STATUS_INACTIVE
- * - If an error code is such that upon refresh we can get a new token which can be used to send event,
- * such error codes fall under REFRESH_TOKEN category
- * - If an error code doesn't fall under both categories, we can return an empty string
- * @param {string} errorCategory - The error code obtained from the destination
- * @returns Destination OAuth Error Category
- */
-const getDestAuthCategory = (errorCategory) => {
-  switch (errorCategory) {
-    case 'PERMISSION_DENIED':
-      return AUTH_STATUS_INACTIVE;
-    case 'UNAUTHENTICATED':
-      return REFRESH_TOKEN;
-    default:
-      return '';
-  }
-};
-
-const destToRudderStatusMap = {
-  403: {
-    rateLimitExceeded: 429,
-    default: 400,
-  },
-  400: {
-    tableUnavailable: 500,
-    default: 400,
-  },
-  500: { default: 500 },
-  503: { default: 500 },
-  401: { default: 500 },
-  404: { default: 400 },
-  501: { default: 400 },
-};
-
-const getStatusAndCategory = (dresponse, status) => {
-  const authErrorCategory = getDestAuthCategory(dresponse.error.status);
-  const reason =
-    dresponse.error.errors &&
-    Array.isArray(dresponse.error.errors) &&
-    dresponse.error.errors.length > 0 &&
-    dresponse.error.errors[0].reason;
-
-  const trStatus = destToRudderStatusMap[status]
-    ? destToRudderStatusMap[status][reason] || destToRudderStatusMap[status].default
-    : 500;
-  return { status: trStatus, authErrorCategory };
-};
-
-/**
- * This class actually handles the response for BigQuery Stream API
- * It can also be used for any Google related API but an API related handling has to be done separately
- *
- * Here we are only trying to handle OAuth related error(s)
- * Any destination specific error handling has to be done in their own way
- *
- * Reference doc for OAuth Errors
- * 1. https://cloud.google.com/apigee/docs/api-platform/reference/policies/oauth-http-status-code-reference
- * 2. https://cloud.google.com/bigquery/docs/error-messages
- *
- * Summary:
- * Abortable -> 403, 501, 400
- * Retryable -> 5[0-9][02-9], 401(UNAUTHENTICATED)
- * "Special Cases":
- * status=200, resp.insertErrors.length > 0  === Failure
- * 403 => AccessDenied -> AUTH_STATUS_INACTIVE, other 403 => Just abort
- *
- */
-const processResponse = ({ dresponse, status } = {}) => {
-  const isSuccess =
-    !dresponse.error &&
-    isHttpStatusSuccess(status) &&
-    (!dresponse.insertErrors || (dresponse.insertErrors && dresponse.insertErrors.length === 0));
-
-  if (!isSuccess) {
-    if (dresponse.error) {
-      const { status: trStatus } = getStatusAndCategory(dresponse, status);
-      throw new NetworkError(
-        dresponse.error.message || `Request failed for ${DESTINATION_NAME} with status: ${status}`,
-        trStatus,
-        {
-          [tags.TAG_NAMES.ERROR_TYPE]: getDynamicErrorType(trStatus),
-        },
-        dresponse,
-      );
-    } else if (dresponse.insertErrors && dresponse.insertErrors.length > 0) {
-      const temp = trimBqStreamResponse(dresponse);
-      throw new AbortedError(
-        'Problem during insert operation',
-        400,
-        {
-          [tags.TAG_NAMES.ERROR_TYPE]: getDynamicErrorType(temp.status || 400),
-        },
-        temp,
-        getDestAuthCategory(temp.code),
-      );
-    }
-    throw new UnhandledStatusCodeError('Unhandled error type while sending to destination');
-  }
-};
-
-const responseHandler = (respTransformPayload) => {
-  const { response, status } = respTransformPayload;
-  processResponse({
-    dresponse: response,
-    status,
-  });
-  return {
-    status,
-    destinationResponse: response,
-    message: 'Request Processed Successfully',
-  };
-};
-
-function networkHandler() {
-  this.responseHandler = responseHandler;
-  this.proxy = proxyRequest;
-  this.processAxiosResponse = processAxiosResponse;
-}
-
+const { isDefinedAndNotNull } = require('../../util');
 /**
  * Optimizes the error response by merging the metadata of the same error type and adding it to the result array.
  *
@@ -175,10 +29,9 @@ const convertMetadataToArray = (eventList) => {
   return processedEvents;
 };
 
-
 /**
  * Formats a list of error events into a composite response.
- * 
+ *
  * @param {Array} errorEvents - A list of error events, where each event can have an `error` property and a `metadata` array.
  * @returns {Array} The formatted composite response, where each element is an array containing the error details.
  */
@@ -189,7 +42,7 @@ const formatCompositeResponse = (errorEvents) => {
   for (const item of errorEvents) {
     if (isDefinedAndNotNull(item.error)) {
       optimizeErrorResponse(item, errorMap, resultArray);
-    } 
+    }
   }
   return resultArray;
 };
@@ -216,15 +69,15 @@ const getRearrangedEvents = (successEventList, errorEventList) => {
   }
   // if there are no batched response, then return the error events
   if (successEventList.length === 0) {
-    return formatCompositeResponse(processedErrorEvents)
+    return formatCompositeResponse(processedErrorEvents);
   }
 
   // if there are both batched response and error events, then order them
   const combinedTransformedEventList = [
     [...processedSuccessfulEvents],
-    ...formatCompositeResponse(processedErrorEvents)
-  ]
+    ...formatCompositeResponse(processedErrorEvents),
+  ];
   return combinedTransformedEventList;
 };
 
-module.exports = { networkHandler, getRearrangedEvents };
+module.exports = { getRearrangedEvents };

--- a/src/v0/destinations/bqstream/util.js
+++ b/src/v0/destinations/bqstream/util.js
@@ -217,12 +217,7 @@ const getRearrangedEvents = (successEventList, errorEventList) => {
   }
   // if there are no batched response, then return the error events
   if (successEventList.length === 0) {
-    const resultArray = [];
-    const errorMap = new Map();
-    processedErrorEvents.forEach((item) => {
-      optimizeErrorResponse(item, errorMap, resultArray);
-    });
-    return resultArray;
+    return formatCompositeResponse(processedErrorEvents)
   }
 
   // if there are both batched response and error events, then order them

--- a/src/v0/destinations/bqstream/util.test.js
+++ b/src/v0/destinations/bqstream/util.test.js
@@ -24,7 +24,7 @@ describe('getRearrangedEvents', () => {
   it('should return an empty array when both input arrays are empty', () => {
     const eachUserSuccessEventslist = [];
     const eachUserErrorEventsList = [];
-    const expected = [[]];
+    const expected = [];
     const result = getRearrangedEvents(eachUserSuccessEventslist, eachUserErrorEventsList);
     expect(result).toEqual(expected);
   });
@@ -58,49 +58,6 @@ describe('getRearrangedEvents', () => {
           ],
         },
       ],
-    ];
-    const result = getRearrangedEvents(eachUserSuccessEventslist, eachUserErrorEventsList);
-    expect(result).toEqual(expected);
-  });
-
-  // Tests that the function returns an ordered array of events with both successful and erroneous events, ordered based on the jobId property of the events' metadata array
-  it('should return an ordered array of events with both successful and erroneous events', () => {
-    const eachUserSuccessEventslist = [
-      {
-        batched: false,
-        destination: {},
-        error: 'Message Type not supported: identify',
-        metadata: [{ jobId: 3, userId: 'user12345' }],
-      },
-      {
-        batched: false,
-        destination: {},
-        error: 'Message Type not supported: identify',
-        metadata: [{ jobId: 4, userId: 'user12345' }],
-      },
-    ];
-    const eachUserErrorEventsList = [
-      { message: { type: 'track' }, metadata: { jobId: 1 } },
-      { message: { type: 'track' }, metadata: { jobId: 2 } },
-      { message: { type: 'track' }, metadata: { jobId: 5 } },
-    ];
-    const expected = [
-      [
-        { message: { type: 'track' }, metadata: [{ jobId: 1 }] },
-        { message: { type: 'track' }, metadata: [{ jobId: 2 }] },
-      ],
-      [
-        {
-          batched: false,
-          destination: {},
-          error: 'Message Type not supported: identify',
-          metadata: [
-            { jobId: 3, userId: 'user12345' },
-            { jobId: 4, userId: 'user12345' },
-          ],
-        },
-      ],
-      [{ message: { type: 'track' }, metadata: [{ jobId: 5 }] }],
     ];
     const result = getRearrangedEvents(eachUserSuccessEventslist, eachUserErrorEventsList);
     expect(result).toEqual(expected);

--- a/src/v0/destinations/bqstream/util.test.js
+++ b/src/v0/destinations/bqstream/util.test.js
@@ -24,7 +24,7 @@ describe('getRearrangedEvents', () => {
   it('should return an empty array when both input arrays are empty', () => {
     const eachUserSuccessEventslist = [];
     const eachUserErrorEventsList = [];
-    const expected = [];
+    const expected = [[]];
     const result = getRearrangedEvents(eachUserSuccessEventslist, eachUserErrorEventsList);
     expect(result).toEqual(expected);
   });
@@ -62,4 +62,47 @@ describe('getRearrangedEvents', () => {
     const result = getRearrangedEvents(eachUserSuccessEventslist, eachUserErrorEventsList);
     expect(result).toEqual(expected);
   });
+});
+
+// Tests that the function returns an ordered array of events with both successful and erroneous events, ordered based on the jobId property of the events' metadata array
+it('should return an ordered array of events with both successful and erroneous events', () => {
+  const errorEventsList = [
+    {
+      batched: false,
+      destination: {},
+      error: 'Message Type not supported: identify',
+      metadata: [{ jobId: 3, userId: 'user12345' }],
+    },
+    {
+      batched: false,
+      destination: {},
+      error: 'Message Type not supported: identify',
+      metadata: [{ jobId: 4, userId: 'user12345' }],
+    },
+  ];
+  const successEventslist = [
+    { message: { type: 'track' }, metadata: { jobId: 1 } },
+    { message: { type: 'track' }, metadata: { jobId: 2 } },
+    { message: { type: 'track' }, metadata: { jobId: 5 } },
+  ];
+  const expected = [
+    [
+      { message: { type: 'track' }, metadata: [{ jobId: 1 }] },
+      { message: { type: 'track' }, metadata: [{ jobId: 2 }] },
+      { message: { type: 'track' }, metadata: [{ jobId: 5 }] }
+    ],
+    [
+      {
+        batched: false,
+        destination: {},
+        error: 'Message Type not supported: identify',
+        metadata: [
+          { jobId: 3, userId: 'user12345' },
+          { jobId: 4, userId: 'user12345' },
+        ],
+      },
+    ],
+  ];
+  const result = getRearrangedEvents(successEventslist, errorEventsList);
+  expect(result).toEqual(expected);
 });

--- a/src/v0/destinations/bqstream/util.test.js
+++ b/src/v0/destinations/bqstream/util.test.js
@@ -1,0 +1,108 @@
+const { getRearrangedEvents } = require('./util');
+
+describe('getRearrangedEvents', () => {
+  // Tests that the function returns an array of transformed events when there are no error events
+  it('should return an array of transformed events when there are no error events', () => {
+    const eachUserSuccessEventslist = [
+      { message: { type: 'track' }, metadata: { jobId: 1 } },
+      { message: { type: 'track' }, metadata: { jobId: 3 } },
+      { message: { type: 'track' }, metadata: { jobId: 5 } },
+    ];
+    const eachUserErrorEventsList = [];
+    const expected = [
+      [
+        { message: { type: 'track' }, metadata: [{ jobId: 1 }] },
+        { message: { type: 'track' }, metadata: [{ jobId: 3 }] },
+        { message: { type: 'track' }, metadata: [{ jobId: 5 }] },
+      ],
+    ];
+    const result = getRearrangedEvents(eachUserSuccessEventslist, eachUserErrorEventsList);
+    expect(result).toEqual(expected);
+  });
+
+  // Tests that the function returns an empty array when both input arrays are empty
+  it('should return an empty array when both input arrays are empty', () => {
+    const eachUserSuccessEventslist = [];
+    const eachUserErrorEventsList = [];
+    const expected = [[]];
+    const result = getRearrangedEvents(eachUserSuccessEventslist, eachUserErrorEventsList);
+    expect(result).toEqual(expected);
+  });
+
+  // Tests that the function returns an array with only error events when all events are erroneous
+  it('should return an array with only error events when all events are erroneous', () => {
+    const eachUserSuccessEventslist = [];
+    const eachUserErrorEventsList = [
+      {
+        batched: false,
+        destination: {},
+        error: 'Message Type not supported: identify',
+        metadata: [{ jobId: 3, userId: 'user12345' }],
+      },
+      {
+        batched: false,
+        destination: {},
+        error: 'Message Type not supported: identify',
+        metadata: [{ jobId: 4, userId: 'user12345' }],
+      },
+    ];
+    const expected = [
+      [
+        {
+          batched: false,
+          destination: {},
+          error: 'Message Type not supported: identify',
+          metadata: [
+            { jobId: 3, userId: 'user12345' },
+            { jobId: 4, userId: 'user12345' },
+          ],
+        },
+      ],
+    ];
+    const result = getRearrangedEvents(eachUserSuccessEventslist, eachUserErrorEventsList);
+    expect(result).toEqual(expected);
+  });
+
+  // Tests that the function returns an ordered array of events with both successful and erroneous events, ordered based on the jobId property of the events' metadata array
+  it('should return an ordered array of events with both successful and erroneous events', () => {
+    const eachUserSuccessEventslist = [
+      {
+        batched: false,
+        destination: {},
+        error: 'Message Type not supported: identify',
+        metadata: [{ jobId: 3, userId: 'user12345' }],
+      },
+      {
+        batched: false,
+        destination: {},
+        error: 'Message Type not supported: identify',
+        metadata: [{ jobId: 4, userId: 'user12345' }],
+      },
+    ];
+    const eachUserErrorEventsList = [
+      { message: { type: 'track' }, metadata: { jobId: 1 } },
+      { message: { type: 'track' }, metadata: { jobId: 2 } },
+      { message: { type: 'track' }, metadata: { jobId: 5 } },
+    ];
+    const expected = [
+      [
+        { message: { type: 'track' }, metadata: [{ jobId: 1 }] },
+        { message: { type: 'track' }, metadata: [{ jobId: 2 }] },
+      ],
+      [
+        {
+          batched: false,
+          destination: {},
+          error: 'Message Type not supported: identify',
+          metadata: [
+            { jobId: 3, userId: 'user12345' },
+            { jobId: 4, userId: 'user12345' },
+          ],
+        },
+      ],
+      [{ message: { type: 'track' }, metadata: [{ jobId: 5 }] }],
+    ];
+    const result = getRearrangedEvents(eachUserSuccessEventslist, eachUserErrorEventsList);
+    expect(result).toEqual(expected);
+  });
+});

--- a/test/integrations/destinations/bqstream/router/data.ts
+++ b/test/integrations/destinations/bqstream/router/data.ts
@@ -301,24 +301,50 @@ export const data = [
         body: {
           output: [
             {
+              batched: true,
               batchedRequest: {
                 datasetId: 'gc_dataset',
                 projectId: 'gc-project-id',
                 properties: [
                   {
                     count: 10,
+                    insertId: '10',
                     productId: 10,
                     productName: 'Product-10',
-                    insertId: '10',
                   },
                   {
                     count: 20,
+                    insertId: '20',
                     productId: 20,
                     productName: 'Product-20',
+                  },
+                  {
+                    count: 20,
                     insertId: '20',
+                    productId: 20,
+                    productName: 'Product-20',
+                  },
+                  {
+                    count: 20,
+                    insertId: '20',
+                    productId: 20,
+                    productName: 'Product-20',
                   },
                 ],
                 tableId: 'gc_table',
+              },
+              destination: {
+                Config: {
+                  datasetId: 'gc_dataset',
+                  eventDelivery: true,
+                  eventDeliveryTS: 1636965406397,
+                  insertId: 'productId',
+                  projectId: 'gc-project-id',
+                  rudderAccountId: '1z8LpaSAuFR9TPWL6fECZfjmRa-',
+                  tableId: 'gc_table',
+                },
+                ID: '1WXjIHpu7ETXgjfiGPW3kCUgZFR',
+                Name: 'bqstream test',
               },
               metadata: [
                 {
@@ -329,93 +355,6 @@ export const data = [
                   jobId: 2,
                   userId: 'user12345',
                 },
-              ],
-              batched: true,
-              statusCode: 200,
-              destination: {
-                Config: {
-                  rudderAccountId: '1z8LpaSAuFR9TPWL6fECZfjmRa-',
-                  projectId: 'gc-project-id',
-                  datasetId: 'gc_dataset',
-                  tableId: 'gc_table',
-                  insertId: 'productId',
-                  eventDelivery: true,
-                  eventDeliveryTS: 1636965406397,
-                },
-
-                ID: '1WXjIHpu7ETXgjfiGPW3kCUgZFR',
-                Name: 'bqstream test',
-              },
-            },
-            {
-              batched: false,
-              destination: {
-                Config: {
-                  datasetId: 'gc_dataset',
-                  eventDelivery: true,
-                  eventDeliveryTS: 1636965406397,
-                  insertId: 'productId',
-                  projectId: 'gc-project-id',
-                  rudderAccountId: '1z8LpaSAuFR9TPWL6fECZfjmRa-',
-                  tableId: 'gc_table',
-                },
-
-                ID: '1WXjIHpu7ETXgjfiGPW3kCUgZFR',
-                Name: 'bqstream test',
-              },
-              error: 'Message Type not supported: identify',
-              metadata: [
-                {
-                  jobId: 3,
-                  userId: 'user12345',
-                },
-              ],
-              statTags: {
-                destType: 'BQSTREAM',
-                errorCategory: 'dataValidation',
-                errorType: 'instrumentation',
-                feature: 'router',
-                implementation: 'native',
-                module: 'destination',
-              },
-              statusCode: 400,
-            },
-            {
-              batched: true,
-              batchedRequest: {
-                datasetId: 'gc_dataset',
-                projectId: 'gc-project-id',
-                properties: [
-                  {
-                    count: 20,
-                    insertId: '20',
-                    productId: 20,
-                    productName: 'Product-20',
-                  },
-                  {
-                    count: 20,
-                    insertId: '20',
-                    productId: 20,
-                    productName: 'Product-20',
-                  },
-                ],
-                tableId: 'gc_table',
-              },
-              destination: {
-                Config: {
-                  datasetId: 'gc_dataset',
-                  eventDelivery: true,
-                  eventDeliveryTS: 1636965406397,
-                  insertId: 'productId',
-                  projectId: 'gc-project-id',
-                  rudderAccountId: '1z8LpaSAuFR9TPWL6fECZfjmRa-',
-                  tableId: 'gc_table',
-                },
-
-                ID: '1WXjIHpu7ETXgjfiGPW3kCUgZFR',
-                Name: 'bqstream test',
-              },
-              metadata: [
                 {
                   jobId: 5,
                   userId: 'user123',
@@ -439,49 +378,15 @@ export const data = [
                   rudderAccountId: '1z8LpaSAuFR9TPWL6fECZfjmRa-',
                   tableId: 'gc_table',
                 },
-
-                ID: '1WXjIHpu7ETXgjfiGPW3kCUgZFR',
-                Name: 'bqstream test',
-              },
-              error: 'Invalid payload for the destination',
-              metadata: [
-                {
-                  jobId: 7,
-                  userId: 'user124',
-                },
-                {
-                  jobId: 8,
-                  userId: 'user125',
-                },
-              ],
-              statTags: {
-                destType: 'BQSTREAM',
-                errorCategory: 'dataValidation',
-                errorType: 'instrumentation',
-                feature: 'router',
-                implementation: 'native',
-                module: 'destination',
-              },
-              statusCode: 400,
-            },
-            {
-              batched: false,
-              destination: {
-                Config: {
-                  datasetId: 'gc_dataset',
-                  eventDelivery: true,
-                  eventDeliveryTS: 1636965406397,
-                  insertId: 'productId',
-                  projectId: 'gc-project-id',
-                  rudderAccountId: '1z8LpaSAuFR9TPWL6fECZfjmRa-',
-                  tableId: 'gc_table',
-                },
-
                 ID: '1WXjIHpu7ETXgjfiGPW3kCUgZFR',
                 Name: 'bqstream test',
               },
               error: 'Message Type not supported: identify',
               metadata: [
+                {
+                  jobId: 3,
+                  userId: 'user12345',
+                },
                 {
                   jobId: 9,
                   userId: 'user125',

--- a/test/integrations/destinations/bqstream/router/data.ts
+++ b/test/integrations/destinations/bqstream/router/data.ts
@@ -13,66 +13,18 @@ export const data = [
               message: {
                 type: 'track',
                 event: 'insert product',
-                sentAt: '2021-09-08T11:10:45.466Z',
                 userId: 'user12345',
-                channel: 'web',
-                context: {
-                  os: {
-                    name: '',
-                    version: '',
-                  },
-                  app: {
-                    name: 'RudderLabs JavaScript SDK',
-                    build: '1.0.0',
-                    version: '1.1.18',
-                    namespace: 'com.rudderlabs.javascript',
-                  },
-                  page: {
-                    url: 'http://127.0.0.1:5500/index.html',
-                    path: '/index.html',
-                    title: 'Document',
-                    search: '',
-                    tab_url: 'http://127.0.0.1:5500/index.html',
-                    referrer: '$direct',
-                    initial_referrer: '$direct',
-                    referring_domain: '',
-                    initial_referring_domain: '',
-                  },
-                  locale: 'en-GB',
-                  screen: {
-                    width: 1536,
-                    height: 960,
-                    density: 2,
-                    innerWidth: 1536,
-                    innerHeight: 776,
-                  },
-                  traits: {},
-                  library: {
-                    name: 'RudderLabs JavaScript SDK',
-                    version: '1.1.18',
-                  },
-                  campaign: {},
-                  userAgent:
-                    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.77 Safari/537.36',
-                },
-                rudderId: 'fa2994a5-2a81-45fd-9919-fcf5596ad380',
-                messageId: 'e2d1a383-d9a2-4e03-a9dc-131d153c4d95',
-                timestamp: '2021-11-15T14:06:42.497+05:30',
+
                 properties: {
                   count: 10,
                   productId: 10,
                   productName: 'Product-10',
                 },
-                receivedAt: '2021-11-15T14:06:42.497+05:30',
-                request_ip: '[::1]',
                 anonymousId: 'd8b2ed61-7fa5-4ef8-bd92-6a506157c0cf',
-                integrations: {
-                  All: true,
-                },
-                originalTimestamp: '2021-09-08T11:10:45.466Z',
               },
               metadata: {
                 jobId: 1,
+                userId: 'user12345',
               },
               destination: {
                 Config: {
@@ -84,7 +36,7 @@ export const data = [
                   eventDelivery: true,
                   eventDeliveryTS: 1636965406397,
                 },
-                Enabled: true,
+
                 ID: '1WXjIHpu7ETXgjfiGPW3kCUgZFR',
                 Name: 'bqstream test',
               },
@@ -93,19 +45,193 @@ export const data = [
               message: {
                 type: 'track',
                 event: 'insert product',
-                sentAt: '2021-09-08T11:10:45.466Z',
                 userId: 'user12345',
-                channel: 'web',
+                properties: {
+                  count: 20,
+                  productId: 20,
+                  productName: 'Product-20',
+                },
+              },
+              metadata: {
+                jobId: 2,
+                userId: 'user12345',
+              },
+              destination: {
+                Config: {
+                  rudderAccountId: '1z8LpaSAuFR9TPWL6fECZfjmRa-',
+                  projectId: 'gc-project-id',
+                  datasetId: 'gc_dataset',
+                  tableId: 'gc_table',
+                  insertId: 'productId',
+                  eventDelivery: true,
+                  eventDeliveryTS: 1636965406397,
+                },
+
+                ID: '1WXjIHpu7ETXgjfiGPW3kCUgZFR',
+                Name: 'bqstream test',
+              },
+            },
+            {
+              message: {
+                type: 'identify',
+                event: 'insert product',
+                userId: 'user12345',
+                traits: {
+                  count: 20,
+                  productId: 20,
+                  productName: 'Product-20',
+                },
+                anonymousId: 'd8b2ed61-7fa5-4ef8-bd92-6a506157c0cf',
+              },
+              metadata: {
+                jobId: 3,
+                userId: 'user12345',
+              },
+              destination: {
+                Config: {
+                  rudderAccountId: '1z8LpaSAuFR9TPWL6fECZfjmRa-',
+                  projectId: 'gc-project-id',
+                  datasetId: 'gc_dataset',
+                  tableId: 'gc_table',
+                  insertId: 'productId',
+                  eventDelivery: true,
+                  eventDeliveryTS: 1636965406397,
+                },
+
+                ID: '1WXjIHpu7ETXgjfiGPW3kCUgZFR',
+                Name: 'bqstream test',
+              },
+            },
+            {
+              message: {
+                type: 'track',
+                event: 'insert product',
+                userId: 'user12345',
+                properties: {
+                  count: 20,
+                  productId: 20,
+                  productName: 'Product-20',
+                },
+                anonymousId: 'd8b2ed61-7fa5-4ef8-bd92-6a506157c0cf',
+              },
+              metadata: {
+                jobId: 5,
+                userId: 'user123',
+              },
+              destination: {
+                Config: {
+                  rudderAccountId: '1z8LpaSAuFR9TPWL6fECZfjmRa-',
+                  projectId: 'gc-project-id',
+                  datasetId: 'gc_dataset',
+                  tableId: 'gc_table',
+                  insertId: 'productId',
+                  eventDelivery: true,
+                  eventDeliveryTS: 1636965406397,
+                },
+
+                ID: '1WXjIHpu7ETXgjfiGPW3kCUgZFR',
+                Name: 'bqstream test',
+              },
+            },
+            {
+              message: {
+                type: 'track',
+                event: 'insert product',
+                userId: 'user12345',
+                properties: {
+                  count: 20,
+                  productId: 20,
+                  productName: 'Product-20',
+                },
+                anonymousId: 'd8b2ed61-7fa5-4ef8-bd92-6a506157c0cf',
+              },
+              metadata: {
+                jobId: 6,
+                userId: 'user124',
+              },
+              destination: {
+                Config: {
+                  rudderAccountId: '1z8LpaSAuFR9TPWL6fECZfjmRa-',
+                  projectId: 'gc-project-id',
+                  datasetId: 'gc_dataset',
+                  tableId: 'gc_table',
+                  insertId: 'productId',
+                  eventDelivery: true,
+                  eventDeliveryTS: 1636965406397,
+                },
+
+                ID: '1WXjIHpu7ETXgjfiGPW3kCUgZFR',
+                Name: 'bqstream test',
+              },
+            },
+            {
+              message: {
+                type: 'track',
+                event: 'insert product',
+
+                userId: 'user12345',
+              },
+              metadata: {
+                jobId: 7,
+                userId: 'user124',
+              },
+              destination: {
+                Config: {
+                  rudderAccountId: '1z8LpaSAuFR9TPWL6fECZfjmRa-',
+                  projectId: 'gc-project-id',
+                  datasetId: 'gc_dataset',
+                  tableId: 'gc_table',
+                  insertId: 'productId',
+                  eventDelivery: true,
+                  eventDeliveryTS: 1636965406397,
+                },
+
+                ID: '1WXjIHpu7ETXgjfiGPW3kCUgZFR',
+                Name: 'bqstream test',
+              },
+            },
+            {
+              message: {
+                type: 'track',
+                event: 'insert product',
+                userId: 'user12345',
+              },
+              metadata: {
+                jobId: 8,
+                userId: 'user125',
+              },
+              destination: {
+                Config: {
+                  rudderAccountId: '1z8LpaSAuFR9TPWL6fECZfjmRa-',
+                  projectId: 'gc-project-id',
+                  datasetId: 'gc_dataset',
+                  tableId: 'gc_table',
+                  insertId: 'productId',
+                  eventDelivery: true,
+                  eventDeliveryTS: 1636965406397,
+                },
+
+                ID: '1WXjIHpu7ETXgjfiGPW3kCUgZFR',
+                Name: 'bqstream test',
+              },
+            },
+            {
+              message: {
+                type: 'identify',
+                event: 'insert product',
+
+                userId: 'user12345',
+
                 context: {
                   os: {
-                    name: '',
+                    Name: '',
                     version: '',
                   },
                   app: {
-                    name: 'RudderLabs JavaScript SDK',
+                    Name: 'RudderLabs JavaScript SDK',
                     build: '1.0.0',
                     version: '1.1.18',
-                    namespace: 'com.rudderlabs.javascript',
+                    Namespace: 'com.rudderlabs.javascript',
                   },
                   page: {
                     url: 'http://127.0.0.1:5500/index.html',
@@ -128,31 +254,25 @@ export const data = [
                   },
                   traits: {},
                   library: {
-                    name: 'RudderLabs JavaScript SDK',
+                    Name: 'RudderLabs JavaScript SDK',
                     version: '1.1.18',
                   },
                   campaign: {},
                   userAgent:
                     'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.77 Safari/537.36',
                 },
-                rudderId: 'fa2994a5-2a81-45fd-9919-fcf5596ad380',
-                messageId: 'e2d1a383-d9a2-4e03-a9dc-131d153c4d95',
-                timestamp: '2021-11-15T14:06:42.497+05:30',
-                properties: {
+
+                traits: {
                   count: 20,
                   productId: 20,
                   productName: 'Product-20',
                 },
                 receivedAt: '2021-11-15T14:06:42.497+05:30',
-                request_ip: '[::1]',
                 anonymousId: 'd8b2ed61-7fa5-4ef8-bd92-6a506157c0cf',
-                integrations: {
-                  All: true,
-                },
-                originalTimestamp: '2021-09-08T11:10:45.466Z',
               },
               metadata: {
-                jobId: 2,
+                jobId: 9,
+                userId: 'user125',
               },
               destination: {
                 Config: {
@@ -164,7 +284,7 @@ export const data = [
                   eventDelivery: true,
                   eventDeliveryTS: 1636965406397,
                 },
-                Enabled: true,
+
                 ID: '1WXjIHpu7ETXgjfiGPW3kCUgZFR',
                 Name: 'bqstream test',
               },
@@ -203,9 +323,11 @@ export const data = [
               metadata: [
                 {
                   jobId: 1,
+                  userId: 'user12345',
                 },
                 {
                   jobId: 2,
+                  userId: 'user12345',
                 },
               ],
               batched: true,
@@ -220,10 +342,160 @@ export const data = [
                   eventDelivery: true,
                   eventDeliveryTS: 1636965406397,
                 },
-                Enabled: true,
+
                 ID: '1WXjIHpu7ETXgjfiGPW3kCUgZFR',
                 Name: 'bqstream test',
               },
+            },
+            {
+              batched: false,
+              destination: {
+                Config: {
+                  datasetId: 'gc_dataset',
+                  eventDelivery: true,
+                  eventDeliveryTS: 1636965406397,
+                  insertId: 'productId',
+                  projectId: 'gc-project-id',
+                  rudderAccountId: '1z8LpaSAuFR9TPWL6fECZfjmRa-',
+                  tableId: 'gc_table',
+                },
+
+                ID: '1WXjIHpu7ETXgjfiGPW3kCUgZFR',
+                Name: 'bqstream test',
+              },
+              error: 'Message Type not supported: identify',
+              metadata: [
+                {
+                  jobId: 3,
+                  userId: 'user12345',
+                },
+              ],
+              statTags: {
+                destType: 'BQSTREAM',
+                errorCategory: 'dataValidation',
+                errorType: 'instrumentation',
+                feature: 'router',
+                implementation: 'native',
+                module: 'destination',
+              },
+              statusCode: 400,
+            },
+            {
+              batched: true,
+              batchedRequest: {
+                datasetId: 'gc_dataset',
+                projectId: 'gc-project-id',
+                properties: [
+                  {
+                    count: 20,
+                    insertId: '20',
+                    productId: 20,
+                    productName: 'Product-20',
+                  },
+                  {
+                    count: 20,
+                    insertId: '20',
+                    productId: 20,
+                    productName: 'Product-20',
+                  },
+                ],
+                tableId: 'gc_table',
+              },
+              destination: {
+                Config: {
+                  datasetId: 'gc_dataset',
+                  eventDelivery: true,
+                  eventDeliveryTS: 1636965406397,
+                  insertId: 'productId',
+                  projectId: 'gc-project-id',
+                  rudderAccountId: '1z8LpaSAuFR9TPWL6fECZfjmRa-',
+                  tableId: 'gc_table',
+                },
+
+                ID: '1WXjIHpu7ETXgjfiGPW3kCUgZFR',
+                Name: 'bqstream test',
+              },
+              metadata: [
+                {
+                  jobId: 5,
+                  userId: 'user123',
+                },
+                {
+                  jobId: 6,
+                  userId: 'user124',
+                },
+              ],
+              statusCode: 200,
+            },
+            {
+              batched: false,
+              destination: {
+                Config: {
+                  datasetId: 'gc_dataset',
+                  eventDelivery: true,
+                  eventDeliveryTS: 1636965406397,
+                  insertId: 'productId',
+                  projectId: 'gc-project-id',
+                  rudderAccountId: '1z8LpaSAuFR9TPWL6fECZfjmRa-',
+                  tableId: 'gc_table',
+                },
+
+                ID: '1WXjIHpu7ETXgjfiGPW3kCUgZFR',
+                Name: 'bqstream test',
+              },
+              error: 'Invalid payload for the destination',
+              metadata: [
+                {
+                  jobId: 7,
+                  userId: 'user124',
+                },
+                {
+                  jobId: 8,
+                  userId: 'user125',
+                },
+              ],
+              statTags: {
+                destType: 'BQSTREAM',
+                errorCategory: 'dataValidation',
+                errorType: 'instrumentation',
+                feature: 'router',
+                implementation: 'native',
+                module: 'destination',
+              },
+              statusCode: 400,
+            },
+            {
+              batched: false,
+              destination: {
+                Config: {
+                  datasetId: 'gc_dataset',
+                  eventDelivery: true,
+                  eventDeliveryTS: 1636965406397,
+                  insertId: 'productId',
+                  projectId: 'gc-project-id',
+                  rudderAccountId: '1z8LpaSAuFR9TPWL6fECZfjmRa-',
+                  tableId: 'gc_table',
+                },
+
+                ID: '1WXjIHpu7ETXgjfiGPW3kCUgZFR',
+                Name: 'bqstream test',
+              },
+              error: 'Message Type not supported: identify',
+              metadata: [
+                {
+                  jobId: 9,
+                  userId: 'user125',
+                },
+              ],
+              statTags: {
+                destType: 'BQSTREAM',
+                errorCategory: 'dataValidation',
+                errorType: 'instrumentation',
+                feature: 'router',
+                implementation: 'native',
+                module: 'destination',
+              },
+              statusCode: 400,
             },
           ],
         },

--- a/test/integrations/destinations/bqstream/router/data.ts
+++ b/test/integrations/destinations/bqstream/router/data.ts
@@ -381,14 +381,14 @@ export const data = [
                 ID: '1WXjIHpu7ETXgjfiGPW3kCUgZFR',
                 Name: 'bqstream test',
               },
-              error: 'Message Type not supported: identify',
+              error: 'Invalid payload for the destination',
               metadata: [
                 {
-                  jobId: 3,
-                  userId: 'user12345',
+                  jobId: 7,
+                  userId: 'user124',
                 },
                 {
-                  jobId: 9,
+                  jobId: 8,
                   userId: 'user125',
                 },
               ],
@@ -402,6 +402,43 @@ export const data = [
               },
               statusCode: 400,
             },
+            {
+              batched: false,
+              destination: {
+                Config: {
+                  datasetId: 'gc_dataset',
+                  eventDelivery: true,
+                  eventDeliveryTS: 1636965406397,
+                  insertId: 'productId',
+                  projectId: 'gc-project-id',
+                  rudderAccountId: '1z8LpaSAuFR9TPWL6fECZfjmRa-',
+                  tableId: 'gc_table',
+                },
+                ID: '1WXjIHpu7ETXgjfiGPW3kCUgZFR',
+                Name: 'bqstream test',
+              },
+
+              error: "Message Type not supported: identify",
+              metadata: [
+                {
+                  jobId: 3,
+                  userId: "user12345"
+                },
+                {
+                  jobId: 9,
+                  userId: "user125"
+                }
+              ],
+              statTags: {
+                destType: "BQSTREAM",
+                errorCategory: "dataValidation",
+                errorType: "instrumentation",
+                feature: "router",
+                implementation: "native",
+                module: "destination"
+              },
+              statusCode: 400
+            }
           ],
         },
       },


### PR DESCRIPTION
## Description of the change

> resolves INT-389

Fixing event ordering issue for BQ stream.
Dividing events to different user journeys and keeping the order of the events intact.

original PR: https://github.com/rudderlabs/rudder-transformer/pull/2558

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
