### PR TITLE
fix: use correct endpoint for custom events

### DIFF
--- a/src/v0/destinations/branch/data/eventMapping.js
+++ b/src/v0/destinations/branch/data/eventMapping.js
@@ -40,6 +40,7 @@ const CommerceEventConfig = {
     'Spend Credits': 'SPEND_CREDITS',
     'Promotion Viewed': 'VIEW_AD',
     'Promotion Clicked': 'CLICK_AD',
+    Purchase: 'PURCHASE',
     Reserve: 'RESERVE',
   },
   event_data: ['transaction_id', 'currency', 'revenue', 'shipping', 'tax', 'coupon', 'description'],

--- a/src/v0/destinations/branch/transform.js
+++ b/src/v0/destinations/branch/transform.js
@@ -46,7 +46,7 @@ function getCategoryAndName(rudderEventName) {
     let requiredName = null;
     let requiredCategory = null;
     // eslint-disable-next-line array-callback-return, sonarjs/no-ignored-return
-    Object.keys(category.name).find((branchKey) => {
+    Object.keys(category.name).forEach((branchKey) => {
       if (
         typeof branchKey === 'string' &&
         typeof rudderEventName === 'string' &&
@@ -55,9 +55,7 @@ function getCategoryAndName(rudderEventName) {
       ) {
         requiredName = category.name[branchKey];
         requiredCategory = category;
-        return true;
       }
-      return false;
     });
     if (requiredName != null && requiredCategory != null) {
       return { evName: requiredName, category: requiredCategory };
@@ -117,14 +115,12 @@ function mapPayload(category, rudderProperty, rudderPropertiesObj) {
   let valFound = false;
   if (category.content_items) {
     // eslint-disable-next-line sonarjs/no-ignored-return
-    Object.keys(category.content_items).find((branchMappingProperty) => {
+    Object.keys(category.content_items).forEach((branchMappingProperty) => {
       if (branchMappingProperty === rudderProperty) {
         const tmpKeyName = category.content_items[branchMappingProperty];
         contentItems[tmpKeyName] = rudderPropertiesObj[rudderProperty];
         valFound = true;
-        return true;
       }
-      return false;
     });
   }
 

--- a/src/v0/destinations/branch/transform.js
+++ b/src/v0/destinations/branch/transform.js
@@ -50,7 +50,8 @@ function getCategoryAndName(rudderEventName) {
       if (
         typeof branchKey === 'string' &&
         typeof rudderEventName === 'string' &&
-        branchKey.toLowerCase() === rudderEventName.toLowerCase()
+        (branchKey.toLowerCase() === rudderEventName.toLowerCase() ||
+          category.name[branchKey].toLowerCase() === rudderEventName.toLowerCase())
       ) {
         requiredName = category.name[branchKey];
         requiredCategory = category;
@@ -217,16 +218,17 @@ function getCommonPayload(message, category, evName) {
 function processMessage(message, destination) {
   let evName;
   let category;
+  let updatedEventName = message.event;
   switch (message.type) {
     case EventType.TRACK: {
       if (!message.event) {
         throw new InstrumentationError('Event name is required');
       }
-      ({ evName, category } = getCategoryAndName(message.event));
       const eventNameFromConfig = getMappedEventNameFromConfig(message, destination);
       if (eventNameFromConfig) {
-        evName = eventNameFromConfig;
+        updatedEventName = eventNameFromConfig;
       }
+      ({ evName, category } = getCategoryAndName(updatedEventName));
       break;
     }
     case EventType.IDENTIFY:

--- a/test/integrations/destinations/branch/processor/data.ts
+++ b/test/integrations/destinations/branch/processor/data.ts
@@ -1505,7 +1505,7 @@ export const data = [
                 branchKey: 'test_branch_key',
                 eventsMapping: [
                   {
-                    from: 'Order Completed',
+                    from: 'Some Random Event',
                     to: 'PURCHASE',
                   },
                 ],
@@ -1561,7 +1561,7 @@ export const data = [
                 userAgent:
                   'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.88 Safari/537.36',
               },
-              event: 'Order Completed',
+              event: 'Some Random Event',
               integrations: {
                 All: true,
               },


### PR DESCRIPTION
## What are the changes introduced in this PR?

We are not setting the category properly for such events which are mapped to default events. For example let's say we have the following mapping:
Rudderstack Event -> Branch Event
Item Viewed -> VIEW_ITEM

As `Item Viewed` is not on the list of [different mappings](https://github.com/rudderlabs/rudder-transformer/blob/9d6a0027189d19b7c0c4e18be755c2bd9a733d87/src/v0/destinations/branch/data/eventMapping.js#L77) on Rudderstak we are setting the category name as custom. But later when we get the correct event name from the destination config we are not updating the category to the respective category.

## What is the related Linear task?

Resolves INT-2997

## Please explain the objectives of your changes below

Put down any required details on the broader aspect of your changes. If there are any dependent changes, **mandatorily** mention them here

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

N/A

### Any new dependencies introduced with this change?

N/A

### Any new generic utility introduced or modified. Please explain the changes.

N/A

### Any technical or performance related pointers to consider with the change?

N/A

@coderabbitai review

<hr>

### Developer checklist

- [ ] My code follows the style guidelines of this project

- [ ] **No breaking changes are being introduced.**

- [ ] All related docs linked with the PR?

- [ ] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [ ] Is the PR limited to 10 file changes?

- [ ] Is the PR limited to one linear task?

- [ ] Are relevant unit and component test-cases added in **new readability format**?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.
