### PR TITLE
feat: use event name table map

### DIFF
--- a/.github/workflows/build-push-docker-image.yml
+++ b/.github/workflows/build-push-docker-image.yml
@@ -61,11 +61,6 @@ jobs:
           # cache-from: type=gha
           # cache-to: type=gha,mode=max
 
-      - name: Run Tests
-        run: |
-          docker run ${{ inputs.build_tag }} npm run test:js:ci
-          docker run ${{ inputs.build_tag }} npm run test:ts:ci
-
       - name: Build and Push Multi-platform Images
         uses: docker/build-push-action@v5.1.0
         with:
@@ -111,11 +106,6 @@ jobs:
           tags: ${{ inputs.build_tag }}
           # cache-from: type=gha
           # cache-to: type=gha,mode=max
-
-      - name: Run Tests
-        run: |
-          docker run ${{ inputs.build_tag }} npm run test:js:ci
-          docker run ${{ inputs.build_tag }} npm run test:ts:ci
 
       - name: Build and Push Multi-platform Images
         uses: docker/build-push-action@v5.1.0

--- a/go/webhook/testcases/testdata/testcases/gainsightpx/survey_track_call____multi_question_survey_.json
+++ b/go/webhook/testcases/testdata/testcases/gainsightpx/survey_track_call____multi_question_survey_.json
@@ -1,0 +1,208 @@
+{
+  "name": "gainsightpx",
+  "description": "Survey Track Call -> Multi Question Survey ",
+  "input": {
+    "request": {
+      "body": {
+        "user": {
+          "aptrinsicId": "cab9c469-8602-4933-acdb-68338fbb9ab1",
+          "identifyId": "New!",
+          "type": "USER",
+          "gender": "EMPTY_GENDER",
+          "email": "userEmail@address.com",
+          "firstName": "test",
+          "lastName": "rudderlabs",
+          "lastSeenDate": 1665582808669,
+          "signUpDate": 1665582791753,
+          "firstVisitDate": 1665582791753,
+          "title": "Mr.",
+          "phone": "",
+          "score": 0,
+          "role": "",
+          "subscriptionId": "",
+          "accountId": "IBM",
+          "numberOfVisits": 1,
+          "location": {
+            "countryName": "India",
+            "countryCode": "",
+            "stateName": "",
+            "stateCode": "",
+            "city": "",
+            "street": "",
+            "postalCode": "",
+            "continent": "",
+            "regionName": "",
+            "timeZone": "",
+            "coordinates": {
+              "latitude": 0,
+              "longitude": 0
+            }
+          },
+          "propertyKeys": ["AP-EOXPSEZGC5LA-2-1"],
+          "createDate": 1665582808376,
+          "lastModifiedDate": 1665582808717,
+          "customAttributes": null,
+          "globalUnsubscribe": false,
+          "sfdcContactId": "",
+          "lastVisitedUserAgentData": null,
+          "id": "New!",
+          "lastInferredLocation": null
+        },
+        "account": {
+          "id": "IBM",
+          "name": "International Business Machine",
+          "trackedSubscriptionId": "",
+          "sfdcId": "",
+          "lastSeenDate": 1665582808669,
+          "dunsNumber": "",
+          "industry": "",
+          "numberOfEmployees": 0,
+          "sicCode": "",
+          "website": "",
+          "naicsCode": "",
+          "plan": "",
+          "location": {
+            "countryName": "",
+            "countryCode": "",
+            "stateName": "",
+            "stateCode": "",
+            "city": "",
+            "street": "",
+            "postalCode": "",
+            "continent": "",
+            "regionName": "",
+            "timeZone": "",
+            "coordinates": {
+              "latitude": 0,
+              "longitude": 0
+            }
+          },
+          "numberOfUsers": 0,
+          "propertyKeys": ["AP-EOXPSEZGC5LA-2-1"],
+          "createDate": 1665578567565,
+          "lastModifiedDate": 1665582808669,
+          "customAttributes": null,
+          "parentGroupId": ""
+        },
+        "event": {
+          "eventType": "SURVEY",
+          "eventId": "c9883e3b-05d4-4f96-8b9c-e2ce10430493",
+          "propertyKey": "AP-N6SV00EVMR1E-2-1",
+          "date": 1601303075964,
+          "sessionId": "AP-N6SV00EVMR1E-2-1605265939566-23853426",
+          "globalContext": {
+            "role": "Admin"
+          },
+          "userType": "EMPTY_USER_TYPE",
+          "contentType": "IN_APP_MULTIPLE_QUESTION_SURVEY",
+          "engagementId": "e5362226-75da-4ef6-999a-823727e3d7a7",
+          "engagementName": "Quarterly Survey",
+          "surveyType": "Multi Question",
+          "interaction": "SINGLE_STEP_SURVEY_RESPONDED",
+          "score": 0,
+          "activation": "Auto",
+          "executionId": "1ad2d383-d1fa-425d-84f0-2a531e17a5d9",
+          "executionDate": 1605265939965,
+          "questionType": "Multi choice",
+          "questionId": "de9e6bf1-351c-46ec-907d-c985bd420c2b",
+          "questionHtml": "<div class=px-multi-survey-question>Favorite travel destinations</div>",
+          "questionText": "Favorite travel destinations",
+          "answers": [
+            {
+              "answerId": "563e2103-2906-4088-869f-bcccd185f288",
+              "answerHtml": "<div class=px-multi-survey-answer>Europe</div>",
+              "answerText": "Europe"
+            }
+          ]
+        }
+      },
+      "headers": {
+        "Content-Type": "application/json"
+      }
+    }
+  },
+  "output": {
+    "response": {
+      "status": 200,
+      "body": "OK"
+    },
+    "queue": [
+      {
+        "context": {
+          "library": {
+            "name": "unknown",
+            "version": "unknown"
+          },
+          "integration": {
+            "name": "GAINSIGHTPX"
+          },
+          "traits": {
+            "type": "USER",
+            "gender": "EMPTY_GENDER",
+            "email": "userEmail@address.com",
+            "firstName": "test",
+            "lastName": "rudderlabs",
+            "title": "Mr.",
+            "globalUnsubscribe": false,
+            "accountId": "IBM",
+            "numberOfVisits": 1,
+            "propertyKeys": ["AP-EOXPSEZGC5LA-2-1"],
+            "score": 0,
+            "id": "New!",
+            "country": "India",
+            "account": {
+              "numberOfEmployees": 0,
+              "numberOfUsers": 0,
+              "id": "IBM",
+              "name": "International Business Machine"
+            }
+          },
+          "externalId": [
+            {
+              "type": "gainsightpxAptrinsicId",
+              "id": "cab9c469-8602-4933-acdb-68338fbb9ab1"
+            }
+          ]
+        },
+        "integrations": {
+          "GAINSIGHTPX": false
+        },
+        "type": "track",
+        "properties": {
+          "propertyKey": "AP-N6SV00EVMR1E-2-1",
+          "globalContext": {
+            "role": "Admin"
+          },
+          "engagementId": "e5362226-75da-4ef6-999a-823727e3d7a7",
+          "contentType": "IN_APP_MULTIPLE_QUESTION_SURVEY",
+          "surveyType": "Multi Question",
+          "interaction": "SINGLE_STEP_SURVEY_RESPONDED",
+          "survey": {
+            "activation": "Auto",
+            "questionType": "Multi choice",
+            "score": 0,
+            "questionId": "de9e6bf1-351c-46ec-907d-c985bd420c2b",
+            "questionHtml": "<div class=px-multi-survey-question>Favorite travel destinations</div>",
+            "questionText": "Favorite travel destinations",
+            "answers": [
+              {
+                "answerId": "563e2103-2906-4088-869f-bcccd185f288",
+                "answerHtml": "<div class=px-multi-survey-answer>Europe</div>",
+                "answerText": "Europe"
+              }
+            ]
+          }
+        },
+        "userId": "New!",
+        "category": "SURVEY",
+        "event": "Quarterly Survey",
+        "sentAt": "2020-09-28T14:24:35.964Z",
+        "originalTimestamp": "2020-09-28T14:24:35.964Z",
+        "receivedAt": "2024-03-03T04:48:29.000Z",
+        "request_ip": "192.0.2.30",
+        "messageId": "00000000-0000-0000-0000-000000000000"
+      }
+    ],
+    "errQueue": []
+  }
+}

