### PR TITLE
fix: handle empty userId (movable ink, bloomreach)

### DIFF
--- a/src/cdk/v2/destinations/bloomreach/procWorkflow.yaml
+++ b/src/cdk/v2/destinations/bloomreach/procWorkflow.yaml
@@ -39,7 +39,7 @@ steps:
       const userId = .message.().(
           {{{{$.getGenericPaths("userIdOnly")}}}};
       );
-      $.assert(userId ?? .message.anonymousId, "Either one of userId or anonymousId is required. Aborting");
+      $.assert(userId || .message.anonymousId, "Either one of userId or anonymousId is required. Aborting");
 
   - name: prepareIdentifyPayload
     condition: $.context.messageType === {{$.EventType.IDENTIFY}}
@@ -64,7 +64,7 @@ steps:
       - name: pageEventName
         condition: $.context.messageType === {{$.EventType.PAGE}}
         template: |
-          const category = .message.category ?? .message.properties.category;
+          const category = .message.category || .message.properties.category;
           const name = .message.name || .message.properties.name;
           const eventNameArray = ["Viewed"];
           category ? eventNameArray.push(category);
@@ -74,7 +74,7 @@ steps:
       - name: screenEventName
         condition: $.context.messageType === {{$.EventType.SCREEN}}
         template: |
-          const category = .message.category ?? .message.properties.category;
+          const category = .message.category || .message.properties.category;
           const name = .message.name || .message.properties.name;
           const eventNameArray = ["Viewed"];
           category ? eventNameArray.push(category);

--- a/src/cdk/v2/destinations/movable_ink/procWorkflow.yaml
+++ b/src/cdk/v2/destinations/movable_ink/procWorkflow.yaml
@@ -33,7 +33,7 @@ steps:
           {{{{$.getGenericPaths("email")}}}};
       );
 
-      $.assert(userId ?? email ?? .message.anonymousId, "Either one of userId or email or anonymousId is required. Aborting");
+      $.assert(userId || email || .message.anonymousId, "Either one of userId or email or anonymousId is required. Aborting");
       $.validateEventPayload(.message);
 
   - name: preparePayload
@@ -50,7 +50,7 @@ steps:
       ));
       $.context.payload = {
         ...(.message),
-        userId: userId ?? email,
+        userId: userId || email,
         timestamp: timestampInUnix,
         anonymousId: .message.anonymousId
       }

