### PR TITLE
fix(dm): add workspaceId in common metadata to be returned to the callers

### DIFF
--- a/src/services/userTransform.ts
+++ b/src/services/userTransform.ts
@@ -65,6 +65,7 @@ export class UserTransformService {
           sourceId: eventsToProcess[0]?.metadata?.sourceId,
           destinationId: eventsToProcess[0]?.metadata.destinationId,
           destinationType: eventsToProcess[0]?.metadata.destinationType,
+          workspaceId: eventsToProcess[0]?.metadata.workspaceId,
           messageIds,
         };
 


### PR DESCRIPTION
## Description of the change

When sending transformation requests from DMT service, we found that in some of the responses, we are not getting the workspaceId back to the caller. This is generating stats with empty workspaceId's in it and therefore, raising this PR to fix it.

Fixes: DAT-677

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
