### PR TITLE
fix: klaviyo remove duplicate profile due anonymousId mapped to external_id

### DIFF
--- a/src/v0/destinations/klaviyo/data/KlaviyoIdentify.json
+++ b/src/v0/destinations/klaviyo/data/KlaviyoIdentify.json
@@ -1,9 +1,13 @@
 [
   {
     "destKey": "external_id",
-    "sourceKeys": "userId",
+    "sourceKeys": "userIdOnly",
     "required": false,
     "sourceFromGenericMap": true
+  },
+  {
+    "destKey": "anonymous_id",
+    "sourceKeys": "anonymousId"
   },
   {
     "destKey": "email",

--- a/test/integrations/destinations/klaviyo/processor/identifyTestData.ts
+++ b/test/integrations/destinations/klaviyo/processor/identifyTestData.ts
@@ -50,6 +50,7 @@ const commonTraits = {
 const commonTraits2 = { ...commonTraits, street: '63, Shibuya' };
 
 const commonOutputUserProps = {
+  anonymous_id: '97c46c81-3140-456d-b2a9-690d70aaca35',
   external_id: 'user@1',
   email: 'test@rudderstack.com',
   first_name: 'Test',

--- a/test/integrations/destinations/klaviyo/router/data.ts
+++ b/test/integrations/destinations/klaviyo/router/data.ts
@@ -253,6 +253,7 @@ export const data: RouterTestData[] = [
                         type: 'profile',
                         attributes: {
                           external_id: 'test',
+                          anonymous_id: '97c46c81-3140-456d-b2a9-690d70aaca35',
                           email: 'test@rudderstack.com',
                           first_name: 'Test',
                           last_name: 'Rudderlabs',
@@ -301,6 +302,7 @@ export const data: RouterTestData[] = [
                       type: 'profile',
                       attributes: {
                         external_id: 'test',
+                        anonymous_id: '97c46c81-3140-456d-b2a9-690d70aaca35',
                         email: 'test@rudderstack.com',
                         first_name: 'Test',
                         last_name: 'Rudderlabs',


### PR DESCRIPTION
## What are the changes introduced in this PR?
For klaviyo destination, anonymous events (no `userId`), we are mapping the main identifier on klaviyo side, `external_id`, with `anonymousId` and once we get identify event for the same user we are mapping userId to `external_id` leading to duplicating profiles. Klaviyo has a parameter as `anonymous_id` which helps to track anonymous user, and once user is identified, it we can send both `external_id` mapped to `userId` and `anonymous_id` mapped to `anonymousId` to merge the profiles. Hence, avoiding creation of duplicate profiles.
This PR resolves this issue by mapping only `userId` to the `external_id` parameter and mapping `anonymousId` to `anonymous_id` always.

## What is the related Linear task?

Resolves INT-2185

## Please explain the objectives of your changes below

Put down any required details on the broader aspect of your changes. If there are any dependent changes, **mandatorily** mention them here

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

N/A

### Any new dependencies introduced with this change?

N/A

### Any new generic utility introduced or modified. Please explain the changes.

N/A

### Any technical or performance related pointers to consider with the change?

N/A

@coderabbitai review

<hr>

### Developer checklist

- [ ] My code follows the style guidelines of this project

- [ ] **No breaking changes are being introduced.**

- [ ] All related docs linked with the PR?

- [ ] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [ ] Is the PR limited to 10 file changes?

- [ ] Is the PR limited to one linear task?

- [ ] Are relevant unit and component test-cases added in **new readability format**?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.
