### PR TITLE
fix: adding a new condition for retrying the function creation in python transformation

### DIFF
--- a/src/util/openfaas/index.js
+++ b/src/util/openfaas/index.js
@@ -241,8 +241,9 @@ const deployFaasFunction = async (
     // To handle concurrent create requests,
     // throw retry error if deployment or service already exists so that request can be retried
     if (
-      (error.statusCode === 500 || error.statusCode === 400) &&
-      error.message.includes('already exists')
+      ((error.statusCode === 500 || error.statusCode === 400) &&
+        error.message.includes('already exists')) ||
+      (error.statusCode === 409 && error.message.includes('Conflict change already made'))
     ) {
       setFunctionInCache(functionName);
       throw new RetryRequestError(`${functionName} already exists`);


### PR DESCRIPTION
## What are the changes introduced in this PR?

`Neuroflow` customer informed us that for one of there transformations, we are generating error codes when creating the function. The issue is that once a day the transformation connected to destination will receive a surge of traffic across all the UT pods and all of them tries to create the function in openfaas. This results in some of requests failing with statusCode 409 and events are dropped.

The fix recognises these failures and retries them so they are not dropped.

## What is the related Linear task?

Resolves DAT-1510

## Please explain the objectives of your changes below

Put down any required details on the broader aspect of your changes. If there are any dependent changes, **mandatorily** mention them here

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

N/A

### Any new dependencies introduced with this change?

N/A

### Any new generic utility introduced or modified. Please explain the changes.

N/A

### Any technical or performance related pointers to consider with the change?

N/A

@coderabbitai review

<hr>

### Developer checklist

- [ ] My code follows the style guidelines of this project

- [ ] **No breaking changes are being introduced.**

- [ ] All related docs linked with the PR?

- [ ] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [ ] Is the PR limited to 10 file changes?

- [ ] Is the PR limited to one linear task?

- [ ] Are relevant unit and component test-cases added in **new readability format**?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.
