### PR TITLE
fix: extend statuscode check to 502 to retry the request

### DIFF
--- a/src/util/openfaas/index.js
+++ b/src/util/openfaas/index.js
@@ -401,7 +401,7 @@ const executeFaasFunction = async (
       throw new RetryRequestError(`Rate limit exceeded for ${name}`);
     }
 
-    if (error.statusCode === 500 || error.statusCode === 503) {
+    if (error.statusCode === 500 || error.statusCode === 503 || error.statusCode === 502) {
       throw new RetryRequestError(error.message);
     }
 


### PR DESCRIPTION
## What are the changes introduced in this PR?
This PR includes a simple statuscode check extension to include 502 status code from upstream openfaas gateway server to retry the request. Currently, an exception is thrown and the rudder-server doesn't retry causing the transient failure to be sticky and permanent.

This results in dataloss for our customers. This change prevents that.

## What is the related Linear task?

Resolves DAT-1900

## Please explain the objectives of your changes below

Put down any required details on the broader aspect of your changes. If there are any dependent changes, **mandatorily** mention them here

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

N/A

### Any new dependencies introduced with this change?

N/A

### Any new generic utility introduced or modified. Please explain the changes.

N/A

### Any technical or performance related pointers to consider with the change?

N/A

@coderabbitai review

<hr>

### Developer checklist

- [ ] My code follows the style guidelines of this project

- [ ] **No breaking changes are being introduced.**

- [ ] All related docs linked with the PR?

- [ ] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [ ] Is the PR limited to 10 file changes?

- [ ] Is the PR limited to one linear task?

- [ ] Are relevant unit and component test-cases added in **new readability format**?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.
