### PR TITLE
fix: braze transformation error due to wrong import

### DIFF
--- a/src/v0/util/errorTypes/filteredEventsError.js
+++ b/src/v0/util/errorTypes/filteredEventsError.js
@@ -1,4 +1,4 @@
-const { BaseError } = require('./base');
+const { BaseError } = require('@rudderstack/integrations-lib');
 const { HTTP_STATUS_CODES } = require('../constant');
 
 class FilteredEventsError extends BaseError {

--- a/src/v0/util/errorTypes/transformerProxyError.js
+++ b/src/v0/util/errorTypes/transformerProxyError.js
@@ -1,5 +1,5 @@
+const { BaseError } = require('@rudderstack/integrations-lib');
 const tags = require('../tags');
-const { BaseError } = require('./base');
 
 const errorTypes = Object.values(tags.ERROR_TYPES);
 const metaTypes = Object.values(tags.METADATA);

--- a/src/v0/util/index.js
+++ b/src/v0/util/index.js
@@ -83,7 +83,7 @@ const isPrimitive = (arg) => {
 const isNewStatusCodesAccepted = (reqMetadata = {}) => {
   if (reqMetadata && typeof reqMetadata === 'object' && !Array.isArray(reqMetadata)) {
     const { features } = reqMetadata;
-    return !!(features && features[FEATURE_FILTER_CODE]);
+    return !!features?.[FEATURE_FILTER_CODE];
   }
   return false;
 };

--- a/src/v0/util/index.test.js
+++ b/src/v0/util/index.test.js
@@ -1,5 +1,7 @@
+const { TAG_NAMES } = require('@rudderstack/integrations-lib');
 const utilities = require('.');
 const { getFuncTestData } = require('../../../test/testHelper');
+const { FilteredEventsError } = require('./errorTypes');
 const { hasCircularReference, flattenJson } = require('./index');
 
 // Names of the utility functions to test
@@ -114,5 +116,13 @@ describe('flattenJson', () => {
     expect(() => flattenJson(data)).toThrow(
       "Event has circular reference. Can't flatten the event",
     );
+  });
+});
+
+describe('tests for generateErrorObject', () => {
+  test('test-0', () => {
+    const myErr = new FilteredEventsError('error-1');
+    const outputErrObj = utilities.generateErrorObject(myErr);
+    expect(outputErrObj.statTags).toEqual({});
   });
 });

--- a/test/__tests__/data/braze_router.json
+++ b/test/__tests__/data/braze_router.json
@@ -841,9 +841,7 @@
         },
         {
           "error": "[Braze Deduplication]: Duplicate user detected, the user is dropped",
-          "statTags": {
-            "errorCategory": "transformation"
-          },
+          "statTags": {},
           "statusCode": 298,
           "batched": false,
           "metadata": [


### PR DESCRIPTION
## What are the changes introduced in this PR?

In `FilteredEventsError` , we are using `BaseError` from `src/v0/util/errorTypes/base.js`
And in `generateErrorObject` we are using `instanceof` on `BaseError` from `integrations-lib`. Hence `instanceof` condition is failing & no matter what specific errorCategory is provided in the error, it is getting converted to `transformation` errorCategory.

This PR aims to fix this inconsistency

Resolves INT-1187

## Please explain the objectives of your changes below

- We have also fixed the import problem in `TransformerProxyError` class as well
- Used `?.` optional-chaining for evaluating if features contains filterCode feature

### Type of change

If the pull request is a **bug-fix**, **enhancement** or a **refactor**, please fill in the details on the changes made.

- Existing capabilities/behavior

- New capabilities/behavior

If the pull request is a **new feature**,

### Any technical or performance related pointers to consider with the change?

N/A

### Any new dependencies introduced with this change?

N/A

### Any new generic utility introduced or modified. Please explain the changes.

N/A

### If the PR has changes in more than 10 files, please mention why the changes were not split into multiple PRs.

N/A

### If multiple linear tasks are associated with the PR changes, please elaborate on the reason:

N/A

<hr>

### Developer checklist

- [x] **No breaking changes are being introduced.**

- [ ] Are all related docs linked with the PR?

- [x] Are all changes manually tested?

- [ ] Does this change require any documentation changes?

- [x] Are relevant unit and component test-cases added?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.
