### PR TITLE
fix: Send FullStory user.uid field instead of user.id

### DIFF
--- a/src/cdk/v2/destinations/fullstory/procWorkflow.yaml
+++ b/src/cdk/v2/destinations/fullstory/procWorkflow.yaml
@@ -10,7 +10,7 @@ steps:
   - name: validateInput
     template: |
       $.assert(.message.type, "message Type is not present. Aborting message.");
-      $.assert(.message.type in {{$.EventType.([.TRACK, .IDENTIFY])}}, 
+      $.assert(.message.type in {{$.EventType.([.TRACK, .IDENTIFY])}},
         "message type " + .message.type + " is not supported");
   - name: prepareContext
     template: |
@@ -76,7 +76,7 @@ steps:
         "use_most_recent": .message.properties.useMostRecent,
       };
       $.context.payload.user = {
-        "id": .message.properties.userId ?? .message.userId,
+        "uid": .message.properties.userId ?? .message.userId,
       }
 
   - name: cleanPayload


### PR DESCRIPTION
## What are the changes introduced in this PR?

This fixes an inconsistency in how Rudderstack was sending user IDs to FullStory for `track` events.


## What is the related Linear task?

N/A

## Please explain the objectives of your changes below

[In the documentation](https://www.rudderstack.com/docs/destinations/streaming-destinations/fullstory/cloud-mode/#user), it says that the `userId` field on the outgoing Rudderstack event is transformed into the `user.uid` field on the outgoing FullStory Create Event request. In practice, the `userId` field was being transformed into the `user.id` field, which carries a different meaning.

According to [the FullStory docs](https://developer.fullstory.com/server/events/create-event/), the `user.uid` represents the "application-assigned user identifier", whereas the `user.id` represents the _FullStory-assigned_ user identifier.

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

N/A

### Any new dependencies introduced with this change?

N/A

### Any new generic utility introduced or modified. Please explain the changes.

N/A

### Any technical or performance related pointers to consider with the change?

N/A

@coderabbitai review

<hr>

### Developer checklist

- [X] My code follows the style guidelines of this project

- [X] **No breaking changes are being introduced.**

- [X] All related docs linked with the PR?

- [X] All changes manually tested?

- [X] Any documentation changes needed with this change?

- [X] Is the PR limited to 10 file changes?

- [X] Is the PR limited to one linear task?

- [X] Are relevant unit and component test-cases added?

### Reviewer checklist

- [X] Is the type of change in the PR title appropriate as per the changes?

- [X] Verified that there are no credentials or confidential data exposed with the changes.