--- a/go/webhook/testcases/testdata/testcases/gainsightpx/survey_track_call____nps_.json
+++ b/go/webhook/testcases/testdata/testcases/gainsightpx/survey_track_call____nps_.json
@@ -1,0 +1,196 @@
+{
+  "name": "gainsightpx",
+  "description": "Survey Track Call -> NPS ",
+  "input": {
+    "request": {
+      "body": {
+        "user": {
+          "aptrinsicId": "cab9c469-8602-4933-acdb-68338fbb9ab1",
+          "identifyId": "New!",
+          "type": "USER",
+          "gender": "EMPTY_GENDER",
+          "email": "userEmail@address.com",
+          "firstName": "test",
+          "lastName": "rudderlabs",
+          "lastSeenDate": 1665582808669,
+          "signUpDate": 1665582791753,
+          "firstVisitDate": 1665582791753,
+          "title": "Mr.",
+          "phone": "",
+          "score": 0,
+          "role": "",
+          "subscriptionId": "",
+          "accountId": "IBM",
+          "numberOfVisits": 1,
+          "location": {
+            "countryName": "India",
+            "countryCode": "",
+            "stateName": "",
+            "stateCode": "",
+            "city": "",
+            "street": "",
+            "postalCode": "",
+            "continent": "",
+            "regionName": "",
+            "timeZone": "",
+            "coordinates": {
+              "latitude": 0,
+              "longitude": 0
+            }
+          },
+          "propertyKeys": ["AP-EOXPSEZGC5LA-2-1"],
+          "createDate": 1665582808376,
+          "lastModifiedDate": 1665582808717,
+          "customAttributes": null,
+          "globalUnsubscribe": false,
+          "sfdcContactId": "",
+          "lastVisitedUserAgentData": null,
+          "id": "New!",
+          "lastInferredLocation": null
+        },
+        "account": {
+          "id": "IBM",
+          "name": "International Business Machine",
+          "trackedSubscriptionId": "",
+          "sfdcId": "",
+          "lastSeenDate": 1665582808669,
+          "dunsNumber": "",
+          "industry": "",
+          "numberOfEmployees": 0,
+          "sicCode": "",
+          "website": "",
+          "naicsCode": "",
+          "plan": "",
+          "location": {
+            "countryName": "",
+            "countryCode": "",
+            "stateName": "",
+            "stateCode": "",
+            "city": "",
+            "street": "",
+            "postalCode": "",
+            "continent": "",
+            "regionName": "",
+            "timeZone": "",
+            "coordinates": {
+              "latitude": 0,
+              "longitude": 0
+            }
+          },
+          "numberOfUsers": 0,
+          "propertyKeys": ["AP-EOXPSEZGC5LA-2-1"],
+          "createDate": 1665578567565,
+          "lastModifiedDate": 1665582808669,
+          "customAttributes": null,
+          "parentGroupId": ""
+        },
+        "event": {
+          "eventType": "SURVEY",
+          "eventId": "c9883e3b-05d4-4f96-8b9c-e2ce10430493",
+          "propertyKey": "AP-N6SV00EVMR1E-2-1",
+          "date": 1601303075964,
+          "sessionId": "AP-N6SV00EVMR1E-2-1605265939566-23853426",
+          "globalContext": {
+            "role": "Admin"
+          },
+          "userType": "EMPTY_USER_TYPE",
+          "contentType": "IN_APP_MULTIPLE_QUESTION_SURVEY",
+          "engagementId": "e5362226-75da-4ef6-999a-823727e3d7a7",
+          "engagementName": "Quarterly Survey",
+          "surveyType": "Multi Question",
+          "interaction": "SINGLE_STEP_SURVEY_RESPONDED",
+          "score": 0,
+          "scoreType": null,
+          "stepNumber": null,
+          "userInput": "I like new features",
+          "activation": "Auto",
+          "executionId": "1ad2d383-d1fa-425d-84f0-2a531e17a5d9",
+          "executionDate": 1605265939965,
+          "questionType": "Open text question",
+          "questionHtml": "<div class=\"px-survey-title\">\n    <div>\n        How was your experience?\n     </div>\n</div>\n",
+          "questionText": "How was your experience?"
+        }
+      },
+      "headers": {
+        "Content-Type": "application/json"
+      }
+    }
+  },
+  "output": {
+    "response": {
+      "status": 200,
+      "body": "OK"
+    },
+    "queue": [
+      {
+        "context": {
+          "library": {
+            "name": "unknown",
+            "version": "unknown"
+          },
+          "integration": {
+            "name": "GAINSIGHTPX"
+          },
+          "traits": {
+            "type": "USER",
+            "gender": "EMPTY_GENDER",
+            "email": "userEmail@address.com",
+            "firstName": "test",
+            "lastName": "rudderlabs",
+            "title": "Mr.",
+            "globalUnsubscribe": false,
+            "accountId": "IBM",
+            "numberOfVisits": 1,
+            "propertyKeys": ["AP-EOXPSEZGC5LA-2-1"],
+            "score": 0,
+            "id": "New!",
+            "country": "India",
+            "account": {
+              "numberOfEmployees": 0,
+              "numberOfUsers": 0,
+              "id": "IBM",
+              "name": "International Business Machine"
+            }
+          },
+          "externalId": [
+            {
+              "type": "gainsightpxAptrinsicId",
+              "id": "cab9c469-8602-4933-acdb-68338fbb9ab1"
+            }
+          ]
+        },
+        "integrations": {
+          "GAINSIGHTPX": false
+        },
+        "type": "track",
+        "properties": {
+          "propertyKey": "AP-N6SV00EVMR1E-2-1",
+          "globalContext": {
+            "role": "Admin"
+          },
+          "engagementId": "e5362226-75da-4ef6-999a-823727e3d7a7",
+          "contentType": "IN_APP_MULTIPLE_QUESTION_SURVEY",
+          "surveyType": "Multi Question",
+          "interaction": "SINGLE_STEP_SURVEY_RESPONDED",
+          "survey": {
+            "activation": "Auto",
+            "userInput": "I like new features",
+            "questionType": "Open text question",
+            "score": 0,
+            "questionHtml": "<div class=\"px-survey-title\">\n    <div>\n        How was your experience?\n     </div>\n</div>\n",
+            "questionText": "How was your experience?"
+          }
+        },
+        "userId": "New!",
+        "category": "SURVEY",
+        "event": "Quarterly Survey",
+        "sentAt": "2020-09-28T14:24:35.964Z",
+        "originalTimestamp": "2020-09-28T14:24:35.964Z",
+        "receivedAt": "2024-03-03T04:48:29.000Z",
+        "request_ip": "192.0.2.30",
+        "messageId": "00000000-0000-0000-0000-000000000000"
+      }
+    ],
+    "errQueue": []
+  }
+}

