### PR TITLE
fix: tiktok_v2 remove default value for content-type for custom events

### DIFF
--- a/src/v0/destinations/tiktok_ads/data/TikTokTrackV2.json
+++ b/src/v0/destinations/tiktok_ads/data/TikTokTrackV2.json
@@ -25,10 +25,7 @@
   },
   {
     "destKey": "properties.content_type",
-    "sourceKeys": ["properties.contentType", "properties.content_type"],
-    "metadata": {
-      "defaultValue": "product"
-    }
+    "sourceKeys": ["properties.contentType", "properties.content_type"]
   },
   {
     "destKey": "properties.shop_id",

--- a/test/integrations/destinations/tiktok_ads/processor/data.ts
+++ b/test/integrations/destinations/tiktok_ads/processor/data.ts
@@ -5224,7 +5224,6 @@ export const data = [
                       event_id: '1616318632825_357',
                       event_time: 1600372167,
                       properties: {
-                        content_type: 'product',
                         contents: [
                           {
                             price: 8,
@@ -6872,7 +6871,7 @@ export const data = [
   },
   {
     name: 'tiktok_ads',
-    description: 'Test 46 -> V2 -> Event with no properties',
+    description: 'Test 46 -> V2 -> Custom Event with no properties',
     feature: 'processor',
     module: 'destination',
     version: 'v0',
@@ -6947,7 +6946,6 @@ export const data = [
                       event: 'customEvent',
                       event_id: '84e26acc-56a5-4835-8233-591137fca468',
                       event_time: 1600372167,
-                      properties: { content_type: 'product' },
                       user: {
                         locale: 'en-US',
                         email: 'dd6ff77f54e2106661089bae4d40cdb600979bf7edc9eb65c0942ba55c7c2d7f',


### PR DESCRIPTION
## What are the changes introduced in this PR?
tiktok_v2 remove default value for content-type for custom events.
We had a default value as it is recommended parameter from tiktok side for standard event but nothing says for custom event and we just got a use case where there should not be a default value

Write a brief explainer on your code changes.

## What is the related Linear task?

Resolves INT-2138

## Please explain the objectives of your changes below

Put down any required details on the broader aspect of your changes. If there are any dependent changes, **mandatorily** mention them here

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

N/A

### Any new dependencies introduced with this change?

N/A

### Any new generic utility introduced or modified. Please explain the changes.

N/A

### Any technical or performance related pointers to consider with the change?

N/A

@coderabbitai review

<hr>

### Developer checklist

- [ ] My code follows the style guidelines of this project

- [ ] **No breaking changes are being introduced.**

- [ ] All related docs linked with the PR?

- [ ] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [ ] Is the PR limited to 10 file changes?

- [ ] Is the PR limited to one linear task?

- [ ] Are relevant unit and component test-cases added?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.
