### PR TITLE
fix: add 2655 error handling to fb error handler at proxy

### DIFF
--- a/src/v0/util/facebookUtils/networkHandler.js
+++ b/src/v0/util/facebookUtils/networkHandler.js
@@ -212,6 +212,12 @@ const errorDetailsMap = {
       .setMessage('There have been too many calls to this ad-account.')
       .build(),
   },
+  2655: {
+    default: new ErrorDetailsExtractorBuilder()
+      .setStatus(400)
+      .setMessage('Marketing Messaging TOS not accepted.')
+      .build(),
+  },
   200: {
     default: new ErrorDetailsExtractorBuilder()
       .setStatus(403)

--- a/test/integrations/destinations/fb_custom_audience/dataDelivery/data.ts
+++ b/test/integrations/destinations/fb_custom_audience/dataDelivery/data.ts
@@ -693,7 +693,7 @@ export const existingTestData = [
             destinationResponse: {
               error: {
                 code: 2655,
-                fbtrace_id: 'KSB2jSGDMX_CwgM9230pDxM',
+                fbtrace_id: 'fbtrace_id',
                 message: '(#2655) Marketing Messaging TOS not accepted',
                 type: 'OAuthException',
               },

--- a/test/integrations/destinations/fb_custom_audience/dataDelivery/data.ts
+++ b/test/integrations/destinations/fb_custom_audience/dataDelivery/data.ts
@@ -648,6 +648,74 @@ export const existingTestData = [
       },
     },
   },
+  {
+    name: 'fb_custom_audience',
+    description: 'User not accepted TOS for messaging API',
+    feature: 'dataDelivery',
+    module: 'destination',
+    version: 'v0',
+    input: {
+      request: {
+        body: {
+          version: '1',
+          type: 'REST',
+          method: 'DELETE',
+          endpoint: getEndPoint('aud1'),
+          headers: {
+            'test-dest-response-key': 'messagingTOSNotAccepted',
+          },
+          params: {
+            access_token: 'ABC',
+            payload: {
+              is_raw: true,
+              data_source: {
+                sub_type: 'ANYTHING',
+              },
+              schema: ['DOBY', 'PHONE', 'GEN', 'FI', 'MADID', 'ZIP', 'ST', 'COUNTRY'],
+              data: [['2013', '@09432457768', 'f', 'Ms.', 'ABC', 'ZIP ', '123abc ', 'IN']],
+            },
+          },
+          body: {
+            JSON: {},
+            XML: {},
+            JSON_ARRAY: {},
+            FORM: {},
+          },
+          files: {},
+        },
+      },
+    },
+    output: {
+      response: {
+        status: 400,
+        body: {
+          output: {
+            destinationResponse: {
+              error: {
+                code: 2655,
+                fbtrace_id: 'KSB2jSGDMX_CwgM9230pDxM',
+                message: '(#2655) Marketing Messaging TOS not accepted',
+                type: 'OAuthException',
+              },
+              status: 400,
+            },
+            message: 'Marketing Messaging TOS not accepted.',
+            statTags: {
+              destType: 'FB_CUSTOM_AUDIENCE',
+              destinationId: 'Non-determininable',
+              errorCategory: 'network',
+              errorType: 'aborted',
+              feature: 'dataDelivery',
+              implementation: 'native',
+              module: 'destination',
+              workspaceId: 'Non-determininable',
+            },
+            status: 400,
+          },
+        },
+      },
+    },
+  },
 ];
 
 export const data = [...existingTestData, ...testScenariosForV1API, ...otherScenariosV1];

--- a/test/integrations/destinations/fb_custom_audience/network.ts
+++ b/test/integrations/destinations/fb_custom_audience/network.ts
@@ -661,7 +661,7 @@ export const networkCallsData = [
           message: '(#2655) Marketing Messaging TOS not accepted',
           type: 'OAuthException',
           code: 2655,
-          fbtrace_id: 'KSB2jSGDMX_CwgM9230pDxM',
+          fbtrace_id: 'fbtrace_id',
         },
       },
       status: 400,

--- a/test/integrations/destinations/fb_custom_audience/network.ts
+++ b/test/integrations/destinations/fb_custom_audience/network.ts
@@ -626,4 +626,45 @@ export const networkCallsData = [
       status: 400,
     },
   },
+  {
+    httpReq: {
+      version: '1',
+      type: 'REST',
+      method: 'DELETE',
+      endpoint: getEndPoint('aud-new'),
+      headers: {
+        'test-dest-response-key': 'messagingTOSNotAccepted',
+      },
+      params: {
+        access_token: 'XYZ',
+        payload: {
+          is_raw: true,
+          data_source: {
+            sub_type: 'ANYTHING',
+          },
+          schema: ['DOBY', 'PHONE', 'GEN', 'FI', 'MADID', 'ZIP', 'ST', 'COUNTRY'],
+          data: [['2013', '@09432457768', 'f', 'Ms.', 'ABC', 'ZIP ', '123abc ', 'IN']],
+        },
+      },
+      userId: '',
+      body: {
+        JSON: {},
+        XML: {},
+        JSON_ARRAY: {},
+        FORM: {},
+      },
+      files: {},
+    },
+    httpRes: {
+      data: {
+        error: {
+          message: '(#2655) Marketing Messaging TOS not accepted',
+          type: 'OAuthException',
+          code: 2655,
+          fbtrace_id: 'KSB2jSGDMX_CwgM9230pDxM',
+        },
+      },
+      status: 400,
+    },
+  },
 ];


### PR DESCRIPTION
## What are the changes introduced in this PR?

Add 2655 error handling to fb error handler at proxy for below error code

`"response": {
    "message": "(#2655) Marketing Messaging TOS not accepted",
    "type": "OAuthException",
    "code": 2655,
    "fbtrace_id": "XX....XX"
  },`

## What is the related Linear task?

Resolves INT-3350

## Please explain the objectives of your changes below

Put down any required details on the broader aspect of your changes. If there are any dependent changes, **mandatorily** mention them here

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

N/A

### Any new dependencies introduced with this change?

N/A

### Any new generic utility introduced or modified. Please explain the changes.

N/A

### Any technical or performance related pointers to consider with the change?

N/A

@coderabbitai review

<hr>

### Developer checklist

- [ ] My code follows the style guidelines of this project

- [ ] **No breaking changes are being introduced.**

- [ ] All related docs linked with the PR?

- [ ] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [ ] Is the PR limited to 10 file changes?

- [ ] Is the PR limited to one linear task?

- [ ] Are relevant unit and component test-cases added in **new readability format**?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.