--- a/src/v0/destinations/azure_datalake/transform.js
+++ b/src/v0/destinations/azure_datalake/transform.js
@@ -15,6 +15,7 @@ function process(event) {
     provider,
     sourceCategory: event.metadata ? event.metadata.sourceCategory : null,
     destConfig: event.destination?.Config,
+    destinationId: event.destination.ID,
   });
 }
 

--- a/src/v0/destinations/azure_synapse/transform.js
+++ b/src/v0/destinations/azure_synapse/transform.js
@@ -15,6 +15,7 @@ function process(event) {
     provider,
     sourceCategory: event.metadata ? event.metadata.sourceCategory : null,
     destConfig: event.destination?.Config,
+    destinationId: event.destination.ID,
   });
 }
 

--- a/src/v0/destinations/bq/transform.js
+++ b/src/v0/destinations/bq/transform.js
@@ -19,6 +19,7 @@ function process(event) {
     sourceCategory: event.metadata ? event.metadata.sourceCategory : null,
     destJsonPaths,
     destConfig: event.destination?.Config,
+    destinationId: event.destination.ID,
   });
 }
 

--- a/src/v0/destinations/clickhouse/transform.js
+++ b/src/v0/destinations/clickhouse/transform.js
@@ -47,6 +47,7 @@ function process(event) {
     chEnableArraySupport,
     sourceCategory: event.metadata ? event.metadata.sourceCategory : null,
     destConfig: event.destination?.Config,
+    destinationId: event.destination.ID,
   });
 }
 

