### PR TITLE
fix: add phone e164 format validation for klaviyo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
         "koa": "^2.15.3",
         "koa-bodyparser": "^4.4.0",
         "koa2-swagger-ui": "^5.7.0",
-        "libphonenumber-js": "^1.11.12",
+        "libphonenumber-js": "^1.11.18",
         "lodash": "^4.17.21",
         "match-json": "^1.3.5",
         "md5": "^2.3.0",
@@ -16763,9 +16763,9 @@
       }
     },
     "node_modules/libphonenumber-js": {
-      "version": "1.11.12",
-      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.11.12.tgz",
-      "integrity": "sha512-QkJn9/D7zZ1ucvT++TQSvZuSA2xAWeUytU+DiEQwbPKLyrDpvbul2AFs1CGbRAPpSCCk47aRAb5DX5mmcayp4g=="
+      "version": "1.11.18",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.11.18.tgz",
+      "integrity": "sha512-okMm/MCoFrm1vByeVFLBdkFIXLSHy/AIK2AEGgY3eoicfWZeOZqv3GfhtQgICkzs/tqorAMm3a4GBg5qNCrqzg=="
     },
     "node_modules/lilconfig": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "koa": "^2.15.3",
     "koa-bodyparser": "^4.4.0",
     "koa2-swagger-ui": "^5.7.0",
-    "libphonenumber-js": "^1.11.12",
+    "libphonenumber-js": "^1.11.18",
     "lodash": "^4.17.21",
     "match-json": "^1.3.5",
     "md5": "^2.3.0",

--- a/test/integrations/destinations/klaviyo/processor/screenTestDataV2.ts
+++ b/test/integrations/destinations/klaviyo/processor/screenTestDataV2.ts
@@ -55,7 +55,7 @@ export const screenTestData: ProcessorTestData[] = [
                     id: 'user@1',
                     age: '22',
                     email: 'test@rudderstack.com',
-                    phone: '9112340375',
+                    phone: '+9112340375',
                     anonymousId: '9c6bd77ea9da3e68',
                     append1: 'value1',
                   },
@@ -125,7 +125,7 @@ export const screenTestData: ProcessorTestData[] = [
                               },
                             },
                           },
-                          phone_number: '9112340375',
+                          phone_number: '+9112340375',
                           properties: {
                             id: 'user@1',
                             age: '22',

--- a/test/integrations/destinations/klaviyo/processor/trackTestDataV2.ts
+++ b/test/integrations/destinations/klaviyo/processor/trackTestDataV2.ts
@@ -46,7 +46,7 @@ const commonOutputHeaders = {
 };
 const profileAttributes = {
   email: 'test@rudderstack.com',
-  phone_number: '9112340375',
+  phone_number: '+9112340375',
   anonymous_id: '9c6bd77ea9da3e68',
   properties: {
     age: '22',
@@ -86,7 +86,7 @@ export const trackTestData: ProcessorTestData[] = [
                   ...commonTraits,
                   name: 'Test',
                   email: 'test@rudderstack.com',
-                  phone: '9112340375',
+                  phone: '+9112340375',
                   description: 'Sample description',
                 },
               },
@@ -174,7 +174,7 @@ export const trackTestData: ProcessorTestData[] = [
                   description: 'Sample description',
                   name: 'Test',
                   email: 'test@rudderstack.com',
-                  phone: '9112340375',
+                  phone: '+9112340375',
                 },
               },
               properties: commonProps,
@@ -257,7 +257,7 @@ export const trackTestData: ProcessorTestData[] = [
                   description: 'Sample description',
                   name: 'Test',
                   email: 'test@rudderstack.com',
-                  phone: '9112340375',
+                  phone: '+9112340375',
                 },
               },
               properties: { ...commonProps, value: { price: 9.99 } },
@@ -288,6 +288,67 @@ export const trackTestData: ProcessorTestData[] = [
             },
             statusCode: 400,
             metadata: generateMetadata(1),
+          },
+        ],
+      },
+    },
+  },
+  {
+    id: 'klaviyo-track-150624-test-4',
+    name: 'klaviyo',
+    description: '150624 -> Track event call, with phone not in E.164 format',
+    scenario: 'Business',
+    successCriteria:
+      'Response should an error message and status code should be 400, as Phone number is not in E.164 format.',
+    feature: 'processor',
+    module: 'destination',
+    version: 'v0',
+    input: {
+      request: {
+        body: [
+          {
+            destination: overrideDestination(destination, { enforceEmailAsPrimary: true }),
+            message: generateSimplifiedTrackPayload({
+              type: 'track',
+              event: 'TestEven001',
+              sentAt: '2025-01-01T11:11:11.111Z',
+              userId: 'invalidPhoneUser',
+              context: {
+                traits: {
+                  ...commonTraits,
+                  description: 'Sample description',
+                  name: 'Test',
+                  email: 'test@rudderstack.com',
+                  phone: '9112340375',
+                },
+              },
+              properties: commonProps,
+              originalTimestamp: '2025-01-01T11:11:11.111Z',
+            }),
+            metadata: generateMetadata(4),
+          },
+        ],
+        method: 'POST',
+      },
+    },
+    output: {
+      response: {
+        status: 200,
+        body: [
+          {
+            error: 'Phone number is not in E.164 format.',
+            statTags: {
+              destType: 'KLAVIYO',
+              destinationId: 'default-destinationId',
+              errorCategory: 'dataValidation',
+              errorType: 'instrumentation',
+              feature: 'processor',
+              implementation: 'native',
+              module: 'destination',
+              workspaceId: 'default-workspaceId',
+            },
+            statusCode: 400,
+            metadata: generateMetadata(4),
           },
         ],
       },

--- a/test/integrations/destinations/klaviyo/router/dataV2.ts
+++ b/test/integrations/destinations/klaviyo/router/dataV2.ts
@@ -2050,4 +2050,108 @@ export const dataV2: RouterTestData[] = [
       },
     },
   },
