### PR TITLE
fix: use destination definition name in place of string for custom object

### DIFF
--- a/src/v0/destinations/salesforce/transform.js
+++ b/src/v0/destinations/salesforce/transform.js
@@ -134,7 +134,7 @@ async function getSaleforceIdForRecord(
     );
   }
   const searchRecord = processedsfSearchResponse.response?.searchRecords?.find(
-    (rec) => typeof identifierValue !== 'undefined' && rec[identifierType] === `${identifierValue}`,
+    (rec) => typeof identifierValue !== 'undefined' && rec[identifierType] === identifierValue,
   );
 
   return searchRecord?.Id;

--- a/src/v0/destinations/salesforce/transform.js
+++ b/src/v0/destinations/salesforce/transform.js
@@ -190,8 +190,9 @@ async function getSalesforceIdFromPayload(
         'Invalid externalId. id, type, identifierType must be provided',
       );
     }
-
-    const objectType = type.toLowerCase().replace('salesforce-', '');
+    const objectType = type
+      .toLowerCase()
+      .replace(`${destination.DestinationDefinition.Name.toLowerCase()}-`, '');
     let salesforceId = id;
 
     // Fetch the salesforce Id if the identifierType is not ID

--- a/src/v0/destinations/salesforce/transform.js
+++ b/src/v0/destinations/salesforce/transform.js
@@ -134,7 +134,10 @@ async function getSaleforceIdForRecord(
     );
   }
   const searchRecord = processedsfSearchResponse.response?.searchRecords?.find(
-    (rec) => typeof identifierValue !== 'undefined' && rec[identifierType] === identifierValue,
+    (rec) =>
+      typeof identifierValue !== 'undefined' &&
+      // eslint-disable-next-line eqeqeq
+      rec[identifierType] == identifierValue,
   );
 
   return searchRecord?.Id;

