### PR TITLE
fix: use UTC in getBirthdayObj to fix the ortto destination test in different timezones

### DIFF
--- a/src/cdk/v2/destinations/ortto/utils.js
+++ b/src/cdk/v2/destinations/ortto/utils.js
@@ -8,11 +8,11 @@ const getBirthdayObj = (birthday) => {
   if (!dateRegex.test(birthday)) {
     return null; // Invalid birthday format
   }
-  const date = new Date(birthday);
+  const date = new Date(`${birthday}T00:00:00Z`);
 
-  const year = date.getFullYear();
-  const month = date.getMonth() + 1; // Month is 0-based, so add 1
-  const day = date.getDate();
+  const year = date.getUTCFullYear();
+  const month = date.getUTCMonth() + 1; // Month is 0-based, so add 1
+  const day = date.getUTCDate();
 
   return { year, month, day };
 };


### PR DESCRIPTION
## What are the changes introduced in this PR?

Fixing ortto component test failure in different timezones.

## What is the related Linear task?

Resolves INT-3119

## Please explain the objectives of your changes below

Put down any required details on the broader aspect of your changes. If there are any dependent changes, **mandatorily** mention them here

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

N/A

### Any new dependencies introduced with this change?

N/A

### Any new generic utility introduced or modified. Please explain the changes.

N/A

### Any technical or performance related pointers to consider with the change?

N/A

@coderabbitai review

<hr>

### Developer checklist

- [ ] My code follows the style guidelines of this project

- [ ] **No breaking changes are being introduced.**

- [ ] All related docs linked with the PR?

- [ ] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [ ] Is the PR limited to 10 file changes?

- [ ] Is the PR limited to one linear task?

- [ ] Are relevant unit and component test-cases added in **new readability format**?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.