+  {
+    id: 'klaviyo-router-150624-test-7',
+    name: 'klaviyo',
+    description:
+      '150624 -> Router tests to check for invalid phone number format in identify and track calls and should throw error',
+    scenario: 'Framework',
+    successCriteria: 'Should throw invalid phone number error for identify and track calls',
+    feature: 'router',
+    module: 'destination',
+    version: 'v0',
+    input: {
+      request: {
+        body: {
+          input: [
+            {
+              message: {
+                userId: 'user123',
+                type: 'identify',
+                traits: { subscribe: true },
+                context: {
+                  traits: {
+                    email: 'test@rudderstack.com',
+                    phone: '123321000',
+                    consent: 'email',
+                  },
+                  ip: '14.5.67.21',
+                  library: { name: 'http' },
+                },
+                timestamp: '2020-01-21T00:21:34.208Z',
+              },
+              destination,
+              metadata: generateMetadata(1),
+            },
+            {
+              message: {
+                type: 'track',
+                event: 'TestEven001',
+                sentAt: '2025-01-01T11:11:11.111Z',
+                userId: 'invalidPhoneUser',
+                context: {
+                  traits: {
+                    name: 'Test',
+                    email: 'test@rudderstack.com',
+                    phone: '9112340375',
+                  },
+                },
+                properties: {
+                  price: 120,
+                },
+                originalTimestamp: '2025-01-01T11:11:11.111Z',
+              },
+              metadata: generateMetadata(2),
+              destination,
+            },
+          ],
+          destType: 'klaviyo',
+        },
+        method: 'POST',
+      },
+    },
+    output: {
+      response: {
+        status: 200,
+        body: {
+          output: [
+            {
+              error: 'Phone number is not in E.164 format.',
+              statTags: {
+                destType: 'KLAVIYO',
+                destinationId: 'default-destinationId',
+                errorCategory: 'dataValidation',
+                errorType: 'instrumentation',
+                feature: 'router',
+                implementation: 'native',
+                module: 'destination',
+                workspaceId: 'default-workspaceId',
+              },
+              metadata: [generateMetadata(1)],
+              batched: false,
+              statusCode: 400,
+              destination,
+            },
+            {
+              error: 'Phone number is not in E.164 format.',
+              statTags: {
+                destType: 'KLAVIYO',
+                destinationId: 'default-destinationId',
+                errorCategory: 'dataValidation',
+                errorType: 'instrumentation',
+                feature: 'router',
+                implementation: 'native',
+                module: 'destination',
+                workspaceId: 'default-workspaceId',
+              },
+              metadata: [generateMetadata(2)],
+              batched: false,
+              statusCode: 400,
+              destination,
+            },
+          ],
+        },
+      },
+    },
+  },
 ];


### PR DESCRIPTION
## What are the changes introduced in this PR?

We have a popular widely used library [libphonenumber-js](https://www.npmjs.com/package/libphonenumber-js) here to validate the phone number being passed to Klaviyo, as Klaviyo rejects events with phone number not in the [E.164](https://en.wikipedia.org/wiki/E.164) standard. Klaviyo [Reference](https://developers.klaviyo.com/en/v2024-06-15/reference/events_api_overview#receiving-a-400).
As a precaution, the phone number is first sanitized ( i.e remove spaces, dashes etc ) and then the library is used on it.

## What is the related Linear task?

Resolves INT-3180

## Please explain the objectives of your changes below

Put down any required details on the broader aspect of your changes. If there are any dependent changes, **mandatorily** mention them here

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

The events which were having the phone numbers in incorrect format and would earlier hit the klaviyo APIs and then get rejected, will now fail at the transformation layer, thereby saving the API calls on the failed events.

### Any new dependencies introduced with this change?

N/A

### Any new generic utility introduced or modified. Please explain the changes.

N/A

### Any technical or performance related pointers to consider with the change?

N/A

@coderabbitai review

<hr>

### Developer checklist

- [x] My code follows the style guidelines of this project

- [ ] **No breaking changes are being introduced.**

- [x] All related docs linked with the PR?

- [x] All changes manually tested?

- [x] Any documentation changes needed with this change?

- [x] Is the PR limited to 10 file changes?

- [x] Is the PR limited to one linear task?

- [x] Are relevant unit and component test-cases added in **new readability format**?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.
