### PR TITLE
fix: update logic for default true configs in Optimizely FS and engage

### DIFF
--- a/src/cdk/v2/destinations/optimizely_fullstack/procWorkflow.yaml
+++ b/src/cdk/v2/destinations/optimizely_fullstack/procWorkflow.yaml
@@ -90,7 +90,7 @@ steps:
         "account_id": .destination.Config.accountId,
         "project_id": .destination.Config.projectId,
         "anonymize_ip": .destination.Config.anonymizeIp || false,
-        "enrich_decisions": .destination.Config.enrichDecisions || true,
+        "enrich_decisions": .destination.Config.enrichDecisions ?? true,
         ...$.CLIENT_INFO
       }
       $.removeUndefinedNullEmptyExclBoolInt(commonPayload);

--- a/src/v0/destinations/engage/transform.js
+++ b/src/v0/destinations/engage/transform.js
@@ -120,7 +120,7 @@ const groupResponseBuilder = (message, Config) => {
   let { method } = ConfigCategories.GROUP;
   const { genericFields, name } = ConfigCategories.GROUP;
   let endpoint = `${ConfigCategories.GROUP.endpoint.replace('id', groupId)}`;
-  const subscriberStatus = context?.traits?.subscriberStatus || true;
+  const subscriberStatus = context?.traits?.subscriberStatus ?? true;
   let payload = { subscribed: subscriberStatus };
   if (uid) {
     endpoint = `${endpoint}/${uid}`;


### PR DESCRIPTION
## What are the changes introduced in this PR?

In some of the integrations, it is incorrectly done for the boolean fields.

`"enrich_decisions": .destination.Config.enrichDecisions || true
`

The above logic is in place to ensure that we use a default value true if the field's value is not defined. However, it'll still fall back to the default value even if the field's actual value is false due to the || true condition.

So, even if the user toggles the field to off in the UI, the integration will always treat is on. Essentially, the field's value is hardcoded.

## What is the related Linear task?

Resolves INT-1806

## Please explain the objectives of your changes below

Put down any required details on the broader aspect of your changes. If there are any dependent changes, **mandatorily** mention them here

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

N/A

### Any new dependencies introduced with this change?

N/A

### Any new generic utility introduced or modified. Please explain the changes.

N/A

### Any technical or performance related pointers to consider with the change?

N/A

@coderabbitai review

<hr>

### Developer checklist

- [ ] My code follows the style guidelines of this project

- [ ] **No breaking changes are being introduced.**

- [ ] All related docs linked with the PR?

- [ ] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [ ] Is the PR limited to 10 file changes?

- [ ] Is the PR limited to one linear task?

- [ ] Are relevant unit and component test-cases added?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.
