### PR TITLE
refactor(iterable): update api limits and batching logic

### DIFF
--- a/src/v0/destinations/iterable/config.js
+++ b/src/v0/destinations/iterable/config.js
@@ -78,10 +78,12 @@ const constructEndpoint = (dataCenter, category) => {
 
 const BULK_ENDPOINTS = ['/api/users/bulkUpdate', '/api/events/trackBulk'];
 
-const IDENTIFY_MAX_BATCH_SIZE = 1000;
-const IDENTIFY_MAX_BODY_SIZE_IN_BYTES = 4000000;
+// Iterable has a single API limit of 4MB request size for all operations
+const MAX_BODY_SIZE_IN_BYTES = 4000000; // 4MB
 
-const TRACK_MAX_BATCH_SIZE = 8000;
+// Batch size limits
+const INITIAL_CHUNK_SIZE = 1000; // Initial chunk size for all operations
+const CATALOG_MAX_ITEMS_PER_REQUEST = 1000;
 
 const ITERABLE_RESPONSE_USER_ID_PATHS = [
   'invalidUserIds',
@@ -105,9 +107,9 @@ module.exports = {
   mappingConfig,
   ConfigCategory,
   constructEndpoint,
-  TRACK_MAX_BATCH_SIZE,
-  IDENTIFY_MAX_BATCH_SIZE,
-  IDENTIFY_MAX_BODY_SIZE_IN_BYTES,
+  MAX_BODY_SIZE_IN_BYTES,
+  INITIAL_CHUNK_SIZE,
+  CATALOG_MAX_ITEMS_PER_REQUEST,
   ITERABLE_RESPONSE_USER_ID_PATHS,
   ITERABLE_RESPONSE_EMAIL_PATHS,
   BULK_ENDPOINTS,


### PR DESCRIPTION
## What are the changes introduced in this PR?

Update Iterable destination to use a single 4MB request size limit for both identify and track operations, and a 1,000 items per request limit for catalog operations.

- Replace separate batch size limits with a single MAX_BODY_SIZE_IN_BYTES constant
- Add CATALOG_MAX_ITEMS_PER_REQUEST constant for catalog operations
- Add INITIAL_CHUNK_SIZE constant to replace hard-coded values
- Simplify catalog batching logic only to respect item count limit
- Add tests to verify batching behavior

## What is the related Linear task?

Resolves INT-3475

## Please explain the objectives of your changes below

Put down any required details on the broader aspect of your changes. If there are any dependent changes, **mandatorily** mention them here

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

N/A

### Any new dependencies introduced with this change?

N/A

### Any new generic utility introduced or modified. Please explain the changes.

N/A

### Any technical or performance related pointers to consider with the change?

N/A

@coderabbitai review

<hr>

### Developer checklist

- [ ] My code follows the style guidelines of this project

- [ ] **No breaking changes are being introduced.**

- [ ] All related docs linked with the PR?

- [ ] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [ ] Is the PR limited to 10 file changes?

- [ ] Is the PR limited to one linear task?

- [ ] Are relevant unit and component test-cases added in **new readability format**?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.
