### PR TITLE
chore: remove rudderlabs org from image workflows

### DIFF
--- a/.github/workflows/prepare-for-prod-deploy.yml
+++ b/.github/workflows/prepare-for-prod-deploy.yml
@@ -39,8 +39,8 @@ jobs:
           echo "Tag Name: $tag_name"
           echo "tag_name=$tag_name" >> $GITHUB_OUTPUT
 
-  build-rudderstack-transformer-image:
-    name: Build Transformer Docker Image for Rudderstack org- Prod
+  build-transformer-image:
+    name: Build Transformer Docker Image - Prod
     # Only merged pull requests from release candidate branches must trigger
     if: ((startsWith(github.event.pull_request.head.ref, 'release/') || startsWith(github.event.pull_request.head.ref, 'hotfix-release/')) && github.event.pull_request.merged == true)
     needs: [generate-tag-names]
@@ -55,26 +55,10 @@ jobs:
     secrets:
       DOCKERHUB_PROD_TOKEN: ${{ secrets.DOCKERHUB_PROD_TOKEN }}
 
-  build-rudderlabs-transformer-image:
-    name: Build Transformer Docker Image for Rudderlabs org - Prod
-    # Only merged pull requests from release candidate branches must trigger
-    if: ((startsWith(github.event.pull_request.head.ref, 'release/') || startsWith(github.event.pull_request.head.ref, 'hotfix-release/')) && github.event.pull_request.merged == true)
-    needs: [generate-tag-names]
-    uses: ./.github/workflows/build-push-docker-image.yml
-    with:
-      build_tag: rudderstack/rudder-transformer:${{ needs.generate-tag-names.outputs.tag_name }}
-      push_tags: rudderlabs/rudder-transformer:${{ needs.generate-tag-names.outputs.tag_name }},rudderlabs/rudder-transformer:latest
-      img_tag: ${{ needs.generate-tag-names.outputs.tag_name }}
-      dockerfile: Dockerfile
-      load_target: development
-      push_target: production
-    secrets:
-      DOCKERHUB_PROD_TOKEN: ${{ secrets.DOCKERHUB_PROD_TOKEN }}
-
   create-pull-request:
     name: Update Helm Charts For Production and Create Pull Request
     runs-on: ubuntu-latest
-    needs: [generate-tag-names, build-rudderstack-transformer-image, build-rudderlabs-transformer-image]
+    needs: [generate-tag-names, build-transformer-image]
     env:
       TAG_NAME: ${{ needs.generate-tag-names.outputs.tag_name }}
       TF_IMAGE_REPOSITORY: rudderstack/rudder-transformer

--- a/.github/workflows/prepare-for-prod-ut-deploy.yml
+++ b/.github/workflows/prepare-for-prod-ut-deploy.yml
@@ -42,8 +42,8 @@ jobs:
           echo "UT Tag Name: $tag_name_ut"
           echo "tag_name_ut=$tag_name_ut" >> $GITHUB_OUTPUT
 
-  build-rudderstack-user-transformer-image:
-    name: Build User Transformer Docker Image for Rudderstack org - Prod
+  build-user-transformer-image:
+    name: Build User Transformer Docker Image - Prod
     # Only merged pull requests from release candidate branches must trigger
     if: ((startsWith(github.event.pull_request.head.ref, 'release/') || startsWith(github.event.pull_request.head.ref, 'hotfix-release/')) && github.event.pull_request.merged == true)
     needs: [generate-tag-names]
@@ -58,27 +58,10 @@ jobs:
     secrets:
       DOCKERHUB_PROD_TOKEN: ${{ secrets.DOCKERHUB_PROD_TOKEN }}
 
-  build-rudderlabs-user-transformer-image:
-    name: Build User Transformer Docker Image for Rudderlabs org - Prod
-    # Only merged pull requests from release candidate branches must trigger
-    if: ((startsWith(github.event.pull_request.head.ref, 'release/') || startsWith(github.event.pull_request.head.ref, 'hotfix-release/')) && github.event.pull_request.merged == true)
-    needs: [generate-tag-names]
-    uses: ./.github/workflows/build-push-docker-image.yml
-    with:
-      build_tag: rudderstack/rudder-transformer:${{ needs.generate-tag-names.outputs.tag_name_ut }}
-      push_tags: rudderlabs/rudder-transformer:${{ needs.generate-tag-names.outputs.tag_name_ut }},rudderlabs/rudder-transformer:ut-latest
-      img_tag: ${{ needs.generate-tag-names.outputs.tag_name_ut }}
-      dockerfile: Dockerfile-ut-func
-      load_target: development
-      push_target: production
-    secrets:
-      DOCKERHUB_PROD_TOKEN: ${{ secrets.DOCKERHUB_PROD_TOKEN }}
-
-
   create-pull-request:
     name: Update Helm Charts For Production and Create Pull Request
     runs-on: ubuntu-latest