--- a/test/integrations/destinations/salesforce/network.ts
+++ b/test/integrations/destinations/salesforce/network.ts
@@ -277,6 +277,48 @@ const transformationMocksData = [
   },
   {
     httpReq: {
+      url: 'https://ap15.salesforce.com/services/data/v50.0/parameterizedSearch/?q=72728&sobject=customobject2&in=CustomObject2__c&customobject2.fields=id,CustomObject2__c',
+      method: 'GET',
+    },
+    httpRes: {
+      status: 200,
+      data: {
+        searchRecords: [
+          {
+            attributes: {
+              type: 'CustomObject2__c',
+              url: '/services/data/v50.0/CustomObject2__c/id1101',
+            },
+            Id: 'id1101',
+            CustomObject2__c: 72728,
+          },
+        ],
+      },
+    },
+  },
+  {
+    httpReq: {
+      url: 'https://ap15.salesforce.com/services/data/v50.0/parameterizedSearch/?q=72729&sobject=customobject2&in=CustomObject2__c&customobject2.fields=id,CustomObject2__c',
+      method: 'GET',
+    },
+    httpRes: {
+      status: 200,
+      data: {
+        searchRecords: [
+          {
+            attributes: {
+              type: 'CustomObject2__c',
+              url: '/services/data/v50.0/CustomObject2__c/id1102',
+            },
+            Id: 'id1102',
+            CustomObject2__c: '72729',
+          },
+        ],
+      },
+    },
+  },
+  {
+    httpReq: {
       url: 'https://ap15.salesforce.com/services/data/v50.0/parameterizedSearch/?q=ddv_ua%2B%7B%7B1234*245%7D%7D%40bugFix.com&sobject=Lead&Lead.fields=id,IsConverted,ConvertedContactId,IsDeleted',
       method: 'GET',
     },

--- a/test/integrations/destinations/salesforce/network.ts
+++ b/test/integrations/destinations/salesforce/network.ts
@@ -247,6 +247,18 @@ const transformationMocksData = [
   },
   {
     httpReq: {
+      url: 'https://ap15.salesforce.com/services/data/v50.0/parameterizedSearch/?q=72727&sobject=customobject&in=CustomObject__c&customobject.fields=id,CustomObject__c',
+      method: 'GET',
+    },
+    httpRes: {
+      status: 200,
+      data: {
+        searchRecords: [],
+      },
+    },
+  },
+  {
+    httpReq: {
       url: 'https://ap15.salesforce.com/services/data/v50.0/parameterizedSearch/?q=peter.gibbons1%40initech.com&sobject=Lead&Lead.fields=id',
       method: 'GET',
     },

--- a/test/integrations/destinations/salesforce/network.ts
+++ b/test/integrations/destinations/salesforce/network.ts
@@ -180,8 +180,7 @@ const transformationMocksData = [
     httpRes: {
       status: 200,
       data: {
-        access_token:
-          '00D2v000002lXbX!ARcAQJBSGNA1Rq.MbUdtmlREscrN_nO3ckBz6kc4jRQGxqAzNkhT1XZIF0yPqyCQSnezWO3osMw1ewpjToO7q41E9.LvedWY',
+        access_token: 'dummy.access.token',
         instance_url: 'https://ap15.salesforce.com',
         id: 'https://login.salesforce.com/id/00D2v000002lXbXEAU/0052v00000ga9WqAAI',
         token_type: 'Bearer',
@@ -198,8 +197,7 @@ const transformationMocksData = [
     httpRes: {
       status: 200,
       data: {
-        access_token:
-          '00D2v000002lXbX!ARcAQJBSGNA1Rq.MbUdtmlREscrN_nO3ckBz6kc4jRQGxqAzNkhT1XZIF0yPqyCQSnezWO3osMw1ewpjToO7q41E9.LvedWY',
+        access_token: 'dummy.access.token',
         instance_url: 'https://ap15.salesforce.com',
         id: 'https://login.salesforce.com/id/00D2v000002lXbXEAU/0052v00000ga9WqAAI',
         token_type: 'Bearer',

--- a/test/integrations/destinations/salesforce/processor/data.ts
+++ b/test/integrations/destinations/salesforce/processor/data.ts
@@ -97,8 +97,7 @@ export const data = [
               endpoint: 'https://ap15.salesforce.com/services/data/v50.0/sobjects/Lead',
               headers: {
                 'Content-Type': 'application/json',
-                Authorization:
-                  'Bearer 00D2v000002lXbX!ARcAQJBSGNA1Rq.MbUdtmlREscrN_nO3ckBz6kc4jRQGxqAzNkhT1XZIF0yPqyCQSnezWO3osMw1ewpjToO7q41E9.LvedWY',
+                Authorization: 'Bearer dummy.access.token',
               },
               params: {},
               body: {
@@ -225,8 +224,7 @@ export const data = [
               endpoint: 'https://ap15.salesforce.com/services/data/v50.0/sobjects/Lead',
               headers: {
                 'Content-Type': 'application/json',
-                Authorization:
-                  'Bearer 00D2v000002lXbX!ARcAQJBSGNA1Rq.MbUdtmlREscrN_nO3ckBz6kc4jRQGxqAzNkhT1XZIF0yPqyCQSnezWO3osMw1ewpjToO7q41E9.LvedWY',
+                Authorization: 'Bearer dummy.access.token',
               },
               params: {},
               body: {
@@ -354,8 +352,7 @@ export const data = [
               endpoint: 'https://ap15.salesforce.com/services/data/v50.0/sobjects/Lead',
               headers: {
                 'Content-Type': 'application/json',
-                Authorization:
-                  'Bearer 00D2v000002lXbX!ARcAQJBSGNA1Rq.MbUdtmlREscrN_nO3ckBz6kc4jRQGxqAzNkhT1XZIF0yPqyCQSnezWO3osMw1ewpjToO7q41E9.LvedWY',
+                Authorization: 'Bearer dummy.access.token',
               },
               params: {},
               body: {
@@ -591,8 +588,7 @@ export const data = [
               endpoint: 'https://ap15.salesforce.com/services/data/v50.0/sobjects/Lead',
               headers: {
                 'Content-Type': 'application/json',
-                Authorization:
-                  'Bearer 00D2v000002lXbX!ARcAQJBSGNA1Rq.MbUdtmlREscrN_nO3ckBz6kc4jRQGxqAzNkhT1XZIF0yPqyCQSnezWO3osMw1ewpjToO7q41E9.LvedWY',
+                Authorization: 'Bearer dummy.access.token',
               },
               params: {},
               body: {
@@ -721,8 +717,7 @@ export const data = [
               endpoint: 'https://ap15.salesforce.com/services/data/v50.0/sobjects/Lead',
               headers: {
                 'Content-Type': 'application/json',
-                Authorization:
-                  'Bearer 00D2v000002lXbX!ARcAQJBSGNA1Rq.MbUdtmlREscrN_nO3ckBz6kc4jRQGxqAzNkhT1XZIF0yPqyCQSnezWO3osMw1ewpjToO7q41E9.LvedWY',
+                Authorization: 'Bearer dummy.access.token',
               },
               params: {},
               body: {
@@ -855,8 +850,7 @@ export const data = [
                 'https://ap15.salesforce.com/services/data/v50.0/sobjects/Contact/sf-contact-id?_HttpMethod=PATCH',
               headers: {
                 'Content-Type': 'application/json',
-                Authorization:
-                  'Bearer 00D2v000002lXbX!ARcAQJBSGNA1Rq.MbUdtmlREscrN_nO3ckBz6kc4jRQGxqAzNkhT1XZIF0yPqyCQSnezWO3osMw1ewpjToO7q41E9.LvedWY',
+                Authorization: 'Bearer dummy.access.token',
               },
               params: {},
               body: {
@@ -989,8 +983,7 @@ export const data = [
                 'https://ap15.salesforce.com/services/data/v50.0/sobjects/Lead/sf-contact-id?_HttpMethod=PATCH',
               headers: {
                 'Content-Type': 'application/json',
-                Authorization:
-                  'Bearer 00D2v000002lXbX!ARcAQJBSGNA1Rq.MbUdtmlREscrN_nO3ckBz6kc4jRQGxqAzNkhT1XZIF0yPqyCQSnezWO3osMw1ewpjToO7q41E9.LvedWY',
+                Authorization: 'Bearer dummy.access.token',
               },
               params: {},
               userId: '',
@@ -1117,8 +1110,7 @@ export const data = [
               endpoint: 'https://ap15.salesforce.com/services/data/v50.0/sobjects/Lead',
               headers: {
                 'Content-Type': 'application/json',
-                Authorization:
-                  'Bearer 00D2v000002lXbX!ARcAQJBSGNA1Rq.MbUdtmlREscrN_nO3ckBz6kc4jRQGxqAzNkhT1XZIF0yPqyCQSnezWO3osMw1ewpjToO7q41E9.LvedWY',
+                Authorization: 'Bearer dummy.access.token',
               },
               params: {},
               body: {
@@ -1244,8 +1236,7 @@ export const data = [
                 'https://ap15.salesforce.com/services/data/v50.0/sobjects/custom_object__c/a005g0000383kmUAAQ?_HttpMethod=PATCH',
               headers: {
                 'Content-Type': 'application/json',
-                Authorization:
-                  'Bearer 00D2v000002lXbX!ARcAQJBSGNA1Rq.MbUdtmlREscrN_nO3ckBz6kc4jRQGxqAzNkhT1XZIF0yPqyCQSnezWO3osMw1ewpjToO7q41E9.LvedWY',
+                Authorization: 'Bearer dummy.access.token',
               },
               params: {},
               body: {
@@ -1360,8 +1351,7 @@ export const data = [
                 'https://ap15.salesforce.com/services/data/v50.0/sobjects/custom_object__c/a005g0000383kmUAAQ?_HttpMethod=PATCH',
               headers: {
                 'Content-Type': 'application/json',
-                Authorization:
-                  'Bearer 00D2v000002lXbX!ARcAQJBSGNA1Rq.MbUdtmlREscrN_nO3ckBz6kc4jRQGxqAzNkhT1XZIF0yPqyCQSnezWO3osMw1ewpjToO7q41E9.LvedWY',
+                Authorization: 'Bearer dummy.access.token',
               },
               params: {},
               body: {

--- a/test/integrations/destinations/salesforce/router/data.ts
+++ b/test/integrations/destinations/salesforce/router/data.ts
@@ -723,4 +723,320 @@ export const data = [
       },
     },
   },
+  {
+    name: 'salesforce_oauth',
+    description:
+      'Test 5: Sending custom object with external id of different type for Salesforce-Oauth (extId number, apiResponse string) ',
+    feature: 'router',
+    module: 'destination',
+    version: 'v0',
+    input: {
+      request: {
+        body: {
+          input: [
+            {
+              message: {
+                anonymousId: '1e7673da-9473-49c6-97f7-da848ecafa76',
+                channel: 'web',
+                context: {
+                  externalId: [
+                    {
+                      id: 72728,
+                      type: 'SALESFORCE_OAUTH-CUSTOMOBJECT2',
+                      identifierType: 'CustomObject2__c',
+                    },
+                  ],
+                  mappedToDestination: 'true',
+                  app: {
+                    build: '1.0.0',
+                    name: 'RudderLabs JavaScript SDK',
+                    namespace: 'com.rudderlabs.javascript',
+                    version: '1.0.0',
+                  },
+                  ip: '0.0.0.0',
+                  library: { name: 'RudderLabs JavaScript SDK', version: '1.0.0' },
+                  locale: 'en-US',
+                  os: { name: '', version: '' },
+                  screen: { density: 2 },
+                  traits: {
+                    anonymousId: '1e7673da-9473-49c6-97f7-da848ecafa76',
+                    company: 'Initech',
+                    address: {
+                      city: 'east greenwich',
+                      country: 'USA',
+                      state: 'California',
+                      street: '19123 forest lane',
+                      postalCode: '94115',
+                    },
+                    email: 'peter.gibbons@initech.com',
+                    name: 'Peter Gibbons',
+                    phone: '570-690-4150',
+                    rating: 'Hot',
+                    title: 'VP of Derp',
+                  },
+                  userAgent:
+                    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.130 Safari/537.36',
+                },
+                integrations: { All: true },
+                messageId: 'f19c35da-e9de-4c6e-b6e5-9e60cccc12c8',
+                originalTimestamp: '2020-01-27T12:20:55.301Z',
+                receivedAt: '2020-01-27T17:50:58.657+05:30',
+                request_ip: '14.98.244.60',
+                sentAt: '2020-01-27T12:20:56.849Z',
+                timestamp: '2020-01-27T17:50:57.109+05:30',
+                type: 'identify',
+                userId: '1e7673da-9473-49c6-97f7-da848ecafa76',
+              },
+              metadata: { jobId: 1, userId: 'u1' },
+              destination: {
+                Config: {
+                  initialAccessToken: 'dummyInitialAccessToken',
+                  password: 'dummyPassword1',
+                  userName: 'testsalesforce1453@gmail.com',
+                },
+                DestinationDefinition: {
+                  DisplayName: 'Salesforce-Oauth',
+                  ID: '1T96GHZ0YZ1qQSLULHCoJkow9KC',
+                  Name: 'SALESFORCE_OAUTH',
+                },
+                Enabled: true,
+                ID: '1WqFFH5esuVPnUgHkvEoYxDcX3y',
+                Name: 'tst',
+                Transformations: [],
+              },
+            },
+          ],
+          destType: 'salesforce_oauth',
+        },
+        method: 'POST',
+      },
+    },
+    output: {
+      response: {
+        status: 200,
+        body: {
+          output: [
+            {
+              batchedRequest: [
+                {
+                  version: '1',
+                  type: 'REST',
+                  method: 'POST',
+                  endpoint:
+                    'https://ap15.salesforce.com/services/data/v50.0/sobjects/customobject2/id1101?_HttpMethod=PATCH',
+                  headers: {
+                    'Content-Type': 'application/json',
+                    Authorization: 'Bearer dummy.access.token',
+                  },
+                  params: {},
+                  body: {
+                    JSON: {
+                      CustomObject2__c: 72728,
+                      address: {
+                        postalCode: '94115',
+                        city: 'east greenwich',
+                        country: 'USA',
+                        state: 'California',
+                        street: '19123 forest lane',
+                      },
+                      anonymousId: '1e7673da-9473-49c6-97f7-da848ecafa76',
+                      company: 'Initech',
+                      email: 'peter.gibbons@initech.com',
+                      name: 'Peter Gibbons',
+                      phone: '570-690-4150',
+                      rating: 'Hot',
+                      title: 'VP of Derp',
+                    },
+                    XML: {},
+                    JSON_ARRAY: {},
+                    FORM: {},
+                  },
+                  files: {},
+                },
+              ],
+              metadata: [
+                { destInfo: { authKey: '1WqFFH5esuVPnUgHkvEoYxDcX3y' }, jobId: 1, userId: 'u1' },
+              ],
+              batched: false,
+              statusCode: 200,
+              destination: {
+                Config: {
+                  initialAccessToken: 'dummyInitialAccessToken',
+                  password: 'dummyPassword1',
+                  userName: 'testsalesforce1453@gmail.com',
+                },
+                DestinationDefinition: {
+                  DisplayName: 'Salesforce-Oauth',
+                  ID: '1T96GHZ0YZ1qQSLULHCoJkow9KC',
+                  Name: 'SALESFORCE_OAUTH',
+                },
+                Enabled: true,
+                ID: '1WqFFH5esuVPnUgHkvEoYxDcX3y',
+                Name: 'tst',
+                Transformations: [],
+              },
+            },
+          ],
+        },
+      },
+    },
+  },
+  {
+    name: 'salesforce_oauth',
+    description:
+      'Test 6: Sending custom object with external id of different type for Salesforce-Oauth (extId string, apiResponse number) ',
+    feature: 'router',
+    module: 'destination',
+    version: 'v0',
+    input: {
+      request: {
+        body: {
+          input: [
+            {
+              message: {
+                anonymousId: '1e7673da-9473-49c6-97f7-da848ecafa76',
+                channel: 'web',
+                context: {
+                  externalId: [
+                    {
+                      id: '72729',
+                      type: 'SALESFORCE_OAUTH-CUSTOMOBJECT2',
+                      identifierType: 'CustomObject2__c',
+                    },
+                  ],
+                  mappedToDestination: 'true',
+                  app: {
+                    build: '1.0.0',
+                    name: 'RudderLabs JavaScript SDK',
+                    namespace: 'com.rudderlabs.javascript',
+                    version: '1.0.0',
+                  },
+                  ip: '0.0.0.0',
+                  library: { name: 'RudderLabs JavaScript SDK', version: '1.0.0' },
+                  locale: 'en-US',
+                  os: { name: '', version: '' },
+                  screen: { density: 2 },
+                  traits: {
+                    anonymousId: '1e7673da-9473-49c6-97f7-da848ecafa76',
+                    company: 'Initech',
+                    address: {
+                      city: 'east greenwich',
+                      country: 'USA',
+                      state: 'California',
+                      street: '19123 forest lane',
+                      postalCode: '94115',
+                    },
+                    email: 'peter.gibbons@initech.com',
+                    name: 'Peter Gibbons',
+                    phone: '570-690-4150',
+                    rating: 'Hot',
+                    title: 'VP of Derp',
+                  },
+                  userAgent:
+                    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.130 Safari/537.36',
+                },
+                integrations: { All: true },
+                messageId: 'f19c35da-e9de-4c6e-b6e5-9e60cccc12c8',
+                originalTimestamp: '2020-01-27T12:20:55.301Z',
+                receivedAt: '2020-01-27T17:50:58.657+05:30',
+                request_ip: '14.98.244.60',
+                sentAt: '2020-01-27T12:20:56.849Z',
+                timestamp: '2020-01-27T17:50:57.109+05:30',
+                type: 'identify',
+                userId: '1e7673da-9473-49c6-97f7-da848ecafa76',
+              },
+              metadata: { jobId: 1, userId: 'u1' },
+              destination: {
+                Config: {
+                  initialAccessToken: 'dummyInitialAccessToken',
+                  password: 'dummyPassword1',
+                  userName: 'testsalesforce1453@gmail.com',
+                },
+                DestinationDefinition: {
+                  DisplayName: 'Salesforce-Oauth',
+                  ID: '1T96GHZ0YZ1qQSLULHCoJkow9KC',
+                  Name: 'SALESFORCE_OAUTH',
+                },
+                Enabled: true,
+                ID: '1WqFFH5esuVPnUgHkvEoYxDcX3y',
+                Name: 'tst',
+                Transformations: [],
+              },
+            },
+          ],
+          destType: 'salesforce_oauth',
+        },
+        method: 'POST',
+      },
+    },
+    output: {
+      response: {
+        status: 200,
+        body: {
+          output: [
+            {
+              batchedRequest: [
+                {
+                  version: '1',
+                  type: 'REST',
+                  method: 'POST',
+                  endpoint:
+                    'https://ap15.salesforce.com/services/data/v50.0/sobjects/customobject2/id1102?_HttpMethod=PATCH',
+                  headers: {
+                    'Content-Type': 'application/json',
+                    Authorization: 'Bearer dummy.access.token',
+                  },
+                  params: {},
+                  body: {
+                    JSON: {
+                      CustomObject2__c: '72729',
+                      address: {
+                        postalCode: '94115',
+                        city: 'east greenwich',
+                        country: 'USA',
+                        state: 'California',
+                        street: '19123 forest lane',
+                      },
+                      anonymousId: '1e7673da-9473-49c6-97f7-da848ecafa76',
+                      company: 'Initech',
+                      email: 'peter.gibbons@initech.com',
+                      name: 'Peter Gibbons',
+                      phone: '570-690-4150',
+                      rating: 'Hot',
+                      title: 'VP of Derp',
+                    },
+                    XML: {},
+                    JSON_ARRAY: {},
+                    FORM: {},
+                  },
+                  files: {},
+                },
+              ],
+              metadata: [
+                { destInfo: { authKey: '1WqFFH5esuVPnUgHkvEoYxDcX3y' }, jobId: 1, userId: 'u1' },
+              ],
+              batched: false,
+              statusCode: 200,
+              destination: {
+                Config: {
+                  initialAccessToken: 'dummyInitialAccessToken',
+                  password: 'dummyPassword1',
+                  userName: 'testsalesforce1453@gmail.com',
+                },
+                DestinationDefinition: {
+                  DisplayName: 'Salesforce-Oauth',
+                  ID: '1T96GHZ0YZ1qQSLULHCoJkow9KC',
+                  Name: 'SALESFORCE_OAUTH',
+                },
+                Enabled: true,
+                ID: '1WqFFH5esuVPnUgHkvEoYxDcX3y',
+                Name: 'tst',
+                Transformations: [],
+              },
+            },
+          ],
+        },
+      },
+    },
+  },
 ];

--- a/test/integrations/destinations/salesforce/router/data.ts
+++ b/test/integrations/destinations/salesforce/router/data.ts
@@ -92,8 +92,7 @@ export const data = [
                   endpoint: 'https://ap15.salesforce.com/services/data/v50.0/sobjects/Lead',
                   headers: {
                     'Content-Type': 'application/json',
-                    Authorization:
-                      'Bearer 00D2v000002lXbX!ARcAQJBSGNA1Rq.MbUdtmlREscrN_nO3ckBz6kc4jRQGxqAzNkhT1XZIF0yPqyCQSnezWO3osMw1ewpjToO7q41E9.LvedWY',
+                    Authorization: 'Bearer dummy.access.token',
                   },
                   params: {},
                   body: {
@@ -239,8 +238,7 @@ export const data = [
                     'https://ap15.salesforce.com/services/data/v50.0/sobjects/Lead/leadId?_HttpMethod=PATCH',
                   headers: {
                     'Content-Type': 'application/json',
-                    Authorization:
-                      'Bearer 00D2v000002lXbX!ARcAQJBSGNA1Rq.MbUdtmlREscrN_nO3ckBz6kc4jRQGxqAzNkhT1XZIF0yPqyCQSnezWO3osMw1ewpjToO7q41E9.LvedWY',
+                    Authorization: 'Bearer dummy.access.token',
                   },
                   params: {},
                   body: {
@@ -385,8 +383,7 @@ export const data = [
                   endpoint: 'https://ap15.salesforce.com/services/data/v50.0/sobjects/Lead',
                   headers: {
                     'Content-Type': 'application/json',
-                    Authorization:
-                      'Bearer 00D2v000002lXbX!ARcAQJBSGNA1Rq.MbUdtmlREscrN_nO3ckBz6kc4jRQGxqAzNkhT1XZIF0yPqyCQSnezWO3osMw1ewpjToO7q41E9.LvedWY',
+                    Authorization: 'Bearer dummy.access.token',
                   },
                   params: {},
                   body: {
@@ -456,8 +453,7 @@ export const data = [
                 endpoint: 'https://ap15.salesforce.com/services/data/v50.0/sobjects/Lead',
                 headers: {
                   'Content-Type': 'application/json',
-                  Authorization:
-                    'Bearer 00D2v000002lXbX!ARcAQJBSGNA1Rq.MbUdtmlREscrN_nO3ckBz6kc4jRQGxqAzNkhT1XZIF0yPqyCQSnezWO3osMw1ewpjToO7q41E9.LvedWY',
+                  Authorization: 'Bearer dummy.access.token',
                 },
                 params: {},
                 body: {
@@ -519,8 +515,7 @@ export const data = [
                 endpoint: 'https://ap15.salesforce.com/services/data/v50.0/sobjects/Lead',
                 headers: {
                   'Content-Type': 'application/json',
-                  Authorization:
-                    'Bearer 00D2v000002lXbX!ARcAQJBSGNA1Rq.MbUdtmlREscrN_nO3ckBz6kc4jRQGxqAzNkhT1XZIF0yPqyCQSnezWO3osMw1ewpjToO7q41E9.LvedWY',
+                  Authorization: 'Bearer dummy.access.token',
                 },
                 params: {},
                 body: {
@@ -673,13 +668,12 @@ export const data = [
                   endpoint: 'https://ap15.salesforce.com/services/data/v50.0/sobjects/customobject',
                   headers: {
                     'Content-Type': 'application/json',
-                    Authorization:
-                      'Bearer 00D2v000002lXbX!ARcAQJBSGNA1Rq.MbUdtmlREscrN_nO3ckBz6kc4jRQGxqAzNkhT1XZIF0yPqyCQSnezWO3osMw1ewpjToO7q41E9.LvedWY',
+                    Authorization: 'Bearer dummy.access.token',
                   },
                   params: {},
                   body: {
                     JSON: {
-                      "CustomObject__c": 72727,
+                      CustomObject__c: 72727,
                       address: {
                         postalCode: '94115',
                         city: 'east greenwich',
@@ -687,13 +681,13 @@ export const data = [
                         state: 'California',
                         street: '19123 forest lane',
                       },
-                      "anonymousId": "1e7673da-9473-49c6-97f7-da848ecafa76",
-                      "company": "Initech",
-                      "email": "peter.gibbons@initech.com",
-                      "name": "Peter Gibbons",
-                      "phone": "570-690-4150",
-                      "rating": "Hot",
-                      "title": "VP of Derp",
+                      anonymousId: '1e7673da-9473-49c6-97f7-da848ecafa76',
+                      company: 'Initech',
+                      email: 'peter.gibbons@initech.com',
+                      name: 'Peter Gibbons',
+                      phone: '570-690-4150',
+                      rating: 'Hot',
+                      title: 'VP of Derp',
                     },
                     XML: {},
                     JSON_ARRAY: {},

--- a/test/integrations/destinations/salesforce/router/data.ts
+++ b/test/integrations/destinations/salesforce/router/data.ts
@@ -572,4 +572,161 @@ export const data = [
       },
     },
   },
+  {
+    name: 'salesforce',
+    description: 'Test 4 : Sending custom object for Salesforce-Oauth ',
+    feature: 'router',
+    module: 'destination',
+    version: 'v0',
+    input: {
+      request: {
+        body: {
+          input: [
+            {
+              message: {
+                anonymousId: '1e7673da-9473-49c6-97f7-da848ecafa76',
+                channel: 'web',
+                context: {
+                  externalId: [
+                    {
+                      id: 72727,
+                      type: 'SALESFORCE_OAUTH-CUSTOMOBJECT',
+                      identifierType: 'CustomObject__c',
+                    },
+                  ],
+                  mappedToDestination: 'true',
+                  app: {
+                    build: '1.0.0',
+                    name: 'RudderLabs JavaScript SDK',
+                    namespace: 'com.rudderlabs.javascript',
+                    version: '1.0.0',
+                  },
+                  ip: '0.0.0.0',
+                  library: { name: 'RudderLabs JavaScript SDK', version: '1.0.0' },
+                  locale: 'en-US',
+                  os: { name: '', version: '' },
+                  screen: { density: 2 },
+                  traits: {
+                    anonymousId: '1e7673da-9473-49c6-97f7-da848ecafa76',
+                    company: 'Initech',
+                    address: {
+                      city: 'east greenwich',
+                      country: 'USA',
+                      state: 'California',
+                      street: '19123 forest lane',
+                      postalCode: '94115',
+                    },
+                    email: 'peter.gibbons@initech.com',
+                    name: 'Peter Gibbons',
+                    phone: '570-690-4150',
+                    rating: 'Hot',
+                    title: 'VP of Derp',
+                  },
+                  userAgent:
+                    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.130 Safari/537.36',
+                },
+                integrations: { All: true },
+                messageId: 'f19c35da-e9de-4c6e-b6e5-9e60cccc12c8',
+                originalTimestamp: '2020-01-27T12:20:55.301Z',
+                receivedAt: '2020-01-27T17:50:58.657+05:30',
+                request_ip: '14.98.244.60',
+                sentAt: '2020-01-27T12:20:56.849Z',
+                timestamp: '2020-01-27T17:50:57.109+05:30',
+                type: 'identify',
+                userId: '1e7673da-9473-49c6-97f7-da848ecafa76',
+              },
+              metadata: { jobId: 1, userId: 'u1' },
+              destination: {
+                Config: {
+                  initialAccessToken: 'dummyInitialAccessToken',
+                  password: 'dummyPassword1',
+                  userName: 'testsalesforce1453@gmail.com',
+                },
+                DestinationDefinition: {
+                  DisplayName: 'Salesforce-Oauth',
+                  ID: '1T96GHZ0YZ1qQSLULHCoJkow9KC',
+                  Name: 'SALESFORCE_OAUTH',
+                },
+                Enabled: true,
+                ID: '1WqFFH5esuVPnUgHkvEoYxDcX3y',
+                Name: 'tst',
+                Transformations: [],
+              },
+            },
+          ],
+          destType: 'salesforce',
+        },
+        method: 'POST',
+      },
+    },
+    output: {
+      response: {
+        status: 200,
+        body: {
+          output: [
+            {
+              batchedRequest: [
+                {
+                  version: '1',
+                  type: 'REST',
+                  method: 'POST',
+                  endpoint: 'https://ap15.salesforce.com/services/data/v50.0/sobjects/customobject',
+                  headers: {
+                    'Content-Type': 'application/json',
+                    Authorization:
+                      'Bearer 00D2v000002lXbX!ARcAQJBSGNA1Rq.MbUdtmlREscrN_nO3ckBz6kc4jRQGxqAzNkhT1XZIF0yPqyCQSnezWO3osMw1ewpjToO7q41E9.LvedWY',
+                  },
+                  params: {},
+                  body: {
+                    JSON: {
+                      "CustomObject__c": 72727,
+                      address: {
+                        postalCode: '94115',
+                        city: 'east greenwich',
+                        country: 'USA',
+                        state: 'California',
+                        street: '19123 forest lane',
+                      },
+                      "anonymousId": "1e7673da-9473-49c6-97f7-da848ecafa76",
+                      "company": "Initech",
+                      "email": "peter.gibbons@initech.com",
+                      "name": "Peter Gibbons",
+                      "phone": "570-690-4150",
+                      "rating": "Hot",
+                      "title": "VP of Derp",
+                    },
+                    XML: {},
+                    JSON_ARRAY: {},
+                    FORM: {},
+                  },
+                  files: {},
+                },
+              ],
+              metadata: [
+                { destInfo: { authKey: '1WqFFH5esuVPnUgHkvEoYxDcX3y' }, jobId: 1, userId: 'u1' },
+              ],
+              batched: false,
+              statusCode: 200,
+              destination: {
+                Config: {
+                  initialAccessToken: 'dummyInitialAccessToken',
+                  password: 'dummyPassword1',
+                  userName: 'testsalesforce1453@gmail.com',
+                },
+                DestinationDefinition: {
+                  DisplayName: 'Salesforce-Oauth',
+                  ID: '1T96GHZ0YZ1qQSLULHCoJkow9KC',
+                  Name: 'SALESFORCE_OAUTH',
+                },
+                Enabled: true,
+                ID: '1WqFFH5esuVPnUgHkvEoYxDcX3y',
+                Name: 'tst',
+                Transformations: [],
+              },
+            },
+          ],
+        },
+      },
+    },
+  },
 ];


### PR DESCRIPTION
## What are the changes introduced in this PR?

Fix to use destination definition name in place of a hardcoded 'Salesforce-' string for custom object, allows the same flow for Salesforce Oauth destination also.

## What is the related Linear task?

Resolves INT-2664

## Please explain the objectives of your changes below

Put down any required details on the broader aspect of your changes. If there are any dependent changes, **mandatorily** mention them here

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

We are removing the stringification of the external Id in the event payload, now the id goes in the same data type as it is sent.

### Any new dependencies introduced with this change?

N/A

### Any new generic utility introduced or modified. Please explain the changes.

N/A

### Any technical or performance related pointers to consider with the change?

N/A

@coderabbitai review

<hr>

### Developer checklist

- [ ] My code follows the style guidelines of this project

- [ ] **No breaking changes are being introduced.**

- [ ] All related docs linked with the PR?

- [ ] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [ ] Is the PR limited to 10 file changes?

- [ ] Is the PR limited to one linear task?

- [ ] Are relevant unit and component test-cases added in **new readability format**?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.
