### PR TITLE
fix: add email validation in HS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -75,6 +75,7 @@
         "unset-value": "^2.0.1",
         "uuid": "^9.0.1",
         "valid-url": "^1.0.9",
+        "validator": "^13.12.0",
         "zod": "^3.22.4"
       },
       "devDependencies": {
@@ -21968,6 +21969,14 @@
       "dependencies": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "node_modules/validator": {
+      "version": "13.12.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.12.0.tgz",
+      "integrity": "sha512-c1Q0mCiPlgdTVVVIJIrBuxNicYE+t/7oKeI9MWLj3fh/uq2Pxh/3eeWbVZ4OcGW1TUf53At0njHw5SMdA3tmMg==",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/vary": {

--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
     "unset-value": "^2.0.1",
     "uuid": "^9.0.1",
     "valid-url": "^1.0.9",
+    "validator": "^13.12.0",
     "zod": "^3.22.4"
   },
   "devDependencies": {

--- a/src/v0/destinations/hs/HSTransform-v2.js
+++ b/src/v0/destinations/hs/HSTransform-v2.js
@@ -5,6 +5,7 @@ const {
   ConfigurationError,
   InstrumentationError,
 } = require('@rudderstack/integrations-lib');
+const validator = require('validator');
 const { MappedToDestinationKey, GENERIC_TRUE_VALUES } = require('../../../constants');
 const {
   defaultPostRequestConfig,
@@ -72,6 +73,11 @@ const addHsAuthentication = (response, Config) => {
 const processIdentify = async ({ message, destination, metadata }, propertyMap) => {
   const { Config } = destination;
   let traits = getFieldValueFromMessage(message, 'traits');
+  // since hubspot does not allow imvalid emails, we need to
+  // validate the email before sending it to hubspot
+  if (traits?.email && !validator.isEmail(traits.email)) {
+    throw new InstrumentationError(`Email ${traits.email} is invalid`);
+  }
   const mappedToDestination = get(message, MappedToDestinationKey);
   const operation = get(message, 'context.hubspotOperation');
   const externalIdObj = getDestinationExternalIDObjectForRetl(message, 'HS');

--- a/src/v0/destinations/hs/HSTransform-v2.js
+++ b/src/v0/destinations/hs/HSTransform-v2.js
@@ -76,7 +76,7 @@ const processIdentify = async ({ message, destination, metadata }, propertyMap) 
   // since hubspot does not allow imvalid emails, we need to
   // validate the email before sending it to hubspot
   if (traits?.email && !validator.isEmail(traits.email)) {
-    throw new InstrumentationError(`Email ${traits.email} is invalid`);
+    throw new InstrumentationError(`Email "${traits.email}" is invalid`);
   }
   const mappedToDestination = get(message, MappedToDestinationKey);
   const operation = get(message, 'context.hubspotOperation');

--- a/test/integrations/destinations/hs/processor/data.ts
+++ b/test/integrations/destinations/hs/processor/data.ts
@@ -5492,7 +5492,7 @@ export const data = [
         status: 200,
         body: [
           {
-            error: 'Email incorrect-email is invalid',
+            error: 'Email "incorrect-email" is invalid',
             statTags: {
               destType: 'HS',
               errorCategory: 'dataValidation',

--- a/test/integrations/destinations/hs/processor/data.ts
+++ b/test/integrations/destinations/hs/processor/data.ts
@@ -5425,4 +5425,86 @@ export const data = [
       },
     },
   },
+  {
+    name: 'hs',
+    description:
+      '[HS] (New API v3) - throw error if invalid email is provided in traits for identify call',
+    feature: 'processor',
+    module: 'destination',
+    version: 'v0',
+    input: {
+      request: {
+        body: [
+          {
+            description:
+              '[HS] (New API v3) - throw error if invalid email is provided in traits for identify call',
+            message: {
+              channel: 'web',
+              context: {
+                traits: {
+                  email: 'incorrect-email',
+                  firstname: 'Test Hubspot',
+                },
+                library: {
+                  name: 'RudderLabs JavaScript SDK',
+                  version: '1.0.0',
+                },
+              },
+              type: 'identify',
+              messageId: 'e8585d9a-7137-4223-b295-68ab1b17dad7',
+              originalTimestamp: '2025-01-01T09:35:31.289Z',
+              anonymousId: '00000000000000000000000000',
+              userId: '12345',
+              properties: '',
+              integrations: {
+                All: true,
+              },
+              sentAt: '2019-10-14T11:15:53.296Z',
+            },
+            destination: {
+              Config: {
+                authorizationType: 'newPrivateAppApi',
+                hubID: '',
+                apiKey: '',
+                accessToken: 'dummy-access-token',
+                apiVersion: 'newApi',
+                lookupField: 'lookupField',
+                eventFilteringOption: 'disable',
+                blacklistedEvents: [
+                  {
+                    eventName: '',
+                  },
+                ],
+                whitelistedEvents: [
+                  {
+                    eventName: '',
+                  },
+                ],
+              },
+              Enabled: true,
+            },
+          },
+        ],
+      },
+    },
+    output: {
+      response: {
+        status: 200,
+        body: [
+          {
+            error: 'Email incorrect-email is invalid',
+            statTags: {
+              destType: 'HS',
+              errorCategory: 'dataValidation',
+              errorType: 'instrumentation',
+              feature: 'processor',
+              implementation: 'native',
+              module: 'destination',
+            },
+            statusCode: 400,
+          },
+        ],
+      },
+    },
+  },
 ];

--- a/test/integrations/destinations/hs/router/data.ts
+++ b/test/integrations/destinations/hs/router/data.ts
@@ -3547,4 +3547,120 @@ export const data = [
       },
     },
   },
+  {
+    name: 'hs',
+    description: 'test when email is of wrong format',
+    feature: 'router',
+    module: 'destination',
+    id: 'emailfailsValidation',
+    version: 'v0',
+    input: {
+      request: {
+        body: {
+          input: [
+            {
+              message: {
+                channel: 'web',
+                context: {
+                  traits: {
+                    email: 'incorrect-email',
+                    firstname: 'Test Hubspot',
+                  },
+                  library: {
+                    name: 'RudderLabs JavaScript SDK',
+                    version: '1.0.0',
+                  },
+                },
+                type: 'identify',
+                messageId: 'e8585d9a-7137-4223-b295-68ab1b17dad7',
+                originalTimestamp: '2025-01-01T09:35:31.289Z',
+                anonymousId: '00000000000000000000000000',
+                userId: '12345',
+                properties: '',
+                integrations: {
+                  All: true,
+                },
+                sentAt: '2019-10-14T11:15:53.296Z',
+              },
+              destination: {
+                Config: {
+                  authorizationType: 'newPrivateAppApi',
+                  hubID: '',
+                  apiKey: '',
+                  accessToken: 'dummy-access-token',
+                  apiVersion: 'newApi',
+                  lookupField: 'lookupField',
+                  eventFilteringOption: 'disable',
+                  blacklistedEvents: [
+                    {
+                      eventName: '',
+                    },
+                  ],
+                  whitelistedEvents: [
+                    {
+                      eventName: '',
+                    },
+                  ],
+                },
+                Enabled: true,
+              },
+              metadata: { jobId: 3, userId: 'u1' },
+            },
+          ],
+          destType: 'hs',
+        },
+        method: 'POST',
+      },
+    },
+    output: {
+      response: {
+        status: 200,
+        body: {
+          output: [
+            {
+              batched: false,
+              destination: {
+                Config: {
+                  accessToken: 'dummy-access-token',
+                  apiKey: '',
+                  apiVersion: 'newApi',
+                  authorizationType: 'newPrivateAppApi',
+                  blacklistedEvents: [
+                    {
+                      eventName: '',
+                    },
+                  ],
+                  eventFilteringOption: 'disable',
+                  hubID: '',
+                  lookupField: 'lookupField',
+                  whitelistedEvents: [
+                    {
+                      eventName: '',
+                    },
+                  ],
+                },
+                Enabled: true,
+              },
+              error: 'Email incorrect-email is invalid',
+              metadata: [
+                {
+                  jobId: 3,
+                  userId: 'u1',
+                },
+              ],
+              statTags: {
+                destType: 'HS',
+                errorCategory: 'dataValidation',
+                errorType: 'instrumentation',
+                feature: 'router',
+                implementation: 'native',
+                module: 'destination',
+              },
+              statusCode: 400,
+            },
+          ],
+        },
+      },
+    },
+  },
 ];

--- a/test/integrations/destinations/hs/router/data.ts
+++ b/test/integrations/destinations/hs/router/data.ts
@@ -3641,7 +3641,7 @@ export const data = [
                 },
                 Enabled: true,
               },
-              error: 'Email incorrect-email is invalid',
+              error: 'Email "incorrect-email" is invalid',
               metadata: [
                 {
                   jobId: 3,


### PR DESCRIPTION
## What are the changes introduced in this PR?

Add email validation in HS, that will reject invalid email at transformation level itself.
Package used: https://www.npmjs.com/package/validator

## What is the related Linear task?

Resolves INT-3086

## Please explain the objectives of your changes below

Put down any required details on the broader aspect of your changes. If there are any dependent changes, **mandatorily** mention them here

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

Yes
These invalid emails like regular strings will not pass the destination transformer, hence they will not go through to HS and get rejected there. There could be some event volume drop.

### Any new dependencies introduced with this change?

https://www.npmjs.com/package/validator

### Any new generic utility introduced or modified. Please explain the changes.

N/A

### Any technical or performance related pointers to consider with the change?

N/A

@coderabbitai review

<hr>

### Developer checklist

- [ ] My code follows the style guidelines of this project

- [ ] **No breaking changes are being introduced.**

- [ ] All related docs linked with the PR?

- [ ] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [ ] Is the PR limited to 10 file changes?

- [ ] Is the PR limited to one linear task?

- [ ] Are relevant unit and component test-cases added in **new readability format**?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.
