### PR TITLE
fix: add support for custom properties for braze purchase events

### DIFF
--- a/src/v0/destinations/braze/braze.util.test.js
+++ b/src/v0/destinations/braze/braze.util.test.js
@@ -1219,4 +1219,75 @@ describe('getPurchaseObjs', () => {
       );
     }
   });
+
+  test('products having extra properties', () => {
+    const output = getPurchaseObjs({
+      properties: {
+        products: [
+          { product_id: '123', price: 10.99, quantity: 2, random_extra_property_a: 'abc' },
+          { product_id: '456', price: 5.49, quantity: 1, random_extra_property_b: 'efg' },
+          {
+            product_id: '789',
+            price: 15.49,
+            quantity: 1,
+            random_extra_property_a: 'abc',
+            random_extra_property_b: 'efg',
+            random_extra_property_c: 'hij',
+          },
+        ],
+        currency: 'USD',
+      },
+      timestamp: '2023-08-04T12:34:56Z',
+      anonymousId: 'abc',
+    });
+    expect(output).toEqual([
+      {
+        product_id: '123',
+        price: 10.99,
+        currency: 'USD',
+        quantity: 2,
+        time: '2023-08-04T12:34:56Z',
+        properties: {
+          random_extra_property_a: 'abc',
+        },
+        _update_existing_only: false,
+        user_alias: {
+          alias_name: 'abc',
+          alias_label: 'rudder_id',
+        },
+      },
+      {
+        product_id: '456',
+        price: 5.49,
+        currency: 'USD',
+        quantity: 1,
+        time: '2023-08-04T12:34:56Z',
+        properties: {
+          random_extra_property_b: 'efg',
+        },
+        _update_existing_only: false,
+        user_alias: {
+          alias_name: 'abc',
+          alias_label: 'rudder_id',
+        },
+      },
+      {
+        product_id: '789',
+        price: 15.49,
+        currency: 'USD',
+        quantity: 1,
+        time: '2023-08-04T12:34:56Z',
+        properties: {
+          random_extra_property_a: 'abc',
+          random_extra_property_b: 'efg',
+          random_extra_property_c: 'hij',
+        },
+        _update_existing_only: false,
+        user_alias: {
+          alias_name: 'abc',
+          alias_label: 'rudder_id',
+        },
+      },
+    ]);
+  });
 });

