### PR TITLE
fix: mapping changes for aifa,andi and asid

### DIFF
--- a/src/v0/destinations/singular/data/SINGULARAndroidEventConfig.json
+++ b/src/v0/destinations/singular/data/SINGULARAndroidEventConfig.json
@@ -88,17 +88,23 @@
   {
     "destKey": "aifa",
     "sourceKeys": "context.device.advertisingId",
-    "required": true
+    "required": false,
+    "metadata": {
+      "defaultValue": ""
+    }
   },
   {
     "destKey": "andi",
     "sourceKeys": "context.device.id",
-    "required": true
+    "required": false,
+    "metadata": {
+      "defaultValue": ""
+    }
   },
   {
     "destKey": "asid",
     "sourceKeys": "properties.asid",
-    "required": true,
+    "required": false,
     "metadata": {
       "defaultValue": ""
     }

--- a/src/v0/destinations/singular/data/SINGULARAndroidSessionConfig.json
+++ b/src/v0/destinations/singular/data/SINGULARAndroidSessionConfig.json
@@ -42,7 +42,7 @@
   {
     "destKey": "asid",
     "sourceKeys": "properties.asid",
-    "required": true,
+    "required": false,
     "metadata": {
       "defaultValue": ""
     }
@@ -91,12 +91,18 @@
   {
     "destKey": "aifa",
     "sourceKeys": "context.device.advertisingId",
-    "required": true
+    "required": false,
+    "metadata": {
+      "defaultValue": ""
+    }
   },
   {
     "destKey": "andi",
     "sourceKeys": "context.device.id",
-    "required": true
+    "required": false,
+    "metadata": {
+      "defaultValue": ""
+    }
   },
   {
     "destKey": "utime",


### PR DESCRIPTION
## What are the changes introduced in this PR?

> For Android requests, Singular requires either AIFA, ASID, or ANDI, in that order of preference. All 3 can be sent if available, and our servers will discard the ANDI per Google's data policies. If AIFA is not available, ASID should be sent. If ASID is not available, ANDI should be sent. If a given device ID is not available, the respective param should be sent with an empty value (rather than null, or some other value).

We are making these changes in our Singular destination integration. 

## What is the related Linear task?

Resolves INT-2241

## Please explain the objectives of your changes below

Put down any required details on the broader aspect of your changes. If there are any dependent changes, **mandatorily** mention them here
> We are making this change as currently the integration does not send Android events to Singular that are missing the ASID property.

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

N/A

### Any new dependencies introduced with this change?

N/A

### Any new generic utility introduced or modified. Please explain the changes.

N/A

### Any technical or performance related pointers to consider with the change?

N/A

@coderabbitai review

<hr>

### Developer checklist

- [x] My code follows the style guidelines of this project

- [ ] **No breaking changes are being introduced.**

- [ ] All related docs linked with the PR?

- [ ] All changes manually tested?

- [x] Any documentation changes needed with this change?

- [x] Is the PR limited to 10 file changes?

- [x] Is the PR limited to one linear task?

- [x] Are relevant unit and component test-cases added in **new readability format**?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.
