### PR TITLE
fix: missing null check in braze populateCustomAttributesWithOperation

### DIFF
--- a/src/v0/destinations/braze/transform.js
+++ b/src/v0/destinations/braze/transform.js
@@ -95,7 +95,10 @@ function populateCustomAttributesWithOperation(
     // add,update,remove on json attributes
     if (enableNestedArrayOperations) {
       Object.keys(traits)
-        .filter((key) => typeof traits[key] === 'object' && !Array.isArray(traits[key]))
+        .filter(
+          (key) =>
+            traits[key] !== null && typeof traits[key] === 'object' && !Array.isArray(traits[key]),
+        )
         .forEach((key) => {
           if (traits[key][CustomAttributeOperationTypes.UPDATE]) {
             CustomAttributeOperationUtil.customAttributeUpdateOperation(


### PR DESCRIPTION
## What are the changes introduced in this PR?
Add null check in populateCustomAttributesWithOperation

## Please explain the objectives of your changes below

Found logs for this error:
Failure occurred during custom attributes operations TypeError: Cannot read properties of null (reading 'update')
so this change is to fix this error.
Fixes INT-1177
### Type of change

If the pull request is a **bug-fix**, **enhancement** or a **refactor**, please fill in the details on the changes made.

- Existing capabilities/behavior

- New capabilities/behavior

If the pull request is a **new feature**,

### Any technical or performance related pointers to consider with the change?

N/A

### Any new dependencies introduced with this change?

N/A

### Any new generic utility introduced or modified. Please explain the changes.

N/A

### If the PR has changes in more than 10 files, please mention why the changes were not split into multiple PRs.

N/A

### If multiple linear tasks are associated with the PR changes, please elaborate on the reason:

N/A

<hr>

### Developer checklist

- [x] **No breaking changes are being introduced.**

- [ ] Are all related docs linked with the PR?

- [ ] Are all changes manually tested?

- [ ] Does this change require any documentation changes?

- [ ] Are relevant unit and component test-cases added?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.
