### PR TITLE
fix: conditional handling in moengage identify event

### DIFF
--- a/src/v0/destinations/moengage/transform.js
+++ b/src/v0/destinations/moengage/transform.js
@@ -119,7 +119,7 @@ const processEvent = (message, destination) => {
       response = responseBuilderSimple(message, category, destination);
       // only if device information is present device info will be added/updated
       // with an identify call otherwise only user info will be added/updated
-      if (message.context.device && message.context.device.type && message.context.device.token) {
+      if (message?.context?.device?.type && message?.context?.device?.token) {
         // build the response
         response = [
           // user api payload (output for identify)

--- a/test/integrations/destinations/moengage/processor/data.ts
+++ b/test/integrations/destinations/moengage/processor/data.ts
@@ -2777,4 +2777,105 @@ export const data = [
       },
     },
   },
+  {
+    name: 'moengage',
+    description:
+      'when identify is sent without context, the event should not throw internal server error',
+    feature: 'processor',
+    module: 'destination',
+    version: 'v0',
+    input: {
+      request: {
+        body: [
+          {
+            message: {
+              type: 'identify',
+              event: 'identify',
+              sentAt: '2023-11-22T03:42:40.346Z',
+              userId: 'userId16',
+              channel: 'mobile',
+              rudderId: 'dummy-rudderId',
+              timestamp: '2023-11-22T03:42:31.470Z',
+              receivedAt: '2023-11-22T03:42:43.281Z',
+              request_ip: '114.122.233.48',
+              anonymousId: 'anon-dummyId-1',
+              integrations: {
+                All: true,
+              },
+              originalTimestamp: '2023-11-22T03:42:28.535Z',
+            },
+            destination: {
+              ID: '1iuTZs6eEZVMm6GjRBe6bNShaL3',
+              Name: 'MoEngage Testing',
+              DestinationDefinition: {
+                ID: '1iu4802Tx27kNC4KNYYou6D8jzL',
+                Name: 'MOENGAGE',
+                DisplayName: 'MoEngage',
+                Config: {
+                  destConfig: { defaultConfig: ['apiId', 'apiKey', 'region'] },
+                  excludeKeys: [],
+                  includeKeys: [],
+                  supportedSourceTypes: [
+                    'android',
+                    'ios',
+                    'web',
+                    'unity',
+                    'amp',
+                    'cloud',
+                    'reactnative',
+                  ],
+                },
+              },
+              Config: {
+                apiId: 'W0ZHNMPI2O4KHJ48ZILZACRA',
+                apiKey: 'dummyApiKey',
+                eventDelivery: false,
+                eventDeliveryTS: 1602757086384,
+                region: 'US',
+              },
+              Enabled: true,
+              Transformations: [],
+              IsProcessorEnabled: true,
+            },
+          },
+        ],
+        method: 'POST',
+      },
+      pathSuffix: '',
+    },
+    output: {
+      response: {
+        status: 200,
+        body: [
+          {
+            output: {
+              body: {
+                FORM: {},
+                JSON: {
+                  attributes: {},
+                  customer_id: 'userId16',
+                  type: 'customer',
+                },
+                JSON_ARRAY: {},
+                XML: {},
+              },
+              endpoint: 'https://api-01.moengage.com/v1/customer/W0ZHNMPI2O4KHJ48ZILZACRA',
+              files: {},
+              headers: {
+                Authorization: 'Basic VzBaSE5NUEkyTzRLSEo0OFpJTFpBQ1JBOmR1bW15QXBpS2V5',
+                'Content-Type': 'application/json',
+                'MOE-APPKEY': 'W0ZHNMPI2O4KHJ48ZILZACRA',
+              },
+              method: 'POST',
+              params: {},
+              type: 'REST',
+              userId: 'anon-dummyId-1',
+              version: '1',
+            },
+            statusCode: 200,
+          },
+        ],
+      },
+    },
+  },
 ];


### PR DESCRIPTION
## Description of the change

In identify event, when context is not sent at all, the event would fail with internal server error. Handled it as part of this PR

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
