### PR TITLE
feat: remove redundant data from traits in hubspot

### DIFF
--- a/src/v0/destinations/hs/HSTransform-v2.js
+++ b/src/v0/destinations/hs/HSTransform-v2.js
@@ -110,11 +110,11 @@ const processIdentify = async (message, destination, propertyMap) => {
     GENERIC_TRUE_VALUES.includes(mappedToDestination.toString()) &&
     operation
   ) {
-    addExternalIdToHSTraits(message);
     if (!objectType) {
       throw new InstrumentationError('objectType not found');
     }
     if (operation === 'createObject') {
+      addExternalIdToHSTraits(message);
       endpoint = CRM_CREATE_UPDATE_ALL_OBJECTS.replace(':objectType', objectType);
     } else if (operation === 'updateObject' && getHsSearchId(message)) {
       const { hsSearchId } = getHsSearchId(message);

--- a/test/integrations/destinations/hs/processor/data.ts
+++ b/test/integrations/destinations/hs/processor/data.ts
@@ -1534,7 +1534,6 @@ export const data = [
                     firstname: 'Test Hubspot',
                     anonymousId: '12345',
                     country: 'India',
-                    email: 'testhubspot2@email.com',
                   },
                 },
                 XML: {},

--- a/test/integrations/destinations/hs/router/data.ts
+++ b/test/integrations/destinations/hs/router/data.ts
@@ -1033,7 +1033,6 @@ export const data = [
                           firstname: 'Test Hubspot',
                           anonymousId: '12345',
                           country: 'India',
-                          email: 'testhubspot2@email.com',
                         },
                         id: '103605',
                       },


### PR DESCRIPTION
## What are the changes introduced in this PR?

As we are considering hs_object_id as an identifier field through integrations-info it is being added to traits. But we can't update this field as it is a read-only field. So moved, adding identifier field to traits when we are creating an object from the common section. And it is also not needed when we are updating the object. The identifier field is only used for getting the valid object id from Hubspot.

## What is the related Linear task?

Resolves INT-1996

## Please explain the objectives of your changes below

Put down any required details on the broader aspect of your changes. If there are any dependent changes, **mandatorily** mention them here

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

N/A

### Any new dependencies introduced with this change?

N/A

### Any new generic utility introduced or modified. Please explain the changes.

N/A

### Any technical or performance related pointers to consider with the change?

N/A

@coderabbitai review

<hr>

### Developer checklist

- [ ] My code follows the style guidelines of this project

- [ ] **No breaking changes are being introduced.**

- [ ] All related docs linked with the PR?

- [ ] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [ ] Is the PR limited to 10 file changes?

- [ ] Is the PR limited to one linear task?

- [ ] Are relevant unit and component test-cases added?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.
