### PR TITLE
fix: encode userId with forward slashes in CustomerIO URLs

### DIFF
--- a/src/v0/destinations/customerio/util.js
+++ b/src/v0/destinations/customerio/util.js
@@ -211,6 +211,8 @@ const groupResponseBuilder = (message) => {
   return { rawPayload, endpoint, requestConfig };
 };
 
+const encodePathParameter = (param) => (param?.includes('/') ? encodeURIComponent(param) : param);
+
 const defaultResponseBuilder = (message, evName, userId, evType, destination, messageType) => {
   const rawPayload = {};
   let endpoint;
@@ -218,7 +220,7 @@ const defaultResponseBuilder = (message, evName, userId, evType, destination, me
   let requestConfig = defaultPostRequestConfig;
   // any other event type except identify
   const token = get(message, 'context.device.token');
-  const id = userId || getFieldValueFromMessage(message, 'email');
+  const id = encodePathParameter(userId) || getFieldValueFromMessage(message, 'email');
   // use this if only top level keys are to be sent
   // DEVICE DELETE from CustomerIO
   const isDeviceDeleteEvent = deviceDeleteRelatedEventName === evName;
@@ -303,6 +305,7 @@ const validateConfigFields = (destination) => {
 };
 
 module.exports = {
+  encodePathParameter,
   getEventChunks,
   identifyResponseBuilder,
   aliasResponseBuilder,

--- a/src/v0/destinations/customerio/util.test.js
+++ b/src/v0/destinations/customerio/util.test.js
@@ -1,8 +1,10 @@
 const {
+  encodePathParameter,
   isdeviceRelatedEventName,
   identifyResponseBuilder,
   aliasResponseBuilder,
   groupResponseBuilder,
+  defaultResponseBuilder,
 } = require('./util');
 
 const getTestMessage = () => {
@@ -18,6 +20,10 @@ const getTestMessage = () => {
       },
       createdAt: '2014-05-21T15:54:20Z',
       timestamp: '2014-05-21T15:54:20Z',
+    },
+    properties: {
+      test: 'property',
+      value: 123,
     },
   };
   return message;
@@ -188,5 +194,105 @@ describe('Unit test cases for customerio groupResponseBuilder', () => {
       requestConfig: { requestFormat: 'JSON', requestMethod: 'POST' },
     };
     expect(groupResponseBuilder(getGroupTestMessage(), 'user1')).toEqual(expectedOutput);
+  });
+});
+
+describe('Unit test cases for customerio encodePathParameter', () => {
+  const testCases = [
+    {
+      name: "should encode path parameter with '/'",
+      param: 'test/param',
+      expectedOutput: 'test%2Fparam',
+    },
+    {
+      name: "should not encode path parameter without '/'",
+      param: 'some@email.com',
+      expectedOutput: 'some@email.com',
+    },
+  ];
+
+  testCases.forEach((testCase) => {
+    it(testCase.name, () => {
+      expect(encodePathParameter(testCase.param)).toEqual(testCase.expectedOutput);
+    });
+  });
+});
+
+describe('Unit test cases for customerio defaultResponseBuilder with userId containing forward slash', () => {
+  const testCases = [
+    {
+      name: 'should encode userId with forward slash in the endpoint URL',
+      message: {
+        properties: { test: 'property' },
+        anonymousId: 'anon123',
+      },
+      evName: 'Test Event',
+      userId: 'user/with/slashes',
+      evType: 'event',
+      destination: {
+        Config: {
+          apiKey: 'test-api-key',
+          siteID: 'test-site-id',
+        },
+      },
+      messageType: 'track',
+      expectedEndpoint: 'https://track.customer.io/api/v1/customers/user%2Fwith%2Fslashes/events',
+      expectedPayloadProps: {
+        data: true,
+        name: 'Test Event',
+        type: 'event',
+      },
+    },
+    {
+      name: 'should encode userId with multiple forward slashes in the endpoint URL',
+      message: {
+        properties: { test: 'property' },
+        anonymousId: 'anon123',
+      },
+      evName: 'Test Event',
+      userId: 'user/with/multiple/slashes',
+      evType: 'event',
+      destination: {
+        Config: {
+          apiKey: 'test-api-key',
+          siteID: 'test-site-id',
+        },
+      },
+      messageType: 'track',
+      expectedEndpoint:
+        'https://track.customer.io/api/v1/customers/user%2Fwith%2Fmultiple%2Fslashes/events',
+      expectedPayloadProps: {
+        data: true,
+        name: 'Test Event',
+        type: 'event',
+      },
+    },
+  ];
+
+  testCases.forEach((testCase) => {
+    it(testCase.name, () => {
+      const result = defaultResponseBuilder(
+        testCase.message,
+        testCase.evName,
+        testCase.userId,
+        testCase.evType,
+        testCase.destination,
+        testCase.messageType,
+      );
+
+      // Check that the userId is properly encoded in the endpoint URL
+      expect(result.endpoint).toEqual(testCase.expectedEndpoint);
+
+      // Verify other parts of the response
+      if (testCase.expectedPayloadProps.data) {
+        expect(result.rawPayload).toHaveProperty('data');
+      }
+      if (testCase.expectedPayloadProps.name) {
+        expect(result.rawPayload).toHaveProperty('name', testCase.expectedPayloadProps.name);
+      }
+      if (testCase.expectedPayloadProps.type) {
+        expect(result.rawPayload).toHaveProperty('type', testCase.expectedPayloadProps.type);
+      }
+    });
   });
 });

