### PR TITLE
chore: added reconcile fn for openfaas fn pods

### DIFF
--- a/src/util/customTransformer-faas.js
+++ b/src/util/customTransformer-faas.js
@@ -11,9 +11,10 @@ const {
 } = require('./openfaas');
 const { getLibraryCodeV1 } = require('./customTransforrmationsStore-v1');
 
+const HASH_SECRET = process.env.OPENFAAS_FN_HASH_SECRET || '';
 const libVersionIdsCache = new NodeCache();
 
-function generateFunctionName(userTransformation, libraryVersionIds, testMode) {
+function generateFunctionName(userTransformation, libraryVersionIds, testMode, hashSecret = '') {
   if (userTransformation.versionId === FAAS_AST_VID) return FAAS_AST_FN_NAME;
 
   if (testMode) {
@@ -21,10 +22,15 @@ function generateFunctionName(userTransformation, libraryVersionIds, testMode) {
     return funcName.substring(0, 63).toLowerCase();
   }
 
-  const ids = [userTransformation.workspaceId, userTransformation.versionId].concat(
+  let ids = [userTransformation.workspaceId, userTransformation.versionId].concat(
     (libraryVersionIds || []).sort(),
   );
 
+  if (hashSecret !== '') {
+    ids = ids.concat([hashSecret]);
+  }
+
+  // FIXME: Why the id's are sorted ?!
   const hash = crypto.createHash('md5').update(`${ids}`).digest('hex');
   return `fn-${userTransformation.workspaceId}-${hash}`.substring(0, 63).toLowerCase();
 }
@@ -90,7 +96,13 @@ async function setOpenFaasUserTransform(
     testMode,
   };
   const functionName =
-    pregeneratedFnName || generateFunctionName(userTransformation, libraryVersionIds, testMode);
+    pregeneratedFnName ||
+    generateFunctionName(
+      userTransformation,
+      libraryVersionIds,
+      testMode,
+      process.env.OPENFAAS_FN_HASH_SECRET,
+    );
   const setupTime = new Date();
 
   await setupFaasFunction(
@@ -130,7 +142,13 @@ async function runOpenFaasUserTransform(
 
   const trMetadata = events[0].metadata ? getTransformationMetadata(events[0].metadata) : {};
   // check and deploy faas function if not exists
-  const functionName = generateFunctionName(userTransformation, libraryVersionIds, testMode);
+  const functionName = generateFunctionName(
+    userTransformation,
+    libraryVersionIds,
+    testMode,
+    process.env.OPENFAAS_FN_HASH_SECRET,
+  );
+
   if (testMode) {
     await setOpenFaasUserTransform(
       userTransformation,

--- a/src/util/openfaas/index.js
+++ b/src/util/openfaas/index.js
@@ -4,6 +4,7 @@ const {
   deployFunction,
   invokeFunction,
   checkFunctionHealth,
+  updateFunction,
 } = require('./faasApi');
 const logger = require('../../logger');
 const { RetryRequestError, RespStatusError } = require('../utils');
@@ -33,6 +34,7 @@ const FAAS_AST_FN_NAME = 'fn-ast';
 const CUSTOM_NETWORK_POLICY_WORKSPACE_IDS = process.env.CUSTOM_NETWORK_POLICY_WORKSPACE_IDS || '';
 const customNetworkPolicyWorkspaceIds = CUSTOM_NETWORK_POLICY_WORKSPACE_IDS.split(',');
 const CUSTOMER_TIER = process.env.CUSTOMER_TIER || 'shared';
+const DISABLE_RECONCILE_FN = process.env.DISABLE_RECONCILE_FN == 'true' || false;
 
 // Initialise node cache
 const functionListCache = new NodeCache();
@@ -67,6 +69,8 @@ const awaitFunctionReadiness = async (
   maxWaitInMs = 22000,
   waitBetweenIntervalsInMs = 250,
 ) => {
+  logger.debug(`Awaiting function readiness: ${functionName}`);
+
   const executionPromise = new Promise(async (resolve) => {
     try {
       await callWithRetry(
@@ -121,6 +125,39 @@ const invalidateFnCache = () => {
   functionListCache.set(FUNC_LIST_KEY, []);
 };
 
+const updateFaasFunction = async (
+  functionName,
+  code,
+  versionId,
+  libraryVersionIDs,
+  testMode,
+  trMetadata = {},
+) => {
+  try {
+    logger.debug(`Updating faas fn: ${functionName}`);
+
+    const payload = buildOpenfaasFn(
+      functionName,
+      code,
+      versionId,
+      libraryVersionIDs,
+      testMode,
+      trMetadata,
+    );
+    await updateFunction(functionName, payload);
+    // wait for function to be ready and then set it in cache
+    await awaitFunctionReadiness(functionName);
+    setFunctionInCache(functionName);
+  } catch (error) {
+    // 404 is statuscode returned from openfaas community edition
+    // when the function don't exist, so we can safely ignore this error
+    // and let the function be created in the next step.
+    if (error.statusCode !== 404) {
+      throw error;
+    }
+  }
+};
+
 const deployFaasFunction = async (
   functionName,
   code,
@@ -130,73 +167,17 @@ const deployFaasFunction = async (
   trMetadata = {},
 ) => {
   try {
-    logger.debug(`[Faas] Deploying a faas function: ${functionName}`);
-    let envProcess = 'python index.py';
+    logger.debug(`Deploying faas fn: ${functionName}`);
 
-    const lvidsString = libraryVersionIDs.join(',');
-
-    if (!testMode) {
-      envProcess = `${envProcess} --vid ${versionId} --config-backend-url ${CONFIG_BACKEND_URL} --lvids "${lvidsString}"`;
-    } else {
-      envProcess = `${envProcess} --code "${code}" --config-backend-url ${CONFIG_BACKEND_URL} --lvids "${lvidsString}"`;
-    }
-
-    const envVars = {};
-    if (FAAS_ENABLE_WATCHDOG_ENV_VARS.trim().toLowerCase() === 'true') {
-      envVars.max_inflight = FAAS_MAX_INFLIGHT;
-      envVars.exec_timeout = FAAS_EXEC_TIMEOUT;
-    }
-    if (GEOLOCATION_URL) {
-      envVars.geolocation_url = GEOLOCATION_URL;
-    }
-    // labels
-    const labels = {
-      'openfaas-fn': 'true',
-      'parent-component': 'openfaas',
-      'com.openfaas.scale.max': FAAS_MAX_PODS_IN_TEXT,
-      'com.openfaas.scale.min': FAAS_MIN_PODS_IN_TEXT,
-      'com.openfaas.scale.zero': FAAS_SCALE_ZERO,
-      'com.openfaas.scale.zero-duration': FAAS_SCALE_ZERO_DURATION,
-      'com.openfaas.scale.target': FAAS_SCALE_TARGET,
-      'com.openfaas.scale.target-proportion': FAAS_SCALE_TARGET_PROPORTION,
-      'com.openfaas.scale.type': FAAS_SCALE_TYPE,
-      transformationId: trMetadata.transformationId,
-      workspaceId: trMetadata.workspaceId,
-      team: 'data-management',
-      service: 'openfaas-fn',
-      customer: 'shared',
-      'customer-tier': CUSTOMER_TIER,
-    };
-    if (
-      trMetadata.workspaceId &&
-      customNetworkPolicyWorkspaceIds.includes(trMetadata.workspaceId)
-    ) {
-      labels['custom-network-policy'] = 'true';
-    }
-
-    // TODO: investigate and add more required labels and annotations
-    const payload = {
-      service: functionName,
-      name: functionName,
-      image: FAAS_BASE_IMG,
-      envProcess,
-      envVars,
-      labels,
-      annotations: {
-        'prometheus.io.scrape': 'true',
-      },
-      limits: {
-        memory: FAAS_LIMITS_MEMORY,
-        cpu: FAAS_LIMITS_CPU,
-      },
-      requests: {
-        memory: FAAS_REQUESTS_MEMORY,
-        cpu: FAAS_REQUESTS_CPU,
-      },
-    };
-
+    const payload = buildOpenfaasFn(
+      functionName,
+      code,
+      versionId,
+      libraryVersionIDs,
+      testMode,
+      trMetadata,
+    );
     await deployFunction(payload);
-    logger.debug('[Faas] Deployed a faas function');
   } catch (error) {
     logger.error(`[Faas] Error while deploying ${functionName}: ${error.message}`);
     // To handle concurrent create requests,
@@ -246,6 +227,95 @@ async function setupFaasFunction(
   }
 }
 
+// reconcileFn runs everytime the service boot's up
+// trying to update the functions which are not in cache to the
+// latest label and envVars
+const reconcileFn = async (name, versionId, libraryVersionIDs, trMetadata) => {
+  if (DISABLE_RECONCILE_FN) {
+    return;
+  }
+
+  logger.debug(`Reconciling faas function: ${name}`);
+  try {
+    if (isFunctionDeployed(name)) {
+      return;
+    }
+    await updateFaasFunction(name, null, versionId, libraryVersionIDs, false, trMetadata);
+  } catch (error) {
+    logger.error(
+      `unexpected error occurred when reconciling the function ${name}: ${error.message}`,
+    );
+    throw error;
+  }
+};
+
+// buildOpenfaasFn is helper function to build openfaas fn CRUD payload
+function buildOpenfaasFn(name, code, versionId, libraryVersionIDs, testMode, trMetadata = {}) {
+  logger.debug(`Building faas fn: ${name}`);
+
+  let envProcess = 'python index.py';
+  const lvidsString = libraryVersionIDs.join(',');
+
+  if (!testMode) {
+    envProcess = `${envProcess} --vid ${versionId} --config-backend-url ${CONFIG_BACKEND_URL} --lvids "${lvidsString}"`;
+  } else {
+    envProcess = `${envProcess} --code "${code}" --config-backend-url ${CONFIG_BACKEND_URL} --lvids "${lvidsString}"`;
+  }
+
+  const envVars = {};
+
+  if (FAAS_ENABLE_WATCHDOG_ENV_VARS.trim().toLowerCase() === 'true') {
+    envVars.max_inflight = FAAS_MAX_INFLIGHT;
+    envVars.exec_timeout = FAAS_EXEC_TIMEOUT;
+  }
+
+  if (GEOLOCATION_URL) {
+    envVars.geolocation_url = GEOLOCATION_URL;
+  }
+
+  const labels = {
+    'openfaas-fn': 'true',
+    'parent-component': 'openfaas',
+    'com.openfaas.scale.max': FAAS_MAX_PODS_IN_TEXT,
+    'com.openfaas.scale.min': FAAS_MIN_PODS_IN_TEXT,
+    'com.openfaas.scale.zero': FAAS_SCALE_ZERO,
+    'com.openfaas.scale.zero-duration': FAAS_SCALE_ZERO_DURATION,
+    'com.openfaas.scale.target': FAAS_SCALE_TARGET,
+    'com.openfaas.scale.target-proportion': FAAS_SCALE_TARGET_PROPORTION,
+    'com.openfaas.scale.type': FAAS_SCALE_TYPE,
+    transformationId: trMetadata.transformationId,
+    workspaceId: trMetadata.workspaceId,
+    team: 'data-management',
+    service: 'openfaas-fn',
+    customer: 'shared',
+    'customer-tier': CUSTOMER_TIER,
+  };
+
+  if (trMetadata.workspaceId && customNetworkPolicyWorkspaceIds.includes(trMetadata.workspaceId)) {
+    labels['custom-network-policy'] = 'true';
+  }
+
+  return {
+    service: name,
+    name: name,
+    image: FAAS_BASE_IMG,
+    envProcess,
+    envVars,
+    labels,
+    annotations: {
+      'prometheus.io.scrape': 'true',
+    },
+    limits: {
+      memory: FAAS_LIMITS_MEMORY,
+      cpu: FAAS_LIMITS_CPU,
+    },
+    requests: {
+      memory: FAAS_REQUESTS_MEMORY,
+      cpu: FAAS_REQUESTS_CPU,
+    },
+  };
+}
+
 const executeFaasFunction = async (
   name,
   events,
@@ -260,7 +330,11 @@ const executeFaasFunction = async (
   let errorRaised;
 
   try {
-    if (testMode) await awaitFunctionReadiness(name);
+    if (testMode) {
+      await awaitFunctionReadiness(name);
+    } else {
+      await reconcileFn(name, versionId, libraryVersionIDs, trMetadata);
+    }
     return await invokeFunction(name, events);
   } catch (error) {
     logger.error(`Error while invoking ${name}: ${error.message}`);
@@ -268,6 +342,7 @@ const executeFaasFunction = async (
 
     if (error.statusCode === 404 && error.message.includes(`error finding function ${name}`)) {
       removeFunctionFromCache(name);
+
       await setupFaasFunction(name, null, versionId, libraryVersionIDs, testMode, trMetadata);
       throw new RetryRequestError(`${name} not found`);
     }
@@ -314,6 +389,8 @@ module.exports = {
   executeFaasFunction,
   setupFaasFunction,
   invalidateFnCache,
+  buildOpenfaasFn,
   FAAS_AST_VID,
   FAAS_AST_FN_NAME,
+  setFunctionInCache,
 };

--- a/test/__tests__/user_transformation.test.js
+++ b/test/__tests__/user_transformation.test.js
@@ -7,9 +7,11 @@ jest.mock("axios", () => ({
   ...jest.requireActual("axios"),
   get: jest.fn(),
   post: jest.fn(),
-  delete: jest.fn()
+  delete: jest.fn(),
+  put: jest.fn()
 }));
 
+const { generateFunctionName } = require('../../src/util/customTransformer-faas.js');
 const { Response, Headers } = jest.requireActual("node-fetch");
 const lodashCore = require("lodash/core");
 const _ = require("lodash");
@@ -35,6 +37,7 @@ const {
 } = require("../../src/util/customTransformer");
 const { parserForImport } = require("../../src/util/parser");
 const { RetryRequestError, RespStatusError } = require("../../src/util/utils");
+const { buildOpenfaasFn, setFunctionInCache, invalidateFnCache } = require("../../src/util/openfaas/index");
 
 const OPENFAAS_GATEWAY_URL = "http://localhost:8080";
 const defaultBasicAuth = {
@@ -88,8 +91,12 @@ const pyLibCode = (name, versionId) => {
   }
 }
 
-const pyfaasFuncName = (workspaceId, versionId, libraryVersionIds=[]) => {
-  const ids = [workspaceId, versionId].concat(libraryVersionIds.sort());
+const pyfaasFuncName = (workspaceId, versionId, libraryVersionIds=[], hashSecret="") => {
+  let ids = [workspaceId, versionId].concat(libraryVersionIds.sort());
+  if (hashSecret !== "") {
+    ids = ids.concat([hashSecret]);
+  }
+
   const hash = crypto.createHash('md5').update(`${ids}`).digest('hex');
 
   return `fn-${workspaceId}-${hash}`
@@ -104,6 +111,19 @@ const getfetchResponse = (resp, url) =>
   );
 
 let importNameLibraryVersionIdsMap;
+
+describe("User transformation utils", () => {
+
+  it("generates the openfaas-fn name correctly", () => {
+    const fnName = generateFunctionName(
+      {workspaceId: 'workspaceId', transformationId: 'transformationId'},
+      [],
+      false,
+      'hash-secret');
+    expect(fnName).toEqual('fn-workspaceid-34a32ade07ebbc7bc5ea795b8200de9f');
+  });
+
+});
 
 describe("User transformation", () => {
   beforeEach(() => {
@@ -1386,6 +1406,7 @@ describe("Geolocation function", () => {
 // Running tests for python transformations with openfaas mocks
 describe("Python transformations", () => {
   beforeEach(() => {
+    invalidateFnCache();
     jest.resetAllMocks();
   });
   afterAll(() => {});
@@ -1421,6 +1442,7 @@ describe("Python transformations", () => {
 
     const expectedData = { success: true, publishedVersion: funcName };
 
+    setFunctionInCache(funcName);
     const output = await setupUserTransformHandler([], trRevCode);
     expect(output).toEqual(expectedData);
     expect(axios.post).toHaveBeenCalledTimes(0);
@@ -1604,13 +1626,15 @@ describe("Python transformations", () => {
     expect(axios.delete).toHaveBeenCalledTimes(1);
   });
 
-  it("Simple transformation run - invokes faas function", async () => {
+  it("Simple transformation run with function in cache - invokes faas function", async () => {
     const inputData = require(`./data/${integration}_input.json`);
     const outputData = require(`./data/${integration}_output.json`);
 
     const versionId = randomID();
     const respBody = pyTrRevCode(versionId);
     const funcName = pyfaasFuncName(respBody.workspaceId, versionId);
+
+    setFunctionInCache(funcName);
 
     const transformerUrl = `https://api.rudderlabs.com/transformation/getByVersionId?versionId=${versionId}`;
     when(fetch)
@@ -1625,7 +1649,7 @@ describe("Python transformations", () => {
     const output = await userTransformHandler(inputData, versionId, []);
     expect(output).toEqual(outputData);
 
-    expect(axios.post).toHaveBeenCalledTimes(1);
+
     expect(axios.post).toHaveBeenCalledWith(
       `${OPENFAAS_GATEWAY_URL}/function/${funcName}`,
       inputData,
@@ -1633,12 +1657,16 @@ describe("Python transformations", () => {
     );
   });
 
-  it("Simple transformation run - function not found", async () => {
+
+  it("Simple transformation run with clean cache - reconciles fn with 200OK and then invokes faas function", async () => {
+
     const inputData = require(`./data/${integration}_input.json`);
+    const outputData = require(`./data/${integration}_output.json`);
 
     const versionId = randomID();
     const respBody = pyTrRevCode(versionId);
-    const funcName = pyfaasFuncName(respBody.workspaceId, respBody.versionId);
+    const funcName = pyfaasFuncName(respBody.workspaceId, versionId);
+
 
     const transformerUrl = `https://api.rudderlabs.com/transformation/getByVersionId?versionId=${versionId}`;
     when(fetch)
@@ -1648,28 +1676,13 @@ describe("Python transformations", () => {
         json: jest.fn().mockResolvedValue(respBody)
       });
 
-    axios.post
-      .mockRejectedValueOnce({
-        response: { status: 404, data: `error finding function ${funcName}` } // invoke function not found
-      })
-      .mockResolvedValueOnce({}); // create function
+    axios.put.mockResolvedValue({});
     axios.get.mockResolvedValue({}); // awaitFunctionReadiness()
+    axios.post.mockResolvedValue({ data: { transformedEvents: outputData } });
 
-    await expect(async () => {
-      await userTransformHandler(inputData, versionId, []);
-    }).rejects.toThrow(RetryRequestError);
+    const output = await userTransformHandler(inputData, versionId, []);
+    expect(output).toEqual(outputData);
 
-    expect(axios.post).toHaveBeenCalledTimes(2);
-    expect(axios.post).toHaveBeenCalledWith(
-      `${OPENFAAS_GATEWAY_URL}/function/${funcName}`,
-      inputData,
-      { auth: defaultBasicAuth },
-    );
-    expect(axios.post).toHaveBeenCalledWith(
-      `${OPENFAAS_GATEWAY_URL}/system/functions`,
-      expect.objectContaining({ name: funcName, service: funcName }),
-      { auth: defaultBasicAuth },
-    );
 
     expect(axios.get).toHaveBeenCalledTimes(1);
     expect(axios.get).toHaveBeenCalledWith(
@@ -1677,6 +1690,154 @@ describe("Python transformations", () => {
       {"headers": {"X-REQUEST-TYPE": "HEALTH-CHECK"}},
       { auth: defaultBasicAuth },
     );
+    expect(axios.put).toHaveBeenCalledTimes(1);
+    expect(axios.put).toHaveBeenCalledWith(
+      `${OPENFAAS_GATEWAY_URL}/system/functions`,
+      buildOpenfaasFn(funcName, null, versionId, [], false, {}),
+      { auth: defaultBasicAuth });
+    expect(axios.post).toHaveBeenCalledTimes(1);
+    expect(axios.post).toHaveBeenCalledWith(
+      `${OPENFAAS_GATEWAY_URL}/function/${funcName}`,
+      inputData,
+      { auth: defaultBasicAuth },
+    );
+  });
+
+  describe("Simple transformation run with clean cache - function not found", () => {
+
+    it('eventually sets up the function on 404 from update and then invokes it', async () => {
+      const inputData = require(`./data/${integration}_input.json`);
+
+      const versionId = randomID();
+      const respBody = pyTrRevCode(versionId);
+      const funcName = pyfaasFuncName(respBody.workspaceId, respBody.versionId);
+
+      const transformerUrl = `https://api.rudderlabs.com/transformation/getByVersionId?versionId=${versionId}`;
+      when(fetch)
+        .calledWith(transformerUrl)
+        .mockResolvedValue({
+          status: 200,
+          json: jest.fn().mockResolvedValue(respBody)
+        });
+
+
+      axios.put.mockRejectedValueOnce({
+        response: { status: 404, data: `deployment not found`}
+      });
+
+      axios.post
+        .mockRejectedValueOnce({
+          response: { status: 404, data: `error finding function ${funcName}` } // invoke function not found
+        })
+        .mockResolvedValueOnce({}); // create function
+      axios.get.mockResolvedValue({}); // awaitFunctionReadiness()
+
+      await expect(async () => {
+        await userTransformHandler(inputData, versionId, []);
+      }).rejects.toThrow(RetryRequestError);
+
+      expect(axios.put).toHaveBeenCalledTimes(1);
+      expect(axios.put).toHaveBeenCalledWith(
+        `${OPENFAAS_GATEWAY_URL}/system/functions`,
+        buildOpenfaasFn(funcName, null, versionId, [], false, {}),
+        { auth: defaultBasicAuth },
+      );
+      expect(axios.post).toHaveBeenCalledTimes(2);
+      expect(axios.post).toHaveBeenCalledWith(
+        `${OPENFAAS_GATEWAY_URL}/function/${funcName}`,
+        inputData,
+        { auth: defaultBasicAuth },
+      );
+      expect(axios.post).toHaveBeenCalledWith(
+        `${OPENFAAS_GATEWAY_URL}/system/functions`,
+        expect.objectContaining({ name: funcName, service: funcName }),
+        { auth: defaultBasicAuth },
+      );
+
+      expect(axios.get).toHaveBeenCalledTimes(1);
+      expect(axios.get).toHaveBeenCalledWith(
+        `${OPENFAAS_GATEWAY_URL}/function/${funcName}`,
+        {"headers": {"X-REQUEST-TYPE": "HEALTH-CHECK"}},
+        { auth: defaultBasicAuth },
+      );
+    });
+
+    it('sets up the function on 202 from update and then invokes it', async() => {
+      const inputData = require(`./data/${integration}_input.json`);
+      const outputData = require(`./data/${integration}_output.json`);
+
+      const versionId = randomID();
+      const respBody = pyTrRevCode(versionId);
+      const funcName = pyfaasFuncName(respBody.workspaceId, respBody.versionId);
+
+      const transformerUrl = `https://api.rudderlabs.com/transformation/getByVersionId?versionId=${versionId}`;
+      when(fetch)
+        .calledWith(transformerUrl)
+        .mockResolvedValue({
+          status: 200,
+          json: jest.fn().mockResolvedValue(respBody)
+        });
+
+
+      axios.put.mockResolvedValueOnce({
+        response: { status: 202, data: `deployment created`}
+      });
+      axios.get.mockResolvedValue({}); // awaitFunctionReadiness()
+      axios.post.mockResolvedValue({ data: { transformedEvents: outputData } });
+
+      const output = await userTransformHandler(inputData, versionId, []);
+      expect(output).toEqual(outputData);
+
+      expect(axios.put).toHaveBeenCalledTimes(1);
+      expect(axios.put).toHaveBeenCalledWith(
+        `${OPENFAAS_GATEWAY_URL}/system/functions`,
+        buildOpenfaasFn(funcName, null, versionId, [], false, {}),
+        { auth: defaultBasicAuth },
+      );
+      expect(axios.post).toHaveBeenCalledTimes(1);
+      expect(axios.post).toHaveBeenCalledWith(
+        `${OPENFAAS_GATEWAY_URL}/function/${funcName}`,
+        inputData,
+        { auth: defaultBasicAuth },
+      );
+      expect(axios.get).toHaveBeenCalledTimes(1);
+      expect(axios.get).toHaveBeenCalledWith(
+        `${OPENFAAS_GATEWAY_URL}/function/${funcName}`,
+        {"headers": {"X-REQUEST-TYPE": "HEALTH-CHECK"}},
+        { auth: defaultBasicAuth },
+      );
+    });
+
+    it('throws from the userTransform handler when reconciles errors with anything other than 404', async() => {
+      const inputData = require(`./data/${integration}_input.json`);
+      const outputData = require(`./data/${integration}_output.json`);
+
+      const versionId = randomID();
+      const respBody = pyTrRevCode(versionId);
+      const funcName = pyfaasFuncName(respBody.workspaceId, respBody.versionId);
+
+      const transformerUrl = `https://api.rudderlabs.com/transformation/getByVersionId?versionId=${versionId}`;
+      when(fetch)
+        .calledWith(transformerUrl)
+        .mockResolvedValue({
+          status: 200,
+          json: jest.fn().mockResolvedValue(respBody)
+        });
+
+
+      axios.put.mockRejectedValueOnce({response: {status: 400, data: 'bad request'}});
+      await expect(async () => {
+        await userTransformHandler(inputData, versionId, []);
+      }).rejects.toThrow(RespStatusError);
+
+      expect(axios.put).toHaveBeenCalledTimes(1);
+      expect(axios.put).toHaveBeenCalledWith(
+        `${OPENFAAS_GATEWAY_URL}/system/functions`,
+        buildOpenfaasFn(funcName, null, versionId, [], false, {}),
+        { auth: defaultBasicAuth },
+      );
+    });
+
   });
 
   it("Simple transformation run - error requests", async () => {
@@ -1693,6 +1854,8 @@ describe("Python transformations", () => {
         status: 200,
         json: jest.fn().mockResolvedValue(respBody)
       });
+
+    setFunctionInCache(funcName);
 
     axios.post
       .mockRejectedValueOnce({


### PR DESCRIPTION
## What are the changes introduced in this PR?

We are introducing a new reconcile step before we execute the fn first time from the perspective of user transformation service. This is done to sync the latest state of ut service to the openfaas-fn pods. Once the function gets added in the cache, we stop the reconciliation step and assume the function is up-to-date as the only way it could be added effectively in cache is when it was reconciled successfully.
## What is the related Linear task?

Fixes DAT-1123

## Please explain the objectives of your changes below

Put down any required details on the broader aspect of your changes. If there are any dependent changes, **mandatorily** mention them here

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

N/A

### Any new dependencies introduced with this change?

N/A

### Any new generic utility introduced or modified. Please explain the changes.

N/A

### Any technical or performance related pointers to consider with the change?

N/A

@coderabbitai review

<hr>

### Developer checklist

- [ ] My code follows the style guidelines of this project

- [ ] **No breaking changes are being introduced.**

- [ ] All related docs linked with the PR?

- [ ] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [ ] Is the PR limited to 10 file changes?

- [ ] Is the PR limited to one linear task?

- [ ] Are relevant unit and component test-cases added?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.
