### PR TITLE
feat: setting empty string as default if app event params are not present

### DIFF
--- a/src/v0/destinations/facebook_conversions/utils.js
+++ b/src/v0/destinations/facebook_conversions/utils.js
@@ -177,7 +177,7 @@ const fetchAppData = (message) => {
   const appData = constructPayload(
     message,
     MAPPING_CONFIG[CONFIG_CATEGORIES.APPDATA.name],
-    'fb_pixel',
+    DESTINATION.toLowerCase(),
   );
 
   if (appData) {
@@ -194,6 +194,10 @@ const fetchAppData = (message) => {
     }
     appData.extinfo[0] = sourceSDK;
   }
+
+  appData.extinfo = ['', '', '', '', '', '', '', '', '', '', '', '', '', '', '', ''].map(
+    (val, ind) => (appData.extinfo[ind] ? appData.extinfo[ind] : val),
+  );
 
   return appData;
 };


### PR DESCRIPTION
## Description of the change

`appData.extinfo` is an array of strings. Setting empty string `""`, if at any index in `appData.extinfo`, value is undefined as it is not sent in the event. These values are not required but FB is expecting them as empty strings.
Note: `appData.extinfo` is being populated from config mapping. `metadata: { defaultValue: "" }` is not working, once setting empty string as default is supported, this can be removed

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
