### PR TITLE
Added  correct referrer parsing to posthog

### DIFF
--- a/src/v0/destinations/posthog/data/PHPropertiesConfig.json
+++ b/src/v0/destinations/posthog/data/PHPropertiesConfig.json
@@ -4,6 +4,10 @@
     "sourceKeys": "context.os.name"
   },
   {
+    "destKey": "$referrer",
+    "sourceKeys": "context.page.referrer"
+  },
+  {
     "destKey": "$current_url",
     "sourceKeys": "context.page.url"
   },


### PR DESCRIPTION
Posthog takes `$referrer` property as referrer field. This PR corrects the transformation.