### PR TITLE
chore: skip users and tracks tables with destConfig

### DIFF
--- a/src/v0/destinations/azure_datalake/transform.js
+++ b/src/v0/destinations/azure_datalake/transform.js
@@ -1,25 +1,24 @@
 const { processWarehouseMessage } = require('../../../warehouse');
 
-const azureDatalake = 'azure_datalake';
-
-function processSingleMessage(message, options) {
-  return processWarehouseMessage(message, options);
-}
+const provider = 'azure_datalake';
 
 function getDataTypeOverride() {}
 
 function process(event) {
   const whSchemaVersion = event.request.query.whSchemaVersion || 'v1';
   const whStoreEvent = event.destination.Config.storeFullEvent === true;
-  const provider = azureDatalake;
-  return processSingleMessage(event.message, {
+  return processWarehouseMessage(event.message, {
     metadata: event.metadata,
     whSchemaVersion,
     whStoreEvent,
     getDataTypeOverride,
     provider,
     sourceCategory: event.metadata ? event.metadata.sourceCategory : null,
+    destConfig: event.destination?.Config,
   });
 }
 
-exports.process = process;
+module.exports = {
+  provider,
+  process,
+};

--- a/src/v0/destinations/azure_synapse/transform.js
+++ b/src/v0/destinations/azure_synapse/transform.js
@@ -1,28 +1,25 @@
 const { processWarehouseMessage } = require('../../../warehouse');
 
-const azureSynapse = 'azure_synapse';
-
-function processSingleMessage(message, options) {
-  return processWarehouseMessage(message, options);
-}
+const provider = 'azure_synapse';
 
 function getDataTypeOverride() {}
 
 function process(event) {
   const whSchemaVersion = event.request.query.whSchemaVersion || 'v1';
   const whStoreEvent = event.destination.Config.storeFullEvent === true;
-  const provider = azureSynapse;
-  return processSingleMessage(event.message, {
+  return processWarehouseMessage(event.message, {
     metadata: event.metadata,
     whSchemaVersion,
     whStoreEvent,
     getDataTypeOverride,
     provider,
     sourceCategory: event.metadata ? event.metadata.sourceCategory : null,
+    destConfig: event.destination?.Config,
   });
 }
 
 module.exports = {
+  name: provider,
   process,
   getDataTypeOverride,
 };

--- a/src/v0/destinations/bq/transform.js
+++ b/src/v0/destinations/bq/transform.js
@@ -1,10 +1,6 @@
 const { processWarehouseMessage } = require('../../../warehouse');
 
-const bigquery = 'bq';
-
-function processSingleMessage(message, options) {
-  return processWarehouseMessage(message, options);
-}
+const provider = 'bq';
 
 function getDataTypeOverride() {}
 
@@ -13,8 +9,7 @@ function process(event) {
   const whIDResolve = event.request.query.whIDResolve === 'true' || false;
   const whStoreEvent = event.destination.Config.storeFullEvent === true;
   const destJsonPaths = event.destination?.Config?.jsonPaths || '';
-  const provider = bigquery;
-  return processSingleMessage(event.message, {
+  return processWarehouseMessage(event.message, {
     metadata: event.metadata,
     whSchemaVersion,
     whStoreEvent,
@@ -23,10 +18,12 @@ function process(event) {
     provider,
     sourceCategory: event.metadata ? event.metadata.sourceCategory : null,
     destJsonPaths,
+    destConfig: event.destination?.Config,
   });
 }
 
 module.exports = {
+  provider,
   process,
   getDataTypeOverride,
 };

--- a/src/v0/destinations/clickhouse/transform.js
+++ b/src/v0/destinations/clickhouse/transform.js
@@ -1,53 +1,43 @@
 const { processWarehouseMessage } = require('../../../warehouse');
 const { getDataType } = require('../../../warehouse/index');
 
-const clickhouse = 'clickhouse';
-
-function processSingleMessage(message, options) {
-  return processWarehouseMessage(message, options);
-}
+const provider = 'clickhouse';
 
 function getDataTypeOverride(key, val, options) {
   if (options.chEnableArraySupport === 'false') {
     return 'string';
   }
-  if (Array.isArray(val)) {
-    // for now returning it as string. confirm this case
-    if (val.length === 0) {
-      return 'string';
-    }
-    // check for different data types in the array. if there are different then return array(string)
-    const firstValueDataType = getDataType(key, val[0], {});
-    let finalDataType = firstValueDataType;
-    for (let i = 1; i < val.length; i += 1) {
-      const dataType = getDataType(key, val[i], {});
-      if (finalDataType !== dataType) {
-        if (finalDataType === 'string') {
-          break;
-        }
-        if (dataType === 'float' && finalDataType === 'int') {
-          finalDataType = 'float';
-          // eslint-disable-next-line no-continue
-          continue;
-        }
-        if (dataType === 'int' && finalDataType === 'float') {
-          // eslint-disable-next-line no-continue
-          continue;
-        }
-        finalDataType = 'string';
-      }
-    }
-    return `array(${finalDataType})`;
+  if (!Array.isArray(val) || val.length === 0) {
+    return 'string';
   }
-  return 'string';
+  // check for different data types in the array. if there are different then return array(string)
+  let finalDataType = getDataType(key, val[0], {});
+  for (let i = 1; i < val.length; i += 1) {
+    const dataType = getDataType(key, val[i], {});
+    if (finalDataType !== dataType) {
+      if (finalDataType === 'string') {
+        break;
+      }
+      if (dataType === 'float' && finalDataType === 'int') {
+        finalDataType = 'float';
+        // eslint-disable-next-line no-continue
+        continue;
+      }
+      if (dataType === 'int' && finalDataType === 'float') {
+        // eslint-disable-next-line no-continue
+        continue;
+      }
+      finalDataType = 'string';
+    }
+  }
+  return `array(${finalDataType})`;
 }
 
 function process(event) {
   const whSchemaVersion = event.request.query.whSchemaVersion || 'v1';
   const whStoreEvent = event.destination.Config.storeFullEvent === true;
-  const provider = clickhouse;
   const chEnableArraySupport = event.request.query.chEnableArraySupport || 'false';
-  return processSingleMessage(event.message, {
+  return processWarehouseMessage(event.message, {
     metadata: event.metadata,
     whSchemaVersion,
     whStoreEvent,
@@ -55,10 +45,12 @@ function process(event) {
     provider,
     chEnableArraySupport,
     sourceCategory: event.metadata ? event.metadata.sourceCategory : null,
+    destConfig: event.destination?.Config,
   });
 }
 
 module.exports = {
+  provider,
   process,
   getDataTypeOverride,
 };

--- a/src/v0/destinations/deltalake/transform.js
+++ b/src/v0/destinations/deltalake/transform.js
@@ -1,25 +1,22 @@
 const { processWarehouseMessage } = require('../../../warehouse');
 
-const deltalake = 'deltalake';
-
-function processSingleMessage(message, options) {
-  return processWarehouseMessage(message, options);
-}
-
-function getDataTypeOverride() {}
+const provider = 'deltalake';
 
 function process(event) {
   const whSchemaVersion = event.request.query.whSchemaVersion || 'v1';
   const whStoreEvent = event.destination.Config.storeFullEvent === true;
-  const provider = deltalake;
-  return processSingleMessage(event.message, {
+  return processWarehouseMessage(event.message, {
     metadata: event.metadata,
     whSchemaVersion,
     whStoreEvent,
-    getDataTypeOverride,
+    getDataTypeOverride: () => {},
     provider,
     sourceCategory: event.metadata ? event.metadata.sourceCategory : null,
+    destConfig: event.destination?.Config,
   });
 }
 
-exports.process = process;
+module.exports = {
+  provider,
+  process,
+};

--- a/src/v0/destinations/gcs_datalake/transform.js
+++ b/src/v0/destinations/gcs_datalake/transform.js
@@ -1,25 +1,22 @@
 const { processWarehouseMessage } = require('../../../warehouse');
 
-const gcsDatalake = 'gcs_datalake';
-
-function processSingleMessage(message, options) {
-  return processWarehouseMessage(message, options);
-}
-
-function getDataTypeOverride() {}
+const provider = 'gcs_datalake';
 
 function process(event) {
   const whSchemaVersion = event.request.query.whSchemaVersion || 'v1';
   const whStoreEvent = event.destination.Config.storeFullEvent === true;
-  const provider = gcsDatalake;
-  return processSingleMessage(event.message, {
+  return processWarehouseMessage(event.message, {
     metadata: event.metadata,
     whSchemaVersion,
     whStoreEvent,
-    getDataTypeOverride,
+    getDataTypeOverride: () => {},
     provider,
     sourceCategory: event.metadata ? event.metadata.sourceCategory : null,
+    destConfig: event.destination?.Config,
   });
 }
 
-exports.process = process;
+module.exports = {
+  provider,
+  process,
+};

--- a/src/v0/destinations/mssql/transform.js
+++ b/src/v0/destinations/mssql/transform.js
@@ -1,28 +1,25 @@
 const { processWarehouseMessage } = require('../../../warehouse');
 
-const mssql = 'mssql';
-
-function processSingleMessage(message, options) {
-  return processWarehouseMessage(message, options);
-}
+const provider = 'mssql';
 
 function getDataTypeOverride() {}
 
 function process(event) {
   const whSchemaVersion = event.request.query.whSchemaVersion || 'v1';
   const whStoreEvent = event.destination.Config.storeFullEvent === true;
-  const provider = mssql;
-  return processSingleMessage(event.message, {
+  return processWarehouseMessage(event.message, {
     metadata: event.metadata,
     whSchemaVersion,
     whStoreEvent,
     getDataTypeOverride,
     provider,
     sourceCategory: event.metadata ? event.metadata.sourceCategory : null,
+    destConfig: event.destination?.Config,
   });
 }
 
 module.exports = {
+  provider,
   process,
   getDataTypeOverride,
 };

--- a/src/v0/destinations/postgres/transform.js
+++ b/src/v0/destinations/postgres/transform.js
@@ -1,10 +1,6 @@
 const { processWarehouseMessage } = require('../../../warehouse');
 
-const postgres = 'postgres';
-
-function processSingleMessage(message, options) {
-  return processWarehouseMessage(message, options);
-}
+const provider = 'postgres';
 
 function getDataTypeOverride(key, val, options, jsonKey = false) {
   if (key === 'violationErrors' || jsonKey) {
@@ -17,8 +13,7 @@ function process(event) {
   const whSchemaVersion = event.request.query.whSchemaVersion || 'v1';
   const whStoreEvent = event.destination.Config.storeFullEvent === true;
   const destJsonPaths = event.destination?.Config?.jsonPaths || '';
-  const provider = postgres;
-  return processSingleMessage(event.message, {
+  return processWarehouseMessage(event.message, {
     metadata: event.metadata,
     whSchemaVersion,
     whStoreEvent,
@@ -26,10 +21,12 @@ function process(event) {
     provider,
     sourceCategory: event.metadata ? event.metadata.sourceCategory : null,
     destJsonPaths,
+    destConfig: event.destination?.Config,
   });
 }
 
 module.exports = {
+  provider,
   process,
   getDataTypeOverride,
 };

--- a/src/v0/destinations/rs/transform.js
+++ b/src/v0/destinations/rs/transform.js
@@ -2,11 +2,7 @@ const { processWarehouseMessage } = require('../../../warehouse');
 
 // redshift destination string limit, if the string length crosses 512 we will change data type to text which is varchar(max) in redshift
 const RSStringLimit = 512;
-const redshift = 'rs';
-
-function processSingleMessage(message, options) {
-  return processWarehouseMessage(message, options);
-}
+const provider = 'rs';
 
 function getDataTypeOverride(key, val, options, jsonKey = false) {
   if (jsonKey) {
@@ -26,8 +22,7 @@ function process(event) {
   const whSchemaVersion = event.request.query.whSchemaVersion || 'v1';
   const whStoreEvent = event.destination.Config.storeFullEvent === true;
   const destJsonPaths = event.destination?.Config?.jsonPaths || '';
-  const provider = redshift;
-  return processSingleMessage(event.message, {
+  return processWarehouseMessage(event.message, {
     metadata: event.metadata,
     whSchemaVersion,
     whStoreEvent,
@@ -35,10 +30,12 @@ function process(event) {
     provider,
     sourceCategory: event.metadata ? event.metadata.sourceCategory : null,
     destJsonPaths,
+    destConfig: event.destination?.Config,
   });
 }
 
 module.exports = {
+  provider,
   process,
   getDataTypeOverride,
 };

--- a/src/v0/destinations/s3_datalake/transform.js
+++ b/src/v0/destinations/s3_datalake/transform.js
@@ -1,29 +1,26 @@
 const { processWarehouseMessage } = require('../../../warehouse');
 
 // use postgres providers for s3-datalake
-const s3datalakeProvider = 's3_datalake';
-
-function processSingleMessage(message, options) {
-  return processWarehouseMessage(message, options);
-}
+const provider = 's3_datalake';
 
 function getDataTypeOverride() {}
 
 function process(event) {
   const whSchemaVersion = event.request.query.whSchemaVersion || 'v1';
   const whStoreEvent = event.destination.Config.storeFullEvent === true;
-  const provider = s3datalakeProvider;
-  return processSingleMessage(event.message, {
+  return processWarehouseMessage(event.message, {
     metadata: event.metadata,
     whSchemaVersion,
     whStoreEvent,
     getDataTypeOverride,
     provider,
     sourceCategory: event.metadata ? event.metadata.sourceCategory : null,
+    destConfig: event.destination?.Config,
   });
 }
 
 module.exports = {
+  provider,
   process,
   getDataTypeOverride,
 };

--- a/src/v0/destinations/snowflake/transform.js
+++ b/src/v0/destinations/snowflake/transform.js
@@ -1,10 +1,6 @@
 const { processWarehouseMessage } = require('../../../warehouse');
 
-const snowflake = 'snowflake';
-
-function processSingleMessage(message, options) {
-  return processWarehouseMessage(message, options);
-}
+const provider = 'snowflake';
 
 function getDataTypeOverride(key, val, options, jsonKey = false) {
   if (key === 'violationErrors' || jsonKey) {
@@ -18,8 +14,7 @@ function process(event) {
   const whIDResolve = event.request.query.whIDResolve === 'true' || false;
   const whStoreEvent = event.destination.Config.storeFullEvent === true;
   const destJsonPaths = event.destination?.Config?.jsonPaths || '';
-  const provider = snowflake;
-  return processSingleMessage(event.message, {
+  return processWarehouseMessage(event.message, {
     metadata: event.metadata,
     whSchemaVersion,
     whStoreEvent,
@@ -28,10 +23,12 @@ function process(event) {
     provider,
     sourceCategory: event.metadata ? event.metadata.sourceCategory : null,
     destJsonPaths,
+    destConfig: event.destination?.Config,
   });
 }
 
 module.exports = {
+  provider,
   process,
   getDataTypeOverride,
 };

--- a/src/warehouse/index.js
+++ b/src/warehouse/index.js
@@ -197,21 +197,30 @@ function setDataFromColumnMappingAndComputeColumnTypes(
 
 */
 function setDataFromInputAndComputeColumnTypes(
-    utils,
-    eventType,
-    output,
-    input,
-    columnTypes,
-    options,
-    completePrefix = '',
-    completeLevel = 0,
-    prefix = '',
-    level = 0,
+  utils,
+  eventType,
+  output,
+  input,
+  columnTypes,
+  options,
+  completePrefix = '',
+  completeLevel = 0,
+  prefix = '',
+  level = 0,
 ) {
   if (!input || !isObject(input)) return;
   Object.keys(input).forEach((key) => {
-    const isValidLegacyJSONPath = isValidLegacyJsonPathKey(eventType, `${prefix + key}`, level, options.jsonLegacyPathKeys);
-    const isValidJSONPath = isValidJsonPathKey(`${completePrefix + key}`, completeLevel, options.jsonPathKeys);
+    const isValidLegacyJSONPath = isValidLegacyJsonPathKey(
+      eventType,
+      `${prefix + key}`,
+      level,
+      options.jsonLegacyPathKeys,
+    );
+    const isValidJSONPath = isValidJsonPathKey(
+      `${completePrefix + key}`,
+      completeLevel,
+      options.jsonPathKeys,
+    );
 
     if (isValidJSONPath || isValidLegacyJSONPath) {
       if (isBlank(input[key])) {
@@ -220,27 +229,27 @@ function setDataFromInputAndComputeColumnTypes(
 
       const val = JSON.stringify(input[key]);
       appendColumnNameAndType(
-          utils,
-          eventType,
-          `${prefix + key}`,
-          val,
-          output,
-          columnTypes,
-          options,
-          true,
+        utils,
+        eventType,
+        `${prefix + key}`,
+        val,
+        output,
+        columnTypes,
+        options,
+        true,
       );
     } else if (isObject(input[key]) && (options.sourceCategory !== 'cloud' || level < 3)) {
       setDataFromInputAndComputeColumnTypes(
-          utils,
-          eventType,
-          output,
-          input[key],
-          columnTypes,
-          options,
-          `${completePrefix + key}_`,
-          completeLevel + 1,
-          `${prefix + key}_`,
-          level + 1,
+        utils,
+        eventType,
+        output,
+        input[key],
+        columnTypes,
+        options,
+        `${completePrefix + key}_`,
+        completeLevel + 1,
+        `${prefix + key}_`,
+        level + 1,
       );
     } else {
       let val = input[key];
@@ -252,13 +261,13 @@ function setDataFromInputAndComputeColumnTypes(
         val = JSON.stringify(val);
       }
       appendColumnNameAndType(
-          utils,
-          eventType,
-          `${prefix + key}`,
-          val,
-          output,
-          columnTypes,
-          options,
+        utils,
+        eventType,
+        `${prefix + key}`,
+        val,
+        output,
+        columnTypes,
+        options,
       );
     }
   });
@@ -323,8 +332,8 @@ function storeRudderEvent(utils, message, output, columnTypes, options) {
 function addJsonKeysToOptions(options) {
   // Add json key paths from integration options and destination config
   const jsonPaths = Array.isArray(options.integrationOptions?.jsonPaths)
-      ? options.integrationOptions.jsonPaths
-      : [];
+    ? options.integrationOptions.jsonPaths
+    : [];
   if (options.destJsonPaths) {
     jsonPaths.push(...options.destJsonPaths.split(','));
   }
@@ -557,8 +566,10 @@ function processWarehouseMessage(message, options) {
       : {};
   const responses = [];
   const eventType = message.type?.toLowerCase();
-  const skipTracksTable = options.integrationOptions.skipTracksTable || false;
-  const skipUsersTable = options.integrationOptions.skipUsersTable || false;
+  const skipTracksTable =
+    options.destConfig?.skipTracksTable || options.integrationOptions.skipTracksTable || false;
+  const skipUsersTable =
+    options.destConfig?.skipUsersTable || options.integrationOptions.skipUsersTable || false;
   const skipReservedKeywordsEscaping =
     options.integrationOptions.skipReservedKeywordsEscaping || false;
 
@@ -594,7 +605,7 @@ function processWarehouseMessage(message, options) {
         commonColumnTypes,
         options,
         `${eventType + '_context_'}`,
-          2,
+        2,
         'context_',
       );
 
@@ -618,7 +629,7 @@ function processWarehouseMessage(message, options) {
         eventTableColumnTypes,
         options,
         `${eventType + '_properties_'}`,
-          2,
+        2,
       );
       setDataFromColumnMappingAndComputeColumnTypes(
         utils,
@@ -673,7 +684,7 @@ function processWarehouseMessage(message, options) {
         commonColumnTypes,
         options,
         `${eventType + '_context_'}`,
-          2,
+        2,
         'context_',
       );
       setDataFromColumnMappingAndComputeColumnTypes(
@@ -749,7 +760,7 @@ function processWarehouseMessage(message, options) {
         eventTableColumnTypes,
         options,
         `${eventType + '_properties_'}`,
-          2,
+        2,
       );
       setDataFromInputAndComputeColumnTypes(
         utils,
@@ -759,7 +770,7 @@ function processWarehouseMessage(message, options) {
         eventTableColumnTypes,
         options,
         `${eventType + '_userProperties_'}`,
-          2,
+        2,
       );
       setDataFromColumnMappingAndComputeColumnTypes(
         utils,
@@ -815,7 +826,7 @@ function processWarehouseMessage(message, options) {
         commonColumnTypes,
         options,
         `${eventType + '_userProperties_'}`,
-          2,
+        2,
       );
       setDataFromInputAndComputeColumnTypes(
         utils,
@@ -825,7 +836,7 @@ function processWarehouseMessage(message, options) {
         commonColumnTypes,
         options,
         `${eventType + '_context_traits_'}`,
-          3,
+        3,
       );
       setDataFromInputAndComputeColumnTypes(
         utils,
@@ -835,7 +846,7 @@ function processWarehouseMessage(message, options) {
         commonColumnTypes,
         options,
         `${eventType + '_traits_'}`,
-          2,
+        2,
         '',
       );
 
@@ -848,7 +859,7 @@ function processWarehouseMessage(message, options) {
         commonColumnTypes,
         options,
         `${eventType + '_context_'}`,
-          2,
+        2,
         'context_',
       );
 
@@ -954,7 +965,7 @@ function processWarehouseMessage(message, options) {
         columnTypes,
         options,
         `${eventType + '_properties_'}`,
-          2,
+        2,
       );
       // set rudder properties after user set properties to prevent overwriting
       setDataFromInputAndComputeColumnTypes(
@@ -965,7 +976,7 @@ function processWarehouseMessage(message, options) {
         columnTypes,
         options,
         `${eventType + '_context_'}`,
-          2,
+        2,
         'context_',
       );
       setDataFromColumnMappingAndComputeColumnTypes(
@@ -1025,7 +1036,7 @@ function processWarehouseMessage(message, options) {
         columnTypes,
         options,
         `${eventType + '_traits_'}`,
-          2,
+        2,
       );
       setDataFromInputAndComputeColumnTypes(
         utils,
@@ -1035,7 +1046,7 @@ function processWarehouseMessage(message, options) {
         columnTypes,
         options,
         `${eventType + '_context_'}`,
-          2,
+        2,
         'context_',
       );
       setDataFromColumnMappingAndComputeColumnTypes(
@@ -1083,7 +1094,7 @@ function processWarehouseMessage(message, options) {
         columnTypes,
         options,
         `${eventType + '_traits_'}`,
-          2,
+        2,
       );
       setDataFromInputAndComputeColumnTypes(
         utils,
@@ -1093,7 +1104,7 @@ function processWarehouseMessage(message, options) {
         columnTypes,
         options,
         `${eventType + '_context_'}`,
-          2,
+        2,
         'context_',
       );
       setDataFromColumnMappingAndComputeColumnTypes(

--- a/test/__tests__/data/warehouse/dest_config_scenarios.js
+++ b/test/__tests__/data/warehouse/dest_config_scenarios.js
@@ -1,0 +1,223 @@
+const _ = require("lodash");
+
+const trackMessage = {
+  destination: { Config: {} },
+  message: {
+    type: "track",
+    messageId: "my-track-message-id-1",
+    userId: "9bb5d4c2-a7aa-4a36-9efb-dd2b1aec5d33",
+    anonymousId: "e6ab2c5e-2cda-44a9-a962-e2f67df78bca",
+    channel: "web",
+    context: {
+      app: {
+        build: "1.0.0",
+        name: "RudderLabs JavaScript SDK",
+        namespace: "com.rudderlabs.javascript",
+        version: "1.0.5"
+      },
+      ip: "0.0.0.0",
+      library: {
+        name: "RudderLabs JavaScript SDK",
+        version: "1.0.5"
+      },
+      locale: "en-GB",
+      os: {
+        name: "",
+        version: ""
+      },
+      screen: { density: 2 },
+      traits: {
+        city: "Disney",
+        country: "USA",
+        email: "mickey@disney.com",
+        firstname: "Mickey"
+      },
+      userAgent: "Mozilla/5.0 Chrome/79.0.3945.117 Safari/537.36"
+    },
+    event: "groups",
+    integrations: { All: true },
+    originalTimestamp: "2020-01-24T06:29:02.364Z",
+    properties: { currency: "USD" },
+    receivedAt: "2020-01-24T11:59:02.403+05:30",
+    request_ip: "[::1]:53708",
+    sentAt: "2020-01-24T06:29:02.364Z",
+    timestamp: "2020-01-24T11:59:02.403+05:30"
+  },
+  request: { query: { whSchemaVersion: "v1" } }
+};
+
+const identifyMessage = {
+  destination: { Config: {} },
+  message: {
+    type: "identify",
+    messageId: "my-identify-message-id-1",
+    sentAt: "2021-01-03T17:02:53.195Z",
+    userId: "user123",
+    channel: "web",
+    integrations: { All: true },
+    context: {
+      os: {
+        "name": "android",
+        "version": "1.12.3"
+      },
+      app: {
+        name: "RudderLabs JavaScript SDK",
+        build: "1.0.0",
+        version: "1.1.11",
+        namespace: "com.rudderlabs.javascript"
+      },
+      traits: {
+        email: "user123@email.com",
+        phone: "+917836362334",
+        userId: "user123"
+      },
+      locale: "en-US",
+      device: {
+        token: "token",
+        id: "id",
+        type: "ios"
+      },
+      library: {
+        name: "RudderLabs JavaScript SDK",
+        version: "1.1.11"
+      },
+      userAgent: "Gecko/20100101 Firefox/84.0"
+    },
+    rudderId: "8f8fa6b5-8e24-489c-8e22-61f23f2e364f",
+    anonymousId: "97c46c81-3140-456d-b2a9-690d70aaca35",
+    originalTimestamp: "2020-01-24T06:29:02.364Z",
+    receivedAt: "2020-01-24T11:59:02.403+05:30",
+    request_ip: "[::1]:53708",
+    timestamp: "2020-01-24T11:59:02.403+05:30"
+  },
+  request: { query: { whSchemaVersion: "v1" } }
+};
+
+const scenarios = [
+  {
+    name: "track event is not skipped when options are not provided",
+    skipUsersTable: null,
+    skipTracksTable: null,
+    event: _.cloneDeep(trackMessage),
+    expected: [
+      {
+        id: "my-track-message-id-1",
+        table: "tracks"
+      },
+      {
+        id: "my-track-message-id-1",
+        table: "_groups"
+      }
+    ]
+  },
+  {
+    name: "track event is not skipped when skipTracksTable is false",
+    skipUsersTable: null,
+    skipTracksTable: false,
+    event: _.cloneDeep(trackMessage),
+    expected: [
+      {
+        id: "my-track-message-id-1",
+        table: "tracks"
+      },
+      {
+        id: "my-track-message-id-1",
+        table: "_groups"
+      }
+    ]
+  },
+  {
+    name: "track event is skipped when skipTracksTable is true",
+    skipUsersTable: null,
+    skipTracksTable: true,
+    event: _.cloneDeep(trackMessage),
+    expected: [
+      {
+        id: "my-track-message-id-1",
+        table: "_groups"
+      }
+    ]
+  },
+  {
+    name: "track event is not affected by skipUsersTable",
+    skipUsersTable: true,
+    skipTracksTable: null,
+    event: _.cloneDeep(trackMessage),
+    expected: [
+      {
+        id: "my-track-message-id-1",
+        table: "tracks"
+      },
+      {
+        id: "my-track-message-id-1",
+        table: "_groups"
+      }
+    ]
+  },
+  {
+    name: "user event is not skipped when options are not provided",
+    skipUsersTable: null,
+    skipTracksTable: null,
+    event: _.cloneDeep(identifyMessage),
+    expected: [
+      {
+        id: "my-identify-message-id-1",
+        table: "identifies"
+      },
+      {
+        id: "user123",
+        table: "users"
+      }
+    ]
+  },
+  {
+    name: "user event is not skipped when skipUsersTable is false",
+    skipUsersTable: false,
+    skipTracksTable: null,
+    event: _.cloneDeep(identifyMessage),
+    expected: [
+      {
+        id: "my-identify-message-id-1",
+        table: "identifies"
+      },
+      {
+        id: "user123",
+        table: "users"
+      }
+    ]
+  },
+  {
+    name: "user event is skipped when skipUsersTable is true",
+    skipUsersTable: true,
+    skipTracksTable: null,
+    event: _.cloneDeep(identifyMessage),
+    expected: [
+      {
+        id: "my-identify-message-id-1",
+        table: "identifies"
+      }
+    ]
+  },
+  {
+    name: "user event is not affected by skipTracksTable",
+    skipUsersTable: null,
+    skipTracksTable: true,
+    event: _.cloneDeep(identifyMessage),
+    expected: [
+      {
+        id: "my-identify-message-id-1",
+        table: "identifies"
+      },
+      {
+        id: "user123",
+        table: "users"
+      }
+    ]
+  },
+];
+
+module.exports = {
+  scenarios: function() {
+    return _.cloneDeep(scenarios);
+  }
+};

--- a/test/__tests__/data/warehouse/integration_options_events.js
+++ b/test/__tests__/data/warehouse/integration_options_events.js
@@ -8,7 +8,7 @@ const _ = require("lodash");
  * SNOWFLAKE: skip tracks, use blendo
  *    no tracks
  *    path to $1,000,000 -> PATH_TO_$1_000_000; 9omega -> _9OMEGA; camelCase123Key -> CAMELCASE123KEY
- * S3_DATALAKE: skip eescaping
+ * S3_DATALAKE: skip escaping
  *    tracks table present
  *    no escaping on reserved keywords groups,timestamp
  *    path to $1,000,000 -> path_to_1_000_000; 9omega -> _9_omega; camelCase123Key -> camel_case_123_key

--- a/test/__tests__/warehouse.test.js
+++ b/test/__tests__/warehouse.test.js
@@ -7,6 +7,7 @@ const {
   opInput,
   opOutput
 } = require(`./data/warehouse/integration_options_events.js`);
+const destConfig = require(`./data/warehouse/dest_config_scenarios.js`);
 const { names } = require(`./data/warehouse/names.js`);
 const {
   largeNoOfColumnsevent
@@ -1002,6 +1003,29 @@ describe("Add receivedAt for events missing it", () => {
         expect(received[0].data).toHaveProperty(
           integrationCasedString(integrations[index], "received_at")
         );
+      });
+    });
+  });
+});
+
+describe("Destination config options", () => {
+  destConfig.scenarios().forEach(scenario => {
+    it(scenario.name, () => {
+      if (scenario.skipUsersTable !== null) {
+        scenario.event.destination.Config.skipUsersTable = scenario.skipUsersTable
+      }
+      if (scenario.skipTracksTable !== null) {
+        scenario.event.destination.Config.skipTracksTable = scenario.skipTracksTable
+      }
+
+      transformers.forEach((transformer, index) => {
+        const received = transformer.process(scenario.event);
+        expect(received).toHaveLength(scenario.expected.length);
+        for (const i in received) {
+          const evt = received[i];
+          expect(evt.data.id ? evt.data.id : evt.data.ID).toEqual(scenario.expected[i].id);
+          expect(evt.metadata.table.toLowerCase()).toEqual(scenario.expected[i].table);
+        }
       });
     });
   });


### PR DESCRIPTION
## Description of the change

Adding the ability to skip users table and tracks tables by looking at the destination config settings. 
Applies to Warehouse only.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [PIPE-137](https://linear.app/rudderstack/issue/PIPE-137/configurable-tracks-and-users-tables) 

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [x] Issue from task tracker has a link to this pull request 
