### PR TITLE
feat: add support filtering component tests by feature and index

### DIFF
--- a/test/integrations/component.test.ts
+++ b/test/integrations/component.test.ts
@@ -25,6 +25,7 @@ import { responses } from '../testHelper';
 // To run single destination test cases
 // npm run test:ts -- component  --destination=adobe_analytics
 // npm run test:ts -- component  --destination=adobe_analytics --feature=router
+// npm run test:ts -- component  --destination=adobe_analytics --feature=router --index=0
 
 // Use below command to generate mocks
 // npm run test:ts -- component --destination=zendesk --generate=true

--- a/test/integrations/component.test.ts
+++ b/test/integrations/component.test.ts
@@ -24,6 +24,7 @@ import { responses } from '../testHelper';
 
 // To run single destination test cases
 // npm run test:ts -- component  --destination=adobe_analytics
+// npm run test:ts -- component  --destination=adobe_analytics --feature=router
 
 // Use below command to generate mocks
 // npm run test:ts -- component --destination=zendesk --generate=true
@@ -32,6 +33,8 @@ const command = new Command();
 command
   .allowUnknownOption()
   .option('-d, --destination <string>', 'Enter Destination Name')
+  .option('-f, --feature <string>', 'Enter Feature Name(processor, router)')
+  .option('-i, --index <number>', 'Enter Test index')
   .option('-g, --generate <string>', 'Enter "true" If you want to generate network file')
   .parse();
 
@@ -91,7 +94,7 @@ if (!opts.generate || opts.generate === 'false') {
 
 // END
 const rootDir = __dirname;
-const allTestDataFilePaths = getTestDataFilePaths(rootDir, opts.destination);
+const allTestDataFilePaths = getTestDataFilePaths(rootDir, opts);
 const DEFAULT_VERSION = 'v0';
 
 const testRoute = async (route, tcData: TestCaseData) => {
@@ -174,7 +177,10 @@ describe.each(allTestDataFilePaths)('%s Tests', (testDataPath) => {
     jest.clearAllMocks();
   });
   // add special mocks for specific destinations
-  const testData: TestCaseData[] = getTestData(testDataPath);
+  let testData: TestCaseData[] = getTestData(testDataPath);
+  if (opts.index !== undefined) {
+    testData = [testData[parseInt(opts.index)]];
+  }
   describe(`${testData[0].name} ${testData[0].module}`, () => {
     test.each(testData)('$feature -> $description', async (tcData) => {
       tcData?.mockFns?.(mock);

--- a/test/integrations/testUtils.ts
+++ b/test/integrations/testUtils.ts
@@ -3,12 +3,16 @@ import { join } from 'path';
 import { MockHttpCallsData, TestCaseData } from './testTypes';
 import MockAdapter from 'axios-mock-adapter';
 import isMatch from 'lodash/isMatch';
+import { OptionValues } from 'commander';
 
-export const getTestDataFilePaths = (dirPath: string, destination: string = ''): string[] => {
+export const getTestDataFilePaths = (dirPath: string, opts: OptionValues): string[] => {
   const globPattern = join(dirPath, '**', 'data.ts');
   let testFilePaths = globSync(globPattern);
-  if (destination) {
-    testFilePaths = testFilePaths.filter((testFile) => testFile.includes(destination));
+  if (opts.destination) {
+    testFilePaths = testFilePaths.filter((testFile) => testFile.includes(opts.destination));
+  }
+  if (opts.feature) {
+    testFilePaths = testFilePaths.filter((testFile) => testFile.includes(opts.feature));
   }
   return testFilePaths;
 };


### PR DESCRIPTION
## Description of the change
Now we can use following commands while running component tests:

`npm run test:ts -- component  --destination=adobe_analytics`
`npm run test:ts -- component  --destination=adobe_analytics --feature=router`
`npm run test:ts -- component  --destination=adobe_analytics --feature=router --index=0`

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
