### PR TITLE
fix: ortto remove phn:phone field if no phone is there in payload

### DIFF
--- a/src/cdk/v2/destinations/ortto/procWorkflow.yaml
+++ b/src/cdk/v2/destinations/ortto/procWorkflow.yaml
@@ -47,7 +47,7 @@ steps:
           "dtz::b": $.getBirthdayObj({{{{$.getGenericPaths("birthday")}}}}),
           "str::ei": {{{{$.getGenericPaths("userId")}}}},
           "str::language": .context.traits.language || .context.locale,
-          "phn::phone": phone ? {"n": phone} : undefined,
+          "phn::phone": phone ? {"n": phone},
           "bol::gdpr": .context.traits.gdpr ?? true,
           "bol::p": .context.traits.emailConsent || false,
           "bol::sp": .context.traits.smsConsent || false,
@@ -58,7 +58,6 @@ steps:
               const trimmedOrttoAttribute = attribute.orttoAttribute.trim().toLowerCase().replace(new RegExp('\\s+', 'g'),'-');
               commonFields.fields[$.fieldTypeMap[attribute.type]+":cm:"+trimmedOrttoAttribute] = $.originalInput.message.context.traits[attribute.rudderTraits]
             )[]
-      console.log("ABVC",commonFields.fields["phn::phone"])
       commonFields.fields = $.removeUndefinedAndNullValues(commonFields.fields)
       $.removeUndefinedAndNullValues(commonFields)
 

--- a/src/cdk/v2/destinations/ortto/procWorkflow.yaml
+++ b/src/cdk/v2/destinations/ortto/procWorkflow.yaml
@@ -34,6 +34,7 @@ steps:
     description: |
       Builds common fields in destination payload.
     template: |
