### PR TITLE
feat: add validation for sourceEvents array type

### DIFF
--- a/src/services/source/nativeIntegration.ts
+++ b/src/services/source/nativeIntegration.ts
@@ -1,4 +1,4 @@
-import { JsonSchemaGenerator } from '@rudderstack/integrations-lib';
+import { JsonSchemaGenerator, TransformationError } from '@rudderstack/integrations-lib';
 import { FetchHandler } from '../../helpers/fetchHandlers';
 import { SourceService } from '../../interfaces/SourceService';
 import {
@@ -37,6 +37,9 @@ export class NativeIntegrationSourceService implements SourceService {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     _requestMetadata: NonNullable<unknown>,
   ): Promise<SourceTransformationResponse[]> {
+    if (!Array.isArray(sourceEvents)) {
+      throw new TransformationError('Invalid source events');
+    }
     const sourceHandler = FetchHandler.getSourceHandler(sourceType);
     const metaTO = this.getTags({ srcType: sourceType });
     const respList: SourceTransformationResponse[] = await Promise.all<FixMe>(


### PR DESCRIPTION


## What are the changes introduced in this PR?

Added validation in sourceTransformRoutine to ensure sourceEvents is an array. If not, it throws a TransformationError with message 'Invalid source events'.

Updated the corresponding test to properly handle async error testing by using await expect().rejects.toThrow() instead of expect().toThrow().

This validation prevents unexpected errors when processing non-array inputs and provides a clear error message for debugging.

## What is the related Linear task?
https://rudderstack.grafana.net/a/grafana-irm-app/alert-groups/ITHVQNPJT22EA
Resolves INT-3457

## Please explain the objectives of your changes below

Put down any required details on the broader aspect of your changes. If there are any dependent changes, **mandatorily** mention them here

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

N/A

### Any new dependencies introduced with this change?

N/A

### Any new generic utility introduced or modified. Please explain the changes.

N/A

### Any technical or performance related pointers to consider with the change?

N/A

@coderabbitai review

<hr>

### Developer checklist

- [ ] My code follows the style guidelines of this project

- [ ] **No breaking changes are being introduced.**

- [ ] All related docs linked with the PR?

- [ ] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [ ] Is the PR limited to 10 file changes?

- [ ] Is the PR limited to one linear task?

- [ ] Are relevant unit and component test-cases added in **new readability format**?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.
