### PR TITLE
feat(klaviyo): remove dependency on subscribe flag make it default if listIs is present

### DIFF
--- a/src/v0/destinations/klaviyo/transform.js
+++ b/src/v0/destinations/klaviyo/transform.js
@@ -110,11 +110,8 @@ const identifyRequestHandler = async (message, category, destination) => {
   // Update Profile
   const responseArray = [profileUpdateResponseBuilder(payload, profileId, category, privateApiKey)];
 
-  // check if user wants to subscribe profile or not and listId is present or not
-  if (
-    traitsInfo?.properties?.subscribe &&
-    (traitsInfo.properties?.listId || destination.Config?.listId)
-  ) {
+  // check if listId is present or not
+  if (traitsInfo.properties?.listId || destination.Config?.listId) {
     responseArray.push(subscribeUserToList(message, traitsInfo, destination));
     return responseArray;
   }


### PR DESCRIPTION
## Description of the change
Resolves INT-578
- This PR makes the subscribe profile request default if `listId` is present in config or payload, and removed dependency on the subscribe flag
## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
