### PR TITLE
feat(integrations/auth0): add Auth0 event type to event context

### DIFF
--- a/src/v0/sources/auth0/mapping.json
+++ b/src/v0/sources/auth0/mapping.json
@@ -65,6 +65,6 @@
   },
   {
     "sourceKeys": "type",
-    "destKeys": "source_type"
+    "destKeys": ["source_type", "context.source_type"]
   }
 ]

--- a/src/v0/sources/auth0/mapping.json
+++ b/src/v0/sources/auth0/mapping.json
@@ -65,6 +65,6 @@
   },
   {
     "sourceKeys": "type",
-    "destKeys": ["source_type", "properties.source_type"]
+    "destKeys": "properties.source_type"
   }
 ]

--- a/src/v0/sources/auth0/mapping.json
+++ b/src/v0/sources/auth0/mapping.json
@@ -65,6 +65,6 @@
   },
   {
     "sourceKeys": "type",
-    "destKeys": ["source_type", "context.source_type"]
+    "destKeys": ["source_type", "properties.source_type"]
   }
 ]

--- a/test/integrations/sources/auth0/data.ts
+++ b/test/integrations/sources/auth0/data.ts
@@ -276,7 +276,6 @@ export const data = [
                     integration: {
                       name: 'Auth0',
                     },
-                    source_type: 'ss',
                   },
                   properties: {
                     log_id: '90020221031055712103169676686005480714681762668315934738',
@@ -292,6 +291,7 @@ export const data = [
                     client_id: 'vQcJNDTxsM1W72eHFonRJdzyOvawlwIt',
                     client_name: 'All Applications',
                     description: '',
+                    source_type: 'ss',
                   },
                   integrations: {
                     Auth0: false,
@@ -325,7 +325,6 @@ export const data = [
                     integration: {
                       name: 'Auth0',
                     },
-                    source_type: 'sapi',
                   },
                   properties: {
                     log_id: '90020221031055712103169676686007898566320991926665347090',
@@ -513,6 +512,7 @@ export const data = [
                     client_id: 'vQcJNDTxsM1W72eHFonRJdzyOvawlwIt',
                     client_name: '',
                     description: 'Create a User',
+                    source_type: 'sapi',
                   },
                   integrations: {
                     Auth0: false,
@@ -616,7 +616,6 @@ export const data = [
                     integration: {
                       name: 'Auth0',
                     },
-                    source_type: 'sapi',
                   },
                   groupId: 'org_eoe8p2atZ7furBxg',
                   properties: {
@@ -653,6 +652,7 @@ export const data = [
                     client_id: 'vQcJNDTxsM1W72eHFonRJdzyOvawlwIt',
                     client_name: '',
                     description: 'Add members to an organization',
+                    source_type: 'sapi',
                   },
                   integrations: {
                     Auth0: false,
@@ -961,7 +961,6 @@ export const data = [
                     integration: {
                       name: 'Auth0',
                     },
-                    source_type: 'sapi',
                   },
                   properties: {
                     log_id: '90020221031061527239169676960191065529099349299958906898',
@@ -1151,6 +1150,7 @@ export const data = [
                     client_id: 'vQcJNDTxsM1W72eHFonRJdzyOvawlwIt',
                     client_name: '',
                     description: 'Update tenant settings',
+                    source_type: 'sapi',
                   },
                   integrations: {
                     Auth0: false,
@@ -1182,7 +1182,6 @@ export const data = [
                     integration: {
                       name: 'Auth0',
                     },
-                    source_type: 'gd_tenant_update',
                   },
                   properties: {
                     log_id: '90020221031061530247169676961198100736838335677367058450',
@@ -1226,6 +1225,7 @@ export const data = [
                       },
                     },
                     description: 'Guardian - Updates tenant settings',
+                    source_type: 'gd_tenant_update',
                   },
                   integrations: {
                     Auth0: false,
@@ -1317,7 +1317,6 @@ export const data = [
                     integration: {
                       name: 'Auth0',
                     },
-                    source_type: 'ss',
                   },
                   properties: {
                     log_id: '90020221031055712103169676686005480714681762668315934738',
@@ -1333,6 +1332,7 @@ export const data = [
                     client_id: 'vQcJNDTxsM1W72eHFonRJdzyOvawlwIt',
                     client_name: 'All Applications',
                     description: '',
+                    source_type: 'ss',
                   },
                   integrations: {
                     Auth0: false,
@@ -1438,7 +1438,6 @@ export const data = [
                     integration: {
                       name: 'Auth0',
                     },
-                    source_type: 'ss',
                   },
                   properties: {
                     log_id: '90020221031055712103169676686005480714681762668315934738',
@@ -1454,6 +1453,7 @@ export const data = [
                     client_id: 'vQcJNDTxsM1W72eHFonRJdzyOvawlwIt',
                     client_name: 'All Applications',
                     description: '',
+                    source_type: 'ss',
                   },
                   integrations: {
                     Auth0: false,
@@ -1483,13 +1483,13 @@ export const data = [
                     integration: {
                       name: 'Auth0',
                     },
-                    source_type: 'sapi',
                   },
                   properties: {
                     log_id: '90020221031055712103169676686007898566320991926665347090',
                     client_id: 'vQcJNDTxsM1W72eHFonRJdzyOvawlwIt',
                     client_name: '',
                     description: 'Create a User',
+                    source_type: 'sapi',
                   },
                   integrations: {
                     Auth0: false,

--- a/test/integrations/sources/auth0/data.ts
+++ b/test/integrations/sources/auth0/data.ts
@@ -276,6 +276,7 @@ export const data = [
                     integration: {
                       name: 'Auth0',
                     },
+                    source_type: 'ss',
                   },
                   properties: {
                     log_id: '90020221031055712103169676686005480714681762668315934738',
@@ -324,6 +325,7 @@ export const data = [
                     integration: {
                       name: 'Auth0',
                     },
+                    source_type: 'sapi',
                   },
                   properties: {
                     log_id: '90020221031055712103169676686007898566320991926665347090',
@@ -614,6 +616,7 @@ export const data = [
                     integration: {
                       name: 'Auth0',
                     },
+                    source_type: 'sapi',
                   },
                   groupId: 'org_eoe8p2atZ7furBxg',
                   properties: {
@@ -958,6 +961,7 @@ export const data = [
                     integration: {
                       name: 'Auth0',
                     },
+                    source_type: 'sapi',
                   },
                   properties: {
                     log_id: '90020221031061527239169676960191065529099349299958906898',
@@ -1178,6 +1182,7 @@ export const data = [
                     integration: {
                       name: 'Auth0',
                     },
+                    source_type: 'gd_tenant_update',
                   },
                   properties: {
                     log_id: '90020221031061530247169676961198100736838335677367058450',
@@ -1312,6 +1317,7 @@ export const data = [
                     integration: {
                       name: 'Auth0',
                     },
+                    source_type: 'ss',
                   },
                   properties: {
                     log_id: '90020221031055712103169676686005480714681762668315934738',
@@ -1432,6 +1438,7 @@ export const data = [
                     integration: {
                       name: 'Auth0',
                     },
+                    source_type: 'ss',
                   },
                   properties: {
                     log_id: '90020221031055712103169676686005480714681762668315934738',
@@ -1476,6 +1483,7 @@ export const data = [
                     integration: {
                       name: 'Auth0',
                     },
+                    source_type: 'sapi',
                   },
                   properties: {
                     log_id: '90020221031055712103169676686007898566320991926665347090',

--- a/test/integrations/sources/auth0/data.ts
+++ b/test/integrations/sources/auth0/data.ts
@@ -254,7 +254,6 @@ export const data = [
               batch: [
                 {
                   type: 'identify',
-                  source_type: 'ss',
                   sentAt: '2022-10-31T05:57:06.859Z',
                   traits: {
                     connection: 'Username-Password-Authentication',
@@ -306,7 +305,6 @@ export const data = [
               batch: [
                 {
                   type: 'track',
-                  source_type: 'sapi',
                   event: 'Success API Operation',
                   sentAt: '2022-10-31T05:57:06.874Z',
                   userId: 'auth0|dummyPassword',
@@ -598,7 +596,6 @@ export const data = [
               batch: [
                 {
                   type: 'group',
-                  source_type: 'sapi',
                   sentAt: '2022-10-31T06:09:59.135Z',
                   userId: 'google-oauth2|123456',
                   anonymousId: '97fcd7b2-cc24-47d7-b776-057b7b199513',
@@ -942,7 +939,6 @@ export const data = [
               batch: [
                 {
                   type: 'track',
-                  source_type: 'sapi',
                   event: 'Success API Operation',
                   sentAt: '2022-10-31T06:15:25.201Z',
                   userId: 'google-oauth2|123456',
@@ -1165,7 +1161,6 @@ export const data = [
               batch: [
                 {
                   type: 'track',
-                  source_type: 'gd_tenant_update',
                   event: 'Guardian tenant update',
                   sentAt: '2022-10-31T06:15:25.196Z',
                   userId: 'google-oauth2|123456',
@@ -1295,7 +1290,6 @@ export const data = [
               batch: [
                 {
                   type: 'identify',
-                  source_type: 'ss',
                   sentAt: '2022-10-31T05:57:06.859Z',
                   traits: {
                     connection: 'Username-Password-Authentication',
@@ -1416,7 +1410,6 @@ export const data = [
               batch: [
                 {
                   type: 'identify',
-                  source_type: 'ss',
                   userId: '',
                   anonymousId: '97fcd7b2-cc24-47d7-b776-057b7b199513',
                   sentAt: '2022-10-31T05:57:06.859Z',
@@ -1468,7 +1461,6 @@ export const data = [
               batch: [
                 {
                   type: 'track',
-                  source_type: 'sapi',
                   event: 'Success API Operation',
                   sentAt: '2022-10-31T05:57:06.874Z',
                   anonymousId: '97fcd7b2-cc24-47d7-b776-057b7b199513',


### PR DESCRIPTION
## What are the changes introduced in this PR?

The Auth0 event type was added to the transformed message at the top level, but that field gets stripped out when messages are exported to warehouse destinations (see [this documentation](https://www.rudderstack.com/docs/destinations/warehouse-destinations/faq/#why-am-i-not-able-to-see-the-properties-added-at-the-top-level-of-an-event-in-warehouse-destination)). Add this field to the context blob as well, so that it will be available when exported to warehouses.

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

N/A

### Any new dependencies introduced with this change?

No.

### Any new generic utility introduced or modified. Please explain the changes.

N/A

### Any technical or performance related pointers to consider with the change?

N/A

@coderabbitai review

<hr>

### Developer checklist

- [x] My code follows the style guidelines of this project

- [x] **No breaking changes are being introduced.**

- [x] All related docs linked with the PR?

- [x] All changes manually tested?

- [x] Any documentation changes needed with this change?

- [x] Is the PR limited to 10 file changes?

- [x] Is the PR limited to one linear task?

- [x] Are relevant unit and component test-cases added?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.