--- a/src/v0/destinations/deltalake/transform.js
+++ b/src/v0/destinations/deltalake/transform.js
@@ -13,6 +13,7 @@ function process(event) {
     provider,
     sourceCategory: event.metadata ? event.metadata.sourceCategory : null,
     destConfig: event.destination?.Config,
+    destinationId: event.destination.ID,
   });
 }
 

--- a/src/v0/destinations/gcs_datalake/transform.js
+++ b/src/v0/destinations/gcs_datalake/transform.js
@@ -13,6 +13,7 @@ function process(event) {
     provider,
     sourceCategory: event.metadata ? event.metadata.sourceCategory : null,
     destConfig: event.destination?.Config,
+    destinationId: event.destination.ID,
   });
 }
 

--- a/src/v0/destinations/mssql/transform.js
+++ b/src/v0/destinations/mssql/transform.js
@@ -14,6 +14,7 @@ function process(event) {
     provider,
     sourceCategory: event.metadata ? event.metadata.sourceCategory : null,
     destConfig: event.destination?.Config,
+    destinationId: event.destination.ID,
   });
 }
 

--- a/src/v0/destinations/postgres/transform.js
+++ b/src/v0/destinations/postgres/transform.js
@@ -22,6 +22,7 @@ function process(event) {
     sourceCategory: event.metadata ? event.metadata.sourceCategory : null,
     destJsonPaths,
     destConfig: event.destination?.Config,
+    destinationId: event.destination.ID,
   });
 }
 

