### PR TITLE
fix(dm): updated the stats definition for the tracking plan service

### DIFF
--- a/src/util/prometheus.js
+++ b/src/util/prometheus.js
@@ -229,7 +229,7 @@ class Prometheus {
         name: 'tp_errors',
         help: 'tp_errors',
         type: 'counter',
-        labelNames: ['sourceType', 'destinationType', 'k8_namespace', 'workspaceId', 'transformationId'],
+        labelNames: ['sourceType', 'destinationType', 'k8_namespace', 'workspaceId', 'trackingPlanId'],
       },
       {
         name: 'tp_events_count',
@@ -575,7 +575,7 @@ class Prometheus {
         name: 'tp_request_latency',
         help: 'tp_request_latency',
         type: 'histogram',
-        labelNames: ['sourceType', 'destinationType', 'k8_namespace', 'workspaceId', 'transformationId'],
+        labelNames: ['sourceType', 'destinationType', 'k8_namespace', 'workspaceId', 'trackingPlanId'],
       },
       {
         name: 'cdk_events_latency',
@@ -609,18 +609,6 @@ class Prometheus {
         labelNames: [
           'workspaceId',
           'transformationId',
-          'sourceType',
-          'destinationType',
-          'k8_namespace',
-        ],
-      },
-      {
-        name: 'user_transform_function_latency',
-        help: 'user_transform_function_latency',
-        type: 'histogram',
-        labelNames: [
-          'transformationVersionId',
-          'processSessions',
           'sourceType',
           'destinationType',
           'k8_namespace',

--- a/src/v0/destinations/iterable/data/IterableTrackConfig.json
+++ b/src/v0/destinations/iterable/data/IterableTrackConfig.json
@@ -23,8 +23,11 @@
   },
   {
     "destKey": "id",
-    "sourceKeys": ["properties.id", "properties.event_id"],
-    "required": false
+    "sourceKeys": "properties.event_id",
+    "required": false,
+    "metadata": {
+      "type": "toString"
+    }
   },
   {
     "destKey": "eventName",

--- a/src/v0/destinations/iterable/data/IterableTrackPurchaseConfig.json
+++ b/src/v0/destinations/iterable/data/IterableTrackPurchaseConfig.json
@@ -6,13 +6,11 @@
   },
   {
     "destKey": "id",
-    "sourceKeys": [
-      "properties.order_id",
-      "properties.orderId",
-      "properties.id",
-      "properties.event_id"
-    ],
-    "required": false
+    "sourceKeys": ["properties.order_id", "properties.orderId", "properties.event_id"],
+    "required": false,
+    "metadata": {
+      "type": "toString"
+    }
   },
   {
     "destKey": "createdAt",

--- a/test/__tests__/data/iterable.json
+++ b/test/__tests__/data/iterable.json
@@ -3103,7 +3103,6 @@
         "JSON_ARRAY": {},
         "FORM": {},
         "JSON": {
-          "id": "event1234",
           "userId": "abcdeeeeeeeexxxx102",
           "createdAt": 1598631966468,
           "dataFields": {


### PR DESCRIPTION
## Description of the change

As part of this hotfix, we are fixing the definition of couple of critical stats for tracking plan in the prometheus.js file to align with the stat fired from the service. The consequence of the issue is that we have critical P0 alerts which are not getting fired for the DM team.

Ticket: https://linear.app/rudderstack/issue/DAT-404/hotfix-for-the-user-transformer-service

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
