### PR TITLE
fix: mixpanel transformer - Fall Back to message.context.traits for Group Key Retrieval

### DIFF
--- a/src/v0/destinations/mp/transform.js
+++ b/src/v0/destinations/mp/transform.js
@@ -369,13 +369,15 @@ const processAliasEvents = (message, type, destination) => {
 const processGroupEvents = (message, type, destination) => {
   const returnValue = [];
   const groupKeys = getValuesAsArrayFromConfig(destination.Config.groupKeySettings, 'groupKey');
+  const traits =
+    Object.keys(message.traits ?? {}).length > 0 ? message.traits : message.context.traits ?? {};
   let groupKeyVal;
   if (groupKeys.length > 0) {
     groupKeys.forEach((groupKey) => {
       groupKeyVal =
         groupKey === 'groupId'
           ? getFieldValueFromMessage(message, 'groupId')
-          : get(message.traits, groupKey);
+          : get(traits, groupKey);
       if (groupKeyVal && !Array.isArray(groupKeyVal)) {
         groupKeyVal = [groupKeyVal];
       }
@@ -399,7 +401,7 @@ const processGroupEvents = (message, type, destination) => {
             $group_key: groupKey,
             $group_id: value,
             $set: {
-              ...message.traits,
+              ...traits,
             },
           };
           const groupResponse = responseBuilderSimple(

--- a/test/integrations/destinations/mp/processor/data.ts
+++ b/test/integrations/destinations/mp/processor/data.ts
@@ -6190,4 +6190,244 @@ export const data = [
       },
     },
   },
+  {
+    name: 'mp',
+    description: 'Test fallback for traits to context traits on group call',
+    feature: 'processor',
+    module: 'destination',
+    version: 'v0',
+    input: {
+      request: {
+        body: [
+          {
+            destination: overrideDestination(sampleDestination, {
+              groupKeySettings: [{ groupKey: 'company' }],
+            }),
+            message: {
+              anonymousId: 'e6ab2c5e-2cda-44a9-a962-e2f67df78bca',
+              channel: 'mobile',
+              name: 'Contact Us',
+              context: {
+                app: {
+                  build: '1.0.0',
+                  name: 'RudderLabs Android SDK',
+                  namespace: 'com.rudderlabs.javascript',
+                  version: '1.0.5',
+                },
+                ip: '0.0.0.0',
+                library: { name: 'RudderLabs JavaScript SDK', version: '1.0.5' },
+                locale: 'en-GB',
+                os: { name: '', version: '' },
+                screen: { density: 2 },
+                traits: { company: 'testComp' },
+                userAgent:
+                  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.117 Safari/537.36',
+              },
+              integrations: { All: true },
+              messageId: 'dd266c67-9199-4a52-ba32-f46ddde67312',
+              originalTimestamp: '2020-01-24T06:29:02.358Z',
+              properties: {
+                path: '/tests/html/index2.html',
+                referrer: '',
+                search: '',
+                title: '',
+                url: 'http://localhost/tests/html/index2.html',
+              },
+              traits: {},
+              receivedAt: '2020-01-24T11:59:02.403+05:30',
+              request_ip: '[::1]:53708',
+              sentAt: '2020-01-24T06:29:02.359Z',
+              timestamp: '2020-01-24T11:59:02.402+05:30',
+              type: 'group',
+              userId: 'hjikl',
+            },
+          },
+        ],
+        method: 'POST',
+      },
+      pathSuffix: '',
+    },
+    output: {
+      response: {
+        status: 200,
+        body: [
+          {
+            output: {
+              version: '1',
+              type: 'REST',
+              method: 'POST',
+              endpoint: 'https://api.mixpanel.com/engage/',
+              headers: {},
+              params: {},
+              body: {
+                JSON: {},
+                JSON_ARRAY: {
+                  batch:
+                    '[{"$token":"test_api_token","$distinct_id":"hjikl","$set":{"company":["testComp"]},"$ip":"0.0.0.0"}]',
+                },
+                XML: {},
+                FORM: {},
+              },
+              files: {},
+              userId: 'hjikl',
+            },
+            statusCode: 200,
+          },
+          {
+            output: {
+              version: '1',
+              type: 'REST',
+              method: 'POST',
+              endpoint: 'https://api.mixpanel.com/groups/',
+              headers: {},
+              params: {},
+              body: {
+                JSON: {},
+                JSON_ARRAY: {
+                  batch:
+                    '[{"$token":"test_api_token","$group_key":"company","$group_id":"testComp","$set":{"company":"testComp"}}]',
+                },
+                XML: {},
+                FORM: {},
+              },
+              files: {},
+              userId: 'hjikl',
+            },
+            statusCode: 200,
+          },
+        ],
+      },
+    },
+  },
+  {
+    name: 'mp',
+    description: 'Test fallback to traits for when groupId is an array',
+    feature: 'processor',
+    module: 'destination',
+    version: 'v0',
+    input: {
+      request: {
+        body: [
+          {
+            destination: overrideDestination(sampleDestination, {
+              groupKeySettings: [{ groupKey: 'company' }],
+            }),
+            message: {
+              anonymousId: 'e6ab2c5e-2cda-44a9-a962-e2f67df78bca',
+              channel: 'mobile',
+              name: 'Contact Us',
+              context: {
+                app: {
+                  build: '1.0.0',
+                  name: 'RudderLabs Android SDK',
+                  namespace: 'com.rudderlabs.javascript',
+                  version: '1.0.5',
+                },
+                ip: '0.0.0.0',
+                library: { name: 'RudderLabs JavaScript SDK', version: '1.0.5' },
+                locale: 'en-GB',
+                os: { name: '', version: '' },
+                screen: { density: 2 },
+                traits: { company: ['testComp', 'testComp1'] },
+                userAgent:
+                  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.117 Safari/537.36',
+              },
+              integrations: { All: true },
+              messageId: 'dd266c67-9199-4a52-ba32-f46ddde67312',
+              originalTimestamp: '2020-01-24T06:29:02.358Z',
+              properties: {
+                path: '/tests/html/index2.html',
+                referrer: '',
+                search: '',
+                title: '',
+                url: 'http://localhost/tests/html/index2.html',
+              },
+              traits: {},
+              receivedAt: '2020-01-24T11:59:02.403+05:30',
+              request_ip: '[::1]:53708',
+              sentAt: '2020-01-24T06:29:02.359Z',
+              timestamp: '2020-01-24T11:59:02.402+05:30',
+              type: 'group',
+              userId: 'hjikl',
+            },
+          },
+        ],
+        method: 'POST',
+      },
+      pathSuffix: '',
+    },
+    output: {
+      response: {
+        status: 200,
+        body: [
+          {
+            output: {
+              version: '1',
+              type: 'REST',
+              method: 'POST',
+              endpoint: 'https://api.mixpanel.com/engage/',
+              headers: {},
+              params: {},
+              body: {
+                JSON: {},
+                JSON_ARRAY: {
+                  batch:
+                    '[{"$token":"test_api_token","$distinct_id":"hjikl","$set":{"company":["testComp","testComp1"]},"$ip":"0.0.0.0"}]',
+                },
+                XML: {},
+                FORM: {},
+              },
+              files: {},
+              userId: 'hjikl',
+            },
+            statusCode: 200,
+          },
+          {
+            output: {
+              version: '1',
+              type: 'REST',
+              method: 'POST',
+              endpoint: 'https://api.mixpanel.com/groups/',
+              headers: {},
+              params: {},
+              body: {
+                JSON: {},
+                JSON_ARRAY: {
+                  batch:
+                    '[{"$token":"test_api_token","$group_key":"company","$group_id":"testComp","$set":{"company":["testComp","testComp1"]}}]',
+                },
+                XML: {},
+                FORM: {},
+              },
+              files: {},
+              userId: 'hjikl',
+            },
+            statusCode: 200,
+          },
+          {
+            output: {
+              version: '1',
+              type: 'REST',
+              method: 'POST',
+              endpoint: 'https://api.mixpanel.com/groups/',
+              headers: {},
+              params: {},
+              body: {
+                JSON: {},
+                JSON_ARRAY: {
+                  batch:
+                    '[{"$token":"test_api_token","$group_key":"company","$group_id":"testComp1","$set":{"company":["testComp","testComp1"]}}]',
+                },
+                XML: {},
+                FORM: {},
+              },
+              files: {},
+              userId: 'hjikl',
+            },
+            statusCode: 200,
+          },
+        ],
+      },
+    },
+  },
 ];


### PR DESCRIPTION
## What are the changes introduced in this PR?
- Fixes an issue where the Mixpanel transformer was not correctly retrieving the group key due to traits no longer being available at the top level in the RudderStack Ruby SDK (3.0.0+).  
- Updates the transformer to correctly fetch the group key from `context.traits` instead of `message.traits`.  

## Please explain the objectives of your changes below
- The Rudderstack Ruby SDK [(3.0.0)](https://github.com/rudderlabs/rudder-sdk-ruby/releases/tag/v3.0.0) removed top-level traits, requiring traits to be merged into `context`.  
- The Mixpanel transformer was still relying on `message.traits[groupKey]`, causing group calls to fail with **"Group Key not present"** errors.  
- This change ensures the group key and traits are retrieved from `message.context.traits` when `message.traits` is empty or not present allowing for backwards and forward compatibility.

### Any changes to existing capabilities/behavior? 
- Fixes group calls failing due to missing group key and traits.  

### Any new dependencies introduced with this change?
N/A  

### Any new generic utility introduced or modified? 
N/A  

### Any technical or performance-related pointers to consider with the change?  
N/A  

@coderabbitai review  

<hr>

### Developer checklist  
- [x] My code follows the style guidelines of this project  
- [x] **No breaking changes are being introduced.**  
- [x] All related docs linked with the PR?  
- [x] All changes manually tested?  
- [x] Any documentation changes needed with this change?  
- [x] Is the PR limited to 10 file changes?  
- [x] Is the PR limited to one Linear task?  
- [x] Are relevant unit and component test-cases added in **new readability format**?  

### Reviewer checklist  
- [ ] Is the type of change in the PR title appropriate as per the changes?  
- [ ] Verified that there are no credentials or confidential data exposed with the changes.