### PR TITLE
feat: add support for subscribing for RETL flow

### DIFF
--- a/src/v0/destinations/klaviyo/klaviyoUtil.test.js
+++ b/src/v0/destinations/klaviyo/klaviyoUtil.test.js
@@ -1,0 +1,156 @@
+const { addSubscribeFlagToTraits } = require('./util');
+
+describe('addSubscribeFlagToTraits', () => {
+  // The function should add a 'subscribe' property to the 'properties' object if it exists in the input 'traitsInfo'.
+  it('should add subscribe property to properties object when it exists in traitsInfo', () => {
+    // Arrange
+    const traitsInfo = {
+      properties: {
+        name: 'John',
+        age: 30,
+      },
+    };
+
+    // Act
+    const result = addSubscribeFlagToTraits(traitsInfo);
+
+    // Assert
+    expect(result.properties.subscribe).toBe(true);
+  });
+
+  // The input 'traitsInfo' object is null.
+  it('should create a new traitsInfo object with properties object containing subscribe property when traitsInfo is null', () => {
+    // Arrange
+    const traitsInfo = null;
+
+    // Act
+    const result = addSubscribeFlagToTraits(traitsInfo);
+
+    // Assert
+    expect(result).toEqual(null);
+  });
+
+  // The function should create a new 'properties' object with a 'subscribe' property and assign it to the 'traitsInfo' if 'properties' does not exist in the input 'traitsInfo'.
+  it("should create a new 'properties' object with a 'subscribe' property when 'properties' does not exist in traitsInfo", () => {
+    // Arrange
+    const traitsInfo = {};
+
+    // Act
+    const result = addSubscribeFlagToTraits(traitsInfo);
+
+    // Assert
+    expect(result.properties).toBeDefined();
+    expect(result.properties.subscribe).toBe(true);
+  });
+
+  // The function should return the modified 'traitsInfo' object with the 'subscribe' property added.
+  it('should add subscribe property to properties object when it exists in traitsInfo', () => {
+    // Arrange
+    const traitsInfo = {
+      properties: {
+        name: 'John',
+        age: 30,
+      },
+    };
+
+    // Act
+    const result = addSubscribeFlagToTraits(traitsInfo);
+
+    // Assert
+    expect(result.properties.subscribe).toBe(true);
+  });
+
+  // The input 'traitsInfo' object has an empty 'properties' object.
+  it('should add subscribe property to properties object when it exists in traitsInfo', () => {
+    // Arrange
+    const traitsInfo = {
+      properties: {},
+    };
+
+    // Act
+    const result = addSubscribeFlagToTraits(traitsInfo);
+
+    // Assert
+    expect(result.properties.subscribe).toBe(true);
+  });
+
+  // The input 'traitsInfo' object has a 'properties' object with a 'subscribe' property already present.
+  it('should add subscribe property to properties object when it exists in traitsInfo', () => {
+    // Arrange
+    const traitsInfo = {
+      properties: {
+        name: 'John',
+        age: 30,
+        subscribe: false,
+      },
+    };
+
+    // Act
+    const result = addSubscribeFlagToTraits(traitsInfo);
+
+    // Assert
+    expect(result.properties.subscribe).toBe(false);
+  });
+
+  // The function should not modify any other properties of the 'traitsInfo' object.
+  it('should not modify any other properties of the traitsInfo object', () => {
+    // Arrange
+    const traitsInfo = {
+      properties: {
+        name: 'John',
+        age: 30,
+      },
+    };
+
+    // Act
+    const result = addSubscribeFlagToTraits(traitsInfo);
+
+    // Assert
+    expect(result.properties.subscribe).toBe(true);
+    expect(result.properties.name).toBe('John');
+    expect(result.properties.age).toBe(30);
+  });
+
+  // The function should handle cases where the input 'traitsInfo' object has nested objects.
+  it('should add subscribe property to nested properties object when it exists in traitsInfo', () => {
+    // Arrange
+    const traitsInfo = {
+      properties: {
+        name: 'John',
+        age: 30,
+        address: {
+          street: '123 Main St',
+          city: 'New York',
+        },
+      },
+    };
+
+    // Act
+    const result = addSubscribeFlagToTraits(traitsInfo);
+
+    // Assert
+    expect(result.properties.subscribe).toBe(true);
+    expect(result.properties.address).toMatchObject({
+      street: '123 Main St',
+      city: 'New York',
+    });
+  });
+
+  // The function should handle cases where the input 'traitsInfo' object has properties with null or undefined values.
+  it('should add subscribe property to properties object when it exists in traitsInfo', () => {
+    // Arrange
+    const traitsInfo = {
+      properties: {
+        name: 'John',
+        age: 30,
+        address: null,
+      },
+    };
+
+    // Act
+    const result = addSubscribeFlagToTraits(traitsInfo);
+
+    // Assert
+    expect(result.properties.subscribe).toBe(true);
+  });
+});

