### PR TITLE
fix(hubspot): add validation for hubspotEvents

### DIFF
--- a/src/v0/destinations/hs/util.js
+++ b/src/v0/destinations/hs/util.js
@@ -407,6 +407,9 @@ const getEventAndPropertiesFromConfig = (message, destination, payload) => {
   if (!event) {
     throw new InstrumentationError('event name is required for track call');
   }
+  if (!hubspotEvents) {
+    throw new InstrumentationError('Event and property mappings are required for track call');
+  }
   event = event.trim().toLowerCase();
   let eventName;
   let eventProperties;

--- a/test/__tests__/data/hs_input.json
+++ b/test/__tests__/data/hs_input.json
@@ -3139,5 +3139,47 @@
       },
       "Enabled": true
     }
+  },
+  {
+    "description": "[HS] (New API v3) - (newPrivateAppApi) sample track call when hubspotEvents is undefined",
+    "message": {
+      "type": "track",
+      "traits": {},
+      "context": {
+        "externalId": [
+          {
+            "id": "osvaldocostaferreira98@gmail.com",
+            "type": "HS-contacts",
+            "identifierType": "email"
+          }
+        ]
+      },
+      "event": "Purchase",
+      "properties": {
+        "Revenue": "name1"
+      }
+    },
+    "destination": {
+      "Config": {
+        "authorizationType": "newPrivateAppApi",
+        "hubID": "",
+        "apiKey": "",
+        "accessToken": "dummy-access-token",
+        "apiVersion": "newApi",
+        "lookupField": "lookupField",
+        "eventFilteringOption": "disable",
+        "blacklistedEvents": [
+          {
+            "eventName": ""
+          }
+        ],
+        "whitelistedEvents": [
+          {
+            "eventName": ""
+          }
+        ]
+      },
+      "Enabled": true
+    }
   }
 ]

--- a/test/__tests__/data/hs_output.json
+++ b/test/__tests__/data/hs_output.json
@@ -826,5 +826,18 @@
       "type": "REST",
       "version": "1"
     }
-  ]
+  ],
+
+  {
+    "statusCode": 400,
+    "error": "Event and property mappings are required for track call",
+    "statTags": {
+      "errorCategory": "dataValidation",
+      "errorType": "instrumentation",
+      "destType": "HS",
+      "module": "destination",
+      "implementation": "native",
+      "feature": "processor"
+    }
+  }
 ]


### PR DESCRIPTION
## Description of the change

>Resolves INT-679
We are adding a validation for hubspotEvents which is the Event name mapping on the dashboard. If we are getting empty mappings for track events we are discarding that event.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
