### PR TITLE
fix: allowing traffic type dynamically for split.io

### DIFF
--- a/src/v0/destinations/splitio/data/EventConfig.json
+++ b/src/v0/destinations/splitio/data/EventConfig.json
@@ -29,5 +29,17 @@
       "type": "toFloat"
     },
     "required": false
+  },
+  {
+    "destKey": "trafficTypeName",
+    "sourceKeys": [
+      "traits.trafficTypeName",
+      "context.traits.trafficTypeName",
+      "properties.trafficTypeName"
+    ],
+    "metadata": {
+      "type": "toString"
+    },
+    "required": false
   }
 ]

--- a/src/v0/destinations/splitio/transform.js
+++ b/src/v0/destinations/splitio/transform.js
@@ -56,6 +56,7 @@ function prepareResponse(message, destination, category) {
 
   let outputPayload = {};
 
+  // ref: https://docs.split.io/reference/events-overview
   outputPayload = constructPayload(message, MAPPING_CONFIG[category.name]);
   outputPayload.eventTypeId = outputPayload.eventTypeId.replace(/ /g, '_');
   if (EVENT_TYPE_ID_REGEX.test(outputPayload.eventTypeId)) {
@@ -93,7 +94,12 @@ function prepareResponse(message, destination, category) {
   if (isDefinedAndNotNullAndNotEmpty(environment)) {
     outputPayload.environmentName = environment;
   }
-  outputPayload.trafficTypeName = trafficType;
+
+  // in case traffic type could not be mapped from the input payloads, falls back to the UI configured default traffic type.
+  if (!isDefinedAndNotNullAndNotEmpty(outputPayload.trafficTypeName)) {
+    outputPayload.trafficTypeName = trafficType;
+  }
+
   outputPayload.properties = removeUndefinedNullValuesAndEmptyObjectArray(
     flattenJson(bufferProperty),
   );

--- a/test/integrations/destinations/splitio/processor/data.ts
+++ b/test/integrations/destinations/splitio/processor/data.ts
@@ -43,7 +43,7 @@ export const data = [
               Config: {
                 apiKey: 'abcde',
                 environment: 'staging',
-                trafficType: 'user',
+                trafficType: 'anonymous',
               },
             },
           },
@@ -246,7 +246,7 @@ export const data = [
               Config: {
                 apiKey: 'abcde',
                 environment: 'production',
-                trafficType: 'user',
+                trafficType: 'anonymous',
               },
             },
           },
@@ -847,6 +847,9 @@ export const data = [
                 library: {
                   name: 'http',
                 },
+                traits: {
+                  trafficTypeName: 'user',
+                },
               },
               type: 'identify',
               timestamp: '2020-01-21T00:21:34.208Z',
@@ -858,7 +861,7 @@ export const data = [
               Config: {
                 apiKey: 'abcde',
                 environment: 'staging',
-                trafficType: 'user',
+                trafficType: 'anonymous',
               },
             },
           },


### PR DESCRIPTION
## What are the changes introduced in this PR?

Traffic type was being mapped from UI only, now, we have added mapping from the payload. The UI mapping will work as default traffic type if the payload field is missing.

## What is the related Linear task?

Resolves INT-2200

## Please explain the objectives of your changes below

Put down any required details on the broader aspect of your changes. If there are any dependent changes, **mandatorily** mention them here

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

N/A

### Any new dependencies introduced with this change?

N/A

### Any new generic utility introduced or modified. Please explain the changes.

N/A

### Any technical or performance related pointers to consider with the change?

N/A

@coderabbitai review

<hr>

### Developer checklist

- [x] My code follows the style guidelines of this project

- [x] **No breaking changes are being introduced.**

- [x] All related docs linked with the PR?

- [x] All changes manually tested?

- [x] Any documentation changes needed with this change?

- [x] Is the PR limited to 10 file changes?

- [x] Is the PR limited to one linear task?

- [x] Are relevant unit and component test-cases added?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.