--- a/src/v0/destinations/klaviyo/transform.js
+++ b/src/v0/destinations/klaviyo/transform.js
@@ -20,6 +20,7 @@ const {
   batchSubscribeEvents,
   getIdFromNewOrExistingProfile,
   profileUpdateResponseBuilder,
+  addSubcribeFlagToTraits,
 } = require('./util');
 const {
   defaultRequestConfig,
@@ -55,11 +56,13 @@ const identifyRequestHandler = async (message, category, destination, reqMetadat
   // If listId property is present try to subscribe/member user in list
   const { privateApiKey, enforceEmailAsPrimary, listId, flattenProperties } = destination.Config;
   const mappedToDestination = get(message, MappedToDestinationKey);
+  let traitsInfo = getFieldValueFromMessage(message, 'traits');
   if (mappedToDestination) {
     addExternalIdToTraits(message);
     adduserIdFromExternalId(message);
+    traitsInfo = addSubcribeFlagToTraits(traitsInfo);
   }
-  const traitsInfo = getFieldValueFromMessage(message, 'traits');
+
   let propertyPayload = constructPayload(message, MAPPING_CONFIG[category.name]);
   // Extract other K-V property from traits about user custom properties
   let customPropertyPayload = {};

--- a/src/v0/destinations/klaviyo/util.js
+++ b/src/v0/destinations/klaviyo/util.js
@@ -1,6 +1,10 @@
 const { defaultRequestConfig } = require('rudder-transformer-cdk/build/utils');
 const lodash = require('lodash');
-const { NetworkError, InstrumentationError } = require('@rudderstack/integrations-lib');
+const {
+  NetworkError,
+  InstrumentationError,
+  isDefinedAndNotNull,
+} = require('@rudderstack/integrations-lib');
 const { WhiteListedTraits } = require('../../../constants');
 
 const {
@@ -305,6 +309,28 @@ const batchSubscribeEvents = (subscribeRespList) => {
   return batchedResponseList;
 };
 
+const addSubscribeFlagToTraits = (traitsInfo) => {
+  let traits = traitsInfo;
+  if (!isDefinedAndNotNull(traits)) {
+    return traits;
+  }
+  // check if properties already contains subscribe flag
+
+  if (traits.properties) {
+    if (traits.properties.subscribe === undefined) {
+      traits.properties.subscribe = true;
+    } else {
+      // return if subscribe flag is already present
+      return traits;
+    }
+  } else {
+    traits = {
+      properties: { subscribe: true },
+    };
+  }
+  return traits;
+};
+
 module.exports = {
   subscribeUserToList,
   createCustomerProperties,
@@ -313,4 +339,5 @@ module.exports = {
   batchSubscribeEvents,
   profileUpdateResponseBuilder,
   getIdFromNewOrExistingProfile,
+  addSubscribeFlagToTraits,
 };


### PR DESCRIPTION
Adding subscribe flag default as true for traits properties object for vdm scenario

## What are the changes introduced in this PR?

For RETL VDM flow adding subscribe as true for enabling subscription flow whenever listId is present

## What is the related Linear task?

Resolves INT-578

## Please explain the objectives of your changes below

Put down any required details on the broader aspect of your changes. If there are any dependent changes, **mandatorily** mention them here

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

N/A

### Any new dependencies introduced with this change?

N/A

### Any new generic utility introduced or modified. Please explain the changes.

N/A

### Any technical or performance related pointers to consider with the change?

N/A

@coderabbitai review

<hr>

### Developer checklist

- [ ] My code follows the style guidelines of this project

- [ ] **No breaking changes are being introduced.**

- [ ] All related docs linked with the PR?

- [ ] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [ ] Is the PR limited to 10 file changes?

- [ ] Is the PR limited to one linear task?

- [ ] Are relevant unit and component test-cases added?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.