--- a/test/integrations/destinations/bloomreach/processor/page.ts
+++ b/test/integrations/destinations/bloomreach/processor/page.ts
@@ -15,7 +15,7 @@ export const page: ProcessorTestData[] = [
   {
     id: 'bloomreach-page-test-1',
     name: destType,
-    description: 'Page call with category, name',
+    description: 'Page call with category from properties and root-level name',
     scenario: 'Framework+Business',
     successCriteria:
       'Response should contain event_name = "Viewed {{ category }} {{ name }} Page" and properties and status code should be 200',
@@ -56,6 +56,63 @@ export const page: ProcessorTestData[] = [
                 data: {
                   customer_ids: { cookie: 'anonId123' },
                   properties,
+                  timestamp: 1709566376,
+                  event_type: 'Viewed Docs Integration Page',
+                },
+                name: 'customers/events',
+              },
+            }),
+            statusCode: 200,
+            metadata: generateMetadata(1),
+          },
+        ],
+      },
+    },
+  },
+  {
+    id: 'bloomreach-page-test-2',
+    name: destType,
+    description: 'Page call with category, name from properties',
+    scenario: 'Framework+Business',
+    successCriteria:
+      'Response should contain event_name = "Viewed {{ category }} {{ name }} Page" and properties and status code should be 200',
+    feature: 'processor',
+    module: 'destination',
+    version: 'v0',
+    input: {
+      request: {
+        body: [
+          {
+            destination,
+            message: {
+              type: 'page',
+              anonymousId: 'anonId123',
+              name: '',
+              properties: { ...properties, name: 'Integration' },
+              integrations: {
+                All: true,
+              },
+              originalTimestamp: '2024-03-04T15:32:56.409Z',
+            },
+            metadata: generateMetadata(1),
+          },
+        ],
+      },
+    },
+    output: {
+      response: {
+        status: 200,
+        body: [
+          {
+            output: transformResultBuilder({
+              method: 'POST',
+              userId: '',
+              endpoint,
+              headers,
+              JSON: {
+                data: {
+                  customer_ids: { cookie: 'anonId123' },
+                  properties: { ...properties, name: 'Integration' },
                   timestamp: 1709566376,
                   event_type: 'Viewed Docs Integration Page',
                 },

--- a/test/integrations/destinations/bloomreach/processor/validation.ts
+++ b/test/integrations/destinations/bloomreach/processor/validation.ts
@@ -1,6 +1,13 @@
 import { ProcessorTestData } from '../../../testTypes';
-import { generateMetadata } from '../../../testUtils';
-import { destType, destination, processorInstrumentationErrorStatTags } from '../common';
+import { generateMetadata, transformResultBuilder } from '../../../testUtils';
+import {
+  destType,
+  destination,
+  processorInstrumentationErrorStatTags,
+  traits,
+  headers,
+  endpoint,
+} from '../common';
 
 export const validation: ProcessorTestData[] = [
   {
@@ -123,6 +130,73 @@ export const validation: ProcessorTestData[] = [
             metadata: generateMetadata(1),
             statTags: processorInstrumentationErrorStatTags,
             statusCode: 400,
+          },
+        ],
+      },
+    },
+  },
+  {
+    id: 'bloomreach-validation-test-4',
+    name: destType,
+    description: 'Empty userId and non empty anonymousId',
+    scenario: 'Framework',
+    successCriteria: 'Response should contain all the mapping and status code should be 200',
+    feature: 'processor',
+    module: 'destination',
+    version: 'v0',
+    input: {
+      request: {
+        body: [
+          {
+            destination,
+            message: {
+              type: 'identify',
+              userId: '',
+              anonymousId: 'anonId123',
+              traits,
+              integrations: {
+                All: true,
+              },
+              originalTimestamp: '2024-03-04T15:32:56.409Z',
+            },
+            metadata: generateMetadata(1),
+          },
+        ],
+      },
+    },
+    output: {
+      response: {
+        status: 200,
+        body: [
+          {
+            output: transformResultBuilder({
+              method: 'POST',
+              userId: '',
+              endpoint,
+              headers,
+              JSON: {
+                data: {
+                  customer_ids: { registered: '', cookie: 'anonId123' },
+                  properties: {
+                    email: 'test@example.com',
+                    first_name: 'John',
+                    last_name: 'Doe',
+                    phone: '1234567890',
+                    city: 'New York',
+                    country: 'USA',
+                    address: {
+                      city: 'New York',
+                      country: 'USA',
+                      pinCode: '123456',
+                    },
+                  },
+                  update_timestamp: 1709566376,
+                },
+                name: 'customers',
+              },
+            }),
+            statusCode: 200,
+            metadata: generateMetadata(1),
           },
         ],
       },

--- a/test/integrations/destinations/movable_ink/processor/identify.ts
+++ b/test/integrations/destinations/movable_ink/processor/identify.ts
@@ -20,6 +20,7 @@ export const identify: ProcessorTestData[] = [
             destination,
             message: {
               type: 'identify',
+              userId: '',
               anonymousId: 'anonId123',
               traits,
               integrations: {


### PR DESCRIPTION
## What are the changes introduced in this PR?

Checking empty userId with `??` is giving wrong result for empty userId `userId= ""` in payload. Updated the `movable ink` and `bloomreach` destination to use `|| `operator to check for truthy values for userId.

## What is the related Linear task?

Resolves INT-2047

## Please explain the objectives of your changes below

Put down any required details on the broader aspect of your changes. If there are any dependent changes, **mandatorily** mention them here

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

N/A

### Any new dependencies introduced with this change?

N/A

### Any new generic utility introduced or modified. Please explain the changes.

N/A

### Any technical or performance related pointers to consider with the change?

N/A

@coderabbitai review

<hr>

### Developer checklist

- [ ] My code follows the style guidelines of this project

- [ ] **No breaking changes are being introduced.**

- [ ] All related docs linked with the PR?

- [ ] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [ ] Is the PR limited to 10 file changes?

- [ ] Is the PR limited to one linear task?

- [ ] Are relevant unit and component test-cases added?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.
