### PR TITLE
chore: enable and disable generic alerts in hosted

### DIFF
--- a/.github/workflows/prepare-for-prod-dt-deploy.yml
+++ b/.github/workflows/prepare-for-prod-dt-deploy.yml
@@ -150,6 +150,11 @@ jobs:
 
           gh pr create --fill
 
+      - name: Update Operator Alerts Configuration
+        uses: ./.github/workflows/update-operator-alerts.yml
+        with:
+          tag_name: ${{ needs.generate-tag-names.outputs.tag_name }}
+
       - name: Update helm charts and raise pull request for enterprise customers on dedicated transformers
         env:
           GITHUB_TOKEN: ${{ secrets.PAT }}

--- a/.github/workflows/update-operator-alerts.yml
+++ b/.github/workflows/update-operator-alerts.yml
@@ -1,0 +1,56 @@
+name: Update Operator Alerts Configuration
+
+on:
+  workflow_call:
+    inputs:
+      tag_name:
+        required: false
+        type: string
+
+jobs:
+  update-alerts:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout operator repo
+        uses: actions/checkout@v4.2.1
+        with:
+          repository: rudderlabs/rudderstack-operator
+          token: ${{ secrets.PAT }}
+          fetch-depth: 1
+
+      - name: Initialize Git Config
+        run: |
+          git config --global user.name "GitHub Actions"
+          git config --global user.email "noreply@github.com"
+
+      - name: Set tag name
+        id: set_tag
+        run: |
+          if [ -z "${{ inputs.tag_name }}" ]; then
+            echo "tag=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+          else
+            echo "tag=${{ inputs.tag_name }}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create PR for enabled alerts
+        env:
+          GITHUB_TOKEN: ${{ secrets.PAT }}
+        run: |
+          git checkout -b transformer-hosted-alerts-enabled-${{ steps.set_tag.outputs.tag }}
+          yq eval -i '.enabled_on_hosted="true"' operator-helm/alerts/cross-customer-pipelines/integrations/generic-transformation-errors.yaml
+          git add operator-helm/alerts/cross-customer-pipelines/integrations/generic-transformation-errors.yaml
+          git commit -m "chore: enable transformer hosted alerts for release ${{ steps.set_tag.outputs.tag }}"
+          git push -u origin transformer-alerts-enabled-${{ steps.set_tag.outputs.tag }}
+          gh pr create --title "Enable transformer hosted alerts for release ${{ steps.set_tag.outputs.tag }}" --body "Enable transformer hosted alerts for release ${{ steps.set_tag.outputs.tag }}" --base main
+
+      - name: Create PR for disabled alerts
+        env:
+          GITHUB_TOKEN: ${{ secrets.PAT }}
+        run: |
+          git checkout main
+          git checkout -b transformer-hosted-alerts-disabled-${{ steps.set_tag.outputs.tag }}
+          yq eval -i '.enabled_on_hosted="false"' operator-helm/alerts/cross-customer-pipelines/integrations/generic-transformation-errors.yaml
+          git add operator-helm/alerts/cross-customer-pipelines/integrations/generic-transformation-errors.yaml
+          git commit -m "chore: disable transformer hosted alerts for release ${{ steps.set_tag.outputs.tag }}"
+          git push -u origin transformer-alerts-disabled-${{ steps.set_tag.outputs.tag }}
+          gh pr create --title "Disable transformer hosted alerts for release ${{ steps.set_tag.outputs.tag }}" --body "Disable transformer hosted alerts for release ${{ steps.set_tag.outputs.tag }}" --base main 

--- a/.github/workflows/update-operator-alerts.yml
+++ b/.github/workflows/update-operator-alerts.yml
@@ -42,21 +42,40 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.PAT }}
         run: |
+          git checkout master
+          git pull origin master
           git checkout -b transformer-hosted-alerts-enabled-${{ steps.set_tag.outputs.tag }}
           yq eval -i '.enabled_on_hosted="true"' operator-helm/alerts/cross-customer-pipelines/integrations/generic-transformation-errors.yaml
           git add operator-helm/alerts/cross-customer-pipelines/integrations/generic-transformation-errors.yaml
           git commit -m "chore: enable transformer hosted alerts for release ${{ steps.set_tag.outputs.tag }}"
