### PR TITLE
feat: add circular reference check in flattern json

### DIFF
--- a/src/v0/util/index.js
+++ b/src/v0/util/index.js
@@ -246,9 +246,38 @@ const getValueFromPropertiesOrTraits = ({ message, key }) => {
   return !_.isNil(val) ? val : null;
 };
 
+/**
+ * Checks if an object contains a circular reference.
+ *
+ * @param {object} obj - The object to check for circular references.
+ * @param {array} [seen=[]] - An array that keeps track of objects already seen during the recursive traversal. Defaults to an empty array.
+ * @returns {boolean} - True if a circular reference is found, false otherwise.
+ */
+const hasCircularReference = (obj, seen = []) => {
+  if (typeof obj !== 'object' || obj === null) {
+    return false;
+  }
+
+  if (seen.includes(obj)) {
+    return true;
+  }
+
+  seen.push(obj);
+  for (const value of Object.values(obj)) {
+    if (hasCircularReference(value, seen)) {
+      return true;
+    }
+  }
+  seen.pop();
+  return false;
+};
+
 // function to flatten a json
 function flattenJson(data, separator = '.', mode = 'normal', flattenArrays = true) {
   const result = {};
+  if (hasCircularReference(data)) {
+    throw new InstrumentationError("Event has circular reference. Can't flatten the event");
+  }
 
   // a recursive function to loop through the array of the data
   function recurse(cur, prop) {
@@ -2094,6 +2123,7 @@ module.exports = {
   getAccessToken,
   formatValues,
   groupEventsByType,
+  hasCircularReference,
   getAuthErrCategoryFromErrDetailsAndStCode,
   getAuthErrCategoryFromStCode,
 };

--- a/src/v0/util/index.test.js
+++ b/src/v0/util/index.test.js
@@ -1,5 +1,6 @@
 const utilities = require('.');
 const { getFuncTestData } = require('../../../test/testHelper');
+const { hasCircularReference, flattenJson } = require('./index');
 
 // Names of the utility functions to test
 const functionNames = [
@@ -68,3 +69,49 @@ describe('Utility Functions Tests', () => {
 });
 
 //Test cases which can't be fit in above test suite, have individual function level test blocks
+
+describe('hasCircularReference', () => {
+  it('should return false when object has no circular reference', () => {
+    const obj = { a: 1, b: 2, c: 3 };
+    expect(hasCircularReference(obj)).toBe(false);
+  });
+
+  it('should return true when object has circular reference', () => {
+    const obj = { a: 1, b: 2 };
+    obj.c = obj;
+    expect(hasCircularReference(obj)).toBe(true);
+  });
+
+  it('should return true when object has nested objects containing circular reference', () => {
+    const obj1 = { a: 1 };
+    const obj2 = { b: 2 };
+    obj1.c = obj2;
+    obj2.d = obj1;
+    expect(hasCircularReference(obj1)).toBe(true);
+  });
+
+  it('should return false when input is null', () => {
+    expect(hasCircularReference(null)).toBe(false);
+  });
+
+  it('should return false when input is not an object', () => {
+    expect(hasCircularReference(123)).toBe(false);
+  });
+
+  it('should return true when object has self-reference', () => {
+    const obj = { a: 1 };
+    obj.b = obj;
+    expect(hasCircularReference(obj)).toBe(true);
+  });
+});
+
+// extra test cases for flattenJson
+describe('flattenJson', () => {
+  it('should throw an error when flattening a json object with circular reference', () => {
+    const data = { name: 'John' };
+    data.self = data;
+    expect(() => flattenJson(data)).toThrow(
+      "Event has circular reference. Can't flatten the event",
+    );
+  });
+});


### PR DESCRIPTION
## Description of the change

> Resolves INT-596
- hasCircularReference: Added a new utility to identify circular references within the payload.
- flattenJson: In the flattenJson utility, Added the `hasCircularReference` check to identify and handle circular references within the payload.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
