### PR TITLE
fix: api contract for v1 proxy

### DIFF
--- a/src/controllers/delivery.ts
+++ b/src/controllers/delivery.ts
@@ -1,6 +1,7 @@
 /* eslint-disable prefer-destructuring */
 /* eslint-disable sonarjs/no-duplicate-string */
 import { Context } from 'koa';
+import { isDefinedAndNotNullAndNotEmpty } from '@rudderstack/integrations-lib';
 import { MiscService } from '../services/misc';
 import {
   DeliveryV1Response,
@@ -84,7 +85,11 @@ export class DeliveryController {
       );
     }
     ctx.body = { output: deliveryResponse };
-    ControllerUtility.deliveryPostProcess(ctx, deliveryResponse.status);
+    if (isDefinedAndNotNullAndNotEmpty(deliveryResponse.authErrorCategory)) {
+      ControllerUtility.deliveryPostProcess(ctx, deliveryResponse.status);
+    } else {
+      ControllerUtility.deliveryPostProcess(ctx);
+    }
 
     logger.debug('Native(Delivery):: Response from transformer::', JSON.stringify(ctx.body));
     return ctx;

--- a/src/services/destination/postTransformation.ts
+++ b/src/services/destination/postTransformation.ts
@@ -186,9 +186,11 @@ export class DestinationPostTransformationService {
     const resp = {
       response: responses,
       statTags: errObj.statTags,
-      authErrorCategory: errObj.authErrorCategory,
       message: errObj.message.toString(),
       status: errObj.status,
+      ...(errObj.authErrorCategory && {
+        authErrorCategory: errObj.authErrorCategory,
+      }),
     } as DeliveryV1Response;
 
     ErrorReportingService.reportError(error, metaTo.errorContext, resp);

--- a/test/integrations/destinations/braze/dataDelivery/data.ts
+++ b/test/integrations/destinations/braze/dataDelivery/data.ts
@@ -629,7 +629,7 @@ export const data = [
     },
     output: {
       response: {
-        status: 401,
+        status: 200,
         body: {
           output: {
             status: 401,
@@ -662,7 +662,6 @@ export const data = [
               module: 'destination',
               workspaceId: '2Csl0lSTbuM3qyHdaOQB2GcDH8o',
             },
-            authErrorCategory: '',
             message: 'Request failed for braze with status: 401',
           },
         },
@@ -770,7 +769,7 @@ export const data = [
     },
     output: {
       response: {
-        status: 401,
+        status: 200,
         body: {
           output: {
             status: 401,
@@ -840,7 +839,6 @@ export const data = [
               module: 'destination',
               workspaceId: '2Csl0lSTbuM3qyHdaOQB2GcDH8o',
             },
-            authErrorCategory: '',
             message: 'Request failed for braze with status: 401',
           },
         },

--- a/test/integrations/destinations/campaign_manager/dataDelivery/other.ts
+++ b/test/integrations/destinations/campaign_manager/dataDelivery/other.ts
@@ -252,7 +252,7 @@ export const otherScenariosV1 = [
     },
     output: {
       response: {
-        status: 500,
+        status: 200,
         body: {
           output: {
             response: [
@@ -284,7 +284,6 @@ export const otherScenariosV1 = [
               destinationId: 'default-destinationId',
               workspaceId: 'default-workspaceId',
             },
-            authErrorCategory: '',
             message:
               'Campaign Manager: Error transformer proxy v1 during CAMPAIGN_MANAGER response transformation',
             status: 500,
@@ -312,7 +311,7 @@ export const otherScenariosV1 = [
     },
     output: {
       response: {
-        status: 500,
+        status: 200,
         body: {
           output: {
             response: [
@@ -343,7 +342,6 @@ export const otherScenariosV1 = [
               destinationId: 'default-destinationId',
               workspaceId: 'default-workspaceId',
             },
-            authErrorCategory: '',
             message:
               'Campaign Manager: Error transformer proxy v1 during CAMPAIGN_MANAGER response transformation',
             status: 500,
@@ -371,7 +369,7 @@ export const otherScenariosV1 = [
     },
     output: {
       response: {
-        status: 500,
+        status: 200,
         body: {
           output: {
             response: [
@@ -402,7 +400,6 @@ export const otherScenariosV1 = [
               destinationId: 'default-destinationId',
               workspaceId: 'default-workspaceId',
             },
-            authErrorCategory: '',
             message:
               'Campaign Manager: Error transformer proxy v1 during CAMPAIGN_MANAGER response transformation',
             status: 500,
@@ -430,7 +427,7 @@ export const otherScenariosV1 = [
     },
     output: {
       response: {
-        status: 500,
+        status: 200,
         body: {
           output: {
             response: [
@@ -461,7 +458,6 @@ export const otherScenariosV1 = [
               destinationId: 'default-destinationId',
               workspaceId: 'default-workspaceId',
             },
-            authErrorCategory: '',
             message:
               'Campaign Manager: Error transformer proxy v1 during CAMPAIGN_MANAGER response transformation',
             status: 500,
@@ -490,7 +486,7 @@ export const otherScenariosV1 = [
     },
     output: {
       response: {
-        status: 500,
+        status: 200,
         body: {
           output: {
             response: [
@@ -521,7 +517,6 @@ export const otherScenariosV1 = [
               destinationId: 'default-destinationId',
               workspaceId: 'default-workspaceId',
             },
-            authErrorCategory: '',
             message:
               'Campaign Manager: Error transformer proxy v1 during CAMPAIGN_MANAGER response transformation',
             status: 500,


### PR DESCRIPTION
As discussed, as per contract changes only in case of oauth error we will be sending non 200 status code from transformer apart from that all scenarios for v1 proxy will return 200

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling for delivery processes, including more precise identification and categorization of authentication errors.

- **Bug Fixes**
	- Corrected response status codes in test environments for more accurate testing scenarios.

- **Refactor**
	- Improved code efficiency and readability in delivery and post-transformation processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->