### PR TITLE
fix: handle empty oauth secret for multiple destination

### DIFF
--- a/src/v0/destinations/salesforce/utils.js
+++ b/src/v0/destinations/salesforce/utils.js
@@ -147,6 +147,10 @@ const getAccessTokenOauth = (metadata) => {
     throw new OAuthSecretError('access_token is undefined/null');
   }
 
+  if (!isDefinedAndNotNullAndNotEmpty(metadata.secret?.instance_url)) {
+    throw new OAuthSecretError('instance_url is undefined/null');
+  }
+
   return {
     token: metadata.secret?.access_token,
     instanceUrl: metadata.secret?.instance_url,

--- a/src/v0/destinations/salesforce/utils.js
+++ b/src/v0/destinations/salesforce/utils.js
@@ -3,6 +3,7 @@ const {
   ThrottledError,
   AbortedError,
   OAuthSecretError,
+  isDefinedAndNotNullAndNotEmpty,
 } = require('@rudderstack/integrations-lib');
 const { handleHttpRequest } = require('../../../adapters/network');
 const {
@@ -141,6 +142,11 @@ const getAccessTokenOauth = (metadata) => {
   if (!isDefinedAndNotNull(metadata?.secret)) {
     throw new OAuthSecretError('secret is undefined/null');
   }
+
+  if (!isDefinedAndNotNullAndNotEmpty(metadata.secret?.access_token)) {
+    throw new OAuthSecretError('access_token is undefined/null');
+  }
+
   return {
     token: metadata.secret?.access_token,
     instanceUrl: metadata.secret?.instance_url,

--- a/src/v0/destinations/twitter_ads/transform.js
+++ b/src/v0/destinations/twitter_ads/transform.js
@@ -1,10 +1,6 @@
 const sha256 = require('sha256');
 
-const {
-  InstrumentationError,
-  OAuthSecretError,
-  ConfigurationError,
-} = require('@rudderstack/integrations-lib');
+const { InstrumentationError, ConfigurationError } = require('@rudderstack/integrations-lib');
 const {
   constructPayload,
   defaultRequestConfig,
@@ -17,20 +13,7 @@ const { EventType } = require('../../../constants');
 const { ConfigCategories, mappingConfig, BASE_URL } = require('./config');
 
 const { JSON_MIME_TYPE } = require('../../util/constant');
-const { getAuthHeaderForRequest } = require('./util');
-
-const getOAuthFields = ({ secret }) => {
-  if (!secret) {
-    throw new OAuthSecretError('[TWITTER ADS]:: OAuth - access keys not found');
-  }
-  const oAuthObject = {
-    consumerKey: secret.consumerKey,
-    consumerSecret: secret.consumerSecret,
-    accessToken: secret.accessToken,
-    accessTokenSecret: secret.accessTokenSecret,
-  };
-  return oAuthObject;
-};
+const { getAuthHeaderForRequest, getOAuthFields } = require('./util');
 
 // build final response
 function buildResponse(message, requestJson, metadata, endpointUrl) {
@@ -45,7 +28,7 @@ function buildResponse(message, requestJson, metadata, endpointUrl) {
     body: response.body.JSON,
   };
 
-  const oAuthObject = getOAuthFields(metadata);
+  const oAuthObject = getOAuthFields(metadata, 'TWITTER ADS');
   const authHeader = getAuthHeaderForRequest(request, oAuthObject).Authorization;
   response.headers = {
     Authorization: authHeader,

--- a/src/v0/destinations/twitter_ads/util.js
+++ b/src/v0/destinations/twitter_ads/util.js
@@ -1,5 +1,9 @@
 const crypto = require('crypto');
 const oauth1a = require('oauth-1.0a');
+const {
+  OAuthSecretError,
+  isDefinedAndNotNullAndNotEmpty,
+} = require('@rudderstack/integrations-lib');
 
 function getAuthHeaderForRequest(request, oAuthObject) {
   const oauth = oauth1a({
@@ -18,4 +22,24 @@ function getAuthHeaderForRequest(request, oAuthObject) {
   return oauth.toHeader(authorization);
 }
 
-module.exports = { getAuthHeaderForRequest };
+function getOAuthFields({ secret }, destinationType) {
+  if (!secret) {
+    throw new OAuthSecretError(`[${destinationType}]:: OAuth - secret not found`);
+  }
+  const requiredFields = ['consumerKey', 'consumerSecret'];
+
+  requiredFields.forEach((field) => {
+    if (!isDefinedAndNotNullAndNotEmpty(secret[field])) {
+      throw new OAuthSecretError(`[${destinationType}]:: OAuth - ${field} not found`);
+    }
+  });
+  const oAuthObject = {
+    consumerKey: secret.consumerKey,
+    consumerSecret: secret.consumerSecret,
+    accessToken: secret.accessToken,
+    accessTokenSecret: secret.accessTokenSecret,
+  };
+  return oAuthObject;
+}
+
+module.exports = { getAuthHeaderForRequest, getOAuthFields };

--- a/src/v0/destinations/twitter_ads/util.js
+++ b/src/v0/destinations/twitter_ads/util.js
@@ -26,7 +26,7 @@ function getOAuthFields({ secret }, destinationType) {
   if (!secret) {
     throw new OAuthSecretError(`[${destinationType}]:: OAuth - secret not found`);
   }
-  const requiredFields = ['consumerKey', 'consumerSecret'];
+  const requiredFields = ['consumerKey', 'consumerSecret', 'accessToken', 'accessTokenSecret'];
 
   requiredFields.forEach((field) => {
     if (!isDefinedAndNotNullAndNotEmpty(secret[field])) {

--- a/src/v0/destinations/twitter_ads/utils.test.js
+++ b/src/v0/destinations/twitter_ads/utils.test.js
@@ -51,21 +51,29 @@ describe('getOAuthFields utility test cases', () => {
     }).toThrow('[TWITTER ADS]:: OAuth - consumerKey not found');
   });
 
-  it('should return an oAuthObject even if optional fields are missing', () => {
+  it('should throw an error if accessToken is missing in the secret object', () => {
     const secret = {
       consumerKey: 'testConsumerKey',
       consumerSecret: 'testConsumerSecret',
+      accessTokenSecret: 'testAccessTokenSecret',
     };
     const destinationType = 'TWITTER ADS';
 
-    const expectedOutput = {
+    expect(() => {
+      getOAuthFields({ secret }, destinationType);
+    }).toThrow('[TWITTER ADS]:: OAuth - accessToken not found');
+  });
+
+  it('should throw an error if accessTokenSecret is missing in the secret object', () => {
+    const secret = {
       consumerKey: 'testConsumerKey',
       consumerSecret: 'testConsumerSecret',
-      accessToken: undefined,
-      accessTokenSecret: undefined,
+      accessToken: 'testAccessToken',
     };
+    const destinationType = 'TWITTER ADS';
 
-    const result = getOAuthFields({ secret }, destinationType);
-    expect(result).toEqual(expectedOutput);
+    expect(() => {
+      getOAuthFields({ secret }, destinationType);
+    }).toThrow('[TWITTER ADS]:: OAuth - accessTokenSecret not found');
   });
 });

--- a/src/v0/destinations/twitter_ads/utils.test.js
+++ b/src/v0/destinations/twitter_ads/utils.test.js
@@ -1,0 +1,71 @@
+const { getOAuthFields } = require('./util');
+
+describe('getOAuthFields utility test cases', () => {
+  it('should return a valid oAuthObject when all required fields are present', () => {
+    const secret = {
+      consumerKey: 'testConsumerKey',
+      consumerSecret: 'testConsumerSecret',
+      accessToken: 'testAccessToken',
+      accessTokenSecret: 'testAccessTokenSecret',
+    };
+    const destinationType = 'TWITTER ADS';
+
+    const expectedOutput = {
+      consumerKey: 'testConsumerKey',
+      consumerSecret: 'testConsumerSecret',
+      accessToken: 'testAccessToken',
+      accessTokenSecret: 'testAccessTokenSecret',
+    };
+
+    const result = getOAuthFields({ secret }, destinationType);
+    expect(result).toEqual(expectedOutput);
+  });
+
+  it('should throw an error if the secret object is not provided', () => {
+    const destinationType = 'TWITTER ADS';
+
+    expect(() => {
+      getOAuthFields({}, destinationType);
+    }).toThrow('[TWITTER ADS]:: OAuth - secret not found');
+  });
+
+  it('should throw an error if a required field is missing in the secret object', () => {
+    const secret = {
+      consumerKey: 'testConsumerKey',
+      accessToken: 'testAccessToken',
+      accessTokenSecret: 'testAccessTokenSecret',
+    };
+    const destinationType = 'TWITTER ADS';
+
+    expect(() => {
+      getOAuthFields({ secret }, destinationType);
+    }).toThrow('[TWITTER ADS]:: OAuth - consumerSecret not found');
+  });
+
+  it('should handle an empty secret object and throw an appropriate error', () => {
+    const secret = {};
+    const destinationType = 'TWITTER ADS';
+
+    expect(() => {
+      getOAuthFields({ secret }, destinationType);
+    }).toThrow('[TWITTER ADS]:: OAuth - consumerKey not found');
+  });
+
+  it('should return an oAuthObject even if optional fields are missing', () => {
+    const secret = {
+      consumerKey: 'testConsumerKey',
+      consumerSecret: 'testConsumerSecret',
+    };
+    const destinationType = 'TWITTER ADS';
+
+    const expectedOutput = {
+      consumerKey: 'testConsumerKey',
+      consumerSecret: 'testConsumerSecret',
+      accessToken: undefined,
+      accessTokenSecret: undefined,
+    };
+
+    const result = getOAuthFields({ secret }, destinationType);
+    expect(result).toEqual(expectedOutput);
+  });
+});

--- a/src/v0/destinations/x_audience/utils.js
+++ b/src/v0/destinations/x_audience/utils.js
@@ -197,31 +197,25 @@ const batchEvents = (responseList, destination) => {
 
 const getUserDetails = (fields, config) => {
   const { enableHash } = config;
-  const { email, phone_number, handle, device_id, twitter_id, partner_user_id } = fields;
+  const hashFields = ['email', 'phone_number', 'handle', 'device_id', 'twitter_id'];
+  const nonHashFields = ['partner_user_id'];
+
+  const getHashList = (value) => (enableHash ? value.split(',').map(sha256) : value.split(','));
+
   const user = {};
-  if (email) {
-    const emailList = email.split(',');
-    user.email = enableHash ? emailList.map(sha256) : emailList;
-  }
-  if (phone_number) {
-    const phone_numberList = phone_number.split(',');
-    user.phone_number = enableHash ? phone_numberList.map(sha256) : phone_numberList;
-  }
-  if (handle) {
-    const handleList = handle.split(',');
-    user.handle = enableHash ? handleList.map(sha256) : handleList;
-  }
-  if (device_id) {
-    const device_idList = device_id.split(',');
-    user.device_id = enableHash ? device_idList.map(sha256) : device_idList;
-  }
-  if (twitter_id) {
-    const twitter_idList = twitter_id.split(',');
-    user.twitter_id = enableHash ? twitter_idList.map(sha256) : twitter_idList;
-  }
-  if (partner_user_id) {
-    user.partner_user_id = partner_user_id.split(',');
-  }
+
+  hashFields.forEach((field) => {
+    if (fields[field]) {
+      user[field] = getHashList(fields[field]);
+    }
+  });
+
+  nonHashFields.forEach((field) => {
+    if (fields[field]) {
+      user[field] = fields[field].split(',');
+    }
+  });
+
   return removeUndefinedAndNullAndEmptyValues(user);
 };
 module.exports = { batchEvents, getUserDetails, buildResponseWithJSON };

--- a/src/v0/destinations/x_audience/utils.js
+++ b/src/v0/destinations/x_audience/utils.js
@@ -2,28 +2,14 @@
 const sha256 = require('sha256');
 const lodash = require('lodash');
 const jsonSize = require('json-size');
-const { OAuthSecretError } = require('@rudderstack/integrations-lib');
 const {
   defaultRequestConfig,
   getSuccessRespEvents,
   removeUndefinedAndNullAndEmptyValues,
 } = require('../../util');
 const { MAX_PAYLOAD_SIZE_IN_BYTES, BASE_URL, MAX_OPERATIONS } = require('./config');
-const { getAuthHeaderForRequest } = require('../twitter_ads/util');
+const { getAuthHeaderForRequest, getOAuthFields } = require('../twitter_ads/util');
 const { JSON_MIME_TYPE } = require('../../util/constant');
-
-const getOAuthFields = ({ secret }) => {
-  if (!secret) {
-    throw new OAuthSecretError('[X Audience]:: OAuth - access keys not found');
-  }
-  const oAuthObject = {
-    consumerKey: secret.consumerKey,
-    consumerSecret: secret.consumerSecret,
-    accessToken: secret.accessToken,
-    accessTokenSecret: secret.accessTokenSecret,
-  };
-  return oAuthObject;
-};
 
 // Docs: https://developer.x.com/en/docs/x-ads-api/audiences/api-reference/custom-audience-user
 const buildResponseWithJSON = (payload, config, metadata) => {
@@ -41,7 +27,7 @@ const buildResponseWithJSON = (payload, config, metadata) => {
     body: response.body.JSON,
   };
 
-  const oAuthObject = getOAuthFields(metadata);
+  const oAuthObject = getOAuthFields(metadata, 'X Audience');
   const authHeader = getAuthHeaderForRequest(request, oAuthObject).Authorization;
   response.headers = {
     Authorization: authHeader,
@@ -238,4 +224,4 @@ const getUserDetails = (fields, config) => {
   }
   return removeUndefinedAndNullAndEmptyValues(user);
 };
-module.exports = { getOAuthFields, batchEvents, getUserDetails, buildResponseWithJSON };
+module.exports = { batchEvents, getUserDetails, buildResponseWithJSON };

--- a/test/integrations/destinations/salesforce/processor/data.ts
+++ b/test/integrations/destinations/salesforce/processor/data.ts
@@ -1608,4 +1608,114 @@ export const data = [
       },
     },
   },
+  {
+    name: 'salesforce',
+    description: 'Test 13 : Retry happens when access_token is undefined in secret',
+    feature: 'processor',
+    module: 'destination',
+    version: 'v0',
+    input: {
+      request: {
+        body: [
+          {
+            destination: {
+              Config: {
+                initialAccessToken: '7fiy1FKcO9sohsxq1v6J88sg',
+                password: 'dummyPassword2',
+                userName: 'test.c97-qvpd@force.com.test',
+                sandbox: true,
+              },
+              DestinationDefinition: {
+                DisplayName: 'Salesforce Sandbox',
+                ID: '1T96GHZ0YZ1qQSLULHCoJkow9KC',
+                Name: 'SALESFORCE_OAUTH_SANDBOX',
+              },
+              Enabled: true,
+              ID: '1ut7LcVW1QC56y2EoTNo7ZwBWSY',
+              Name: 'Test SF',
+              Transformations: [],
+            },
+            metadata: {
+              jobId: 1,
+              secret: {},
+            },
+            message: {
+              anonymousId: '1e7673da-9473-49c6-97f7-da848ecafa76',
+              channel: 'web',
+              context: {
+                mappedToDestination: true,
+                externalId: [
+                  {
+                    id: 'a005g0000383kmUAAQ',
+                    type: 'SALESFORCE_OAUTH_SANDBOX-custom_object__c',
+                    identifierType: 'Id',
+                  },
+                ],
+                app: {
+                  build: '1.0.0',
+                  name: 'RudderLabs JavaScript SDK',
+                  namespace: 'com.rudderlabs.javascript',
+                  version: '1.0.0',
+                },
+                ip: '0.0.0.0',
+                library: {
+                  name: 'RudderLabs JavaScript SDK',
+                  version: '1.0.0',
+                },
+                locale: 'en-US',
+                os: {
+                  name: '',
+                  version: '',
+                },
+                screen: {
+                  density: 2,
+                },
+                traits: {
+                  email: 'john@rs.com',
+                  firstname: 'john doe',
+                  Id: 'some-id',
+                },
+                userAgent:
+                  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.130 Safari/537.36',
+              },
+              integrations: {
+                All: true,
+              },
+              messageId: 'f19c35da-e9de-4c6e-b6e5-9e60cccc12c8',
+              originalTimestamp: '2020-01-27T12:20:55.301Z',
+              receivedAt: '2020-01-27T17:50:58.657+05:30',
+              request_ip: '14.98.244.60',
+              sentAt: '2020-01-27T12:20:56.849Z',
+              timestamp: '2020-01-27T17:50:57.109+05:30',
+              type: 'identify',
+              userId: '1e7673da-9473-49c6-97f7-da848ecafa76',
+            },
+          },
+        ],
+      },
+    },
+    output: {
+      response: {
+        status: 200,
+        body: [
+          {
+            statusCode: 500,
+            error: 'access_token is undefined/null',
+            metadata: {
+              jobId: 1,
+              secret: {},
+            },
+            statTags: {
+              errorCategory: 'platform',
+              errorType: 'oAuthSecret',
+              destType: 'SALESFORCE',
+              module: 'destination',
+              implementation: 'native',
+              feature: 'processor',
+            },
+          },
+        ],
+      },
+    },
+  },
 ];

--- a/test/integrations/destinations/salesforce/processor/data.ts
+++ b/test/integrations/destinations/salesforce/processor/data.ts
@@ -1718,4 +1718,118 @@ export const data = [
       },
     },
   },
+  {
+    name: 'salesforce',
+    description: 'Test 14 : Retry happens when instance_url is undefined in secret',
+    feature: 'processor',
+    module: 'destination',
+    version: 'v0',
+    input: {
+      request: {
+        body: [
+          {
+            destination: {
+              Config: {
+                initialAccessToken: '7fiy1FKcO9sohsxq1v6J88sg',
+                password: 'dummyPassword2',
+                userName: 'test.c97-qvpd@force.com.test',
+                sandbox: true,
+              },
+              DestinationDefinition: {
+                DisplayName: 'Salesforce Sandbox',
+                ID: '1T96GHZ0YZ1qQSLULHCoJkow9KC',
+                Name: 'SALESFORCE_OAUTH_SANDBOX',
+              },
+              Enabled: true,
+              ID: '1ut7LcVW1QC56y2EoTNo7ZwBWSY',
+              Name: 'Test SF',
+              Transformations: [],
+            },
+            metadata: {
+              jobId: 1,
+              secret: {
+                access_token: secret2,
+              },
+            },
+            message: {
+              anonymousId: '1e7673da-9473-49c6-97f7-da848ecafa76',
+              channel: 'web',
+              context: {
+                mappedToDestination: true,
+                externalId: [
+                  {
+                    id: 'a005g0000383kmUAAQ',
+                    type: 'SALESFORCE_OAUTH_SANDBOX-custom_object__c',
+                    identifierType: 'Id',
+                  },
+                ],
+                app: {
+                  build: '1.0.0',
+                  name: 'RudderLabs JavaScript SDK',
+                  namespace: 'com.rudderlabs.javascript',
+                  version: '1.0.0',
+                },
+                ip: '0.0.0.0',
+                library: {
+                  name: 'RudderLabs JavaScript SDK',
+                  version: '1.0.0',
+                },
+                locale: 'en-US',
+                os: {
+                  name: '',
+                  version: '',
+                },
+                screen: {
+                  density: 2,
+                },
+                traits: {
+                  email: 'john@rs.com',
+                  firstname: 'john doe',
+                  Id: 'some-id',
+                },
+                userAgent:
+                  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.130 Safari/537.36',
+              },
+              integrations: {
+                All: true,
+              },
+              messageId: 'f19c35da-e9de-4c6e-b6e5-9e60cccc12c8',
+              originalTimestamp: '2020-01-27T12:20:55.301Z',
+              receivedAt: '2020-01-27T17:50:58.657+05:30',
+              request_ip: '14.98.244.60',
+              sentAt: '2020-01-27T12:20:56.849Z',
+              timestamp: '2020-01-27T17:50:57.109+05:30',
+              type: 'identify',
+              userId: '1e7673da-9473-49c6-97f7-da848ecafa76',
+            },
+          },
+        ],
+      },
+    },
+    output: {
+      response: {
+        status: 200,
+        body: [
+          {
+            statusCode: 500,
+            error: 'instance_url is undefined/null',
+            metadata: {
+              jobId: 1,
+              secret: {
+                access_token: secret2,
+              },
+            },
+            statTags: {
+              errorCategory: 'platform',
+              errorType: 'oAuthSecret',
+              destType: 'SALESFORCE',
+              module: 'destination',
+              implementation: 'native',
+              feature: 'processor',
+            },
+          },
+        ],
+      },
+    },
+  },
 ];

--- a/test/integrations/destinations/salesforce/processor/data.ts
+++ b/test/integrations/destinations/salesforce/processor/data.ts
@@ -1533,42 +1533,6 @@ export const data = [
             message: {
               anonymousId: '1e7673da-9473-49c6-97f7-da848ecafa76',
               channel: 'web',
-              context: {
-                mappedToDestination: true,
-                externalId: [
-                  {
-                    id: 'a005g0000383kmUAAQ',
-                    type: 'SALESFORCE_OAUTH_SANDBOX-custom_object__c',
-                    identifierType: 'Id',
-                  },
-                ],
-                app: {
-                  build: '1.0.0',
-                  name: 'RudderLabs JavaScript SDK',
-                  namespace: 'com.rudderlabs.javascript',
-                  version: '1.0.0',
-                },
-                ip: '0.0.0.0',
-                library: {
-                  name: 'RudderLabs JavaScript SDK',
-                  version: '1.0.0',
-                },
-                locale: 'en-US',
-                os: {
-                  name: '',
-                  version: '',
-                },
-                screen: {
-                  density: 2,
-                },
-                traits: {
-                  email: 'john@rs.com',
-                  firstname: 'john doe',
-                  Id: 'some-id',
-                },
-                userAgent:
-                  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.130 Safari/537.36',
-              },
               integrations: {
                 All: true,
               },
@@ -1642,42 +1606,6 @@ export const data = [
             message: {
               anonymousId: '1e7673da-9473-49c6-97f7-da848ecafa76',
               channel: 'web',
-              context: {
-                mappedToDestination: true,
-                externalId: [
-                  {
-                    id: 'a005g0000383kmUAAQ',
-                    type: 'SALESFORCE_OAUTH_SANDBOX-custom_object__c',
-                    identifierType: 'Id',
-                  },
-                ],
-                app: {
-                  build: '1.0.0',
-                  name: 'RudderLabs JavaScript SDK',
-                  namespace: 'com.rudderlabs.javascript',
-                  version: '1.0.0',
-                },
-                ip: '0.0.0.0',
-                library: {
-                  name: 'RudderLabs JavaScript SDK',
-                  version: '1.0.0',
-                },
-                locale: 'en-US',
-                os: {
-                  name: '',
-                  version: '',
-                },
-                screen: {
-                  density: 2,
-                },
-                traits: {
-                  email: 'john@rs.com',
-                  firstname: 'john doe',
-                  Id: 'some-id',
-                },
-                userAgent:
-                  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.130 Safari/537.36',
-              },
               integrations: {
                 All: true,
               },
@@ -1754,42 +1682,6 @@ export const data = [
             message: {
               anonymousId: '1e7673da-9473-49c6-97f7-da848ecafa76',
               channel: 'web',
-              context: {
-                mappedToDestination: true,
-                externalId: [
-                  {
-                    id: 'a005g0000383kmUAAQ',
-                    type: 'SALESFORCE_OAUTH_SANDBOX-custom_object__c',
-                    identifierType: 'Id',
-                  },
-                ],
-                app: {
-                  build: '1.0.0',
-                  name: 'RudderLabs JavaScript SDK',
-                  namespace: 'com.rudderlabs.javascript',
-                  version: '1.0.0',
-                },
-                ip: '0.0.0.0',
-                library: {
-                  name: 'RudderLabs JavaScript SDK',
-                  version: '1.0.0',
-                },
-                locale: 'en-US',
-                os: {
-                  name: '',
-                  version: '',
-                },
-                screen: {
-                  density: 2,
-                },
-                traits: {
-                  email: 'john@rs.com',
-                  firstname: 'john doe',
-                  Id: 'some-id',
-                },
-                userAgent:
-                  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.130 Safari/537.36',
-              },
               integrations: {
                 All: true,
               },

--- a/test/integrations/destinations/twitter_ads/processor/data.ts
+++ b/test/integrations/destinations/twitter_ads/processor/data.ts
@@ -2400,10 +2400,124 @@ export const data = [
       },
     },
   },
+  {
+    name: 'twitter_ads',
+    description: 'Test case to validate if secret do not contain required field',
+    feature: 'processor',
+    module: 'destination',
+    version: 'v0',
+    input: {
+      request: {
+        body: [
+          {
+            message: {
+              type: 'track',
+              event: 'Home Page Viewed',
+              channel: 'web',
+              context: {
+                source: 'test',
+                userAgent: 'chrome',
+                traits: {
+                  anonymousId: '50be5c78-6c3f-4b60-be84-97805a316fb1',
+                  email: 'abc@gmail.com',
+                  phone: '+1234589947',
+                  ge: 'male',
+                  db: '19950715',
+                  lastname: 'Rudderlabs',
+                  firstName: 'Test',
+                  address: {
+                    city: 'Kolkata',
+                    state: 'WB',
+                    zip: '700114',
+                    country: 'IN',
+                  },
+                },
+                device: {
+                  advertisingId: 'abc123',
+                },
+                library: {
+                  name: 'rudder-sdk-ruby-sync',
+                  version: '1.0.6',
+                },
+              },
+              messageId: '7208bbb6-2c4e-45bb-bf5b-ad426f3593e9',
+              timestamp: '2020-08-14T05:30:30.118Z',
+              properties: {
+                pixelId: 'dummyPixelId',
+                conversionTime: '2023-06-01T06:03:08.739Z',
+                eventId: '429047995',
+                phone: '+919927455678',
+                twclid: '543',
+                shipping: 3,
+                subtotal: 22.5,
+                affiliation: 'Google Store',
+                checkout_id: 'fksdjfsdjfisjf9sdfjsd9f',
+                email: 'abc@ax.com',
+              },
+              anonymousId: '50be5c78-6c3f-4b60-be84-97805a316fb1',
+              integrations: {
+                All: true,
+              },
+            },
+            metadata: {
+              secret: {
+                consumerKey: 'qwe',
+                accessToken: 'dummyAccessToken',
+                accessTokenSecret: 'testAccessTokenSecret',
+              },
+            },
+            destination: {
+              Config: {
+                pixelId: 'dummyPixelId',
+                rudderAccountId: '2EOknn1JNH7WK1MfNku4fGYKkRK',
+                twitterAdsEventNames: [
+                  {
+                    rudderEventName: 'ABC Searched',
+                    twitterEventId: 'tw-234234324234',
+                  },
+                  {
+                    rudderEventName: 'Home Page Viewed',
+                    twitterEventId: 'tw-324fdsf',
+                  },
+                ],
+              },
+            },
+          },
+        ],
+      },
+    },
+    output: {
+      response: {
+        status: 200,
+        body: [
+          {
+            error: '[TWITTER ADS]:: OAuth - consumerSecret not found',
+            statTags: {
+              errorCategory: 'platform',
+              errorType: 'oAuthSecret',
+              destType: 'TWITTER_ADS',
+              module: 'destination',
+              implementation: 'native',
+              feature: 'processor',
+            },
+            metadata: {
+              secret: {
+                consumerKey: 'qwe',
+                accessToken: 'dummyAccessToken',
+                accessTokenSecret: 'testAccessTokenSecret',
+              },
+            },
+            statusCode: 500,
+          },
+        ],
+      },
+    },
+  },
 ].map((tc) => ({
   ...tc,
   mockFns: (_) => {
     jest.mock('../../../../../src/v0/destinations/twitter_ads/util', () => ({
+      ...jest.requireActual('../../../../../src/v0/destinations/twitter_ads/util'),
       getAuthHeaderForRequest: (_a, _b) => {
         return { Authorization: authHeaderConstant };
       },

--- a/test/integrations/destinations/twitter_ads/processor/data.ts
+++ b/test/integrations/destinations/twitter_ads/processor/data.ts
@@ -2414,32 +2414,31 @@ export const data = [
               type: 'track',
               event: 'Home Page Viewed',
               channel: 'web',
-              context: {
-                source: 'test',
-                userAgent: 'chrome',
-                traits: {
-                  anonymousId: '50be5c78-6c3f-4b60-be84-97805a316fb1',
-                  email: 'abc@gmail.com',
-                  phone: '+1234589947',
-                  ge: 'male',
-                  db: '19950715',
-                  lastname: 'Rudderlabs',
-                  firstName: 'Test',
-                  address: {
-                    city: 'Kolkata',
-                    state: 'WB',
-                    zip: '700114',
-                    country: 'IN',
-                  },
-                },
-                device: {
-                  advertisingId: 'abc123',
-                },
-                library: {
-                  name: 'rudder-sdk-ruby-sync',
-                  version: '1.0.6',
-                },
-              },
+              //   source: 'test',
+              //   userAgent: 'chrome',
+              //   traits: {
+              //     anonymousId: '50be5c78-6c3f-4b60-be84-97805a316fb1',
+              //     email: 'abc@gmail.com',
+              //     phone: '+1234589947',
+              //     ge: 'male',
+              //     db: '19950715',
+              //     lastname: 'Rudderlabs',
+              //     firstName: 'Test',
+              //     address: {
+              //       city: 'Kolkata',
+              //       state: 'WB',
+              //       zip: '700114',
+              //       country: 'IN',
+              //     },
+              //   },
+              //   device: {
+              //     advertisingId: 'abc123',
+              //   },
+              //   library: {
+              //     name: 'rudder-sdk-ruby-sync',
+              //     version: '1.0.6',
+              //   },
+              // },
               messageId: '7208bbb6-2c4e-45bb-bf5b-ad426f3593e9',
               timestamp: '2020-08-14T05:30:30.118Z',
               properties: {

--- a/test/integrations/destinations/twitter_ads/processor/data.ts
+++ b/test/integrations/destinations/twitter_ads/processor/data.ts
@@ -2414,31 +2414,6 @@ export const data = [
               type: 'track',
               event: 'Home Page Viewed',
               channel: 'web',
-              //   source: 'test',
-              //   userAgent: 'chrome',
-              //   traits: {
-              //     anonymousId: '50be5c78-6c3f-4b60-be84-97805a316fb1',
-              //     email: 'abc@gmail.com',
-              //     phone: '+1234589947',
-              //     ge: 'male',
-              //     db: '19950715',
-              //     lastname: 'Rudderlabs',
-              //     firstName: 'Test',
-              //     address: {
-              //       city: 'Kolkata',
-              //       state: 'WB',
-              //       zip: '700114',
-              //       country: 'IN',
-              //     },
-              //   },
-              //   device: {
-              //     advertisingId: 'abc123',
-              //   },
-              //   library: {
-              //     name: 'rudder-sdk-ruby-sync',
-              //     version: '1.0.6',
-              //   },
-              // },
               messageId: '7208bbb6-2c4e-45bb-bf5b-ad426f3593e9',
               timestamp: '2020-08-14T05:30:30.118Z',
               properties: {

--- a/test/integrations/destinations/twitter_ads/router/data.ts
+++ b/test/integrations/destinations/twitter_ads/router/data.ts
@@ -326,7 +326,7 @@ export const data = [
                 },
               },
               statusCode: 500,
-              error: '[TWITTER ADS]:: OAuth - access keys not found',
+              error: '[TWITTER ADS]:: OAuth - secret not found',
               metadata: [{}],
               statTags: {
                 errorCategory: 'platform',
@@ -420,6 +420,7 @@ export const data = [
   ...tc,
   mockFns: (_) => {
     jest.mock('../../../../../src/v0/destinations/twitter_ads/util', () => ({
+      ...jest.requireActual('../../../../../src/v0/destinations/twitter_ads/util'),
       getAuthHeaderForRequest: (_a, _b) => {
         return { Authorization: authHeaderConstant };
       },

--- a/test/integrations/destinations/x_audience/processor/data.ts
+++ b/test/integrations/destinations/x_audience/processor/data.ts
@@ -224,10 +224,158 @@ export const data = [
       },
     },
   },
+  {
+    name: 'x_audience',
+    description: 'Validation for oauth secret',
+    successCriteria: 'It should be passed with 200 and return oauth secret not found for jobs',
+    feature: 'processor',
+    module: 'destination',
+    version: 'v0',
+    input: {
+      request: {
+        body: [
+          {
+            destination,
+            message: {
+              type: 'record',
+              action: 'insert',
+              fields: {
+                ...fields,
+                device_id: 'did123,did456',
+                effective_at: '2024-05-15T00:00:00Z',
+                expires_at: '2025-05-15T00:00:00Z',
+              },
+              context: {},
+              recordId: '1',
+            },
+            metadata: {
+              jobId: 1,
+              attemptNum: 1,
+              userId: 'default-userId',
+              sourceId: 'default-sourceId',
+              destinationId: 'default-destinationId',
+              workspaceId: 'default-workspaceId',
+              dontBatch: false,
+            },
+          },
+        ],
+      },
+    },
+    output: {
+      response: {
+        status: 200,
+        body: [
+          {
+            metadata: {
+              jobId: 1,
+              attemptNum: 1,
+              userId: 'default-userId',
+              sourceId: 'default-sourceId',
+              destinationId: 'default-destinationId',
+              workspaceId: 'default-workspaceId',
+              dontBatch: false,
+            },
+            statusCode: 500,
+            error: '[X Audience]:: OAuth - secret not found',
+            statTags: {
+              errorCategory: 'platform',
+              destinationId: 'default-destinationId',
+              errorType: 'oAuthSecret',
+              destType: 'X_AUDIENCE',
+              module: 'destination',
+              implementation: 'native',
+              workspaceId: 'default-workspaceId',
+              feature: 'processor',
+            },
+          },
+        ],
+      },
+    },
+  },
+  {
+    name: 'x_audience',
+    description: 'Validation for oauth secret',
+    successCriteria:
+      'It should be passed with 200 Ok and and return oauth consumerKey not found for jobs',
+    feature: 'processor',
+    module: 'destination',
+    version: 'v0',
+    input: {
+      request: {
+        body: [
+          {
+            destination,
+            message: {
+              type: 'record',
+              action: 'insert',
+              fields: {
+                ...fields,
+                device_id: 'did123,did456',
+                effective_at: '2024-05-15T00:00:00Z',
+                expires_at: '2025-05-15T00:00:00Z',
+              },
+              context: {},
+              recordId: '1',
+            },
+            metadata: {
+              jobId: 1,
+              attemptNum: 1,
+              userId: 'default-userId',
+              sourceId: 'default-sourceId',
+              destinationId: 'default-destinationId',
+              workspaceId: 'default-workspaceId',
+              dontBatch: false,
+              secret: {
+                consumerSecret: 'validConsumerSecret',
+                accessToken: 'validAccessToken',
+                accessTokenSecret: 'validAccessTokenSecret',
+              },
+            },
+          },
+        ],
+      },
+    },
+    output: {
+      response: {
+        status: 200,
+        body: [
+          {
+            metadata: {
+              jobId: 1,
+              attemptNum: 1,
+              userId: 'default-userId',
+              sourceId: 'default-sourceId',
+              destinationId: 'default-destinationId',
+              workspaceId: 'default-workspaceId',
+              dontBatch: false,
+              secret: {
+                consumerSecret: 'validConsumerSecret',
+                accessToken: 'validAccessToken',
+                accessTokenSecret: 'validAccessTokenSecret',
+              },
+            },
+            statusCode: 500,
+            error: '[X Audience]:: OAuth - consumerKey not found',
+            statTags: {
+              errorCategory: 'platform',
+              destinationId: 'default-destinationId',
+              errorType: 'oAuthSecret',
+              destType: 'X_AUDIENCE',
+              module: 'destination',
+              implementation: 'native',
+              workspaceId: 'default-workspaceId',
+              feature: 'processor',
+            },
+          },
+        ],
+      },
+    },
+  },
 ].map((tc) => ({
   ...tc,
   mockFns: (_) => {
     jest.mock('../../../../../src/v0/destinations/twitter_ads/util', () => ({
+      ...jest.requireActual('../../../../../src/v0/destinations/twitter_ads/util'),
       getAuthHeaderForRequest: (_a, _b) => {
         return { Authorization: authHeaderConstant };
       },

--- a/test/integrations/destinations/x_audience/router/data.ts
+++ b/test/integrations/destinations/x_audience/router/data.ts
@@ -221,6 +221,7 @@ export const data = [
   ...tc,
   mockFns: (_) => {
     jest.mock('../../../../../src/v0/destinations/twitter_ads/util', () => ({
+      ...jest.requireActual('../../../../../src/v0/destinations/twitter_ads/util'),
       getAuthHeaderForRequest: (_a, _b) => {
         return { Authorization: authHeaderConstant };
       },


### PR DESCRIPTION
## What are the changes introduced in this PR?

Check for the OAuth secrets field; if any required field is absent, throw an OAuth error.
We made this change for the following destinations:
* salesforce
* x_audience
* twitter_ads

## What is the related Linear task?

Resolves INT-3607

## Please explain the objectives of your changes below

Put down any required details on the broader aspect of your changes. If there are any dependent changes, **mandatorily** mention them here

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

N/A

### Any new dependencies introduced with this change?

N/A

### Any new generic utility introduced or modified. Please explain the changes.

N/A

### Any technical or performance related pointers to consider with the change?

N/A

@coderabbitai review

<hr>

### Developer checklist

- [x] My code follows the style guidelines of this project

- [x] **No breaking changes are being introduced.**

- [ ] All related docs linked with the PR?

- [ ] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [x] Is the PR limited to 10 file changes?

- [x] Is the PR limited to one linear task?

- [ ] Are relevant unit and component test-cases added in **new readability format**?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.
