### PR TITLE
fix: prefer event check vs config check for vdm

### DIFF
--- a/src/v0/destinations/fb_custom_audience/recordTransform.js
+++ b/src/v0/destinations/fb_custom_audience/recordTransform.js
@@ -269,10 +269,11 @@ const processRecordInputsV2 = (groupedRecordInputs) => {
 
 function processRecordInputs(groupedRecordInputs) {
   const event = groupedRecordInputs[0];
-  if (isEventSentByVDMV2Flow(event)) {
-    return processRecordInputsV2(groupedRecordInputs);
+  // First check for rETL flow and second check for ES flow
+  if (isEventSentByVDMV1Flow(event) || !isEventSentByVDMV2Flow(event)) {
+    return processRecordInputsV1(groupedRecordInputs);
   }
-  return processRecordInputsV1(groupedRecordInputs);
+  return processRecordInputsV2(groupedRecordInputs);
 }
 
 module.exports = {


### PR DESCRIPTION
## What are the changes introduced in this PR?

Some syncs may still be in progress when migrating from FBCA to VDM v2. Currently, the transformation process prioritizes the connection configuration, which results in treating these syncs as new VDM v2 events. We are updating the preference to prioritize the "mapped to destination" flag in the event instead to address this.

## What is the related Linear task?

Resolves INT-2624
## Please explain the objectives of your changes below

Put down any required details on the broader aspect of your changes. If there are any dependent changes, **mandatorily** mention them here

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

N/A

### Any new dependencies introduced with this change?

N/A

### Any new generic utility introduced or modified. Please explain the changes.

N/A

### Any technical or performance related pointers to consider with the change?

N/A

@coderabbitai review

<hr>

### Developer checklist

- [ ] My code follows the style guidelines of this project

- [ ] **No breaking changes are being introduced.**

- [ ] All related docs linked with the PR?

- [ ] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [ ] Is the PR limited to 10 file changes?

- [ ] Is the PR limited to one linear task?

- [ ] Are relevant unit and component test-cases added in **new readability format**?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.
