### PR TITLE
chore: add env vars for controlling the connection pooling on python transformations

### DIFF
--- a/src/util/openfaas/index.js
+++ b/src/util/openfaas/index.js
@@ -41,6 +41,11 @@ const FAAS_READINESS_HTTP_SUCCESS_THRESHOLD =
 const PARENT_NAMESPACE = process.env.NAMESPACE || 'default';
 const PARENT_CLUSTER = process.env.FAAS_FN_PARENT_CLUSTER || 'default';
 
+const FAAS_CONN_POOL_ENABLE = process.env.FAAS_CONN_POOL_ENABLE || 'false';
+const FAAS_CONN_POOL_TRACKER_MAX_COUNT = process.env.FAAS_CONN_TRACKER_COUNT || '100';
+const FAAS_CONN_POOL_MAX_SIZE = process.env.FAAS_CONN_POOL_SIZE || '2';
+const FAAS_CONN_POOL_BLOCK = process.env.FAAS_CONN_POOL_BLOCK || 'false';
+
 const CONFIG_BACKEND_URL = process.env.CONFIG_BACKEND_URL || 'https://api.rudderlabs.com';
 const GEOLOCATION_URL = process.env.GEOLOCATION_URL || '';
 const FAAS_AST_VID = 'ast';
@@ -304,6 +309,13 @@ function buildOpenfaasFn(name, code, versionId, libraryVersionIDs, testMode, trM
   }
 
   const envVars = {};
+
+  if (FAAS_CONN_POOL_ENABLE.trim().toLowerCase() === 'true') {
+    envVars.conn_pool_enable = FAAS_CONN_POOL_ENABLE;
+    envVars.conn_pool_max_size = FAAS_CONN_POOL_MAX_SIZE;
+    envVars.conn_pool_block = FAAS_CONN_POOL_BLOCK;
+    envVars.conn_pool_tracker_max_count = FAAS_CONN_POOL_TRACKER_MAX_COUNT;
+  }
 
   if (FAAS_ENABLE_WATCHDOG_ENV_VARS.trim().toLowerCase() === 'true') {
     envVars.max_inflight = FAAS_MAX_INFLIGHT;


### PR DESCRIPTION
## What are the changes introduced in this PR?

We are introducing ability to re-use the pooled connections within python transformations when making requests to the internal services like geolocation. This is needed to make sure that we can efficiently request geolocation information within python transformations.

## What is the related Linear task?

Resolves DAT-1889

## Please explain the objectives of your changes below

Put down any required details on the broader aspect of your changes. If there are any dependent changes, **mandatorily** mention them here

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

N/A

### Any new dependencies introduced with this change?

N/A

### Any new generic utility introduced or modified. Please explain the changes.

N/A

### Any technical or performance related pointers to consider with the change?

N/A

@coderabbitai review

<hr>

### Developer checklist

- [ ] My code follows the style guidelines of this project

- [ ] **No breaking changes are being introduced.**

- [ ] All related docs linked with the PR?

- [ ] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [ ] Is the PR limited to 10 file changes?

- [ ] Is the PR limited to one linear task?

- [ ] Are relevant unit and component test-cases added in **new readability format**?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.
