### PR TITLE
posthog user agent report field updated

### DIFF
--- a/src/v0/destinations/posthog/data/PHPropertiesConfig.json
+++ b/src/v0/destinations/posthog/data/PHPropertiesConfig.json
@@ -91,7 +91,7 @@
     "isMobile": true
   },
   {
-    "destKey": "$useragent",
+    "destKey": "$raw_user_agent",
     "sourceKeys": "context.userAgent",
     "isMobile": true
   },


### PR DESCRIPTION
Posthog uses `$raw_user_agent` as field to ingest `userAgent`. This PR fixes it.
