### PR TITLE
fix: add missing field for pinterest_tag single product events

### DIFF
--- a/src/cdk/v2/destinations/pinterest_tag/procWorkflow.yaml
+++ b/src/cdk/v2/destinations/pinterest_tag/procWorkflow.yaml
@@ -167,7 +167,11 @@ steps:
               "content_ids": (props.product_id ?? props.sku ?? props.id)[],
               "contents": {
                 "quantity": Number(props.quantity) || 1,
-                "item_price": String(props.price)
+                "item_price": String(props.price),
+                "item_name": String(props.name),
+                "id": props.product_id ?? props.sku,
+                "item_category": props.category,
+                "item_brand": props.brand
               }[]
             };
       - name: combineAllEcomFields

--- a/test/apitests/data_scenarios/cdk_v2/failure.json
+++ b/test/apitests/data_scenarios/cdk_v2/failure.json
@@ -556,6 +556,10 @@
               "content_ids": ["123"],
               "contents": [
                 {
+                  "id": "123",
+                  "item_brand": "Gamepro",
+                  "item_category": "Games",
+                  "item_name": "Game",
                   "quantity": 11,
                   "item_price": "13.49"
                 }
@@ -679,6 +683,10 @@
               "content_ids": ["123"],
               "contents": [
                 {
+                  "id": "123",
+                  "item_brand": "Gamepro",
+                  "item_category": "Games",
+                  "item_name": "Game",
                   "quantity": 11,
                   "item_price": "13.49"
                 }

--- a/test/apitests/data_scenarios/cdk_v2/success.json
+++ b/test/apitests/data_scenarios/cdk_v2/success.json
@@ -556,6 +556,10 @@
               "content_ids": ["123"],
               "contents": [
                 {
+                  "id": "123",
+                  "item_brand": "Gamepro",
+                  "item_category": "Games",
+                  "item_name": "Game",
                   "quantity": 11,
                   "item_price": "13.49"
                 }
@@ -634,6 +638,10 @@
               "content_ids": ["123"],
               "contents": [
                 {
+                  "id": "123",
+                  "item_brand": "Gamepro",
+                  "item_category": "Games",
+                  "item_name": "Game",
                   "quantity": 11,
                   "item_price": "13.49"
                 }
@@ -712,6 +720,10 @@
               "content_ids": ["123"],
               "contents": [
                 {
+                  "id": "123",
+                  "item_brand": "Gamepro",
+                  "item_category": "Games",
+                  "item_name": "Game",
                   "quantity": 11,
                   "item_price": "13.49"
                 }

--- a/test/apitests/data_scenarios/destination/proc/batch_input_multiplex.json
+++ b/test/apitests/data_scenarios/destination/proc/batch_input_multiplex.json
@@ -388,6 +388,10 @@
               "content_ids": ["123"],
               "contents": [
                 {
+                  "id": "123",
+                  "item_brand": "Gamepro",
+                  "item_category": "Games",
+                  "item_name": "Game",
                   "quantity": 11,
                   "item_price": "13.49"
                 }
@@ -466,6 +470,10 @@
               "content_ids": ["123"],
               "contents": [
                 {
+                  "id": "123",
+                  "item_brand": "Gamepro",
+                  "item_category": "Games",
+                  "item_name": "Game",
                   "quantity": 11,
                   "item_price": "13.49"
                 }
@@ -544,6 +552,10 @@
               "content_ids": ["123"],
               "contents": [
                 {
+                  "id": "123",
+                  "item_brand": "Gamepro",
+                  "item_category": "Games",
+                  "item_name": "Game",
                   "quantity": 11,
                   "item_price": "13.49"
                 }

--- a/test/apitests/data_scenarios/destination/proc/multiplex_partial_failure.json
+++ b/test/apitests/data_scenarios/destination/proc/multiplex_partial_failure.json
@@ -388,6 +388,10 @@
               "content_ids": ["123"],
               "contents": [
                 {
+                  "id": "123",
+                  "item_brand": "Gamepro",
+                  "item_category": "Games",
+                  "item_name": "Game",
                   "quantity": 11,
                   "item_price": "13.49"
                 }
@@ -466,6 +470,10 @@
               "content_ids": ["123"],
               "contents": [
                 {
+                  "id": "123",
+                  "item_brand": "Gamepro",
+                  "item_category": "Games",
+                  "item_name": "Game",
                   "quantity": 11,
                   "item_price": "13.49"
                 }

--- a/test/apitests/data_scenarios/destination/proc/multiplex_success.json
+++ b/test/apitests/data_scenarios/destination/proc/multiplex_success.json
@@ -207,6 +207,10 @@
               "content_ids": ["123"],
               "contents": [
                 {
+                  "id": "123",
+                  "item_brand": "Gamepro",
+                  "item_category": "Games",
+                  "item_name": "Game",
                   "quantity": 11,
                   "item_price": "13.49"
                 }
@@ -285,6 +289,10 @@
               "content_ids": ["123"],
               "contents": [
                 {
+                  "id": "123",
+                  "item_brand": "Gamepro",
+                  "item_category": "Games",
+                  "item_name": "Game",
                   "quantity": 11,
                   "item_price": "13.49"
                 }

--- a/test/apitests/data_scenarios/destination/router/failure_test.json
+++ b/test/apitests/data_scenarios/destination/router/failure_test.json
@@ -754,6 +754,10 @@
                     "content_ids": ["123"],
                     "contents": [
                       {
+                        "id": "123",
+                        "item_brand": "Gamepro",
+                        "item_category": "Games",
+                        "item_name": "Game",
                         "quantity": 11,
                         "item_price": "13.49"
                       }
@@ -781,6 +785,10 @@
                     "content_ids": ["123"],
                     "contents": [
                       {
+                        "id": "123",
+                        "item_brand": "Gamepro",
+                        "item_category": "Games",
+                        "item_name": "Game",
                         "quantity": 11,
                         "item_price": "13.49"
                       }

--- a/test/integrations/destinations/pinterest_tag/processor/data.ts
+++ b/test/integrations/destinations/pinterest_tag/processor/data.ts
@@ -482,7 +482,9 @@ export const data = [
                     order_id: '50314b8e9bcf000000000000',
                     num_items: 2,
                     content_ids: ['123'],
-                    contents: [{ quantity: 2, item_price: '25' }],
+                    contents: [
+                      { id: '123', item_name: 'undefined', quantity: 2, item_price: '25' },
+                    ],
                   },
                 },
                 JSON_ARRAY: {},
@@ -2405,7 +2407,9 @@ export const data = [
                     order_id: '50314b8e9bcf000000000000',
                     num_items: 0,
                     content_ids: ['1234'],
-                    contents: [{ quantity: 1, item_price: 'undefined' }],
+                    contents: [
+                      { id: '1234', item_name: 'undefined', quantity: 1, item_price: 'undefined' },
+                    ],
                   },
                 },
                 JSON_ARRAY: {},
@@ -2666,7 +2670,7 @@ export const data = [
                   advertiser_id: '123456',
                   app_id: '429047995',
                   custom_data: {
-                    contents: [{ item_price: 'undefined', quantity: 1 }],
+                    contents: [{ item_price: 'undefined', quantity: 1, item_name: 'undefined' }],
                     currency: 'USD',
                     num_items: 0,
                     order_id: '50314b8e9bcf000000000000',
@@ -3497,6 +3501,7 @@ export const data = [
                 subtotal: 22.5,
                 affiliation: 'Google Store',
                 checkout_id: 'fksdjfsdjfisjf9sdfjsd9f',
+                category: 'Apparel',
               },
               anonymousId: '50be5c78-6c3f-4b60-be84-97805a316fb1',
               integrations: { All: true },
@@ -3563,6 +3568,8 @@ export const data = [
                       {
                         quantity: 1,
                         item_price: 'undefined',
+                        item_name: 'undefined',
+                        item_category: 'Apparel',
                       },
                     ],
                     currency: 'USD',

--- a/test/integrations/destinations/pinterest_tag/router/data.ts
+++ b/test/integrations/destinations/pinterest_tag/router/data.ts
@@ -815,7 +815,9 @@ export const data = [
                           order_id: '50314b8e9bcf000000000000',
                           num_items: 2,
                           content_ids: ['123'],
-                          contents: [{ quantity: 2, item_price: '25' }],
+                          contents: [
+                            { id: '123', item_name: 'undefined', quantity: 2, item_price: '25' },
+                          ],
                         },
                       },
                       {

--- a/test/integrations/destinations/pinterest_tag/step/data.ts
+++ b/test/integrations/destinations/pinterest_tag/step/data.ts
@@ -468,7 +468,9 @@ export const data = [
                     order_id: '50314b8e9bcf000000000000',
                     num_items: 2,
                     content_ids: ['123'],
-                    contents: [{ quantity: 2, item_price: '25' }],
+                    contents: [
+                      { id: '123', item_name: 'undefined', quantity: 2, item_price: '25' },
+                    ],
                   },
                 },
                 JSON_ARRAY: {},
@@ -2420,7 +2422,9 @@ export const data = [
                     order_id: '50314b8e9bcf000000000000',
                     num_items: 0,
                     content_ids: ['1234'],
-                    contents: [{ quantity: 1, item_price: 'undefined' }],
+                    contents: [
+                      { id: '1234', item_name: 'undefined', quantity: 1, item_price: 'undefined' },
+                    ],
                   },
                 },
                 JSON_ARRAY: {},
@@ -2685,7 +2689,7 @@ export const data = [
                   advertiser_id: '123456',
                   app_id: '429047995',
                   custom_data: {
-                    contents: [{ item_price: 'undefined', quantity: 1 }],
+                    contents: [{ item_name: 'undefined', item_price: 'undefined', quantity: 1 }],
                     currency: 'USD',
                     num_items: 0,
                     order_id: '50314b8e9bcf000000000000',
@@ -3605,6 +3609,7 @@ export const data = [
                     num_items: 0,
                     contents: [
                       {
+                        item_name: 'undefined',
                         quantity: 1,
                         item_price: 'undefined',
                       },


### PR DESCRIPTION
## What are the changes introduced in this PR?

We are adding missing mapping of ecomm events with single product

## What is the related Linear task?

Resolves INT-2743

## Please explain the objectives of your changes below

Put down any required details on the broader aspect of your changes. If there are any dependent changes, **mandatorily** mention them here

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

N/A

### Any new dependencies introduced with this change?

N/A

### Any new generic utility introduced or modified. Please explain the changes.

N/A

### Any technical or performance related pointers to consider with the change?

N/A

@coderabbitai review

<hr>

### Developer checklist

- [ ] My code follows the style guidelines of this project

- [ ] **No breaking changes are being introduced.**

- [ ] All related docs linked with the PR?

- [ ] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [ ] Is the PR limited to 10 file changes?

- [ ] Is the PR limited to one linear task?

- [ ] Are relevant unit and component test-cases added in **new readability format**?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.
