### PR TITLE
fix: handle null properties for ga nonEcomGenericEvent

### DIFF
--- a/src/v0/destinations/ga/transform.js
+++ b/src/v0/destinations/ga/transform.js
@@ -362,15 +362,12 @@ function processNonEComGenericEvent(message, destination) {
   let { nonInteraction } = destination.Config;
   nonInteraction = nonInteraction || false;
   const nonInteractionProp =
-    message.properties !== undefined && message.properties.nonInteraction !== undefined
+    message.properties?.nonInteraction !== undefined
       ? !!message.properties.nonInteraction
       : !!nonInteraction;
   const parameters = {
     ea: message.event,
-    ec:
-      message.properties !== undefined && message.properties.category !== undefined
-        ? message.properties.category
-        : 'All',
+    ec: message.properties?.category !== undefined ? message.properties.category : 'All',
     ni: nonInteractionProp === false ? 0 : 1,
   };
 
@@ -840,4 +837,4 @@ const processRouterDest = async (inputs, reqMetadata) => {
   const respList = await simpleProcessRouterDest(inputs, process, reqMetadata);
   return respList;
 };
-module.exports = { process, processRouterDest };
+module.exports = { process, processRouterDest, processNonEComGenericEvent };

--- a/src/v0/destinations/ga/transform.test.ts
+++ b/src/v0/destinations/ga/transform.test.ts
@@ -1,0 +1,68 @@
+const { processNonEComGenericEvent } = require('./transform');
+
+describe('transform', () => {
+  describe('processNonEComGenericEvent function tests', () => {
+    // Function returns an object with ea, ec, and ni properties
+    it('should return an object with ea, ec, and ni properties', () => {
+      const message = {
+        event: 'test_event',
+        properties: {
+          category: 'test_category',
+          nonInteraction: false,
+        },
+      };
+
+      const destination = {
+        Config: {
+          nonInteraction: true,
+        },
+      };
+
+      const result = processNonEComGenericEvent(message, destination);
+
+      expect(result).toHaveProperty('ea', 'test_event');
+      expect(result).toHaveProperty('ec', 'test_category');
+      expect(result).toHaveProperty('ni', 0);
+    });
+    // Handle when message.properties is undefined or null
+    it('should handle when message.properties is null', () => {
+      const message = {
+        event: 'test_event',
+        properties: null,
+      };
+
+      const destination = {
+        Config: {
+          nonInteraction: false,
+        },
+      };
+
+      const result = processNonEComGenericEvent(message, destination);
+
+      expect(result).toHaveProperty('ea', 'test_event');
+      expect(result).toHaveProperty('ec', 'All');
+      expect(result).toHaveProperty('ni', 0);
+    });
+    // Handle when message.event is undefined or null
+    it('should return an object with ea as undefined and default ec when message.event is undefined', () => {
+      const message = {
+        properties: {
+          category: 'test_category',
+          nonInteraction: false,
+        },
+      };
+
+      const destination = {
+        Config: {
+          nonInteraction: true,
+        },
+      };
+
+      const result = processNonEComGenericEvent(message, destination);
+
+      expect(result).toHaveProperty('ea', undefined);
+      expect(result).toHaveProperty('ec', 'test_category');
+      expect(result).toHaveProperty('ni', 0);
+    });
+  });
+});


### PR DESCRIPTION
## What are the changes introduced in this PR?

We are handling null properties for `processNonEComGenericEvent` function.

## What is the related Linear task?

Resolves INT-3450

## Please explain the objectives of your changes below

Put down any required details on the broader aspect of your changes. If there are any dependent changes, **mandatorily** mention them here

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

N/A

### Any new dependencies introduced with this change?

N/A

### Any new generic utility introduced or modified. Please explain the changes.

N/A

### Any technical or performance related pointers to consider with the change?

N/A

@coderabbitai review

<hr>

### Developer checklist

- [ ] My code follows the style guidelines of this project

- [ ] **No breaking changes are being introduced.**

- [ ] All related docs linked with the PR?

- [ ] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [ ] Is the PR limited to 10 file changes?

- [ ] Is the PR limited to one linear task?

- [ ] Are relevant unit and component test-cases added in **new readability format**?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new capability for processing non-commerce events, enhancing how event tracking data is interpreted.
- **Refactor**
  - Streamlined event property validations using modern syntax for improved clarity and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->