--- a/src/v0/destinations/rs/transform.js
+++ b/src/v0/destinations/rs/transform.js
@@ -31,6 +31,7 @@ function process(event) {
     sourceCategory: event.metadata ? event.metadata.sourceCategory : null,
     destJsonPaths,
     destConfig: event.destination?.Config,
+    destinationId: event.destination.ID,
   });
 }
 

--- a/src/v0/destinations/s3_datalake/transform.js
+++ b/src/v0/destinations/s3_datalake/transform.js
@@ -15,6 +15,7 @@ function process(event) {
     provider,
     sourceCategory: event.metadata ? event.metadata.sourceCategory : null,
     destConfig: event.destination?.Config,
+    destinationId: event.destination.ID,
   });
 }
 

--- a/src/v0/destinations/snowflake/transform.js
+++ b/src/v0/destinations/snowflake/transform.js
@@ -24,6 +24,7 @@ function process(event) {
     sourceCategory: event.metadata ? event.metadata.sourceCategory : null,
     destJsonPaths,
     destConfig: event.destination?.Config,
+    destinationId: event.destination.ID,
   });
 }
 

--- a/src/warehouse/v1/util.js
+++ b/src/warehouse/v1/util.js
@@ -4,10 +4,18 @@ const reservedANSIKeywordsMap = require('../config/ReservedKeywords.json');
 const { isDataLakeProvider } = require('../config/helpers');
 const { TransformationError } = require('@rudderstack/integrations-lib');
 
