### PR TITLE
fix: hubspot: hs_additional_email comparision logic

### DIFF
--- a/src/v0/destinations/hs/util.js
+++ b/src/v0/destinations/hs/util.js
@@ -752,11 +752,18 @@ const splitEventsForCreateUpdate = async (inputs, destination) => {
     }
     const secondaryProp = primaryToSecondaryFields[identifierType];
     if (secondaryProp) {
-      // second condition is for secondary property for identifier type
+      /* second condition is for secondary property for identifier type
+       For example:
+       update[secondaryProp] = "abc@e.com;cd@e.com;k@w.com"
+       destinationExternalId = "cd@e.com"
+       So we are splitting all the emails in update[secondaryProp] into an array using ';'
+       and then checking if array includes  destinationExternalId
+       */
       const filteredInfoForSecondaryProp = hsIdsToBeUpdated.filter((update) =>
         update[secondaryProp]
           ?.toString()
           .toLowerCase()
+          .split(';')
           .includes(destinationExternalId.toString().toLowerCase()),
       );
       if (filteredInfoForSecondaryProp.length > 0) {


### PR DESCRIPTION
## What are the changes introduced in this PR?

Suppose we have `hs_additonal_emails` as `abc@e.com;cdf@e.com;k@w.com` and our email is `c@e.com` then `hs_additonal_emails.includes(email)` will return true which is wrong.
Hence now we are splitting the string into valid email emails separting them with `;` and after we get an array of list we are checking if a particular email is present in that list
<img width="471" alt="Screenshot 2024-04-16 at 11 57 31 AM" src="https://github.com/rudderlabs/rudder-transformer/assets/62471433/307e73fc-96c8-4c79-ab21-437bda124888">

## What is the related Linear task?

Resolves INT-XXX

## Please explain the objectives of your changes below

Put down any required details on the broader aspect of your changes. If there are any dependent changes, **mandatorily** mention them here

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

N/A

### Any new dependencies introduced with this change?

N/A

### Any new generic utility introduced or modified. Please explain the changes.

N/A

### Any technical or performance related pointers to consider with the change?

N/A

@coderabbitai review

<hr>

### Developer checklist

- [ ] My code follows the style guidelines of this project

- [ ] **No breaking changes are being introduced.**

- [ ] All related docs linked with the PR?

- [ ] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [ ] Is the PR limited to 10 file changes?

- [ ] Is the PR limited to one linear task?

- [ ] Are relevant unit and component test-cases added?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.