-          git push -u origin transformer-alerts-enabled-${{ steps.set_tag.outputs.tag }}
-          gh pr create --title "Enable transformer hosted alerts for release ${{ steps.set_tag.outputs.tag }}" --body "Enable transformer hosted alerts for release ${{ steps.set_tag.outputs.tag }}" --base main
+          git push -u origin transformer-hosted-alerts-enabled-${{ steps.set_tag.outputs.tag }}
+          # Add error handling for PR creation
+          if gh pr create --title "chore: enable transformer hosted alerts for release ${{ steps.set_tag.outputs.tag }}" \
+             --body "chore: enable transformer hosted alerts for release ${{ steps.set_tag.outputs.tag }}" \
+             --base master; then
+            echo "PR created successfully"
+          else
+            echo "Failed to create PR, checking if changes exist"
+            exit 1
+          fi
 
       - name: Create PR for disabled alerts
         env:
           GITHUB_TOKEN: ${{ secrets.PAT }}
         run: |
-          git checkout main
+          git checkout master
+          git pull origin master
           git checkout -b transformer-hosted-alerts-disabled-${{ steps.set_tag.outputs.tag }}
           yq eval -i '.enabled_on_hosted="false"' operator-helm/alerts/cross-customer-pipelines/integrations/generic-transformation-errors.yaml
           git add operator-helm/alerts/cross-customer-pipelines/integrations/generic-transformation-errors.yaml
           git commit -m "chore: disable transformer hosted alerts for release ${{ steps.set_tag.outputs.tag }}"
-          git push -u origin transformer-alerts-disabled-${{ steps.set_tag.outputs.tag }}
-          gh pr create --title "Disable transformer hosted alerts for release ${{ steps.set_tag.outputs.tag }}" --body "Disable transformer hosted alerts for release ${{ steps.set_tag.outputs.tag }}" --base main 
+          git push -u origin transformer-hosted-alerts-disabled-${{ steps.set_tag.outputs.tag }}
+          # Add error handling for PR creation
+          if gh pr create --title "chore: disable transformer hosted alerts for release ${{ steps.set_tag.outputs.tag }}" \
+             --body "chore: disable transformer hosted alerts for release ${{ steps.set_tag.outputs.tag }}" \
+             --base master; then
+            echo "PR created successfully"
+          else
+            echo "Failed to create PR, checking if changes exist"
+            exit 1
+          fi 

--- a/.github/workflows/update-operator-alerts.yml
+++ b/.github/workflows/update-operator-alerts.yml
@@ -6,6 +6,12 @@ on:
       tag_name:
         required: false
         type: string
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: 'Tag name for the release (defaults to current date if empty)'
+        required: false
+        type: string
 
 jobs:
   update-alerts:


### PR DESCRIPTION
## What are the changes introduced in this PR?

New github workflow to create operator PRs which will enable/disable generic transformer error alerts

## What is the related Linear task?

Resolves INT-3169

## Please explain the objectives of your changes below

We want to enable and disable generic transformation alerts in hosted environment when we make a new release. But we cannot keep them enabled all the time as they might be very noisy. These PRs will help the release owner to enable the alerts for the day we monitor on hosted and then disable once we move on to production release.

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

No

### Any new dependencies introduced with this change?

N/A

### Any new generic utility introduced or modified. Please explain the changes.

Github workflows have changed

### Any technical or performance related pointers to consider with the change?

N/A

@coderabbitai review

<hr>

### Developer checklist

- [x] My code follows the style guidelines of this project

- [x] **No breaking changes are being introduced.**

- [x] All related docs linked with the PR?

- [ ] All changes manually tested?

- [] Any documentation changes needed with this change?
    - Yes, we should include the process change in release process documentation ( integrations team )

- [x] Is the PR limited to 10 file changes?

- [x] Is the PR limited to one linear task?

- [ ] Are relevant unit and component test-cases added in **new readability format**?

### Reviewer checklist

- [x] Is the type of change in the PR title appropriate as per the changes?

- [x] Verified that there are no credentials or confidential data exposed with the changes.
