### PR TITLE
fix: populate source destination info env set properly

### DIFF
--- a/src/warehouse/index.js
+++ b/src/warehouse/index.js
@@ -30,7 +30,7 @@ const whExtractEventTableColumnMappingRules = require('./config/WHExtractEventTa
 const maxColumnsInEvent = parseInt(process.env.WH_MAX_COLUMNS_IN_EVENT || '200', 10);
 
 const WH_POPULATE_SRC_DEST_INFO_IN_CONTEXT =
-  process.env.WH_POPULATE_SRC_DEST_INFO_IN_CONTEXT || true;
+  process.env.WH_POPULATE_SRC_DEST_INFO_IN_CONTEXT !== 'false';
 
 const getDataType = (key, val, options, jsonKey = false) => {
   const type = typeof val;


### PR DESCRIPTION
## What are the changes introduced in this PR?

- Since we are doing `process.env.WH_POPULATE_SRC_DEST_INFO_IN_CONTEXT`, it is impossible to override it . 
- If we set some value, it comes as a string and it is true. If we don't set some value by default, it's true. So it's always true.

## What is the related Linear task?

- ResolvesPIPE-1640

### Developer checklist

- [ ] My code follows the style guidelines of this project
- [x] **No breaking changes are being introduced.**
- [ ] All related docs linked with the PR?
- [x] All changes manually tested?
- [ ] Any documentation changes needed with this change?
- [x] Is the PR limited to 10 file changes?
- [x] Is the PR limited to one linear task?
- [ ] Are relevant unit and component test-cases added in **new readability format**?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?
- [ ] Verified that there are no credentials or confidential data exposed with the changes.
