### PR TITLE
fix: awin product_id mapping backward compatible

### DIFF
--- a/src/v0/destinations/awin/utils.js
+++ b/src/v0/destinations/awin/utils.js
@@ -54,7 +54,11 @@ const trackProduct = (properties, advertiserId, commissionParts) => {
     productsArray.forEach((product) => {
       const productPayloadNew = {
         advertiserId,
-        orderReference: properties.order_id || properties.orderId,
+        orderReference:
+          properties.order_id ||
+          properties.orderId ||
+          properties.orderReference ||
+          properties.order_reference,
         productId: product.product_id || product.productId,
         productName: product.name,
         productItemPrice: product.price,


### PR DESCRIPTION
## What are the changes introduced in this PR?

made the product_id mapping as it is existing in root level.
Ref: https://www.rudderstack.com/docs/destinations/streaming-destinations/awin/#supported-mappings:~:text=properties.order_id%0Aproperties.orderId%0Aproperties.orderReference,orderReference

## What is the related Linear task?

Resolves INT-XXX

## Please explain the objectives of your changes below

Put down any required details on the broader aspect of your changes. If there are any dependent changes, **mandatorily** mention them here

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

N/A

### Any new dependencies introduced with this change?

N/A

### Any new generic utility introduced or modified. Please explain the changes.

N/A

### Any technical or performance related pointers to consider with the change?

N/A

@coderabbitai review

<hr>

### Developer checklist

- [x] My code follows the style guidelines of this project

- [x] **No breaking changes are being introduced.**

- [x] All related docs linked with the PR?

- [x] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [x] Is the PR limited to 10 file changes?

- [x] Is the PR limited to one linear task?

- [ ] Are relevant unit and component test-cases added?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.
