### PR TITLE
chore: capture correct status code on faas pod time out

### DIFF
--- a/src/util/openfaas/index.js
+++ b/src/util/openfaas/index.js
@@ -277,7 +277,7 @@ const executeFaasFunction = async (
     }
 
     if (error.statusCode === 504) {
-      throw new RespStatusError(`${name} timed out`);
+      throw new RespStatusError(`${name} timed out`, 504);
     }
 
     throw error;


### PR DESCRIPTION
## Description of the change
We were getting notified for faas timed out alerts in the system because it was getting captured with status code 400 inspite of status code 504 timedout. The error itself is a valid error and doesn't need to raise an alert on.

The fix raises the error with code as well to allow the stat to capture the code and then we will make changes in alert to bypass this code i.e. `504`.


## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

Fix DAT-508 https://linear.app/rudderstack/issue/DAT-508/python-transformations-high-internal-error-count

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
