### PR TITLE
fix: marketo bulk ignore null while checking data type mismatch

### DIFF
--- a/src/v0/destinations/marketo_bulk_upload/marketo_bulk_upload.util.test.js
+++ b/src/v0/destinations/marketo_bulk_upload/marketo_bulk_upload.util.test.js
@@ -514,7 +514,7 @@ describe('checkEventStatusViaSchemaMatching', () => {
   });
 
   // The function correctly handles events with null values.
-  it('should correctly handle events with null values', () => {
+  it('should ignore event properties with null values', () => {
     const event = {
       input: [
         {
@@ -537,8 +537,6 @@ describe('checkEventStatusViaSchemaMatching', () => {
 
     const result = checkEventStatusViaSchemaMatching(event, fieldSchemaMapping);
 
-    expect(result).toEqual({
-      job1: 'invalid id',
-    });
+    expect(result).toEqual({});
   });
 });

--- a/src/v0/destinations/marketo_bulk_upload/util.js
+++ b/src/v0/destinations/marketo_bulk_upload/util.js
@@ -3,6 +3,7 @@ const {
   RetryableError,
   NetworkError,
   TransformationError,
+  isDefinedAndNotNull,
 } = require('@rudderstack/integrations-lib');
 const { handleHttpRequest } = require('../../../adapters/network');
 const tags = require('../../util/tags');
@@ -360,7 +361,6 @@ const getFieldSchemaMap = async (accessToken, munchkinId) => {
       module: 'router',
     },
   );
-
   if (fieldSchemaMapping.response.errors) {
     handleCommonErrorResponse(
       fieldSchemaMapping,
@@ -411,7 +411,11 @@ const checkEventStatusViaSchemaMatching = (event, fieldMap) => {
       const expectedDataType = SCHEMA_DATA_TYPE_MAP[fieldMap[paramName]];
       const actualDataType = typeof paramValue;
 
-      if (!mismatchedFields[job_id] && actualDataType !== expectedDataType) {
+      if (
+        isDefinedAndNotNull(paramValue) &&
+        !mismatchedFields[job_id] &&
+        actualDataType !== expectedDataType
+      ) {
         mismatchedFields[job_id] = `invalid ${paramName}`;
       }
     });


### PR DESCRIPTION
## What are the changes introduced in this PR?

If any data fails ( warning or failure ), which eventually activates the fetch job status route, we do a line-by-line data type match to find the warnings beforehand to reduce dependency on the clumsy error response that Marketo sends.

In our previous implementation, we also considered the data with null values in this data matching operation, which led to unwanted failures for even those data points where the user chose not to send any data, rather sending a `null` value. 

That is why we are checking if the data that the user sent, is defined and not null, then only to perform the data type match check.

## What is the related Linear task?

Resolves INT-1872

## Please explain the objectives of your changes below

Put down any required details on the broader aspect of your changes. If there are any dependent changes, **mandatorily** mention them here

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

N/A

### Any new dependencies introduced with this change?

N/A

### Any new generic utility introduced or modified. Please explain the changes.

N/A

### Any technical or performance related pointers to consider with the change?

N/A

@coderabbitai review

<hr>

### Developer checklist

- [x] My code follows the style guidelines of this project

- [x] **No breaking changes are being introduced.**

- [ ] All related docs linked with the PR?

- [x] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [x] Is the PR limited to 10 file changes?

- [x] Is the PR limited to one linear task?

- [x] Are relevant unit and component test-cases added?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.