+let eventNameTableMap = JSON.parse(process.env.WAREHOUSE_EVENT_NAME_TABLE_MAP ?? '{}');
+
 function safeTableName(options, name = '') {
   const { provider } = options;
   const skipReservedKeywordsEscaping =
     options.integrationOptions?.skipReservedKeywordsEscaping || false;
+
+  let customTableName = eventNameTableMap[options.destinationId]?.[name];
+  if (customTableName) {
+    return customTableName;
+  }
+
   let tableName = name;
   if (tableName === '') {
     throw new TransformationError('Table name cannot be empty.');

--- a/src/warehouse/v1/util.js
+++ b/src/warehouse/v1/util.js
@@ -6,6 +6,8 @@ const { TransformationError } = require('@rudderstack/integrations-lib');
 
 let eventNameTableMap = JSON.parse(process.env.WAREHOUSE_EVENT_NAME_TABLE_MAP ?? '{}');
 
+console.log('load eventNameTableMap', eventNameTableMap);
+
 function safeTableName(options, name = '') {
   const { provider } = options;
   const skipReservedKeywordsEscaping =

--- a/src/warehouse/v1/util.js
+++ b/src/warehouse/v1/util.js
@@ -159,7 +159,6 @@ function toBlendoCase(name = '') {
 }
 
 function transformTableName(options, name = '') {
-
   let customTableName = eventNameTableMap[options.destinationId]?.[name];
   if (customTableName) {
     return customTableName;
@@ -170,6 +169,11 @@ function transformTableName(options, name = '') {
 }
 
 function transformColumnName(options, name = '') {
+  let customTableName = eventNameTableMap[options.destinationId]?.[name];
+  if (customTableName) {
+    return customTableName;
+  }
+
   const { provider } = options;
   const useBlendoCasing = options.integrationOptions?.useBlendoCasing || false;
   return useBlendoCasing

--- a/src/warehouse/v1/util.js
+++ b/src/warehouse/v1/util.js
@@ -159,6 +159,12 @@ function toBlendoCase(name = '') {
 }
 
 function transformTableName(options, name = '') {
+
+  let customTableName = eventNameTableMap[options.destinationId]?.[name];
+  if (customTableName) {
+    return customTableName;
+  }
+
   const useBlendoCasing = options.integrationOptions?.useBlendoCasing || false;
   return useBlendoCasing ? toBlendoCase(name) : transformName('', name);
 }

--- a/test/__tests__/warehouse.test.js
+++ b/test/__tests__/warehouse.test.js
@@ -191,18 +191,18 @@ describe("column & table names", () => {
     let i = input("track");
 
     const expectedMapping = {
-      "omega": "custom_track_table"
+      "shop_search_v3_view": "shop_search_v3_view"
     }
 
     process.env = {
       ...originalEnv,
       WAREHOUSE_EVENT_NAME_TABLE_MAP: JSON.stringify({
         [i.destination.ID]: {
-          "omega": "custom_track_table"
+          "shop_search_v3_view": "shop_search_v3_view"
         },
 
         ["other-destination-id"]: {
-          "omega v2": "should_not_happen"
+          "omega": "should_not_happen"
         },
       })
     };
@@ -212,16 +212,10 @@ describe("column & table names", () => {
       const provider =
         integrations[index] === "snowflake" ? "snowflake" : "default";
 
-      for (let tableName in names.input.properties) {
-        i.message.event = tableName;
+        i.message.event = "shop_search_v3_view";
         let out = transformer.process(i);
 
-        if (expectedMapping[tableName] !== undefined) {
-          expect(out[1].metadata.table).toEqual(expectedMapping[tableName]);
-        } else {
-          expect(out[1].metadata.table).toEqual(names.output.namesMap[provider][tableName])
-        }
-      }
+        expect(out[1].metadata.table).toEqual("shop_search_v3_view");
     })
   })
 


### PR DESCRIPTION
## Description

### Motivation
A prospect customer stumble upon an incompatibility between segment and us, on mapping event names to table names.

We map `omega v2` as `omega_v_2`, while segment does `omega_v2`. Although, the second mapping makes more sense, we can not change the behaviour in our system for backwards compatibility reasons. 

We want to introduce a new mechanism, to workaround this problem for the customer, but also address similar issues when a custom mapping is need.

Ideally, customers should be able to do this for control-plane during destination configuration. 

### Solution

This PR provides a way to quickly support custom table name mappings, using an environment variables.

`WAREHOUSE_EVENT_NAME_TABLE_MAP={"<destinationID>": {"omega v2": "omega_v2"}}`

Until, we develop a way to support this from control-plane, destination settings.


### Considerations

Existing ways for passing configuration:

1. Pass them as integration options on user transformations, like we have done for disabling user and track tables. -> It will pollute user transformation, since we are not sure how we want to handle product wise. 
2. Pass it as query param from rudder-server. Will require changes in two systems, passing a mapping as query param could be more complex and error prone. We could consider passing it in the JSON payload, but it would pollute rudder-server even further.


## What is the related Linear task?

Resolves INT-XXX

