### PR TITLE
fix(destination): zoho search api params encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [1.91.0](https://github.com/rudderlabs/rudder-transformer/compare/v1.90.2...v1.91.0) (2025-02-17)
+
+
+### Features
+
+* add support for hashed cart token as anonymousid ([#4048](https://github.com/rudderlabs/rudder-transformer/issues/4048)) ([2b350fe](https://github.com/rudderlabs/rudder-transformer/commit/2b350fe22919d99b803cb17629b30f0c83dc5f8a))
+* added drop traits in track call feature for mixpanel ([#4034](https://github.com/rudderlabs/rudder-transformer/issues/4034)) ([bdd735d](https://github.com/rudderlabs/rudder-transformer/commit/bdd735df38d92b6658250e500d13f3e4b4c7ffad))
+* **http:** add support for isDefaultMapping ([#4073](https://github.com/rudderlabs/rudder-transformer/issues/4073)) ([05553eb](https://github.com/rudderlabs/rudder-transformer/commit/05553eb5cbf3aa0afd752dca9af74e32722876ed))
+
+
+### Bug Fixes
+
+* airship array handling ([#4011](https://github.com/rudderlabs/rudder-transformer/issues/4011)) ([ce86cec](https://github.com/rudderlabs/rudder-transformer/commit/ce86cecbc0a2edbdff8878541771a2ebcf3f6dd9))
+* content_price should be a number with decimal point in twitter ads ([#4075](https://github.com/rudderlabs/rudder-transformer/issues/4075)) ([711e18b](https://github.com/rudderlabs/rudder-transformer/commit/711e18bfcec1518830076bbe7e49ba7b2f2e3757))
+* fixing wrong identifiers in payload for twitter ads destination ([#3988](https://github.com/rudderlabs/rudder-transformer/issues/3988)) ([3fdc92b](https://github.com/rudderlabs/rudder-transformer/commit/3fdc92b93869e875c50c482f890283c97611dc4f))
+
 ### [1.90.2](https://github.com/rudderlabs/rudder-transformer/compare/v1.90.1...v1.90.2) (2025-02-11)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rudder-transformer",
-  "version": "1.90.2",
+  "version": "1.91.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rudder-transformer",
-      "version": "1.90.2",
+      "version": "1.91.0",
       "license": "ISC",
       "dependencies": {
         "@amplitude/ua-parser-js": "0.7.24",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rudder-transformer",
-  "version": "1.90.2",
+  "version": "1.91.0",
   "description": "",
   "homepage": "https://github.com/rudderlabs/rudder-transformer#readme",
   "bugs": {

--- a/src/cdk/v2/destinations/zoho/utils.js
+++ b/src/cdk/v2/destinations/zoho/utils.js
@@ -86,7 +86,9 @@ const handleDuplicateCheck = (addDefaultDuplicateCheck, identifierType, operatio
 };
 
 function escapeAndEncode(value) {
-  return encodeURIComponent(value.replace(/([(),\\])/g, '\\$1'));
+  return encodeURIComponent(
+    typeof value === 'string' ? value.replace(/([(),\\])/g, '\\$1') : value,
+  );
 }
 
 function transformToURLParams(fields, Config) {


### PR DESCRIPTION
## What are the changes introduced in this PR?

- Fixed an issue where an event with an action type of `delete` caused an error.  
- The transformation process involves calling the [Zoho Search API](https://www.zoho.com/crm/developer/docs/api/v6/search-records.html) to retrieve `recordId` using the `criteria` query parameter.  
- The `criteria` parameter follows this format:  
  ```
  (({api_name}:{operator}:{value})and/or({api_name}:{operator}:{value}))
  ```
  where `{value}` needs to be properly escaped and encoded.  
- Our function for escaping and encoding values previously threw an error when the input was not a string.  
- This PR updates the function to first check if the value is a string. If it is, we escape and encode it; otherwise, we only encode it.  


## What is the related Linear task?

Resolves INT-3206

## Please explain the objectives of your changes below

Put down any required details on the broader aspect of your changes. If there are any dependent changes, **mandatorily** mention them here

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

N/A

### Any new dependencies introduced with this change?

N/A

### Any new generic utility introduced or modified. Please explain the changes.

N/A

### Any technical or performance related pointers to consider with the change?

N/A

@coderabbitai review

<hr>

### Developer checklist

- [ ] My code follows the style guidelines of this project

- [ ] **No breaking changes are being introduced.**

- [ ] All related docs linked with the PR?

- [ ] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [ ] Is the PR limited to 10 file changes?

- [ ] Is the PR limited to one linear task?

- [ ] Are relevant unit and component test-cases added in **new readability format**?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.