--- a/test/integrations/destinations/customerio/processor/data.ts
+++ b/test/integrations/destinations/customerio/processor/data.ts
@@ -15,6 +15,75 @@ import {
 export const data = [
   {
     name: 'customerio',
+    description: 'Test for userId with forward slash',
+    feature: 'processor',
+    module: 'destination',
+    version: 'v0',
+    input: {
+      request: {
+        body: [
+          {
+            message: {
+              channel: 'web',
+              type: 'track',
+              userId: 'user/with/slashes',
+              event: 'Test Event',
+              properties: {
+                test: 'property',
+                value: 123,
+              },
+              sentAt: '2023-05-14T09:03:22.563Z',
+            },
+            destination: {
+              Config: {
+                datacenter: 'US',
+                siteID: secret1,
+                apiKey: secret2,
+              },
+            },
+          },
+        ],
+      },
+    },
+    output: {
+      response: {
+        status: 200,
+        body: [
+          {
+            output: {
+              body: {
+                XML: {},
+                JSON_ARRAY: {},
+                JSON: {
+                  data: {
+                    test: 'property',
+                    value: 123,
+                  },
+                  name: 'Test Event',
+                  type: 'event',
+                },
+                FORM: {},
+              },
+              files: {},
+              endpoint: 'https://track.customer.io/api/v1/customers/user%2Fwith%2Fslashes/events',
+              userId: 'user/with/slashes',
+              headers: {
+                Authorization: authHeader1,
+              },
+              version: '1',
+              params: {},
+              type: 'REST',
+              method: 'POST',
+              statusCode: 200,
+            },
+            statusCode: 200,
+          },
+        ],
+      },
+    },
+  },
+  {
+    name: 'customerio',
     description: 'Test 0',
     feature: 'processor',
     module: 'destination',


### PR DESCRIPTION


## What are the changes introduced in this PR?

This commit fixes an issue where userIds containing forward slashes were not properly encoded

in CustomerIO destination URLs.

Changes:

- Added encodePathParameter function to encode forward slashes in userIds

- Updated defaultResponseBuilder to use encodePathParameter for userId

- Added unit tests for encodePathParameter using table test format

- Added unit tests for defaultResponseBuilder with userIds containing slashes

- Added component tests to verify end-to-end functionality

This ensures that CustomerIO API calls work correctly when userIds contain forward slashes.

## What is the related Linear task?

Resolves INT-3470

## Please explain the objectives of your changes below

Put down any required details on the broader aspect of your changes. If there are any dependent changes, **mandatorily** mention them here

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

N/A

### Any new dependencies introduced with this change?

N/A

### Any new generic utility introduced or modified. Please explain the changes.

N/A

### Any technical or performance related pointers to consider with the change?

N/A

@coderabbitai review

<hr>

### Developer checklist

- [ ] My code follows the style guidelines of this project

- [ ] **No breaking changes are being introduced.**

- [ ] All related docs linked with the PR?

- [ ] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [ ] Is the PR limited to 10 file changes?

- [ ] Is the PR limited to one linear task?

- [ ] Are relevant unit and component test-cases added in **new readability format**?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.