--- a/src/v0/destinations/braze/braze.util.test.js
+++ b/src/v0/destinations/braze/braze.util.test.js
@@ -1221,25 +1221,30 @@ describe('getPurchaseObjs', () => {
   });
 
   test('products having extra properties', () => {
-    const output = getPurchaseObjs({
-      properties: {
-        products: [
-          { product_id: '123', price: 10.99, quantity: 2, random_extra_property_a: 'abc' },
-          { product_id: '456', price: 5.49, quantity: 1, random_extra_property_b: 'efg' },
-          {
-            product_id: '789',
-            price: 15.49,
-            quantity: 1,
-            random_extra_property_a: 'abc',
-            random_extra_property_b: 'efg',
-            random_extra_property_c: 'hij',
-          },
-        ],
-        currency: 'USD',
+    const output = getPurchaseObjs(
+      {
+        properties: {
+          products: [
+            { product_id: '123', price: 10.99, quantity: 2, random_extra_property_a: 'abc' },
+            { product_id: '456', price: 5.49, quantity: 1, random_extra_property_b: 'efg' },
+            {
+              product_id: '789',
+              price: 15.49,
+              quantity: 1,
+              random_extra_property_a: 'abc',
+              random_extra_property_b: 'efg',
+              random_extra_property_c: 'hij',
+            },
+          ],
+          currency: 'USD',
+        },
+        timestamp: '2023-08-04T12:34:56Z',
+        anonymousId: 'abc',
       },
-      timestamp: '2023-08-04T12:34:56Z',
-      anonymousId: 'abc',
-    });
+      {
+        sendPurchaseEventWithExtraProperties: true,
+      },
+    );
     expect(output).toEqual([
       {
         product_id: '123',
@@ -1282,6 +1287,71 @@ describe('getPurchaseObjs', () => {
           random_extra_property_b: 'efg',
           random_extra_property_c: 'hij',
         },
+        _update_existing_only: false,
+        user_alias: {
+          alias_name: 'abc',
+          alias_label: 'rudder_id',
+        },
+      },
+    ]);
+  });
+
+  test('products having extra properties with sendPurchaseEventWithExtraProperties as false', () => {
+    const output = getPurchaseObjs(
+      {
+        properties: {
+          products: [
+            { product_id: '123', price: 10.99, quantity: 2, random_extra_property_a: 'abc' },
+            { product_id: '456', price: 5.49, quantity: 1, random_extra_property_b: 'efg' },
+            {
+              product_id: '789',
+              price: 15.49,
+              quantity: 1,
+              random_extra_property_a: 'abc',
+              random_extra_property_b: 'efg',
+              random_extra_property_c: 'hij',
+            },
+          ],
+          currency: 'USD',
+        },
+        timestamp: '2023-08-04T12:34:56Z',
+        anonymousId: 'abc',
+      },
+      {
+        sendPurchaseEventWithExtraProperties: false,
+      },
+    );
+    expect(output).toEqual([
+      {
+        product_id: '123',
+        price: 10.99,
+        currency: 'USD',
+        quantity: 2,
+        time: '2023-08-04T12:34:56Z',
+        _update_existing_only: false,
+        user_alias: {
+          alias_name: 'abc',
+          alias_label: 'rudder_id',
+        },
+      },
+      {
+        product_id: '456',
+        price: 5.49,
+        currency: 'USD',
+        quantity: 1,
+        time: '2023-08-04T12:34:56Z',
+        _update_existing_only: false,
+        user_alias: {
+          alias_name: 'abc',
+          alias_label: 'rudder_id',
+        },
+      },
+      {
+        product_id: '789',
+        price: 15.49,
+        currency: 'USD',
+        quantity: 1,
+        time: '2023-08-04T12:34:56Z',
         _update_existing_only: false,
         user_alias: {
           alias_name: 'abc',

--- a/src/v0/destinations/braze/config.js
+++ b/src/v0/destinations/braze/config.js
@@ -56,6 +56,7 @@ const BRAZE_NON_BILLABLE_ATTRIBUTES = [
   'subscription_groups',
 ];
 
+const BRAZE_PURCHASE_STANDARD_PROPERTIES = ['product_id', 'sku', 'price', 'quantity', 'currency'];
 module.exports = {
   ConfigCategory,
   mappingConfig,
@@ -64,6 +65,7 @@ module.exports = {
   getSubscriptionGroupEndPoint,
   getAliasMergeEndPoint,
   BRAZE_PARTNER_NAME,
+  BRAZE_PURCHASE_STANDARD_PROPERTIES,
   TRACK_BRAZE_MAX_REQ_COUNT,
   IDENTIFY_BRAZE_MAX_REQ_COUNT,
   DESTINATION,
@@ -71,5 +73,5 @@ module.exports = {
   DEL_MAX_BATCH_SIZE,
   BRAZE_NON_BILLABLE_ATTRIBUTES,
   ALIAS_BRAZE_MAX_REQ_COUNT,
-  SUBSCRIPTION_BRAZE_MAX_REQ_COUNT
+  SUBSCRIPTION_BRAZE_MAX_REQ_COUNT,
 };

--- a/src/v0/destinations/braze/transform.js
+++ b/src/v0/destinations/braze/transform.js
@@ -315,7 +315,7 @@ function processTrackEvent(messageType, message, destination, mappingJson, proce
     typeof eventName === 'string' &&
     eventName.toLowerCase() === 'order completed'
   ) {
-    const purchaseObjs = getPurchaseObjs(message);
+    const purchaseObjs = getPurchaseObjs(message, destination.Config);
 
     // del used properties
     delete properties.products;

--- a/src/v0/destinations/braze/util.js
+++ b/src/v0/destinations/braze/util.js
@@ -21,6 +21,7 @@ const {
   SUBSCRIPTION_BRAZE_MAX_REQ_COUNT,
   ALIAS_BRAZE_MAX_REQ_COUNT,
   TRACK_BRAZE_MAX_REQ_COUNT,
+  BRAZE_PURCHASE_STANDARD_PROPERTIES,
 } = require('./config');
 const { JSON_MIME_TYPE, HTTP_STATUS_CODES } = require('../../util/constant');
 const { isObject } = require('../../util');
@@ -539,7 +540,7 @@ function addMandatoryPurchaseProperties(productId, price, currencyCode, quantity
   };
 }
 
-function getPurchaseObjs(message, Config) {
+function getPurchaseObjs(message, config) {
   // ref:https://www.braze.com/docs/api/objects_filters/purchase_object/
   const validateForPurchaseEvent = (message) => {
     const { properties } = message;
@@ -634,8 +635,8 @@ function getPurchaseObjs(message, Config) {
       parseInt(quantity, 10),
       timestamp,
     );
-    const extraProperties = _.omit(product, ['product_id', 'sku', 'price', 'quantity', 'currency']);
-    if (Object.keys(extraProperties).length > 0 && Config.sendPurchaseEventWithExtraProperties) {
+    const extraProperties = _.omit(product, BRAZE_PURCHASE_STANDARD_PROPERTIES);
+    if (Object.keys(extraProperties).length > 0 && config.sendPurchaseEventWithExtraProperties) {
       purchaseObj = { ...purchaseObj, properties: extraProperties };
     }
     purchaseObj = setExternalIdOrAliasObject(purchaseObj, message);

--- a/src/v0/destinations/braze/util.js
+++ b/src/v0/destinations/braze/util.js
@@ -634,6 +634,10 @@ function getPurchaseObjs(message) {
       parseInt(quantity, 10),
       timestamp,
     );
+    const extraProperties = _.omit(product, ['product_id', 'sku', 'price', 'quantity', 'currency']);
+    if (Object.keys(extraProperties).length > 0) {
+      purchaseObj = { ...purchaseObj, properties: extraProperties };
+    }
     purchaseObj = setExternalIdOrAliasObject(purchaseObj, message);
     purchaseObjs.push(purchaseObj);
   });

--- a/src/v0/destinations/braze/util.js
+++ b/src/v0/destinations/braze/util.js
@@ -539,7 +539,7 @@ function addMandatoryPurchaseProperties(productId, price, currencyCode, quantity
   };
 }
 
-function getPurchaseObjs(message) {
+function getPurchaseObjs(message, Config) {
   // ref:https://www.braze.com/docs/api/objects_filters/purchase_object/
   const validateForPurchaseEvent = (message) => {
     const { properties } = message;
@@ -635,7 +635,7 @@ function getPurchaseObjs(message) {
       timestamp,
     );
     const extraProperties = _.omit(product, ['product_id', 'sku', 'price', 'quantity', 'currency']);
-    if (Object.keys(extraProperties).length > 0) {
+    if (Object.keys(extraProperties).length > 0 && Config.sendPurchaseEventWithExtraProperties) {
       purchaseObj = { ...purchaseObj, properties: extraProperties };
     }
     purchaseObj = setExternalIdOrAliasObject(purchaseObj, message);

--- a/test/__tests__/data/braze_input.json
+++ b/test/__tests__/data/braze_input.json
@@ -1814,5 +1814,101 @@
       "type": "track",
       "userId": "mickeyMouse"
     }
+  },
+  {
+    "destination": {
+      "Config": {
+        "restApiKey": "dummyApiKey",
+        "prefixProperties": true,
+        "useNativeSDK": false,
+        "sendPurchaseEventWithExtraProperties": true
+      },
+      "DestinationDefinition": {
+        "DisplayName": "Braze",
+        "ID": "1WhbSZ6uA3H5ChVifHpfL2H6sie",
+        "Name": "BRAZE"
+      },
+      "Enabled": true,
+      "ID": "1WhcOCGgj9asZu850HvugU2C3Aq",
+      "Name": "Braze",
+      "Transformations": []
+    },
+    "message": {
+      "anonymousId": "e6ab2c5e-2cda-44a9-a962-e2f67df78bca",
+      "channel": "web",
+      "context": {
+        "app": {
+          "build": "1.0.0",
+          "name": "RudderLabs JavaScript SDK",
+          "namespace": "com.rudderlabs.javascript",
+          "version": "1.0.5"
+        },
+        "ip": "0.0.0.0",
+        "library": {
+          "name": "RudderLabs JavaScript SDK",
+          "version": "1.0.5"
+        },
+        "locale": "en-GB",
+        "os": {
+          "name": "",
+          "version": ""
+        },
+        "screen": {
+          "density": 2
+        },
+        "traits": {
+          "city": "Disney",
+          "country": "USA",
+          "email": "mickey@disney.com",
+          "firstname": "Mickey"
+        },
+        "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.117 Safari/537.36"
+      },
+      "event": "Order Completed",
+      "integrations": {
+        "All": true
+      },
+      "messageId": "aa5f5e44-8756-40ad-ad1e-b0d3b9fa710a",
+      "originalTimestamp": "2020-01-24T06:29:02.367Z",
+      "properties": {
+        "affiliation": "Google Store",
+        "checkout_id": "fksdjfsdjfisjf9sdfjsd9f",
+        "coupon": "hasbros",
+        "currency": "USD",
+        "discount": 2.5,
+        "order_id": "50314b8e9bcf000000000000",
+        "products": [
+          {
+            "category": "Games",
+            "image_url": "https:///www.example.com/product/path.jpg",
+            "name": "Monopoly: 3rd Edition",
+            "price": 0,
+            "product_id": "507f1f77bcf86cd799439023",
+            "quantity": 1,
+            "sku": "45790-32",
+            "url": "https://www.example.com/product/path"
+          },
+          {
+            "category": "Games",
+            "name": "Uno Card Game",
+            "price": 0,
+            "product_id": "505bd76785ebb509fc183724",
+            "quantity": 2,
+            "sku": "46493-32"
+          }
+        ],
+        "revenue": 25,
+        "shipping": 3,
+        "subtotal": 22.5,
+        "tax": 2,
+        "total": 27.5
+      },
+      "receivedAt": "2020-01-24T11:59:02.403+05:30",
+      "request_ip": "[::1]:53712",
+      "sentAt": "2020-01-24T06:29:02.368Z",
+      "timestamp": "2020-01-24T11:59:02.402+05:30",
+      "type": "track",
+      "userId": ""
+    }
   }
 ]

--- a/test/__tests__/data/braze_output.json
+++ b/test/__tests__/data/braze_output.json
@@ -396,6 +396,12 @@
             "currency": "USD",
             "price": 0,
             "product_id": "507f1f77bcf86cd799439011",
+            "properties": {
+              "category": "Games",
+              "image_url": "https:///www.example.com/product/path.jpg",
+              "name": "Monopoly: 3rd Edition",
+              "url": "https://www.example.com/product/path"
+            },
             "quantity": 1,
             "time": "2020-01-24T11:59:02.402+05:30",
             "user_alias": {
@@ -408,6 +414,10 @@
             "currency": "USD",
             "price": 0,
             "product_id": "505bd76785ebb509fc183733",
+            "properties": {
+              "category": "Games",
+              "name": "Uno Card Game"
+            },
             "quantity": 2,
             "time": "2020-01-24T11:59:02.402+05:30",
             "user_alias": {
@@ -457,6 +467,12 @@
             "currency": "USD",
             "price": 0,
             "product_id": "507f1f77bcf86cd799439011",
+            "properties": {
+              "category": "Games",
+              "image_url": "https:///www.example.com/product/path.jpg",
+              "name": "Monopoly: 3rd Edition",
+              "url": "https://www.example.com/product/path"
+            },
             "quantity": 1,
             "time": "2020-01-24T11:59:02.402+05:30",
             "user_alias": {
@@ -469,6 +485,10 @@
             "currency": "USD",
             "price": 10,
             "product_id": "505bd76785ebb509fc183733",
+            "properties": {
+              "category": "Games",
+              "name": "Uno Card Game"
+            },
             "quantity": 2,
             "time": "2020-01-24T11:59:02.402+05:30",
             "user_alias": {
@@ -855,6 +875,12 @@
         "purchases": [
           {
             "product_id": "507f1f77bcf86cd799439011",
+            "properties": {
+              "category": "Games",
+              "image_url": "https:///www.example.com/product/path.jpg",
+              "name": "Monopoly: 3rd Edition",
+              "url": "https://www.example.com/product/path"
+            },
             "price": 0,
             "currency": "USD",
             "quantity": 1,

--- a/test/__tests__/data/braze_output.json
+++ b/test/__tests__/data/braze_output.json
@@ -396,12 +396,6 @@
             "currency": "USD",
             "price": 0,
             "product_id": "507f1f77bcf86cd799439011",
-            "properties": {
-              "category": "Games",
-              "image_url": "https:///www.example.com/product/path.jpg",
-              "name": "Monopoly: 3rd Edition",
-              "url": "https://www.example.com/product/path"
-            },
             "quantity": 1,
             "time": "2020-01-24T11:59:02.402+05:30",
             "user_alias": {
@@ -414,10 +408,6 @@
             "currency": "USD",
             "price": 0,
             "product_id": "505bd76785ebb509fc183733",
-            "properties": {
-              "category": "Games",
-              "name": "Uno Card Game"
-            },
             "quantity": 2,
             "time": "2020-01-24T11:59:02.402+05:30",
             "user_alias": {
@@ -467,12 +457,6 @@
             "currency": "USD",
             "price": 0,
             "product_id": "507f1f77bcf86cd799439011",
-            "properties": {
-              "category": "Games",
-              "image_url": "https:///www.example.com/product/path.jpg",
-              "name": "Monopoly: 3rd Edition",
-              "url": "https://www.example.com/product/path"
-            },
             "quantity": 1,
             "time": "2020-01-24T11:59:02.402+05:30",
             "user_alias": {
@@ -485,10 +469,6 @@
             "currency": "USD",
             "price": 10,
             "product_id": "505bd76785ebb509fc183733",
-            "properties": {
-              "category": "Games",
-              "name": "Uno Card Game"
-            },
             "quantity": 2,
             "time": "2020-01-24T11:59:02.402+05:30",
             "user_alias": {
@@ -875,12 +855,6 @@
         "purchases": [
           {
             "product_id": "507f1f77bcf86cd799439011",
-            "properties": {
-              "category": "Games",
-              "image_url": "https:///www.example.com/product/path.jpg",
-              "name": "Monopoly: 3rd Edition",
-              "url": "https://www.example.com/product/path"
-            },
             "price": 0,
             "currency": "USD",
             "quantity": 1,
@@ -989,5 +963,76 @@
     },
     "files": {},
     "userId": "mickeyMouse"
+  },
+  {
+    "body": {
+      "FORM": {},
+      "JSON": {
+        "attributes": [
+          {
+            "_update_existing_only": false,
+            "city": "Disney",
+            "country": "USA",
+            "email": "mickey@disney.com",
+            "firstname": "Mickey",
+            "user_alias": {
+              "alias_label": "rudder_id",
+              "alias_name": "e6ab2c5e-2cda-44a9-a962-e2f67df78bca"
+            }
+          }
+        ],
+        "partner": "RudderStack",
+        "purchases": [
+          {
+            "_update_existing_only": false,
+            "currency": "USD",
+            "price": 0,
+            "product_id": "507f1f77bcf86cd799439023",
+            "properties": {
+              "category": "Games",
+              "image_url": "https:///www.example.com/product/path.jpg",
+              "name": "Monopoly: 3rd Edition",
+              "url": "https://www.example.com/product/path"
+            },
+            "quantity": 1,
+            "time": "2020-01-24T11:59:02.402+05:30",
+            "user_alias": {
+              "alias_label": "rudder_id",
+              "alias_name": "e6ab2c5e-2cda-44a9-a962-e2f67df78bca"
+            }
+          },
+          {
+            "_update_existing_only": false,
+            "currency": "USD",
+            "price": 0,
+            "product_id": "505bd76785ebb509fc183724",
+            "properties": {
+              "category": "Games",
+              "name": "Uno Card Game"
+            },
+            "quantity": 2,
+            "time": "2020-01-24T11:59:02.402+05:30",
+            "user_alias": {
+              "alias_label": "rudder_id",
+              "alias_name": "e6ab2c5e-2cda-44a9-a962-e2f67df78bca"
+            }
+          }
+        ]
+      },
+      "JSON_ARRAY": {},
+      "XML": {}
+    },
+    "endpoint": "https://rest.fra-01.braze.eu/users/track",
+    "files": {},
+    "headers": {
+      "Accept": "application/json",
+      "Authorization": "Bearer dummyApiKey",
+      "Content-Type": "application/json"
+    },
+    "method": "POST",
+    "params": {},
+    "type": "REST",
+    "userId": "e6ab2c5e-2cda-44a9-a962-e2f67df78bca",
+    "version": "1"
   }
 ]


### PR DESCRIPTION
## Description of the change

Adding support for `properties` fields for Purchase events to Braze [ref](https://www.braze.com/docs/api/objects_filters/purchase_object/)

<img width="913" alt="Screenshot 2023-11-29 at 6 06 27 PM" src="https://github.com/rudderlabs/rudder-transformer/assets/25389167/362e3d60-3a43-4f52-b95f-2de7c8d106d0">

The `properties` field is mapped with all the extra fields perent in each of the `product` elements present in `Order Completed` event.

This change introduces additional data to be sent into Braze

Refer to linear ticket INT-1076 for further details

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
