### PR TITLE
fix: unhandled error code in facebook_custom_audience

### DIFF
--- a/src/v0/util/facebookUtils/networkHandler.js
+++ b/src/v0/util/facebookUtils/networkHandler.js
@@ -195,6 +195,9 @@ const errorDetailsMap = {
       .setMessage('There have been too many calls to this ad-account.')
       .build(),
   },
+  200: {
+    default: new ErrorDetailsExtractorBuilder().setStatus(403).setMessageField('message').build(),
+  },
 };
 
 const getErrorDetailsFromErrorMap = (error) => {

--- a/test/integrations/destinations/fb_custom_audience/dataDelivery/data.ts
+++ b/test/integrations/destinations/fb_custom_audience/dataDelivery/data.ts
@@ -1,617 +1,573 @@
 export const data = [
-    {
-        name: 'fb_custom_audience',
-        description: 'successfully adding users to audience',
-        feature: 'dataDelivery',
-        module: 'destination',
-        version: 'v0',
-        input: {
-            request: {
-                body: {
-                    version: '1',
-                    type: 'REST',
-                    method: 'DELETE',
-                    endpoint: 'https://graph.facebook.com/v17.0/aud1/users',
-                    headers: {
-                        "test-dest-response-key": "successResponse"
-                    },
-                    params: {
-                        access_token: 'ABC',
-                        payload: {
-                            is_raw: true,
-                            data_source: {
-                                sub_type: 'ANYTHING',
-                            },
-                            schema: [
-                                'EMAIL',
-                                'DOBM',
-                                'DOBD',
-                                'DOBY',
-                                'PHONE',
-                                'GEN',
-                                'FI',
-                                'MADID',
-                                'ZIP',
-                                'ST',
-                                'COUNTRY',
-                            ],
-                            data: [
-                                [
-                                    'shrouti@abc.com',
-                                    '2',
-                                    '13',
-                                    '2013',
-                                    '@09432457768',
-                                    'f',
-                                    'Ms.',
-                                    'ABC',
-                                    'ZIP ',
-                                    '123abc ',
-                                    'IN',
-                                ],
-                            ],
-                        },
-                    },
-                    userId: '',
-                    body: {
-                        JSON: {},
-                        XML: {},
-                        JSON_ARRAY: {},
-                        FORM: {},
-                    },
-                    files: {},
-                }
+  {
+    name: 'fb_custom_audience',
+    description: 'successfully adding users to audience',
+    feature: 'dataDelivery',
+    module: 'destination',
+    version: 'v0',
+    input: {
+      request: {
+        body: {
+          version: '1',
+          type: 'REST',
+          method: 'DELETE',
+          endpoint: 'https://graph.facebook.com/v17.0/aud1/users',
+          headers: {
+            'test-dest-response-key': 'successResponse',
+          },
+          params: {
+            access_token: 'ABC',
+            payload: {
+              is_raw: true,
+              data_source: {
+                sub_type: 'ANYTHING',
+              },
+              schema: [
+                'EMAIL',
+                'DOBM',
+                'DOBD',
+                'DOBY',
+                'PHONE',
+                'GEN',
+                'FI',
+                'MADID',
+                'ZIP',
+                'ST',
+                'COUNTRY',
+              ],
+              data: [
+                [
+                  'shrouti@abc.com',
+                  '2',
+                  '13',
+                  '2013',
+                  '@09432457768',
+                  'f',
+                  'Ms.',
+                  'ABC',
+                  'ZIP ',
+                  '123abc ',
+                  'IN',
+                ],
+              ],
             },
+          },
+          userId: '',
+          body: {
+            JSON: {},
+            XML: {},
+            JSON_ARRAY: {},
+            FORM: {},
+          },
+          files: {},
         },
-        output: {
-            response: {
-                status: 200,
-                body: {
-                    output: {
-                        status: 200,
-                        message: 'Request Processed Successfully',
-                        destinationResponse: {
-                            audience_id: 'aud1',
-                            invalid_entry_samples: {},
-                            num_invalid_entries: 0,
-                            num_received: 4,
-                            session_id: '123'
-                        }
-                    }
-                }
-            },
-        },
+      },
     },
-    {
-        name: 'fb_custom_audience',
-        description: 'user addition failed due to missing permission',
-        feature: 'dataDelivery',
-        module: 'destination',
-        version: 'v0',
-        input: {
-            request: {
-                body: {
-                    version: '1',
-                    type: 'REST',
-                    method: 'POST',
-                    endpoint: 'https://graph.facebook.com/v17.0/aud1/users',
-                    headers: {
-                        "test-dest-response-key": "permissionMissingError"
-                    },
-                    params: {
-                        access_token: 'BCD',
-                        payload: {
-                            is_raw: true,
-                            data_source: {
-                                sub_type: 'ANYTHING',
-                            },
-                            schema: [
-                                'DOBM',
-                                'DOBD',
-                                'DOBY',
-                                'PHONE',
-                                'GEN',
-                                'FI',
-                                'MADID',
-                                'ZIP',
-                                'ST',
-                                'COUNTRY',
-                            ],
-                            data: [
-                                [
-                                    '2',
-                                    '13',
-                                    '2013',
-                                    '@09432457768',
-                                    'f',
-                                    'Ms.',
-                                    'ABC',
-                                    'ZIP ',
-                                    '123abc ',
-                                    'IN',
-                                ],
-                            ],
-                        },
-                    },
-                    body: {
-                        JSON: {},
-                        XML: {},
-                        JSON_ARRAY: {},
-                        FORM: {},
-                    },
-                    files: {},
-                }
+    output: {
+      response: {
+        status: 200,
+        body: {
+          output: {
+            status: 200,
+            message: 'Request Processed Successfully',
+            destinationResponse: {
+              audience_id: 'aud1',
+              invalid_entry_samples: {},
+              num_invalid_entries: 0,
+              num_received: 4,
+              session_id: '123',
             },
+          },
         },
-        output: {
-            response: {
-                status: 400,
-                body: {
-                    output: {
-                        destinationResponse: {
-                            error: {
-                                code: 294,
-                                message: "Missing permission. Please make sure you have ads_management permission and the application is included in the allowlist",
-                                type: "GraphMethodException",
-                            },
-                            status: 400,
-
-                        },
-                        message: "Missing permission. Please make sure you have ads_management permission and the application is included in the allowlist",
-                        statTags: {
-                            destType: "FB_CUSTOM_AUDIENCE",
-                            destinationId: "Non-determininable",
-                            errorCategory: "network",
-                            errorType: "aborted",
-                            feature: "dataDelivery",
-                            implementation: "native",
-                            module: "destination",
-                            workspaceId: "Non-determininable",
-                        },
-                        "status": 400,
-                    },
-                },
-            },
-        },
+      },
     },
-    {
-        name: 'fb_custom_audience',
-        description: 'user addition failed due to unavailable audience error',
-        feature: 'dataDelivery',
-        module: 'destination',
-        version: 'v0',
-        input: {
-            request: {
-                body: {
-                    version: '1',
-                    type: 'REST',
-                    method: 'DELETE',
-                    endpoint: 'https://graph.facebook.com/v17.0/aud1/users',
-                    headers: {
-                        "test-dest-response-key": "audienceUnavailableError"
-                    },
-                    params: {
-                        access_token: 'ABC',
-                        payload: {
-                            is_raw: true,
-                            data_source: {
-                                sub_type: 'ANYTHING',
-                            },
-                            schema: [
-                                'DOBY',
-                                'PHONE',
-                                'GEN',
-                                'FI',
-                                'MADID',
-                                'ZIP',
-                                'ST',
-                                'COUNTRY',
-                            ],
-                            data: [
-                                [
-                                    '2013',
-                                    '@09432457768',
-                                    'f',
-                                    'Ms.',
-                                    'ABC',
-                                    'ZIP ',
-                                    '123abc ',
-                                    'IN',
-                                ],
-                            ],
-                        },
-                    },
-                    body: {
-                        JSON: {},
-                        XML: {},
-                        JSON_ARRAY: {},
-                        FORM: {},
-                    },
-                    files: {},
-                }
+  },
+  {
+    name: 'fb_custom_audience',
+    description: 'user addition failed due to missing permission',
+    feature: 'dataDelivery',
+    module: 'destination',
+    version: 'v0',
+    input: {
+      request: {
+        body: {
+          version: '1',
+          type: 'REST',
+          method: 'POST',
+          endpoint: 'https://graph.facebook.com/v17.0/aud1/users',
+          headers: {
+            'test-dest-response-key': 'permissionMissingError',
+          },
+          params: {
+            access_token: 'BCD',
+            payload: {
+              is_raw: true,
+              data_source: {
+                sub_type: 'ANYTHING',
+              },
+              schema: [
+                'DOBM',
+                'DOBD',
+                'DOBY',
+                'PHONE',
+                'GEN',
+                'FI',
+                'MADID',
+                'ZIP',
+                'ST',
+                'COUNTRY',
+              ],
+              data: [
+                ['2', '13', '2013', '@09432457768', 'f', 'Ms.', 'ABC', 'ZIP ', '123abc ', 'IN'],
+              ],
             },
+          },
+          body: {
+            JSON: {},
+            XML: {},
+            JSON_ARRAY: {},
+            FORM: {},
+          },
+          files: {},
         },
-        output: {
-            response: {
-                status: 400,
-                body: {
-                    output: {
-                        destinationResponse: {
-                            error: {
-                                code: 1487301,
-                                message: "Custom Audience Unavailable: The custom audience you are trying to use has not been shared with your ad account",
-                                type: "GraphMethodException",
-                            },
-                            status: 400,
-
-                        },
-                        message: "Custom Audience Unavailable: The custom audience you are trying to use has not been shared with your ad account",
-                        statTags: {
-                            destType: "FB_CUSTOM_AUDIENCE",
-                            destinationId: "Non-determininable",
-                            errorCategory: "network",
-                            errorType: "aborted",
-                            feature: "dataDelivery",
-                            implementation: "native",
-                            module: "destination",
-                            workspaceId: "Non-determininable",
-                        },
-                        "status": 400,
-                    },
-                },
-            },
-        },
+      },
     },
-    {
-        name: 'fb_custom_audience',
-        description: 'user addition failed because the custom audience has been deleted',
-        feature: 'dataDelivery',
-        module: 'destination',
-        version: 'v0',
-        input: {
-            request: {
-                body: {
-                    version: '1',
-                    type: 'REST',
-                    method: 'DELETE',
-                    endpoint: 'https://graph.facebook.com/v17.0/aud1/users',
-                    headers: {
-                        "test-dest-response-key": "audienceDeletedError"
-                    },
-                    params: {
-                        access_token: 'ABC',
-                        payload: {
-                            is_raw: true,
-                            data_source: {
-                                sub_type: 'ANYTHING',
-                            },
-                            schema: [
-                                'DOBY',
-                                'PHONE',
-                                'GEN',
-                                'FI',
-                                'MADID',
-                                'ZIP',
-                                'ST',
-                                'COUNTRY',
-                            ],
-                            data: [
-                                [
-                                    '2013',
-                                    '@09432457768',
-                                    'f',
-                                    'Ms.',
-                                    'ABC',
-                                    'ZIP ',
-                                    '123abc ',
-                                    'IN',
-                                ],
-                            ],
-                        },
-                    },
-                    body: {
-                        JSON: {},
-                        XML: {},
-                        JSON_ARRAY: {},
-                        FORM: {},
-                    },
-                    files: {},
-                }
+    output: {
+      response: {
+        status: 400,
+        body: {
+          output: {
+            destinationResponse: {
+              error: {
+                code: 294,
+                message:
+                  'Missing permission. Please make sure you have ads_management permission and the application is included in the allowlist',
+                type: 'GraphMethodException',
+              },
+              status: 400,
             },
-        },
-        output: {
-            response: {
-                status: 400,
-                body: {
-                    output: {
-                        destinationResponse: {
-                            error: {
-                                code: 1487366,
-                                message: "Custom Audience Has Been Deleted",
-                                type: "GraphMethodException",
-                            },
-                            status: 400,
-
-                        },
-                        message: "Custom Audience Has Been Deleted",
-                        statTags: {
-                            destType: "FB_CUSTOM_AUDIENCE",
-                            destinationId: "Non-determininable",
-                            errorCategory: "network",
-                            errorType: "aborted",
-                            feature: "dataDelivery",
-                            implementation: "native",
-                            module: "destination",
-                            workspaceId: "Non-determininable",
-                        },
-                        "status": 400,
-                    },
-                },
+            message:
+              'Missing permission. Please make sure you have ads_management permission and the application is included in the allowlist',
+            statTags: {
+              destType: 'FB_CUSTOM_AUDIENCE',
+              destinationId: 'Non-determininable',
+              errorCategory: 'network',
+              errorType: 'aborted',
+              feature: 'dataDelivery',
+              implementation: 'native',
+              module: 'destination',
+              workspaceId: 'Non-determininable',
             },
+            status: 400,
+          },
         },
+      },
     },
-    {
-        name: 'fb_custom_audience',
-        description: 'Failed to update the custom audience for unknown reason',
-        feature: 'dataDelivery',
-        module: 'destination',
-        version: 'v0',
-        input: {
-            request: {
-                body: {
-                    version: '1',
-                    type: 'REST',
-                    method: 'DELETE',
-                    endpoint: 'https://graph.facebook.com/v17.0/aud1/users',
-                    headers: {
-                        "test-dest-response-key": "failedToUpdateAudienceError"
-                    },
-                    params: {
-                        access_token: 'ABC',
-                        payload: {
-                            is_raw: true,
-                            data_source: {
-                                sub_type: 'ANYTHING',
-                            },
-                            schema: [
-                                'DOBY',
-                                'PHONE',
-                                'GEN',
-                                'FI',
-                                'MADID',
-                                'ZIP',
-                                'ST',
-                                'COUNTRY',
-                            ],
-                            data: [
-                                [
-                                    '2013',
-                                    '@09432457768',
-                                    'f',
-                                    'Ms.',
-                                    'ABC',
-                                    'ZIP ',
-                                    '123abc ',
-                                    'IN',
-                                ],
-                            ],
-                        },
-                    },
-                    body: {
-                        JSON: {},
-                        XML: {},
-                        JSON_ARRAY: {},
-                        FORM: {},
-                    },
-                    files: {},
-                }
+  },
+  {
+    name: 'fb_custom_audience',
+    description: 'user addition failed due to unavailable audience error',
+    feature: 'dataDelivery',
+    module: 'destination',
+    version: 'v0',
+    input: {
+      request: {
+        body: {
+          version: '1',
+          type: 'REST',
+          method: 'DELETE',
+          endpoint: 'https://graph.facebook.com/v17.0/aud1/users',
+          headers: {
+            'test-dest-response-key': 'audienceUnavailableError',
+          },
+          params: {
+            access_token: 'ABC',
+            payload: {
+              is_raw: true,
+              data_source: {
+                sub_type: 'ANYTHING',
+              },
+              schema: ['DOBY', 'PHONE', 'GEN', 'FI', 'MADID', 'ZIP', 'ST', 'COUNTRY'],
+              data: [['2013', '@09432457768', 'f', 'Ms.', 'ABC', 'ZIP ', '123abc ', 'IN']],
             },
+          },
+          body: {
+            JSON: {},
+            XML: {},
+            JSON_ARRAY: {},
+            FORM: {},
+          },
+          files: {},
         },
-        output: {
-            response: {
-                status: 400,
-                body: {
-                    output: {
-                        destinationResponse: {
-                            error: {
-                                code: 2650,
-                                message: "Failed to update the custom audience",
-                                type: "GraphMethodException",
-                            },
-                            status: 400,
-
-                        },
-                        message: "Failed to update the custom audience",
-                        statTags: {
-                            destType: "FB_CUSTOM_AUDIENCE",
-                            destinationId: "Non-determininable",
-                            errorCategory: "network",
-                            errorType: "aborted",
-                            feature: "dataDelivery",
-                            implementation: "native",
-                            module: "destination",
-                            workspaceId: "Non-determininable",
-                        },
-                        "status": 400,
-                    },
-                },
-            },
-        },
+      },
     },
-    {
-        name: 'fb_custom_audience',
-        description: 'Failed to update the custom audience as excessive number of parameters were passed in the request',
-        feature: 'dataDelivery',
-        module: 'destination',
-        version: 'v0',
-        input: {
-            request: {
-                body: {
-                    version: '1',
-                    type: 'REST',
-                    method: 'DELETE',
-                    endpoint: 'https://graph.facebook.com/v17.0/aud1/users',
-                    headers: {
-                        "test-dest-response-key": "parameterExceededError"
-                    },
-                    params: {
-                        access_token: 'ABC',
-                        payload: {
-                            is_raw: true,
-                            data_source: {
-                                sub_type: 'ANYTHING',
-                            },
-                            schema: [
-                                'DOBY',
-                                'PHONE',
-                                'GEN',
-                                'FI',
-                                'MADID',
-                                'ZIP',
-                                'ST',
-                                'COUNTRY',
-                            ],
-                            data: [
-                                [
-                                    '2013',
-                                    '@09432457768',
-                                    'f',
-                                    'Ms.',
-                                    'ABC',
-                                    'ZIP ',
-                                    '123abc ',
-                                    'IN',
-                                ],
-                            ],
-                        },
-                    },
-                    body: {
-                        JSON: {},
-                        XML: {},
-                        JSON_ARRAY: {},
-                        FORM: {},
-                    },
-                    files: {},
-                }
+    output: {
+      response: {
+        status: 400,
+        body: {
+          output: {
+            destinationResponse: {
+              error: {
+                code: 1487301,
+                message:
+                  'Custom Audience Unavailable: The custom audience you are trying to use has not been shared with your ad account',
+                type: 'GraphMethodException',
+              },
+              status: 400,
             },
-        },
-        output: {
-            response: {
-                status: 400,
-                body: {
-                    output: {
-                        destinationResponse: {
-                            error: {
-                                code: 105,
-                                message: "The number of parameters exceeded the maximum for this operation",
-                                type: "GraphMethodException",
-                            },
-                            status: 400,
-
-                        },
-                        message: "The number of parameters exceeded the maximum for this operation",
-                        statTags: {
-                            destType: "FB_CUSTOM_AUDIENCE",
-                            destinationId: "Non-determininable",
-                            errorCategory: "network",
-                            errorType: "aborted",
-                            feature: "dataDelivery",
-                            implementation: "native",
-                            module: "destination",
-                            workspaceId: "Non-determininable",
-                        },
-                        "status": 400,
-                    },
-                },
+            message:
+              'Custom Audience Unavailable: The custom audience you are trying to use has not been shared with your ad account',
+            statTags: {
+              destType: 'FB_CUSTOM_AUDIENCE',
+              destinationId: 'Non-determininable',
+              errorCategory: 'network',
+              errorType: 'aborted',
+              feature: 'dataDelivery',
+              implementation: 'native',
+              module: 'destination',
+              workspaceId: 'Non-determininable',
             },
+            status: 400,
+          },
         },
+      },
     },
-    {
-        name: 'fb_custom_audience',
-        description: 'user update request is throttled due to too many calls to the ad account',
-        feature: 'dataDelivery',
-        module: 'destination',
-        version: 'v0',
-        input: {
-            request: {
-                body: {
-                    version: '1',
-                    type: 'REST',
-                    method: 'DELETE',
-                    endpoint: 'https://graph.facebook.com/v17.0/aud1/users',
-                    headers: {
-                        "test-dest-response-key": "tooManyCallsError"
-                    },
-                    params: {
-                        access_token: 'ABC',
-                        payload: {
-                            is_raw: true,
-                            data_source: {
-                                sub_type: 'ANYTHING',
-                            },
-                            schema: [
-                                'DOBY',
-                                'PHONE',
-                                'GEN',
-                                'FI',
-                                'MADID',
-                                'ZIP',
-                                'ST',
-                                'COUNTRY',
-                            ],
-                            data: [
-                                [
-                                    '2013',
-                                    '@09432457768',
-                                    'f',
-                                    'Ms.',
-                                    'ABC',
-                                    'ZIP ',
-                                    '123abc ',
-                                    'IN',
-                                ],
-                            ],
-                        },
-                    },
-                    body: {
-                        JSON: {},
-                        XML: {},
-                        JSON_ARRAY: {},
-                        FORM: {},
-                    },
-                    files: {},
-                }
+  },
+  {
+    name: 'fb_custom_audience',
+    description: 'user addition failed because the custom audience has been deleted',
+    feature: 'dataDelivery',
+    module: 'destination',
+    version: 'v0',
+    input: {
+      request: {
+        body: {
+          version: '1',
+          type: 'REST',
+          method: 'DELETE',
+          endpoint: 'https://graph.facebook.com/v17.0/aud1/users',
+          headers: {
+            'test-dest-response-key': 'audienceDeletedError',
+          },
+          params: {
+            access_token: 'ABC',
+            payload: {
+              is_raw: true,
+              data_source: {
+                sub_type: 'ANYTHING',
+              },
+              schema: ['DOBY', 'PHONE', 'GEN', 'FI', 'MADID', 'ZIP', 'ST', 'COUNTRY'],
+              data: [['2013', '@09432457768', 'f', 'Ms.', 'ABC', 'ZIP ', '123abc ', 'IN']],
             },
+          },
+          body: {
+            JSON: {},
+            XML: {},
+            JSON_ARRAY: {},
+            FORM: {},
+          },
+          files: {},
         },
-        output: {
-            response: {
-                status: 429,
-                body: {
-                    output: {
-                        destinationResponse: {
-                            error: {
-                                code: 80003,
-                                message: "There have been too many calls to this ad-account.",
-                                type: "GraphMethodException",
-                            },
-                            status: 429,
-
-                        },
-                        message: "There have been too many calls to this ad-account.",
-                        statTags: {
-                            destType: "FB_CUSTOM_AUDIENCE",
-                            destinationId: "Non-determininable",
-                            errorCategory: "network",
-                            errorType: "throttled",
-                            feature: "dataDelivery",
-                            implementation: "native",
-                            module: "destination",
-                            workspaceId: "Non-determininable",
-                        },
-                        "status": 429,
-                    },
-                },
+      },
+    },
+    output: {
+      response: {
+        status: 400,
+        body: {
+          output: {
+            destinationResponse: {
+              error: {
+                code: 1487366,
+                message: 'Custom Audience Has Been Deleted',
+                type: 'GraphMethodException',
+              },
+              status: 400,
             },
+            message: 'Custom Audience Has Been Deleted',
+            statTags: {
+              destType: 'FB_CUSTOM_AUDIENCE',
+              destinationId: 'Non-determininable',
+              errorCategory: 'network',
+              errorType: 'aborted',
+              feature: 'dataDelivery',
+              implementation: 'native',
+              module: 'destination',
+              workspaceId: 'Non-determininable',
+            },
+            status: 400,
+          },
         },
-    }
-]
+      },
+    },
+  },
+  {
+    name: 'fb_custom_audience',
+    description: 'Failed to update the custom audience for unknown reason',
+    feature: 'dataDelivery',
+    module: 'destination',
+    version: 'v0',
+    input: {
+      request: {
+        body: {
+          version: '1',
+          type: 'REST',
+          method: 'DELETE',
+          endpoint: 'https://graph.facebook.com/v17.0/aud1/users',
+          headers: {
+            'test-dest-response-key': 'failedToUpdateAudienceError',
+          },
+          params: {
+            access_token: 'ABC',
+            payload: {
+              is_raw: true,
+              data_source: {
+                sub_type: 'ANYTHING',
+              },
+              schema: ['DOBY', 'PHONE', 'GEN', 'FI', 'MADID', 'ZIP', 'ST', 'COUNTRY'],
+              data: [['2013', '@09432457768', 'f', 'Ms.', 'ABC', 'ZIP ', '123abc ', 'IN']],
+            },
+          },
+          body: {
+            JSON: {},
+            XML: {},
+            JSON_ARRAY: {},
+            FORM: {},
+          },
+          files: {},
+        },
+      },
+    },
+    output: {
+      response: {
+        status: 400,
+        body: {
+          output: {
+            destinationResponse: {
+              error: {
+                code: 2650,
+                message: 'Failed to update the custom audience',
+                type: 'GraphMethodException',
+              },
+              status: 400,
+            },
+            message: 'Failed to update the custom audience',
+            statTags: {
+              destType: 'FB_CUSTOM_AUDIENCE',
+              destinationId: 'Non-determininable',
+              errorCategory: 'network',
+              errorType: 'aborted',
+              feature: 'dataDelivery',
+              implementation: 'native',
+              module: 'destination',
+              workspaceId: 'Non-determininable',
+            },
+            status: 400,
+          },
+        },
+      },
+    },
+  },
+  {
+    name: 'fb_custom_audience',
+    description:
+      'Failed to update the custom audience as excessive number of parameters were passed in the request',
+    feature: 'dataDelivery',
+    module: 'destination',
+    version: 'v0',
+    input: {
+      request: {
+        body: {
+          version: '1',
+          type: 'REST',
+          method: 'DELETE',
+          endpoint: 'https://graph.facebook.com/v17.0/aud1/users',
+          headers: {
+            'test-dest-response-key': 'parameterExceededError',
+          },
+          params: {
+            access_token: 'ABC',
+            payload: {
+              is_raw: true,
+              data_source: {
+                sub_type: 'ANYTHING',
+              },
+              schema: ['DOBY', 'PHONE', 'GEN', 'FI', 'MADID', 'ZIP', 'ST', 'COUNTRY'],
+              data: [['2013', '@09432457768', 'f', 'Ms.', 'ABC', 'ZIP ', '123abc ', 'IN']],
+            },
+          },
+          body: {
+            JSON: {},
+            XML: {},
+            JSON_ARRAY: {},
+            FORM: {},
+          },
+          files: {},
+        },
+      },
+    },
+    output: {
+      response: {
+        status: 400,
+        body: {
+          output: {
+            destinationResponse: {
+              error: {
+                code: 105,
+                message: 'The number of parameters exceeded the maximum for this operation',
+                type: 'GraphMethodException',
+              },
+              status: 400,
+            },
+            message: 'The number of parameters exceeded the maximum for this operation',
+            statTags: {
+              destType: 'FB_CUSTOM_AUDIENCE',
+              destinationId: 'Non-determininable',
+              errorCategory: 'network',
+              errorType: 'aborted',
+              feature: 'dataDelivery',
+              implementation: 'native',
+              module: 'destination',
+              workspaceId: 'Non-determininable',
+            },
+            status: 400,
+          },
+        },
+      },
+    },
+  },
+  {
+    name: 'fb_custom_audience',
+    description: 'user update request is throttled due to too many calls to the ad account',
+    feature: 'dataDelivery',
+    module: 'destination',
+    version: 'v0',
+    input: {
+      request: {
+        body: {
+          version: '1',
+          type: 'REST',
+          method: 'DELETE',
+          endpoint: 'https://graph.facebook.com/v17.0/aud1/users',
+          headers: {
+            'test-dest-response-key': 'tooManyCallsError',
+          },
+          params: {
+            access_token: 'ABC',
+            payload: {
+              is_raw: true,
+              data_source: {
+                sub_type: 'ANYTHING',
+              },
+              schema: ['DOBY', 'PHONE', 'GEN', 'FI', 'MADID', 'ZIP', 'ST', 'COUNTRY'],
+              data: [['2013', '@09432457768', 'f', 'Ms.', 'ABC', 'ZIP ', '123abc ', 'IN']],
+            },
+          },
+          body: {
+            JSON: {},
+            XML: {},
+            JSON_ARRAY: {},
+            FORM: {},
+          },
+          files: {},
+        },
+      },
+    },
+    output: {
+      response: {
+        status: 429,
+        body: {
+          output: {
+            destinationResponse: {
+              error: {
+                code: 80003,
+                message: 'There have been too many calls to this ad-account.',
+                type: 'GraphMethodException',
+              },
+              status: 429,
+            },
+            message: 'There have been too many calls to this ad-account.',
+            statTags: {
+              destType: 'FB_CUSTOM_AUDIENCE',
+              destinationId: 'Non-determininable',
+              errorCategory: 'network',
+              errorType: 'throttled',
+              feature: 'dataDelivery',
+              implementation: 'native',
+              module: 'destination',
+              workspaceId: 'Non-determininable',
+            },
+            status: 429,
+          },
+        },
+      },
+    },
+  },
+  {
+    name: 'fb_custom_audience',
+    description: 'user having permission issue while updating audience',
+    feature: 'dataDelivery',
+    module: 'destination',
+    version: 'v0',
+    input: {
+      request: {
+        body: {
+          version: '1',
+          type: 'REST',
+          method: 'DELETE',
+          endpoint: 'https://graph.facebook.com/v17.0/aud1/users',
+          headers: {
+            'test-dest-response-key': 'code200PermissionError',
+          },
+          params: {
+            access_token: 'ABC',
+            payload: {
+              is_raw: true,
+              data_source: {
+                sub_type: 'ANYTHING',
+              },
+              schema: ['DOBY', 'PHONE', 'GEN', 'FI', 'MADID', 'ZIP', 'ST', 'COUNTRY'],
+              data: [['2013', '@09432457768', 'f', 'Ms.', 'ABC', 'ZIP ', '123abc ', 'IN']],
+            },
+          },
+          body: {
+            JSON: {},
+            XML: {},
+            JSON_ARRAY: {},
+            FORM: {},
+          },
+          files: {},
+        },
+      },
+    },
+    output: {
+      response: {
+        status: 403,
+        body: {
+          output: {
+            destinationResponse: {
+              error: {
+                code: 200,
+                fbtrace_id: 'AFfWqjY-_y2Q92DsyJ4DQ6f',
+                message: '(#200) The current user can not update audience 23861283180290489',
+                type: 'OAuthException',
+              },
+              status: 403,
+            },
+            message: '(#200) The current user can not update audience 23861283180290489',
+            statTags: {
+              destType: 'FB_CUSTOM_AUDIENCE',
+              destinationId: 'Non-determininable',
+              errorCategory: 'network',
+              errorType: 'aborted',
+              feature: 'dataDelivery',
+              implementation: 'native',
+              module: 'destination',
+              workspaceId: 'Non-determininable',
+            },
+            status: 403,
+          },
+        },
+      },
+    },
+  },
+];

--- a/test/integrations/destinations/fb_custom_audience/network.ts
+++ b/test/integrations/destinations/fb_custom_audience/network.ts
@@ -1,456 +1,481 @@
 export const networkCallsData = [
-    {
-        httpReq: {
-            version: '1',
-            type: 'REST',
-            method: 'DELETE',
-            endpoint: 'https://graph.facebook.com/v17.0/aud1/users',
-            headers: {
-                'test-dest-response-key': 'successResponse'
-            },
-            params: {
-                access_token: 'ABC',
-                payload: {
-                    is_raw: true,
-                    data_source: {
-                        sub_type: 'ANYTHING',
-                    },
-                    schema: [
-                        'EMAIL',
-                        'DOBM',
-                        'DOBD',
-                        'DOBY',
-                        'PHONE',
-                        'GEN',
-                        'FI',
-                        'MADID',
-                        'ZIP',
-                        'ST',
-                        'COUNTRY',
-                    ],
-                    data: [
-                        [
-                            'shrouti@abc.com',
-                            '2',
-                            '13',
-                            '2013',
-                            '@09432457768',
-                            'f',
-                            'Ms.',
-                            'ABC',
-                            'ZIP ',
-                            '123abc ',
-                            'IN',
-                        ],
-                    ],
-                },
-            },
-            userId: '',
-            body: {
-                JSON: {},
-                XML: {},
-                JSON_ARRAY: {},
-                FORM: {},
-            },
-            files: {},
+  {
+    httpReq: {
+      version: '1',
+      type: 'REST',
+      method: 'DELETE',
+      endpoint: 'https://graph.facebook.com/v17.0/aud1/users',
+      headers: {
+        'test-dest-response-key': 'successResponse',
+      },
+      params: {
+        access_token: 'ABC',
+        payload: {
+          is_raw: true,
+          data_source: {
+            sub_type: 'ANYTHING',
+          },
+          schema: [
+            'EMAIL',
+            'DOBM',
+            'DOBD',
+            'DOBY',
+            'PHONE',
+            'GEN',
+            'FI',
+            'MADID',
+            'ZIP',
+            'ST',
+            'COUNTRY',
+          ],
+          data: [
+            [
+              'shrouti@abc.com',
+              '2',
+              '13',
+              '2013',
+              '@09432457768',
+              'f',
+              'Ms.',
+              'ABC',
+              'ZIP ',
+              '123abc ',
+              'IN',
+            ],
+          ],
         },
-        httpRes: {
-            "data": {
-                "audience_id": "aud1",
-                "session_id": "123",
-                "num_received": 4,
-                "num_invalid_entries": 0,
-                "invalid_entry_samples": {}
-            },
-            "status": 200
-        }
+      },
+      userId: '',
+      body: {
+        JSON: {},
+        XML: {},
+        JSON_ARRAY: {},
+        FORM: {},
+      },
+      files: {},
     },
-    {
-        httpReq: {
-            version: '1',
-            type: 'REST',
-            method: 'POST',
-            endpoint: 'https://graph.facebook.com/v17.0/aud1/users',
-            headers: {
-                'test-dest-response-key': 'permissionMissingError'
-            },
-            params: {
-                access_token: 'BCD',
-                payload: {
-                    is_raw: true,
-                    data_source: {
-                        sub_type: 'ANYTHING',
-                    },
-                    schema: [
-                        'DOBM',
-                        'DOBD',
-                        'DOBY',
-                        'PHONE',
-                        'GEN',
-                        'FI',
-                        'MADID',
-                        'ZIP',
-                        'ST',
-                        'COUNTRY',
-                    ],
-                    data: [
-                        [
-                            '2',
-                            '13',
-                            '2013',
-                            '@09432457768',
-                            'f',
-                            'Ms.',
-                            'ABC',
-                            'ZIP ',
-                            '123abc ',
-                            'IN',
-                        ],
-                    ],
-                },
-            },
-            userId: '',
-            body: {
-                JSON: {},
-                XML: {},
-                JSON_ARRAY: {},
-                FORM: {},
-            },
-            files: {},
-        },
-        httpRes: {
-            data: {
-                error: {
-                code: 294,
-                message: "Missing permission. Please make sure you have ads_management permission and the application is included in the allowlist",
-                type: "GraphMethodException",
-                }
-            },
-            "status": 400
-        }
+    httpRes: {
+      data: {
+        audience_id: 'aud1',
+        session_id: '123',
+        num_received: 4,
+        num_invalid_entries: 0,
+        invalid_entry_samples: {},
+      },
+      status: 200,
     },
-    {
-        httpReq: {
-            version: '1',
-            type: 'REST',
-            method: 'DELETE',
-            endpoint: 'https://graph.facebook.com/v17.0/aud1/users',
-            headers: {
-                'test-dest-response-key': 'audienceUnavailableError'
-            },
-            params: {
-                access_token: 'ABC',
-                payload: {
-                    is_raw: true,
-                    data_source: {
-                        sub_type: 'ANYTHING',
-                    },
-                    schema: [
-                        'DOBY',
-                        'PHONE',
-                        'GEN',
-                        'FI',
-                        'MADID',
-                        'ZIP',
-                        'ST',
-                        'COUNTRY',
-                    ],
-                    data: [
-                        [
-                            '2013',
-                            '@09432457768',
-                            'f',
-                            'Ms.',
-                            'ABC',
-                            'ZIP ',
-                            '123abc ',
-                            'IN',
-                        ],
-                    ],
-                },
-            },
-            userId: '',
-            body: {
-                JSON: {},
-                XML: {},
-                JSON_ARRAY: {},
-                FORM: {},
-            },
-            files: {},
+  },
+  {
+    httpReq: {
+      version: '1',
+      type: 'REST',
+      method: 'POST',
+      endpoint: 'https://graph.facebook.com/v17.0/aud1/users',
+      headers: {
+        'test-dest-response-key': 'permissionMissingError',
+      },
+      params: {
+        access_token: 'BCD',
+        payload: {
+          is_raw: true,
+          data_source: {
+            sub_type: 'ANYTHING',
+          },
+          schema: ['DOBM', 'DOBD', 'DOBY', 'PHONE', 'GEN', 'FI', 'MADID', 'ZIP', 'ST', 'COUNTRY'],
+          data: [['2', '13', '2013', '@09432457768', 'f', 'Ms.', 'ABC', 'ZIP ', '123abc ', 'IN']],
         },
-        httpRes: {
-            data: {
-                error: {
-                code: 1487301,
-                message: "Custom Audience Unavailable: The custom audience you are trying to use has not been shared with your ad account",
-                type: "GraphMethodException",
-                }
-            },
-            "status": 400
-        }
+      },
+      userId: '',
+      body: {
+        JSON: {},
+        XML: {},
+        JSON_ARRAY: {},
+        FORM: {},
+      },
+      files: {},
     },
-    {
-        httpReq: {
-            version: '1',
-            type: 'REST',
-            method: 'DELETE',
-            endpoint: 'https://graph.facebook.com/v17.0/aud1/users',
-            headers: {
-                'test-dest-response-key': 'audienceDeletedError'
-            },
-            params: {
-                access_token: 'ABC',
-                payload: {
-                    is_raw: true,
-                    data_source: {
-                        sub_type: 'ANYTHING',
-                    },
-                    schema: [
-                        'EMAIL',
-                        'DOBM',
-                        'DOBD',
-                        'DOBY',
-                        'PHONE',
-                        'GEN',
-                        'FI',
-                        'MADID',
-                        'ZIP',
-                        'ST',
-                        'COUNTRY',
-                    ],
-                    data: [
-                        [
-                            'shrouti@abc.com',
-                            '2',
-                            '13',
-                            '2013',
-                            '@09432457768',
-                            'f',
-                            'Ms.',
-                            'ABC',
-                            'ZIP ',
-                            '123abc ',
-                            'IN',
-                        ],
-                    ],
-                },
-            },
-            userId: '',
-            body: {
-                JSON: {},
-                XML: {},
-                JSON_ARRAY: {},
-                FORM: {},
-            },
-            files: {},
+    httpRes: {
+      data: {
+        error: {
+          code: 294,
+          message:
+            'Missing permission. Please make sure you have ads_management permission and the application is included in the allowlist',
+          type: 'GraphMethodException',
         },
-        httpRes: {
-            data: {
-                error: {
-                code: 1487366,
-                message: "Custom Audience Has Been Deleted",
-                type: "GraphMethodException",
-                }
-            },
-            "status": 400
-        }
+      },
+      status: 400,
     },
-    {
-        httpReq: {
-            version: '1',
-            type: 'REST',
-            method: 'DELETE',
-            endpoint: 'https://graph.facebook.com/v17.0/aud1/users',
-            headers: {
-                'test-dest-response-key': 'failedToUpdateAudienceError'
-            },
-            params: {
-                access_token: 'ABC',
-                payload: {
-                    is_raw: true,
-                    data_source: {
-                        sub_type: 'ANYTHING',
-                    },
-                    schema: [
-                        'EMAIL',
-                        'DOBM',
-                        'DOBD',
-                        'DOBY',
-                        'PHONE',
-                        'GEN',
-                        'FI',
-                        'MADID',
-                        'ZIP',
-                        'ST',
-                        'COUNTRY',
-                    ],
-                    data: [
-                        [
-                            'shrouti@abc.com',
-                            '2',
-                            '13',
-                            '2013',
-                            '@09432457768',
-                            'f',
-                            'Ms.',
-                            'ABC',
-                            'ZIP ',
-                            '123abc ',
-                            'IN',
-                        ],
-                    ],
-                },
-            },
-            userId: '',
-            body: {
-                JSON: {},
-                XML: {},
-                JSON_ARRAY: {},
-                FORM: {},
-            },
-            files: {},
+  },
+  {
+    httpReq: {
+      version: '1',
+      type: 'REST',
+      method: 'DELETE',
+      endpoint: 'https://graph.facebook.com/v17.0/aud1/users',
+      headers: {
+        'test-dest-response-key': 'audienceUnavailableError',
+      },
+      params: {
+        access_token: 'ABC',
+        payload: {
+          is_raw: true,
+          data_source: {
+            sub_type: 'ANYTHING',
+          },
+          schema: ['DOBY', 'PHONE', 'GEN', 'FI', 'MADID', 'ZIP', 'ST', 'COUNTRY'],
+          data: [['2013', '@09432457768', 'f', 'Ms.', 'ABC', 'ZIP ', '123abc ', 'IN']],
         },
-        httpRes: {
-            data: {
-                error: {
-                code: 2650,
-                message: "Failed to update the custom audience",
-                type: "GraphMethodException",
-                }
-            },
-            "status": 400
-        }
+      },
+      userId: '',
+      body: {
+        JSON: {},
+        XML: {},
+        JSON_ARRAY: {},
+        FORM: {},
+      },
+      files: {},
     },
-    {
-        httpReq: {
-            version: '1',
-            type: 'REST',
-            method: 'DELETE',
-            endpoint: 'https://graph.facebook.com/v17.0/aud1/users',
-            headers: {
-                'test-dest-response-key': 'parameterExceededError'
-            },
-            params: {
-                access_token: 'ABC',
-                payload: {
-                    is_raw: true,
-                    data_source: {
-                        sub_type: 'ANYTHING',
-                    },
-                    schema: [
-                        'EMAIL',
-                        'DOBM',
-                        'DOBD',
-                        'DOBY',
-                        'PHONE',
-                        'GEN',
-                        'FI',
-                        'MADID',
-                        'ZIP',
-                        'ST',
-                        'COUNTRY',
-                    ],
-                    data: [
-                        [
-                            'shrouti@abc.com',
-                            '2',
-                            '13',
-                            '2013',
-                            '@09432457768',
-                            'f',
-                            'Ms.',
-                            'ABC',
-                            'ZIP ',
-                            '123abc ',
-                            'IN',
-                        ],
-                    ],
-                },
-            },
-            userId: '',
-            body: {
-                JSON: {},
-                XML: {},
-                JSON_ARRAY: {},
-                FORM: {},
-            },
-            files: {},
+    httpRes: {
+      data: {
+        error: {
+          code: 1487301,
+          message:
+            'Custom Audience Unavailable: The custom audience you are trying to use has not been shared with your ad account',
+          type: 'GraphMethodException',
         },
-        httpRes: {
-            data: {
-                error: {
-                code: 105,
-                message: "The number of parameters exceeded the maximum for this operation",
-                type: "GraphMethodException",
-                }
-            },
-            "status": 400
-        }
+      },
+      status: 400,
     },
-    {
-        httpReq: {
-            version: '1',
-            type: 'REST',
-            method: 'DELETE',
-            endpoint: 'https://graph.facebook.com/v17.0/aud1/users',
-            headers: {
-                'test-dest-response-key': 'tooManyCallsError'
-            },
-            params: {
-                access_token: 'ABC',
-                payload: {
-                    is_raw: true,
-                    data_source: {
-                        sub_type: 'ANYTHING',
-                    },
-                    schema: [
-                        'EMAIL',
-                        'DOBM',
-                        'DOBD',
-                        'DOBY',
-                        'PHONE',
-                        'GEN',
-                        'FI',
-                        'MADID',
-                        'ZIP',
-                        'ST',
-                        'COUNTRY',
-                    ],
-                    data: [
-                        [
-                            'shrouti@abc.com',
-                            '2',
-                            '13',
-                            '2013',
-                            '@09432457768',
-                            'f',
-                            'Ms.',
-                            'ABC',
-                            'ZIP ',
-                            '123abc ',
-                            'IN',
-                        ],
-                    ],
-                },
-            },
-            userId: '',
-            body: {
-                JSON: {},
-                XML: {},
-                JSON_ARRAY: {},
-                FORM: {},
-            },
-            files: {},
+  },
+  {
+    httpReq: {
+      version: '1',
+      type: 'REST',
+      method: 'DELETE',
+      endpoint: 'https://graph.facebook.com/v17.0/aud1/users',
+      headers: {
+        'test-dest-response-key': 'audienceDeletedError',
+      },
+      params: {
+        access_token: 'ABC',
+        payload: {
+          is_raw: true,
+          data_source: {
+            sub_type: 'ANYTHING',
+          },
+          schema: [
+            'EMAIL',
+            'DOBM',
+            'DOBD',
+            'DOBY',
+            'PHONE',
+            'GEN',
+            'FI',
+            'MADID',
+            'ZIP',
+            'ST',
+            'COUNTRY',
+          ],
+          data: [
+            [
+              'shrouti@abc.com',
+              '2',
+              '13',
+              '2013',
+              '@09432457768',
+              'f',
+              'Ms.',
+              'ABC',
+              'ZIP ',
+              '123abc ',
+              'IN',
+            ],
+          ],
         },
-        httpRes: {
-            data: {
-                error: {
-                code: 80003,
-                message: "There have been too many calls to this ad-account.",
-                type: "GraphMethodException",
-                }
-            },
-            "status": 429
-        }
-    }
+      },
+      userId: '',
+      body: {
+        JSON: {},
+        XML: {},
+        JSON_ARRAY: {},
+        FORM: {},
+      },
+      files: {},
+    },
+    httpRes: {
+      data: {
+        error: {
+          code: 1487366,
+          message: 'Custom Audience Has Been Deleted',
+          type: 'GraphMethodException',
+        },
+      },
+      status: 400,
+    },
+  },
+  {
+    httpReq: {
+      version: '1',
+      type: 'REST',
+      method: 'DELETE',
+      endpoint: 'https://graph.facebook.com/v17.0/aud1/users',
+      headers: {
+        'test-dest-response-key': 'failedToUpdateAudienceError',
+      },
+      params: {
+        access_token: 'ABC',
+        payload: {
+          is_raw: true,
+          data_source: {
+            sub_type: 'ANYTHING',
+          },
+          schema: [
+            'EMAIL',
+            'DOBM',
+            'DOBD',
+            'DOBY',
+            'PHONE',
+            'GEN',
+            'FI',
+            'MADID',
+            'ZIP',
+            'ST',
+            'COUNTRY',
+          ],
+          data: [
+            [
+              'shrouti@abc.com',
+              '2',
+              '13',
+              '2013',
+              '@09432457768',
+              'f',
+              'Ms.',
+              'ABC',
+              'ZIP ',
+              '123abc ',
+              'IN',
+            ],
+          ],
+        },
+      },
+      userId: '',
+      body: {
+        JSON: {},
+        XML: {},
+        JSON_ARRAY: {},
+        FORM: {},
+      },
+      files: {},
+    },
+    httpRes: {
+      data: {
+        error: {
+          code: 2650,
+          message: 'Failed to update the custom audience',
+          type: 'GraphMethodException',
+        },
+      },
+      status: 400,
+    },
+  },
+  {
+    httpReq: {
+      version: '1',
+      type: 'REST',
+      method: 'DELETE',
+      endpoint: 'https://graph.facebook.com/v17.0/aud1/users',
+      headers: {
+        'test-dest-response-key': 'parameterExceededError',
+      },
+      params: {
+        access_token: 'ABC',
+        payload: {
+          is_raw: true,
+          data_source: {
+            sub_type: 'ANYTHING',
+          },
+          schema: [
+            'EMAIL',
+            'DOBM',
+            'DOBD',
+            'DOBY',
+            'PHONE',
+            'GEN',
+            'FI',
+            'MADID',
+            'ZIP',
+            'ST',
+            'COUNTRY',
+          ],
+          data: [
+            [
+              'shrouti@abc.com',
+              '2',
+              '13',
+              '2013',
+              '@09432457768',
+              'f',
+              'Ms.',
+              'ABC',
+              'ZIP ',
+              '123abc ',
+              'IN',
+            ],
+          ],
+        },
+      },
+      userId: '',
+      body: {
+        JSON: {},
+        XML: {},
+        JSON_ARRAY: {},
+        FORM: {},
+      },
+      files: {},
+    },
+    httpRes: {
+      data: {
+        error: {
+          code: 105,
+          message: 'The number of parameters exceeded the maximum for this operation',
+          type: 'GraphMethodException',
+        },
+      },
+      status: 400,
+    },
+  },
+  {
+    httpReq: {
+      version: '1',
+      type: 'REST',
+      method: 'DELETE',
+      endpoint: 'https://graph.facebook.com/v17.0/aud1/users',
+      headers: {
+        'test-dest-response-key': 'tooManyCallsError',
+      },
+      params: {
+        access_token: 'ABC',
+        payload: {
+          is_raw: true,
+          data_source: {
+            sub_type: 'ANYTHING',
+          },
+          schema: [
+            'EMAIL',
+            'DOBM',
+            'DOBD',
+            'DOBY',
+            'PHONE',
+            'GEN',
+            'FI',
+            'MADID',
+            'ZIP',
+            'ST',
+            'COUNTRY',
+          ],
+          data: [
+            [
+              'shrouti@abc.com',
+              '2',
+              '13',
+              '2013',
+              '@09432457768',
+              'f',
+              'Ms.',
+              'ABC',
+              'ZIP ',
+              '123abc ',
+              'IN',
+            ],
+          ],
+        },
+      },
+      userId: '',
+      body: {
+        JSON: {},
+        XML: {},
+        JSON_ARRAY: {},
+        FORM: {},
+      },
+      files: {},
+    },
+    httpRes: {
+      data: {
+        error: {
+          code: 80003,
+          message: 'There have been too many calls to this ad-account.',
+          type: 'GraphMethodException',
+        },
+      },
+      status: 429,
+    },
+  },
+  {
+    httpReq: {
+      version: '1',
+      type: 'REST',
+      method: 'DELETE',
+      endpoint: 'https://graph.facebook.com/v17.0/aud1/users',
+      headers: {
+        'test-dest-response-key': 'code200PermissionError',
+      },
+      params: {
+        access_token: 'ABC',
+        payload: {
+          is_raw: true,
+          data_source: {
+            sub_type: 'ANYTHING',
+          },
+          schema: [
+            'EMAIL',
+            'DOBM',
+            'DOBD',
+            'DOBY',
+            'PHONE',
+            'GEN',
+            'FI',
+            'MADID',
+            'ZIP',
+            'ST',
+            'COUNTRY',
+          ],
+          data: [
+            [
+              'shrouti@abc.com',
+              '2',
+              '13',
+              '2013',
+              '@09432457768',
+              'f',
+              'Ms.',
+              'ABC',
+              'ZIP ',
+              '123abc ',
+              'IN',
+            ],
+          ],
+        },
+      },
+      userId: '',
+      body: {
+        JSON: {},
+        XML: {},
+        JSON_ARRAY: {},
+        FORM: {},
+      },
+      files: {},
+    },
+    httpRes: {
+      data: {
+        error: {
+          code: 200,
+          fbtrace_id: 'AFfWqjY-_y2Q92DsyJ4DQ6f',
+          message: '(#200) The current user can not update audience 23861283180290489',
+          type: 'OAuthException',
+        },
+      },
+      status: 403,
+    },
+  },
 ];


### PR DESCRIPTION
## Description of the change

The error code `200` has not been handled properly in `facebook_custom_audience` destination. We have seen it being retried and getting aborted after retries are complete. Since this is a permissions issue, ideally it should be `aborted`.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

Resolves INT-1086

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling with a new default error message for unauthorized access attempts.
	- Standardized quotation marks in HTTP headers for consistency.

- **Tests**
	- Updated integration test data to reflect new HTTP status codes and response body content.
	- Enhanced network test scenarios with additional request and response configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->