### PR TITLE
fix: ensure marketo_static_list metadata is always an array

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -4,6 +4,7 @@ reports/
 test/
 benchmark/
 dist/
+dist-test/
 **/warehouse/
 **/lambda/
 **/openfaas/

--- a/src/v0/destinations/marketo_static_list/transform.js
+++ b/src/v0/destinations/marketo_static_list/transform.js
@@ -14,6 +14,7 @@ const { getDestinationExternalID, defaultRequestConfig } = require('../../util')
 const { formatConfig, MAX_LEAD_IDS_SIZE } = require('./config');
 const { getAuthToken } = require('../marketo/util');
 const { processRecordInputs } = require('./transformV2');
+const { CommonUtils } = require('../../../util/common');
 
 const responseBuilder = (endPoint, leadIds, operation, token) => {
   let updatedEndpoint = endPoint;
@@ -161,14 +162,16 @@ const processRouterDest = async (inputs, reqMetadata) => {
  */
 function processMetadataForRouter(output) {
   const { metadata, destination } = output;
-  const clonedMetadata = cloneDeep(metadata);
-  if (Array.isArray(clonedMetadata)) {
-    clonedMetadata.forEach((metadataElement) => {
-      // eslint-disable-next-line no-param-reassign
-      metadataElement.destInfo = { authKey: destination?.ID };
-    });
-  }
-  return clonedMetadata;
+  // Ensure metadata is always an array
+  const metadataArray = CommonUtils.toArray(cloneDeep(metadata));
+
+  // Add destInfo to each metadata element
+  metadataArray.forEach((metadataElement) => {
+    // eslint-disable-next-line no-param-reassign
+    metadataElement.destInfo = { authKey: destination?.ID };
+  });
+
+  return metadataArray;
 }
 
 module.exports = {

--- a/src/v0/destinations/marketo_static_list/transform.test.js
+++ b/src/v0/destinations/marketo_static_list/transform.test.js
@@ -1,0 +1,28 @@
+const { processMetadataForRouter } = require('./transform');
+
+describe('transform', () => {
+  describe('processMetadataForRouter', () => {
+    it('should always return an array of metadata', () => {
+      // Test with array metadata
+      const outputWithArrayMetadata = {
+        metadata: [{ userId: 'user1' }, { userId: 'user2' }],
+        destination: { ID: 'dest1' },
+      };
+      const resultWithArray = processMetadataForRouter(outputWithArrayMetadata);
+      expect(Array.isArray(resultWithArray)).toBe(true);
+      expect(resultWithArray.length).toBe(2);
+      expect(resultWithArray[0].destInfo).toEqual({ authKey: 'dest1' });
+      expect(resultWithArray[1].destInfo).toEqual({ authKey: 'dest1' });
+
+      // Test with non-array metadata
+      const outputWithSingleMetadata = {
+        metadata: { userId: 'user1' },
+        destination: { ID: 'dest1' },
+      };
+      const resultWithSingle = processMetadataForRouter(outputWithSingleMetadata);
+      expect(Array.isArray(resultWithSingle)).toBe(true);
+      expect(resultWithSingle.length).toBe(1);
+      expect(resultWithSingle[0].destInfo).toEqual({ authKey: 'dest1' });
+    });
+  });
+});


### PR DESCRIPTION


## What are the changes introduced in this PR?
This fix ensures that the processMetadataForRouter function in marketo_static_list always returns metadata as an array, which is required by the router. Previously, it was not ensuring that the metadata was always an array, which could cause issues with the router transform.

Write a brief explainer on your code changes.

## What is the related Linear task?

Resolves INT-3458

## Please explain the objectives of your changes below

Put down any required details on the broader aspect of your changes. If there are any dependent changes, **mandatorily** mention them here

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

N/A

### Any new dependencies introduced with this change?

N/A

### Any new generic utility introduced or modified. Please explain the changes.

N/A

### Any technical or performance related pointers to consider with the change?

N/A

@coderabbitai review

<hr>

### Developer checklist

- [ ] My code follows the style guidelines of this project

- [ ] **No breaking changes are being introduced.**

- [ ] All related docs linked with the PR?

- [ ] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [ ] Is the PR limited to 10 file changes?

- [ ] Is the PR limited to one linear task?

- [ ] Are relevant unit and component test-cases added in **new readability format**?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.
