### PR TITLE
fix: salesforce: handle ECONNABORTED error

### DIFF
--- a/src/adapters/utils/networkUtils.js
+++ b/src/adapters/utils/networkUtils.js
@@ -71,6 +71,14 @@ const nodeSysErrorToStatus = (code) => {
       status: 500,
       message: '[ETIMEDOUT] :: Operation timed out',
     },
+    EAI_AGAIN: {
+      status: 500,
+      message: '[EAI_AGAIN] :: Temporary failure in name resolution',
+    },
+    ECONNABORTED: {
+      status: 500,
+      message: '[ECONNABORTED] :: Connection aborted',
+    },
   };
   return sysErrorToStatusMap[code] || { status: 400, message: `[${code}]` };
 };

--- a/src/v0/destinations/salesforce/utils.js
+++ b/src/v0/destinations/salesforce/utils.js
@@ -71,14 +71,6 @@ const salesforceResponseHandler = (destResponse, sourceMessage, authKey) => {
     if (response && Array.isArray(response)) {
       errorMessage = response[0].message;
     }
-    // handling ECONNABORTED ( Connection Aborted ) and EAI_AGAIN (DNS Temporary Not Found) errors
-    if (['[EAI_AGAIN]', '[ECONNABORTED]'].includes(errorMessage)) {
-      throw new RetryableError(
-        `${DESTINATION} Request Failed - due ${errorMessage} error", (Retryable) ${sourceMessage}`,
-        500,
-        destResponse,
-      );
-    }
     // aborting for all other error codes
     throw new AbortedError(
       `${DESTINATION} Request Failed: "${status}" due to "${

--- a/src/v0/destinations/salesforce/utils.js
+++ b/src/v0/destinations/salesforce/utils.js
@@ -53,6 +53,18 @@ const salesforceResponseHandler = (destResponse, sourceMessage, authKey) => {
         500,
         destResponse,
       );
+    } else if (
+      status === 400 &&
+      matchErrorCode('ECONNABORTED') &&
+      response.message.includes('ECONNABORTED')
+    ) {
+      // handling the error case where the record is failed due to ECONNABORTED error ( some salesforce internal error )
+      // this is a retryable error
+      throw new RetryableError(
+        `${DESTINATION} Request Failed - "ECONNABORTED error", (Retryable) ${sourceMessage}`,
+        500,
+        destResponse,
+      );
     } else if (status === 503 || status === 500) {
       // The salesforce server is unavailable to handle the request. Typically this occurs if the server is down
       // for maintenance or is currently overloaded.

--- a/test/__mocks__/data/salesforce/proxy_response.json
+++ b/test/__mocks__/data/salesforce/proxy_response.json
@@ -1,25 +1,43 @@
 {
   "https://rudderstack.my.salesforce.com/services/data/v50.0/sobjects/Lead/101": {
-    "response": {
-      "data": [
-        {
-          "message": "[ECONNABORTED]",
-          "errorCode": "ECONNABORTED"
-        }
+    "message": "timeout of 1ms exceeded",
+    "name": "Error",
+    "stack": "Error: timeout of 1ms exceeded\n at createError (webpack-internal:///./node_modules/axios/lib/core/createError.js:16:15)\n at XMLHttpRequest.handleTimeout (webpack-internal:///./node_modules/axios/lib/adapters/xhr.js:89:14)",
+    "config": {
+      "url": "redacted",
+      "method": "get",
+      "headers": {
+        "Accept": "application/json, text/plain, */*"
+      },
+      "transformRequest": [
+        null
       ],
-      "status": 400
-    }
+      "transformResponse": [
+        null
+      ],
+      "timeout": 1
+    },
+    "code": "ECONNABORTED"
   },
   "https://rudderstack.my.salesforce.com/services/data/v50.0/sobjects/Lead/102": {
-    "response": {
-      "data": [
-        {
-          "message": "[EAI_AGAIN]",
-          "errorCode": "EAI_AGAIN"
-        }
+    "message": "DNS not found",
+    "name": "Error",
+    "stack": "Error: timeout of 1ms exceeded\n at createError (webpack-internal:///./node_modules/axios/lib/core/createError.js:16:15)\n at XMLHttpRequest.handleTimeout (webpack-internal:///./node_modules/axios/lib/adapters/xhr.js:89:14)",
+    "config": {
+      "url": "redacted",
+      "method": "get",
+      "headers": {
+        "Accept": "application/json, text/plain, */*"
+      },
+      "transformRequest": [
+        null
       ],
-      "status": 400
-    }
+      "transformResponse": [
+        null
+      ],
+      "timeout": 1
+    },
+    "code": "EAI_AGAIN"
   },
   "https://rudderstack.my.salesforce.com/services/data/v50.0/sobjects/Lead/1": {
     "response": {

--- a/test/__mocks__/data/salesforce/proxy_response.json
+++ b/test/__mocks__/data/salesforce/proxy_response.json
@@ -1,42 +1,12 @@
 {
   "https://rudderstack.my.salesforce.com/services/data/v50.0/sobjects/Lead/101": {
-    "message": "timeout of 1ms exceeded",
+    "message": "Connection Aborted",
     "name": "Error",
-    "stack": "Error: timeout of 1ms exceeded\n at createError (webpack-internal:///./node_modules/axios/lib/core/createError.js:16:15)\n at XMLHttpRequest.handleTimeout (webpack-internal:///./node_modules/axios/lib/adapters/xhr.js:89:14)",
-    "config": {
-      "url": "redacted",
-      "method": "get",
-      "headers": {
-        "Accept": "application/json, text/plain, */*"
-      },
-      "transformRequest": [
-        null
-      ],
-      "transformResponse": [
-        null
-      ],
-      "timeout": 1
-    },
     "code": "ECONNABORTED"
   },
   "https://rudderstack.my.salesforce.com/services/data/v50.0/sobjects/Lead/102": {
     "message": "DNS not found",
     "name": "Error",
-    "stack": "Error: timeout of 1ms exceeded\n at createError (webpack-internal:///./node_modules/axios/lib/core/createError.js:16:15)\n at XMLHttpRequest.handleTimeout (webpack-internal:///./node_modules/axios/lib/adapters/xhr.js:89:14)",
-    "config": {
-      "url": "redacted",
-      "method": "get",
-      "headers": {
-        "Accept": "application/json, text/plain, */*"
-      },
-      "transformRequest": [
-        null
-      ],
-      "transformResponse": [
-        null
-      ],
-      "timeout": 1
-    },
     "code": "EAI_AGAIN"
   },
   "https://rudderstack.my.salesforce.com/services/data/v50.0/sobjects/Lead/1": {

--- a/test/__mocks__/data/salesforce/proxy_response.json
+++ b/test/__mocks__/data/salesforce/proxy_response.json
@@ -1,4 +1,26 @@
 {
+  "https://rudderstack.my.salesforce.com/services/data/v50.0/sobjects/Lead/101": {
+    "response": {
+      "data": [
+        {
+          "message": "[ECONNABORTED]",
+          "errorCode": "ECONNABORTED"
+        }
+      ],
+      "status": 400
+    }
+  },
+  "https://rudderstack.my.salesforce.com/services/data/v50.0/sobjects/Lead/102": {
+    "response": {
+      "data": [
+        {
+          "message": "[EAI_AGAIN]",
+          "errorCode": "EAI_AGAIN"
+        }
+      ],
+      "status": 400
+    }
+  },
   "https://rudderstack.my.salesforce.com/services/data/v50.0/sobjects/Lead/1": {
     "response": {
       "data": {

--- a/test/__tests__/data/salesforce_proxy_input.json
+++ b/test/__tests__/data/salesforce_proxy_input.json
@@ -9,6 +9,72 @@
       "Authorization": "Bearer token"
     },
     "version": "1",
+    "endpoint": "https://rudderstack.my.salesforce.com/services/data/v50.0/sobjects/Lead/101",
+    "body": {
+      "XML": {},
+      "FORM": {},
+      "JSON": {
+        "Email": "denis.kornilov@sbermarket.ru",
+        "Company": "sbermarket.ru",
+        "LastName": "Корнилов",
+        "FirstName": "Денис",
+        "LeadSource": "App Signup",
+        "account_type__c": "free_trial"
+      },
+      "JSON_ARRAY": {}
+    },
+    "metadata": {
+      "destInfo": {
+        "authKey": "2HezPl1w11opbFSxnLDEgZ7kWTf"
+      }
+    },
+    "params": {
+      "destination": "salesforce"
+    }
+  },
+  {
+    "type": "REST",
+    "files": {},
+    "method": "POST",
+    "userId": "",
+    "headers": {
+      "Content-Type": "application/json",
+      "Authorization": "Bearer token"
+    },
+    "version": "1",
+    "endpoint": "https://rudderstack.my.salesforce.com/services/data/v50.0/sobjects/Lead/102",
+    "body": {
+      "XML": {},
+      "FORM": {},
+      "JSON": {
+        "Email": "denis.kornilov@sbermarket.ru",
+        "Company": "sbermarket.ru",
+        "LastName": "Корнилов",
+        "FirstName": "Денис",
+        "LeadSource": "App Signup",
+        "account_type__c": "free_trial"
+      },
+      "JSON_ARRAY": {}
+    },
+    "metadata": {
+      "destInfo": {
+        "authKey": "2HezPl1w11opbFSxnLDEgZ7kWTf"
+      }
+    },
+    "params": {
+      "destination": "salesforce"
+    }
+  },
+  {
+    "type": "REST",
+    "files": {},
+    "method": "POST",
+    "userId": "",
+    "headers": {
+      "Content-Type": "application/json",
+      "Authorization": "Bearer token"
+    },
+    "version": "1",
     "endpoint": "https://rudderstack.my.salesforce.com/services/data/v50.0/sobjects/Lead/1",
     "body": {
       "XML": {},

--- a/test/__tests__/data/salesforce_proxy_output.json
+++ b/test/__tests__/data/salesforce_proxy_output.json
@@ -1,6 +1,66 @@
 [
   {
     "output": {
+      "status": 500,
+      "message": "Salesforce Request Failed - due [ECONNABORTED] error\", (Retryable) during Salesforce Response Handling",
+      "destinationResponse": {
+        "response": [
+          {
+            "message": "[ECONNABORTED]",
+            "errorCode": "ECONNABORTED"
+          }
+        ],
+        "status": 400,
+        "rudderJobMetadata": {
+          "destInfo": {
+            "authKey": "2HezPl1w11opbFSxnLDEgZ7kWTf"
+          }
+        }
+      },
+      "statTags": {
+        "destType": "SALESFORCE",
+        "errorCategory": "network",
+        "destinationId": "Non-determininable",
+        "workspaceId": "Non-determininable",
+        "errorType": "retryable",
+        "feature": "dataDelivery",
+        "implementation": "native",
+        "module": "destination"
+      }
+    }
+  },
+  {
+    "output": {
+      "status": 500,
+      "message": "Salesforce Request Failed - due [EAI_AGAIN] error\", (Retryable) during Salesforce Response Handling",
+      "destinationResponse": {
+        "response": [
+          {
+            "message": "[EAI_AGAIN]",
+            "errorCode": "EAI_AGAIN"
+          }
+        ],
+        "status": 400,
+        "rudderJobMetadata": {
+          "destInfo": {
+            "authKey": "2HezPl1w11opbFSxnLDEgZ7kWTf"
+          }
+        }
+      },
+      "statTags": {
+        "destType": "SALESFORCE",
+        "errorCategory": "network",
+        "destinationId": "Non-determininable",
+        "workspaceId": "Non-determininable",
+        "errorType": "retryable",
+        "feature": "dataDelivery",
+        "implementation": "native",
+        "module": "destination"
+      }
+    }
+  },
+  {
+    "output": {
       "status": 200,
       "message": "Request for destination: salesforce Processed Successfully",
       "destinationResponse": {

--- a/test/__tests__/data/salesforce_proxy_output.json
+++ b/test/__tests__/data/salesforce_proxy_output.json
@@ -2,15 +2,10 @@
   {
     "output": {
       "status": 500,
-      "message": "Salesforce Request Failed - due [ECONNABORTED] error\", (Retryable) during Salesforce Response Handling",
+      "message": "Salesforce Request Failed - due to \"\"[ECONNABORTED] :: Connection aborted\"\", (Retryable) during Salesforce Response Handling",
       "destinationResponse": {
-        "response": [
-          {
-            "message": "[ECONNABORTED]",
-            "errorCode": "ECONNABORTED"
-          }
-        ],
-        "status": 400,
+        "response": "[ECONNABORTED] :: Connection aborted",
+        "status": 500,
         "rudderJobMetadata": {
           "destInfo": {
             "authKey": "2HezPl1w11opbFSxnLDEgZ7kWTf"
@@ -32,15 +27,10 @@
   {
     "output": {
       "status": 500,
-      "message": "Salesforce Request Failed - due [EAI_AGAIN] error\", (Retryable) during Salesforce Response Handling",
+      "message": "Salesforce Request Failed - due to \"\"[EAI_AGAIN] :: Temporary failure in name resolution\"\", (Retryable) during Salesforce Response Handling",
       "destinationResponse": {
-        "response": [
-          {
-            "message": "[EAI_AGAIN]",
-            "errorCode": "EAI_AGAIN"
-          }
-        ],
-        "status": 400,
+        "response": "[EAI_AGAIN] :: Temporary failure in name resolution",
+        "status": 500,
         "rudderJobMetadata": {
           "destInfo": {
             "authKey": "2HezPl1w11opbFSxnLDEgZ7kWTf"


### PR DESCRIPTION
## Description of the change

> Resolves INT-852
We are getting multiple alerts over many days for `ECONNABORTED` error which is some network error form salesforce and should be retried from our end. 
This PR has a check to convert this to `retryable` error

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
