### PR TITLE
fix: remove errorCategory for braze dedup error

### DIFF
--- a/src/v0/util/errorTypes/filteredEventsError.js
+++ b/src/v0/util/errorTypes/filteredEventsError.js
@@ -1,13 +1,9 @@
-const tags = require('../tags');
 const { BaseError } = require('./base');
 const { HTTP_STATUS_CODES } = require('../constant');
 
 class FilteredEventsError extends BaseError {
   constructor(message, statusCode = HTTP_STATUS_CODES.FILTER_EVENTS) {
-    const finalStatTags = {
-      [tags.TAG_NAMES.ERROR_CATEGORY]: tags.ERROR_CATEGORIES.TRANSFORMATION,
-    };
-    super(message, statusCode, finalStatTags);
+    super(message, statusCode);
   }
 }
 


### PR DESCRIPTION
## Description of the change

Remove unnecessary errorCategory in braze

Resolves INT-964

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

INT-964

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified error handling by removing unnecessary tagging in `FilteredEventsError`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->