### PR TITLE
revert: fix: amplitude page and screen call containg double spaces

### DIFF
--- a/src/v0/destinations/am/transform.js
+++ b/src/v0/destinations/am/transform.js
@@ -196,7 +196,7 @@ const getScreenevTypeAndUpdatedProperties = (message, CATEGORY_KEY) => {
   const name = message.name || message.event || get(message, CATEGORY_KEY);
 
   return {
-    eventType: `Viewed ${name} Screen`,
+    eventType: `Viewed ${message.name || message.event || get(message, CATEGORY_KEY) || ''} Screen`,
     updatedProperties: {
       ...message.properties,
       name,
@@ -609,10 +609,10 @@ const processSingleMessage = (message, destination) => {
           userProvidedPageEventString.trim() === ''
             ? name
             : userProvidedPageEventString
-              .trim()
-              .replaceAll(/{{([^{}]+)}}/g, get(message, getMessagePath));
+                .trim()
+                .replaceAll(/{{([^{}]+)}}/g, get(message, getMessagePath));
       } else {
-        evType = `Viewed ${name || get(message, CATEGORY_KEY)} Page`;
+        evType = `Viewed ${name || get(message, CATEGORY_KEY) || ''} Page`;
       }
       message.properties = {
         ...properties,
@@ -836,7 +836,7 @@ const getBatchEvents = (message, destination, metadata, batchEventResponse) => {
     if (
       batchEventArray.length < AMBatchEventLimit &&
       JSON.stringify(batchPayloadJSON).length + JSON.stringify(incomingMessageEvent).length <
-      AMBatchSizeLimit
+        AMBatchSizeLimit
     ) {
       batchEventArray.push(incomingMessageEvent); // set value
       batchEventJobs.push(metadata);

--- a/src/v0/destinations/am/transform.js
+++ b/src/v0/destinations/am/transform.js
@@ -194,9 +194,9 @@ const handleTraits = (messageTrait, destination) => {
 
 const getScreenevTypeAndUpdatedProperties = (message, CATEGORY_KEY) => {
   const name = message.name || message.event || get(message, CATEGORY_KEY);
-  const updatedName = name ? `${name} ` : '';
+
   return {
-    eventType: `Viewed ${updatedName}Screen`,
+    eventType: `Viewed ${name} Screen`,
     updatedProperties: {
       ...message.properties,
       name,
@@ -577,8 +577,6 @@ const getGroupInfo = (destination, groupInfo, groupTraits) => {
   }
   return groupInfo;
 };
-const getUpdatedPageNameWithoutUserDefinedPageEventName = (name, message, CATEGORY_KEY) =>
-  name || get(message, CATEGORY_KEY) ? `${name || get(message, CATEGORY_KEY)} ` : undefined;
 
 // Generic process function which invokes specific handler functions depending on message type
 // and event type where applicable
@@ -611,15 +609,10 @@ const processSingleMessage = (message, destination) => {
           userProvidedPageEventString.trim() === ''
             ? name
             : userProvidedPageEventString
-                .trim()
-                .replaceAll(/{{([^{}]+)}}/g, get(message, getMessagePath));
+              .trim()
+              .replaceAll(/{{([^{}]+)}}/g, get(message, getMessagePath));
       } else {
-        const updatedName = getUpdatedPageNameWithoutUserDefinedPageEventName(
-          name,
-          message,
-          CATEGORY_KEY,
-        );
-        evType = `Viewed ${updatedName || ''}Page`;
+        evType = `Viewed ${name || get(message, CATEGORY_KEY)} Page`;
       }
       message.properties = {
         ...properties,
@@ -843,7 +836,7 @@ const getBatchEvents = (message, destination, metadata, batchEventResponse) => {
     if (
       batchEventArray.length < AMBatchEventLimit &&
       JSON.stringify(batchPayloadJSON).length + JSON.stringify(incomingMessageEvent).length <
-        AMBatchSizeLimit
+      AMBatchSizeLimit
     ) {
       batchEventArray.push(incomingMessageEvent); // set value
       batchEventJobs.push(metadata);

--- a/test/__tests__/data/am_output.json
+++ b/test/__tests__/data/am_output.json
@@ -3944,7 +3944,7 @@
               "id": "User Android",
               "userId": "User Android"
             },
-            "event_type": "Viewed Screen",
+            "event_type": "Viewed  Screen",
             "user_id": "User Android",
             "device_brand": "Google",
             "time": 1662393883250,
@@ -4276,7 +4276,7 @@
             "app_name": "RudderLabs JavaScript SDK",
             "app_version": "1.0.0",
             "language": "en-US",
-            "event_type": "Viewed Page",
+            "event_type": "Viewed  Page",
             "event_properties": {
               "path": "/destinations/amplitude",
               "referrer": "",


### PR DESCRIPTION
## Description of the change

> We introduced a change on 07/11/23 where in page calls were sent as `Viewed(single space)Page` instead of `Viewed(double space)Page` and similar for screen calls. Since this caused a breaking change we are reverting this fix

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
