### PR TITLE
feat(customerio): add timestamp conversion to unix based on config value

### DIFF
--- a/src/v0/destinations/customerio/transform.js
+++ b/src/v0/destinations/customerio/transform.js
@@ -24,6 +24,7 @@ const {
   groupResponseBuilder,
   defaultResponseBuilder,
   validateConfigFields,
+  convertTimestampsToUnix,
 } = require('./util');
 const { JSON_MIME_TYPE } = require('../../util/constant');
 
@@ -75,7 +76,10 @@ function responseBuilder(message, evType, evName, destination, messageType) {
       break;
   }
 
-  const payload = removeUndefinedValues(temporaryResponseDetails.rawPayload);
+  let payload = removeUndefinedValues(temporaryResponseDetails.rawPayload);
+  if (destination.Config.convertToUnix) {
+    payload = convertTimestampsToUnix(payload);
+  }
   response.endpoint = temporaryResponseDetails.endpoint;
   response.method = temporaryResponseDetails.requestConfig.requestMethod;
   response.body.JSON = payload;

--- a/test/integrations/destinations/customerio/processor/data.ts
+++ b/test/integrations/destinations/customerio/processor/data.ts
@@ -683,6 +683,7 @@ export const data = [
                 user_actual_role: 'system_admin',
                 user_actual_id: 12345,
                 user_time_spent: 50000,
+                customTimestamp: '2022-02-01T19:14:18.381Z',
               },
               integrations: {
                 All: true,
@@ -694,6 +695,7 @@ export const data = [
                 datacenter: 'US',
                 siteID: '46be54768e7d49ab2628',
                 apiKey: 'dummyApiKey',
+                convertToUnix: true,
               },
             },
           },
@@ -715,6 +717,7 @@ export const data = [
                     user_actual_id: 12345,
                     user_actual_role: 'system_admin',
                     user_time_spent: 50000,
+                    customTimestamp: 1643742858,
                   },
                   timestamp: 1571051718,
                   name: 'test track event',


### PR DESCRIPTION
## What are the changes introduced in this PR?

- This PR adds support for converting all the ISO 8601 timestamp values from transformed response to unix based on the boolean value for the field (`convertToUnix`) received from UI

## Please explain the objectives of your changes below

Put down any required details on the broader aspect of your changes. If there are any dependent changes, **mandatorily** mention them here

### Type of change

If the pull request is a **bug-fix**, **enhancement** or a **refactor**, please fill in the details on the changes made.

- Existing capabilities/behavior

- New capabilities/behavior

If the pull request is a **new feature**,

### Any technical or performance related pointers to consider with the change?

N/A

### Any new dependencies introduced with this change?

N/A

### Any new generic utility introduced or modified. Please explain the changes.

N/A

### If the PR has changes in more than 10 files, please mention why the changes were not split into multiple PRs.

N/A

### If multiple linear tasks are associated with the PR changes, please elaborate on the reason:

N/A

<hr>

### Developer checklist

- [ ] **No breaking changes are being introduced.**

- [ ] Are all related docs linked with the PR?

- [ ] Are all changes manually tested?

- [ ] Does this change require any documentation changes?

- [ ] Are relevant unit and component test-cases added?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.
