### PR TITLE
fix: salesforce transformer proxy response handling issue for authorization flow

### DIFF
--- a/src/v0/destinations/salesforce/networkHandler.js
+++ b/src/v0/destinations/salesforce/networkHandler.js
@@ -1,14 +1,18 @@
 const { proxyRequest, prepareProxyRequest } = require('../../../adapters/network');
 const { processAxiosResponse } = require('../../../adapters/utils/networkUtils');
+const { LEGACY, OAUTH } = require('./config');
 const { salesforceResponseHandler } = require('./utils');
 
 const responseHandler = (destinationResponse, destType) => {
   const message = `Request for destination: ${destType} Processed Successfully`;
 
+  const authorizationFlow = destType === 'salesforce' ? LEGACY : OAUTH;
+
   salesforceResponseHandler(
     destinationResponse,
     'during Salesforce Response Handling',
     destinationResponse?.rudderJobMetadata?.destInfo?.authKey,
+    authorizationFlow
   );
 
   // else successfully return status as 200, message and original destination response

--- a/src/v0/destinations/salesforce/utils.js
+++ b/src/v0/destinations/salesforce/utils.js
@@ -33,7 +33,7 @@ const salesforceResponseHandler = (destResponse, sourceMessage, authKey, authori
     const matchErrorCode = (errorCode) =>
       response && Array.isArray(response) && response.some((resp) => resp?.errorCode === errorCode);
     if (status === 401 && authKey && matchErrorCode('INVALID_SESSION_ID')) {
-      if (authorizationFlow === OAUTH)  {
+      if (authorizationFlow === OAUTH) {
         throw new RetryableError(
           `${DESTINATION} Request Failed - due to "INVALID_SESSION_ID", (Retryable) ${sourceMessage}`,
           500,
@@ -41,8 +41,8 @@ const salesforceResponseHandler = (destResponse, sourceMessage, authKey, authori
           getAuthErrCategoryFromStCode(status),
         );
       }
-        // checking for invalid/expired token errors and evicting cache in that case
-        // rudderJobMetadata contains some destination info which is being used to evict the cache
+      // checking for invalid/expired token errors and evicting cache in that case
+      // rudderJobMetadata contains some destination info which is being used to evict the cache
       ACCESS_TOKEN_CACHE.del(authKey);
       throw new RetryableError(
         `${DESTINATION} Request Failed - due to "INVALID_SESSION_ID", (Retryable) ${sourceMessage}`,

--- a/src/v0/destinations/salesforce/utils.js
+++ b/src/v0/destinations/salesforce/utils.js
@@ -33,16 +33,22 @@ const salesforceResponseHandler = (destResponse, sourceMessage, authKey, authori
     const matchErrorCode = (errorCode) =>
       response && Array.isArray(response) && response.some((resp) => resp?.errorCode === errorCode);
     if (status === 401 && authKey && matchErrorCode('INVALID_SESSION_ID')) {
-      if (authorizationFlow === LEGACY) {
+      if (authorizationFlow === OAUTH)  {
+        throw new RetryableError(
+          `${DESTINATION} Request Failed - due to "INVALID_SESSION_ID", (Retryable) ${sourceMessage}`,
+          500,
+          destResponse,
+          getAuthErrCategoryFromStCode(status),
+        );
+      }
         // checking for invalid/expired token errors and evicting cache in that case
         // rudderJobMetadata contains some destination info which is being used to evict the cache
-        ACCESS_TOKEN_CACHE.del(authKey);
-      }
+      ACCESS_TOKEN_CACHE.del(authKey);
       throw new RetryableError(
         `${DESTINATION} Request Failed - due to "INVALID_SESSION_ID", (Retryable) ${sourceMessage}`,
         500,
         destResponse,
-        authorizationFlow === LEGACY ? '' : getAuthErrCategoryFromStCode(status),
+        '',
       );
     } else if (status === 403 && matchErrorCode('REQUEST_LIMIT_EXCEEDED')) {
       // If the error code is REQUEST_LIMIT_EXCEEDED, you’ve exceeded API request limits in your org.

--- a/src/v0/destinations/salesforce/utils.js
+++ b/src/v0/destinations/salesforce/utils.js
@@ -48,7 +48,6 @@ const salesforceResponseHandler = (destResponse, sourceMessage, authKey, authori
         `${DESTINATION} Request Failed - due to "INVALID_SESSION_ID", (Retryable) ${sourceMessage}`,
         500,
         destResponse,
-        '',
       );
     } else if (status === 403 && matchErrorCode('REQUEST_LIMIT_EXCEEDED')) {
       // If the error code is REQUEST_LIMIT_EXCEEDED, you’ve exceeded API request limits in your org.

--- a/src/v0/destinations/salesforce_oauth/networkHandler.js
+++ b/src/v0/destinations/salesforce_oauth/networkHandler.js
@@ -1,7 +1,7 @@
 const { proxyRequest, prepareProxyRequest } = require('../../../adapters/network');
 const { processAxiosResponse } = require('../../../adapters/utils/networkUtils');
-const { LEGACY } = require('./config');
-const { salesforceResponseHandler } = require('./utils');
+const { OAUTH } = require('../salesforce/config');
+const { salesforceResponseHandler } = require('../salesforce/utils');
 
 const responseHandler = (destinationResponse, destType) => {
   const message = `Request for destination: ${destType} Processed Successfully`;
@@ -10,7 +10,7 @@ const responseHandler = (destinationResponse, destType) => {
     destinationResponse,
     'during Salesforce Response Handling',
     destinationResponse?.rudderJobMetadata?.destInfo?.authKey,
-    LEGACY
+    OAUTH
   );
 
   // else successfully return status as 200, message and original destination response

--- a/test/__tests__/facebook_conversions.test.js
+++ b/test/__tests__/facebook_conversions.test.js
@@ -23,6 +23,8 @@ const outputRouterDataFile = fs.readFileSync(
 const inputRouterData = JSON.parse(inputRouterDataFile);
 const expectedRouterData = JSON.parse(outputRouterDataFile);
 
+Date.now = jest.fn(() => new Date("2023-11-12T15:46:51.000Z")); // 2023-11-12T15:46:51.693229+05:30
+
 describe(`${name} Tests`, () => {
   describe("Processor", () => {
     testData.forEach((dataPoint, index) => {

--- a/test/integrations/destinations/salesforce/dataDelivery/data.ts
+++ b/test/integrations/destinations/salesforce/dataDelivery/data.ts
@@ -119,7 +119,6 @@ export const data = [
         body: {
           output: {
             status: 500,
-            authErrorCategory: 'REFRESH_TOKEN',
             message:
               'Salesforce Request Failed - due to "INVALID_SESSION_ID", (Retryable) during Salesforce Response Handling',
             destinationResponse: {


### PR DESCRIPTION
## Description of the change

> Salesforce network handler was not sending `authorizationFlow` variable. We have added logic to set it. Also handled it specifically for salesforce ouath version, inside the `responseHandler` function

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
