### PR TITLE
chore: add metrics for braze alias failures

### DIFF
--- a/src/util/prometheus.js
+++ b/src/util/prometheus.js
@@ -602,16 +602,10 @@ class Prometheus {
         labelNames: ['destination_id'],
       },
       {
-        name: 'braze_alias_failure_error_count',
-        help: 'braze_alias_failure_error_count',
+        name: 'braze_alias_failure_count',
+        help: 'braze_alias_failure_count',
         type: 'counter',
         labelNames: ['destination_id'],
-      },
-      {
-        name: 'braze_alias_failure_error_type',
-        help: 'braze_alias_failure_error_type',
-        type: 'counter',
-        labelNames: ['destination_id', 'alias_error_type'],
       },
       {
         name: 'mixpanel_batch_engage_pack_size',

--- a/src/util/prometheus.js
+++ b/src/util/prometheus.js
@@ -602,6 +602,18 @@ class Prometheus {
         labelNames: ['destination_id'],
       },
       {
+        name: 'braze_alias_failure_error_count',
+        help: 'braze_alias_failure_error_count',
+        type: 'counter',
+        labelNames: ['destination_id'],
+      },
+      {
+        name: 'braze_alias_failure_error_type',
+        help: 'braze_alias_failure_error_type',
+        type: 'counter',
+        labelNames: ['destination_id', 'alias_error_type'],
+      },
+      {
         name: 'mixpanel_batch_engage_pack_size',
         help: 'mixpanel_batch_engage_pack_size',
         type: 'gauge',

--- a/src/v0/destinations/braze/transform.js
+++ b/src/v0/destinations/braze/transform.js
@@ -230,8 +230,6 @@ async function processIdentify(message, destination) {
     },
   );
 
-  collectStatsForAliasFailure(brazeIdentifyResp, destination.ID);
-
   if (!isHttpStatusSuccess(brazeIdentifyResp.status)) {
     throw new NetworkError(
       `Braze identify failed - ${JSON.stringify(brazeIdentifyResp.response)}`,
@@ -242,6 +240,8 @@ async function processIdentify(message, destination) {
       brazeIdentifyResp.response,
     );
   }
+
+  collectStatsForAliasFailure(brazeIdentifyResp, destination.ID);
 }
 
 function processTrackWithUserAttributes(

--- a/src/v0/destinations/braze/transform.js
+++ b/src/v0/destinations/braze/transform.js
@@ -241,7 +241,7 @@ async function processIdentify(message, destination) {
     );
   }
 
-  collectStatsForAliasFailure(brazeIdentifyResp, destination.ID);
+  collectStatsForAliasFailure(brazeIdentifyResp.response, destination.ID);
 }
 
 function processTrackWithUserAttributes(

--- a/src/v0/destinations/braze/transform.js
+++ b/src/v0/destinations/braze/transform.js
@@ -13,6 +13,7 @@ const {
   getPurchaseObjs,
   setExternalId,
   setAliasObjectWithAnonId,
+  collectStatsForAliasFailure,
 } = require('./util');
 const tags = require('../../util/tags');
 const { EventType, MappedToDestinationKey } = require('../../../constants');
@@ -228,6 +229,9 @@ async function processIdentify(message, destination) {
       endpointPath: '/users/identify',
     },
   );
+
+  collectStatsForAliasFailure(brazeIdentifyResp, destination.ID);
+
   if (!isHttpStatusSuccess(brazeIdentifyResp.status)) {
     throw new NetworkError(
       `Braze identify failed - ${JSON.stringify(brazeIdentifyResp.response)}`,

--- a/src/v0/destinations/braze/util.js
+++ b/src/v0/destinations/braze/util.js
@@ -1,6 +1,7 @@
 /* eslint-disable */
 const _ = require('lodash');
 const get = require('get-value');
+const { structuredLogger: logger } = require('@rudderstack/integrations-lib');
 const stats = require('../../../util/stats');
 const { handleHttpRequest } = require('../../../adapters/network');
 const {
@@ -682,16 +683,13 @@ const collectStatsForAliasFailure = (brazeResponse, destinationId) => {
   const { aliases_processed: aliasesProcessed, errors } = brazeResponse;
   if (aliasesProcessed === 0) {
     stats.increment('braze_alias_failure_count', { destination_id: destinationId });
-    const errorType = [];
+
     if (Array.isArray(errors)) {
-      errors.forEach((error) => {
-        errorType.push(error.type);
+      logger.info('Braze Alias Failure Errors:', {
+        destinationId,
+        errors,
       });
     }
-    stats.increment('braze_alias_failure_error_type', {
-      destination_id: destinationId,
-      alias_error_type: errorType.join(','),
-    });
   }
 };
 

--- a/src/v0/destinations/braze/util.js
+++ b/src/v0/destinations/braze/util.js
@@ -655,6 +655,46 @@ function getPurchaseObjs(message, config) {
   return purchaseObjs;
 }
 
+const collectStatsForAliasFailure = (brazeResponse, destinationId) => {
+  /**
+   * Braze Response for Alias failure
+   * {
+   * "aliases_processed": 0,
+   * "message": "success",
+   * "errors": [
+   *     {
+   *         "type": "'external_id' is required",
+   *         "input_array": "user_identifiers",
+   *         "index": 0
+   *     }
+   *   ]
+   * }
+   */
+
+  /**
+   * Braze Response for Alias success
+   * {
+   *   "aliases_processed": 1,
+   *   "message": "success"
+   *   }
+   */
+
+  const { aliases_processed: aliasesProcessed, errors } = brazeResponse;
+  if (aliasesProcessed === 0) {
+    stats.increment('braze_alias_failure_count', { destination_id: destinationId });
+    const errorType = [];
+    if (Array.isArray(errors)) {
+      errors.forEach((error) => {
+        errorType.push(error.type);
+      });
+    }
+    stats.increment('braze_alias_failure_error_type', {
+      destination_id: destinationId,
+      alias_error_type: errorType.join(','),
+    });
+  }
+};
+
 module.exports = {
   BrazeDedupUtility,
   CustomAttributeOperationUtil,
@@ -667,4 +707,5 @@ module.exports = {
   setExternalId,
   setAliasObjectWithAnonId,
   addMandatoryPurchaseProperties,
+  collectStatsForAliasFailure,
 };

--- a/src/v0/destinations/braze/util.js
+++ b/src/v0/destinations/braze/util.js
@@ -680,6 +680,10 @@ const collectStatsForAliasFailure = (brazeResponse, destinationId) => {
    *   }
    */
 
+  // Should not happen but still checking for unhandled exceptions
+  if (!isDefinedAndNotNull(brazeResponse)) {
+    return;
+  }
   const { aliases_processed: aliasesProcessed, errors } = brazeResponse;
   if (aliasesProcessed === 0) {
     stats.increment('braze_alias_failure_count', { destination_id: destinationId });


### PR DESCRIPTION
## What are the changes introduced in this PR?

This PR adds metrics for braze identify flow where errors are observed due missing `userId`, as braze returns 200 with an error message in response body we want to capture that as metrics

## What is the related Linear task?

Resolves INT-2259
