### PR TITLE
fix: adding throttled status code for server unavailable error in salesforce

### DIFF
--- a/src/v0/destinations/salesforce/utils.js
+++ b/src/v0/destinations/salesforce/utils.js
@@ -84,6 +84,7 @@ const salesforceResponseHandler = (destResponse, sourceMessage, authKey, authori
     } else if (status === 503 || status === 500) {
       // The salesforce server is unavailable to handle the request. Typically this occurs if the server is down
       // for maintenance or is currently overloaded.
+      // ref : https://help.salesforce.com/s/articleView?id=000387190&type=1
       if (matchErrorCode('SERVER_UNAVAILABLE')) {
         throw new ThrottledError(
           `${DESTINATION} Request Failed: ${status} - due to Search unavailable, ${sourceMessage}`,

--- a/src/v0/destinations/salesforce/utils.js
+++ b/src/v0/destinations/salesforce/utils.js
@@ -23,6 +23,22 @@ const {
 
 const ACCESS_TOKEN_CACHE = new Cache(ACCESS_TOKEN_CACHE_TTL);
 
+/**
+ * Extracts and returns the error message from a response object.
+ * If the response is an array and contains a message in the first element,
+ * it returns that message. Otherwise, it returns the stringified response.
+ * Error Message Format Example: ref: https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/errorcodes.htm#:~:text=Incorrect%20ID%20example
+        [
+        {
+          "fields" : [ "Id" ],
+          "message" : "Account ID: id value of incorrect type: 001900K0001pPuOAAU",
+          "errorCode" : "MALFORMED_ID"
+        }
+        ]
+ * @param {Object|Array} response - The response object or array to extract the message from.
+ * @returns {string} The extracted error message or the stringified response.
+ */
+
 const getErrorMessage = (response) => {
   if (Array.isArray(response) && response?.[0]?.message && response?.[0]?.message?.length > 0) {
     return response[0].message;

--- a/src/v0/destinations/salesforce/utils.js
+++ b/src/v0/destinations/salesforce/utils.js
@@ -103,7 +103,7 @@ const salesforceResponseHandler = (destResponse, sourceMessage, authKey, authori
       // ref : https://help.salesforce.com/s/articleView?id=000387190&type=1
       if (matchErrorCode('SERVER_UNAVAILABLE')) {
         throw new ThrottledError(
-          `${DESTINATION} Request Failed: ${status} - due to Search unavailable, ${sourceMessage}`,
+          `${DESTINATION} Request Failed: ${status} - due to ${getErrorMessage(response)}, ${sourceMessage}`,
           destResponse,
         );
       } else {

--- a/test/integrations/destinations/salesforce/dataDelivery/business.ts
+++ b/test/integrations/destinations/salesforce/dataDelivery/business.ts
@@ -277,7 +277,7 @@ export const testScenariosForV1API: ProxyV1TestData[] = [
         body: {
           output: {
             message:
-              'Salesforce Request Failed: 503 - due to Search unavailable, during Salesforce Response Handling',
+              'Salesforce Request Failed: 503 - due to Server Unavailable, during Salesforce Response Handling',
             response: [
               {
                 error: '[{"message":"Server Unavailable","errorCode":"SERVER_UNAVAILABLE"}]',

--- a/test/integrations/destinations/salesforce/dataDelivery/business.ts
+++ b/test/integrations/destinations/salesforce/dataDelivery/business.ts
@@ -150,7 +150,7 @@ export const testScenariosForV1API: ProxyV1TestData[] = [
           output: {
             status: 500,
             message:
-              'Salesforce Request Failed - due to "Session expired or invalid", (Retryable) during Salesforce Response Handling',
+              'Salesforce Request Failed: 500 - due to "Session expired or invalid", (Retryable) during Salesforce Response Handling',
             response: [
               {
                 error:
@@ -277,16 +277,16 @@ export const testScenariosForV1API: ProxyV1TestData[] = [
         body: {
           output: {
             message:
-              'Salesforce Request Failed - due to "Server Unavailable", (Retryable) during Salesforce Response Handling',
+              'Salesforce Request Failed: 503 - due to Search unavailable, during Salesforce Response Handling',
             response: [
               {
                 error: '[{"message":"Server Unavailable","errorCode":"SERVER_UNAVAILABLE"}]',
                 metadata: proxyMetdata,
-                statusCode: 500,
+                statusCode: 429,
               },
             ],
-            statTags: statTags.retryable,
-            status: 500,
+            statTags: statTags.throttled,
+            status: 429,
           },
         },
       },

--- a/test/integrations/destinations/salesforce/dataDelivery/data.ts
+++ b/test/integrations/destinations/salesforce/dataDelivery/data.ts
@@ -319,7 +319,7 @@ const legacyTests = [
           output: {
             status: 429,
             message:
-              'Salesforce Request Failed: 503 - due to Search unavailable, during Salesforce Response Handling',
+              'Salesforce Request Failed: 503 - due to Server Unavailable, during Salesforce Response Handling',
             destinationResponse: {
               response: [
                 {

--- a/test/integrations/destinations/salesforce/dataDelivery/data.ts
+++ b/test/integrations/destinations/salesforce/dataDelivery/data.ts
@@ -314,12 +314,12 @@ const legacyTests = [
     },
     output: {
       response: {
-        status: 500,
+        status: 429,
         body: {
           output: {
-            status: 500,
+            status: 429,
             message:
-              'Salesforce Request Failed - due to "Server Unavailable", (Retryable) during Salesforce Response Handling',
+              'Salesforce Request Failed: 503 - due to Search unavailable, during Salesforce Response Handling',
             destinationResponse: {
               response: [
                 {
@@ -334,7 +334,7 @@ const legacyTests = [
               errorCategory: 'network',
               destinationId: 'Non-determininable',
               workspaceId: 'Non-determininable',
-              errorType: 'retryable',
+              errorType: 'throttled',
               feature: 'dataDelivery',
               implementation: 'native',
               module: 'destination',
@@ -461,7 +461,7 @@ const legacyTests = [
               status: 503,
             },
             message:
-              'Salesforce Request Failed - due to "{"message":"Server Unavailable","errorCode":"SERVER_UNAVAILABLE"}", (Retryable) during Salesforce Response Handling',
+              'Salesforce Request Failed: 503 - due to "{"message":"Server Unavailable","errorCode":"SERVER_UNAVAILABLE"}", (Retryable) during Salesforce Response Handling',
             statTags: {
               destType: 'SALESFORCE',
               errorCategory: 'network',
@@ -603,7 +603,7 @@ const legacyTests = [
           output: {
             status: 500,
             message:
-              'Salesforce Request Failed - due to ""[ECONNABORTED] :: Connection aborted"", (Retryable) during Salesforce Response Handling',
+              'Salesforce Request Failed: 500 - due to ""[ECONNABORTED] :: Connection aborted"", (Retryable) during Salesforce Response Handling',
             destinationResponse: {
               response: '[ECONNABORTED] :: Connection aborted',
               status: 500,
@@ -696,7 +696,7 @@ const legacyTests = [
           output: {
             status: 500,
             message:
-              'Salesforce Request Failed - due to ""[EAI_AGAIN] :: Temporary failure in name resolution"", (Retryable) during Salesforce Response Handling',
+              'Salesforce Request Failed: 500 - due to ""[EAI_AGAIN] :: Temporary failure in name resolution"", (Retryable) during Salesforce Response Handling',
             destinationResponse: {
               response: '[EAI_AGAIN] :: Temporary failure in name resolution',
               status: 500,

--- a/test/integrations/destinations/salesforce/dataDelivery/other.ts
+++ b/test/integrations/destinations/salesforce/dataDelivery/other.ts
@@ -58,7 +58,7 @@ export const otherSalesforceScenariosV1: ProxyV1TestData[] = [
             ],
             statTags,
             message:
-              'Salesforce Request Failed - due to "{"error":{"message":"Service Unavailable","description":"The server is currently unable to handle the request due to temporary overloading or maintenance of the server. Please try again later."}}", (Retryable) during Salesforce Response Handling',
+              'Salesforce Request Failed: 503 - due to "{"error":{"message":"Service Unavailable","description":"The server is currently unable to handle the request due to temporary overloading or maintenance of the server. Please try again later."}}", (Retryable) during Salesforce Response Handling',
             status: 500,
           },
         },
@@ -96,7 +96,7 @@ export const otherSalesforceScenariosV1: ProxyV1TestData[] = [
             ],
             statTags,
             message:
-              'Salesforce Request Failed - due to ""Internal Server Error"", (Retryable) during Salesforce Response Handling',
+              'Salesforce Request Failed: 500 - due to ""Internal Server Error"", (Retryable) during Salesforce Response Handling',
             status: 500,
           },
         },


### PR DESCRIPTION
## What are the changes introduced in this PR?

For salesforce when the salesforce server is busy or unavailable we were throwing retriable which was being failed eventually by retrying  3 times.
Now, we are throwing 429 status code appropriately.

## What is the related Linear task?

Resolves INT-2847

## Please explain the objectives of your changes below

Put down any required details on the broader aspect of your changes. If there are any dependent changes, **mandatorily** mention them here

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

N/A

### Any new dependencies introduced with this change?

N/A

### Any new generic utility introduced or modified. Please explain the changes.

N/A

### Any technical or performance related pointers to consider with the change?

N/A

@coderabbitai review

<hr>

### Developer checklist

- [x] My code follows the style guidelines of this project

- [x] **No breaking changes are being introduced.**

- [x] All related docs linked with the PR?

- [x] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [x] Is the PR limited to 10 file changes?

- [x] Is the PR limited to one linear task?

- [x] Are relevant unit and component test-cases added in **new readability format**?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.
