### PR TITLE
fix: userpilot response structure

### DIFF
--- a/src/cdk/v2/destinations/userpilot/procWorkflow.yaml
+++ b/src/cdk/v2/destinations/userpilot/procWorkflow.yaml
@@ -26,7 +26,8 @@ steps:
         "Content-Type": "application/json",
         "X-API-Version": $.context.apiVersion
       };
-
+  # Central API docs: https://docs.userpilot.com/article/195-identify-users-and-track-api
+  # Identify user API
   - name: identifyPayload
     condition: $.context.messageType == {{$.EventType.IDENTIFY}}
     template: |
@@ -40,6 +41,7 @@ steps:
       $.context.payload.metadata = $.removeUndefinedAndNullValues(traits);
       $.context.endpoint = $.getEndpoints(.destination.Config).IDENTIFY;
 
+  # Track event API
   - name: trackPayload
     condition: $.context.messageType == {{$.EventType.TRACK}}
     template: |
@@ -54,6 +56,7 @@ steps:
 
       $.context.endpoint = $.getEndpoints(.destination.Config).TRACK;
 
+  # Group company API
   - name: groupPayload
     condition: $.context.messageType == {{$.EventType.GROUP}}
     template: |
@@ -74,5 +77,5 @@ steps:
       response.endpoint = $.context.endpoint;
       response.headers = $.context.finalHeaders;
       response.method = "POST";
-      response.body = $.context.payload;
+      response.body.JSON = $.context.payload;
       response

--- a/test/integrations/destinations/userpilot/processor/data.ts
+++ b/test/integrations/destinations/userpilot/processor/data.ts
@@ -105,39 +105,44 @@ export const data = [
         status: 200,
         body: [
           {
+            metadata: {
+              destinationId: 'destId',
+              workspaceId: 'wspId',
+            },
             output: {
-              version: '1',
-              type: 'REST',
-              method: 'POST',
+              body: {
+                FORM: {},
+                JSON: {
+                  metadata: {
+                    city: 'Austin',
+                    company: 'Company123',
+                    country: 'US',
+                    email: 'name.surname@domain.com',
+                    name: 'John Doe',
+                    phone: '123-456-7890',
+                    postalCode: '12345',
+                    rating: 'Hot',
+                    state: 'TX',
+                    street: 'Sample Address',
+                    title: 'CEO',
+                  },
+                  user_id: 'customUserID',
+                },
+                JSON_ARRAY: {},
+                XML: {},
+              },
               endpoint: 'https://analytex.userpilot.io/v1/identify',
+              files: {},
               headers: {
                 Authorization: 'Token your-userpilot-api-key',
                 'Content-Type': 'application/json',
                 'X-API-Version': '2020-09-22',
               },
+              method: 'POST',
               params: {},
-              body: {
-                user_id: 'customUserID',
-                metadata: {
-                  name: 'John Doe',
-                  title: 'CEO',
-                  email: 'name.surname@domain.com',
-                  company: 'Company123',
-                  phone: '123-456-7890',
-                  rating: 'Hot',
-                  city: 'Austin',
-                  postalCode: '12345',
-                  country: 'US',
-                  street: 'Sample Address',
-                  state: 'TX',
-                },
-              },
-              files: {},
+              type: 'REST',
               userId: '',
-            },
-            metadata: {
-              destinationId: 'destId',
-              workspaceId: 'wspId',
+              version: '1',
             },
             statusCode: 200,
           },
@@ -255,32 +260,37 @@ export const data = [
         status: 200,
         body: [
           {
+            metadata: {
+              destinationId: 'destId',
+              workspaceId: 'wspId',
+            },
             output: {
-              version: '1',
-              type: 'REST',
-              method: 'POST',
+              body: {
+                FORM: {},
+                JSON: {
+                  event: 'test track event 1',
+                  metadata: {
+                    currency: 'USD',
+                    revenue: 30,
+                    user_actual_id: 12345,
+                  },
+                  user_id: 'customUserID',
+                },
+                JSON_ARRAY: {},
+                XML: {},
+              },
               endpoint: 'https://analytex.userpilot.io/v1/track',
+              files: {},
               headers: {
                 Authorization: 'Token your-userpilot-api-key',
                 'Content-Type': 'application/json',
                 'X-API-Version': '2020-09-22',
               },
+              method: 'POST',
               params: {},
-              body: {
-                user_id: 'customUserID',
-                event: 'test track event 1',
-                metadata: {
-                  revenue: 30,
-                  currency: 'USD',
-                  user_actual_id: 12345,
-                },
-              },
-              files: {},
+              type: 'REST',
               userId: '',
-            },
-            metadata: {
-              destinationId: 'destId',
-              workspaceId: 'wspId',
+              version: '1',
             },
             statusCode: 200,
           },
@@ -399,30 +409,35 @@ export const data = [
         status: 200,
         body: [
           {
+            metadata: {
+              destinationId: 'destId',
+              workspaceId: 'wspId',
+            },
             output: {
-              version: '1',
-              type: 'REST',
-              method: 'POST',
+              body: {
+                FORM: {},
+                JSON: {
+                  company_id: 'sample_group_id',
+                  metadata: {
+                    location: 'USA',
+                    name: 'Apple Inc.',
+                  },
+                },
+                JSON_ARRAY: {},
+                XML: {},
+              },
               endpoint: 'https://analytex.userpilot.io/v1/companies/identify',
+              files: {},
               headers: {
                 Authorization: 'Token your-userpilot-api-key',
                 'Content-Type': 'application/json',
                 'X-API-Version': '2020-09-22',
               },
+              method: 'POST',
               params: {},
-              body: {
-                company_id: 'sample_group_id',
-                metadata: {
-                  name: 'Apple Inc.',
-                  location: 'USA',
-                },
-              },
-              files: {},
+              type: 'REST',
               userId: '',
-            },
-            metadata: {
-              destinationId: 'destId',
-              workspaceId: 'wspId',
+              version: '1',
             },
             statusCode: 200,
           },


### PR DESCRIPTION
## What are the changes introduced in this PR?

This pull request includes updates to the `procWorkflow.yaml` file and improvements to the test data in `data.ts` for better handling of user and event tracking in the Userpilot integration. The most important changes include adding comments for API documentation, updating the response body format, and enhancing the test data structure.

Documentation and comments:

* Added comments to provide links to the central API documentation and descriptions for the Identify, Track, and Group APIs in `procWorkflow.yaml`. 

Response formatting:

* Changed the response body format from `$.context.payload` to `$.context.payload.JSON` in `procWorkflow.yaml` to ensure the payload is correctly formatted as JSON.


## What is the related Linear task?

Resolves INT-XXX

## Please explain the objectives of your changes below

Put down any required details on the broader aspect of your changes. If there are any dependent changes, **mandatorily** mention them here

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

N/A

### Any new dependencies introduced with this change?

N/A

### Any new generic utility introduced or modified. Please explain the changes.

N/A

### Any technical or performance related pointers to consider with the change?

N/A

@coderabbitai review

<hr>

### Developer checklist

- [ ] My code follows the style guidelines of this project

- [ ] **No breaking changes are being introduced.**

- [ ] All related docs linked with the PR?

- [ ] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [ ] Is the PR limited to 10 file changes?

- [ ] Is the PR limited to one linear task?

- [ ] Are relevant unit and component test-cases added in **new readability format**?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.