-    needs: [generate-tag-names, build-rudderstack-user-transformer-image, build-rudderlabs-user-transformer-image]
+    needs: [generate-tag-names, build-user-transformer-image]
     env:
       UT_TAG_NAME: ${{ needs.generate-tag-names.outputs.tag_name_ut }}
       TF_IMAGE_REPOSITORY: rudderstack/rudder-transformer

--- a/.github/workflows/prepare-for-staging-deploy.yml
+++ b/.github/workflows/prepare-for-staging-deploy.yml
@@ -35,8 +35,8 @@ jobs:
           echo "UT Tag Name: $tag_name_ut"
           echo "tag_name_ut=$tag_name_ut" >> $GITHUB_OUTPUT
 
-  build-rudderstack-transformer-image:
-    name: Build Transformer Docker Image For Rudderstack org - Staging
+  build-transformer-image:
+    name: Build Transformer Docker Image - Staging
     # Only pull requests from release candidate branches must trigger
     if: (startsWith(github.event.pull_request.head.ref, 'release/') || startsWith(github.event.pull_request.head.ref, 'hotfix-release/'))
     needs: [generate-tag-names]
@@ -51,24 +51,8 @@ jobs:
     secrets:
       DOCKERHUB_PROD_TOKEN: ${{ secrets.DOCKERHUB_PROD_TOKEN }}
 
-  build-rudderlabs-transformer-image:
-    name: Build Transformer Docker Image For Rudderlabs org - Staging
-    # Only pull requests from release candidate branches must trigger
-    if: (startsWith(github.event.pull_request.head.ref, 'release/') || startsWith(github.event.pull_request.head.ref, 'hotfix-release/'))
-    needs: [generate-tag-names]
-    uses: ./.github/workflows/build-push-docker-image.yml
-    with:
-      build_tag: rudderstack/rudder-transformer:${{ needs.generate-tag-names.outputs.tag_name }}
-      push_tags: rudderlabs/rudder-transformer:${{ needs.generate-tag-names.outputs.tag_name }}
-      img_tag: ${{ needs.generate-tag-names.outputs.tag_name }}
-      dockerfile: Dockerfile
-      load_target: development
-      push_target: production
-    secrets:
-      DOCKERHUB_PROD_TOKEN: ${{ secrets.DOCKERHUB_PROD_TOKEN }}  
-
-  build-rudderstack-user-transformer-image:
-    name: Build User Transformer Docker Image For Rudderstack org - Staging
+  build-user-transformer-image:
+    name: Build User Transformer Docker Image - Staging
     # Only pull requests from release candidate branches must trigger
     if: (startsWith(github.event.pull_request.head.ref, 'release/') || startsWith(github.event.pull_request.head.ref, 'hotfix-release/'))
 
@@ -84,27 +68,11 @@ jobs:
     secrets:
       DOCKERHUB_PROD_TOKEN: ${{ secrets.DOCKERHUB_PROD_TOKEN }}
 
-  build-rudderlabs-user-transformer-image:
-    name: Build User Transformer Docker Image For Rudderlabs org - Staging
-    # Only pull requests from release candidate branches must trigger
-    if: (startsWith(github.event.pull_request.head.ref, 'release/') || startsWith(github.event.pull_request.head.ref, 'hotfix-release/'))
-
-    needs: [generate-tag-names]
-    uses: ./.github/workflows/build-push-docker-image.yml
-    with:
-      build_tag: rudderstack/rudder-transformer:${{ needs.generate-tag-names.outputs.tag_name_ut }}
-      push_tags: rudderlabs/rudder-transformer:${{ needs.generate-tag-names.outputs.tag_name_ut }}
-      img_tag: ${{ needs.generate-tag-names.outputs.tag_name_ut }}
-      dockerfile: Dockerfile-ut-func
-      load_target: development
-      push_target: production
-    secrets:
-      DOCKERHUB_PROD_TOKEN: ${{ secrets.DOCKERHUB_PROD_TOKEN }}
 
   create-pull-request:
     name: Update Helm Charts For Staging and Create Pull Request
     runs-on: ubuntu-latest
-    needs: [generate-tag-names, build-rudderstack-transformer-image, build-rudderlabs-transformer-image, build-rudderstack-user-transformer-image, build-rudderlabs-user-transformer-image]
+    needs: [generate-tag-names, build-transformer-image, build-user-transformer-image]
     env:
       TAG_NAME: ${{ needs.generate-tag-names.outputs.tag_name }}
       UT_TAG_NAME: ${{ needs.generate-tag-names.outputs.tag_name_ut }}


### PR DESCRIPTION
## Description of the change

> As we depricated usage of rudderlabs org for transformer images, we are removing the concerned workflows 

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