+      let phone = .message.().({{{{$.getGenericPaths("phone")}}}});
       let commonFields = .message.().({
         "fields": { 
           "str::first": {{{{$.getGenericPaths("firstName")}}}}, 
@@ -46,7 +47,7 @@ steps:
           "dtz::b": $.getBirthdayObj({{{{$.getGenericPaths("birthday")}}}}),
           "str::ei": {{{{$.getGenericPaths("userId")}}}},
           "str::language": .context.traits.language || .context.locale,
-          "phn::phone": {"n": {{{{$.getGenericPaths("phone")}}}}},
+          "phn::phone": phone ? {"n": phone} : undefined,
           "bol::gdpr": .context.traits.gdpr ?? true,
           "bol::p": .context.traits.emailConsent || false,
           "bol::sp": .context.traits.smsConsent || false,
@@ -57,6 +58,7 @@ steps:
               const trimmedOrttoAttribute = attribute.orttoAttribute.trim().toLowerCase().replace(new RegExp('\\s+', 'g'),'-');
               commonFields.fields[$.fieldTypeMap[attribute.type]+":cm:"+trimmedOrttoAttribute] = $.originalInput.message.context.traits[attribute.rudderTraits]
             )[]
+      console.log("ABVC",commonFields.fields["phn::phone"])
       commonFields.fields = $.removeUndefinedAndNullValues(commonFields.fields)
       $.removeUndefinedAndNullValues(commonFields)
 

--- a/test/integrations/destinations/ortto/processor/data.ts
+++ b/test/integrations/destinations/ortto/processor/data.ts
@@ -1070,6 +1070,220 @@ export const data = [
   },
   {
     name: 'ortto',
+    description: 'Track call for updating activities with no phone provided',
+    feature: 'processor',
+    module: 'destination',
+    version: 'v0',
+    input: {
+      request: {
+        body: [
+          {
+            destination: {
+              DestinationDefinition: {
+                Config: {
+                  cdkV2Enabled: true,
+                },
+              },
+              ID: '1pYpzzvcn7AQ2W9GGIAZSsN6Mfq',
+              Name: 'ORTTO',
+              Config: {
+                privateApiKey: 'dummyApiKey',
+                instanceRegion: 'other',
+                orttoEventsMapping: [
+                  {
+                    rsEventName: 'RudderEvent',
+                    orttoEventName: 'Ortto Event',
+                    eventProperties: [
+                      {
+                        rudderProperty: 'RudderProp',
+                        orttoProperty: 'OrttoProp',
+                        type: 'text',
+                      },
+                      {
+                        rudderProperty: 'RudderProp',
+                        orttoProperty: 'OrttoProp',
+                        type: 'longText',
+                      },
+                    ],
+                  },
+                ],
+                orttoPersonAttributes: [
+                  {
+                    rudderTraits: 'ruddertrait0',
+                    orttoAttribute: 'ortto attirbute0',
+                    type: 'email',
+                  },
+                  {
+                    rudderTraits: 'ruddertrait1',
+                    orttoAttribute: 'ortto attirbute1',
+                    type: 'email',
+                  },
+                ],
+              },
+              Enabled: true,
+              Transformations: [],
+            },
+            metadata: { destintionId: '1pYpzzvcn7AQ2W9GGIAZSsN6Mfq', jobId: 2 },
+            message: {
+              anonymousId: '8d872292709c6fbe',
+              channel: 'mobile',
+              context: {
+                app: {
+                  build: '1',
+                  name: 'AMTestProject',
+                  namespace: 'com.rudderstack.android.rudderstack.sampleAndroidApp',
+                  version: '1.0',
+                },
+                device: {
+                  id: '8d872292709c6fbe',
+                  manufacturer: 'Google',
+                  model: 'AOSPonIAEmulator',
+                  name: 'generic_x86_arm',
+                  type: 'android',
+                },
+                library: {
+                  name: 'com.rudderstack.android.sdk.core',
+                  version: '1.0.2',
+                },
+                locale: 'en-US',
+                network: {
+                  carrier: 'Android',
+                  bluetooth: false,
+                  cellular: true,
+                  wifi: true,
+                },
+                os: {
+                  name: 'Android',
+                  version: '9',
+                },
+                screen: {
+                  density: 420,
+                  height: 1794,
+                  width: 1080,
+                },
+                timezone: 'Asia/Kolkata',
+                traits: {
+                  ruddertrait0: 'abc',
+                  ruddertrait1: 'def',
+                  address: {
+                    city: 'Kolkata',
+                    country: 'India',
+                    postalcode: '700096',
+                    state: 'West bengal',
+                    street: 'Park Street',
+                  },
+                  age: '30',
+                  anonymousId: '8d872292709c6fbe',
+                  birthday: '2020-05-26',
+                  createDate: '18th March 2020',
+                  description: 'Premium User for 3 years',
+                  email: 'identify@test.com',
+                  firstname: 'John',
+                  gdpr: false,
+                  userId: 'sample_user_id',
+                  lastname: 'Sparrow',
+                  name: 'John Sparrow',
+                  id: 'sample_user_id',
+                  username: 'john_sparrow',
+                },
+                userAgent:
+                  'Dalvik/2.1.0 (Linux; U; Android 9; AOSP on IA Emulator Build/PSR1.180720.117)',
+              },
+              event: 'RudderEvent',
+              integrations: {
+                All: true,
+              },
+              messageId: '1590431830915-73bed370-5889-436d-9a9e-0c0e0c809d06',
+              properties: {
+                revenue: '30',
+                RudderProp: 'USD',
+                quantity: '5',
+                test_key_2: {
+                  test_child_key_1: 'test_child_value_1',
+                },
+                price: '58.0',
+              },
+              originalTimestamp: '2020-05-25T18:37:10.917Z',
+              type: 'track',
+              userId: 'sample_user_id',
+            },
+          },
+        ],
+        method: 'POST',
+      },
+      pathSuffix: '',
+    },
+    output: {
+      response: {
+        status: 200,
+        body: [
+          {
+            output: {
+              version: '1',
+              type: 'REST',
+              method: 'POST',
+              endpoint: 'https://api.ap3api.com/v1/activities/create',
+              headers: {
+                'X-Api-Key': 'dummyApiKey',
+                'Content-Type': 'application/json',
+              },
+              params: {},
+              body: {
+                JSON: {
+                  activities: [
+                    {
+                      fields: {
+                        'str::first': 'John',
+                        'str::last': 'Sparrow',
+                        'str::email': 'identify@test.com',
+                        'geo::city': {
+                          name: 'Kolkata',
+                        },
+                        'geo::country': {},
+                        'geo::region': {},
+                        'dtz::b': {
+                          day: 26,
+                          month: 5,
+                          year: 2020,
+                        },
+                        'str::postal': '700096',
+                        'str::language': 'en-US',
+                        'str::ei': 'sample_user_id',
+                        'bol::gdpr': false,
+                        'bol::p': false,
+                        'bol::sp': false,
+                        'str:cm:ortto-attirbute0': 'abc',
+                        'str:cm:ortto-attirbute1': 'def',
+                      },
+                      activity_id: 'act:cm:ortto-event',
+                      attributes: {
+                        'str:cm:orttoprop': 'USD',
+                        'txt:cm:orttoprop': 'USD',
+                      },
+                      location: {},
+                    },
+                  ],
+                  merge_by: ['str::ei', 'str::email'],
+                },
+                JSON_ARRAY: {},
+                XML: {},
+                FORM: {},
+              },
+              files: {},
+              userId: '',
+            },
+            metadata: {
+              destintionId: '1pYpzzvcn7AQ2W9GGIAZSsN6Mfq',
+              jobId: 2,
+            },
+            statusCode: 200,
+          },
+        ],
+      },
+    },
+  },
+  {
+    name: 'ortto',
     description: 'Track call for updating activities',
     feature: 'processor',
     module: 'destination',


### PR DESCRIPTION
## What are the changes introduced in this PR?
When there is no phone field provided we were previously sending `phn:phone ={}` which was resulting in error as ` empty phone value for phn::phone"`.
In this PR we have put a check that if no phone field is provided we won't map it and there won't be any phn:phone field getting delivered to ortto.

## What is the related Linear task?

Resolves INT-1293

## Please explain the objectives of your changes below
This change will result in successful delivery of jobs when there is no phone provided in the payload

Put down any required details on the broader aspect of your changes. If there are any dependent changes, **mandatorily** mention them here

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

We won't be mapping `phn:phone `field even there is nothing to map

### Any new dependencies introduced with this change?

N/A

### Any new generic utility introduced or modified. Please explain the changes.

N/A

### Any technical or performance related pointers to consider with the change?

N/A

<hr>

### Developer checklist

- [x] My code follows the style guidelines of this project

- [x] **No breaking changes are being introduced.**

- [x] All related docs linked with the PR?

- [x] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [x] Is the PR limited to 10 file changes?

- [x] Is the PR limited to one linear task?

- [x] Are relevant unit and component test-cases added?

### Reviewer checklist

- [x] Is the type of change in the PR title appropriate as per the changes?

- [x] Verified that there are no credentials or confidential data exposed with the changes.
