### PR TITLE
chore: payload size middleware performance improvement

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -24,11 +24,7 @@ const metricsApp = new Koa();
 addStatMiddleware(metricsApp);
 metricsApp.use(metricsRouter.routes()).use(metricsRouter.allowedMethods());
 
-app.use(
-  bodyParser({
-    jsonLimit: '200mb',
-  }),
-);
+app.use(bodyParser({ jsonLimit: '200mb' }));
 addRequestSizeMiddleware(app);
 addSwaggerRoutes(app);
 

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -26,8 +26,21 @@ function durationMiddleware() {
   };
 }
 
-function requestSizeMiddleware() {
-  return async (ctx, next) => {
+function addStatMiddleware(app) {
+  app.use(durationMiddleware());
+}
+
+/**
+ * Adds middleware to track request and response sizes.
+ *
+ * It depends on `koa-bodyparser` for parsing request bodies,
+ * since it makes use of `ctx.request.rawBody`.
+ *
+ * @param {Object} app - The Koa application instance.
+ * @returns {void}
+ */
+function addRequestSizeMiddleware(app) {
+  app.use(async (ctx, next) => {
     await next();
 
     const labels = {
@@ -36,21 +49,11 @@ function requestSizeMiddleware() {
       route: ctx.request.url,
     };
 
-    const inputLength = ctx.request?.body ? Buffer.byteLength(JSON.stringify(ctx.request.body)) : 0;
+    const inputLength = ctx.request?.rawBody ? Buffer.byteLength(ctx.request.rawBody) : 0;
     stats.histogram('http_request_size', inputLength, labels);
-    const outputLength = ctx.response?.body
-      ? Buffer.byteLength(JSON.stringify(ctx.response.body))
-      : 0;
+    const outputLength = ctx.response?.length || 0;
     stats.histogram('http_response_size', outputLength, labels);
-  };
-}
-
-function addStatMiddleware(app) {
-  app.use(durationMiddleware());
-}
-
-function addRequestSizeMiddleware(app) {
-  app.use(requestSizeMiddleware());
+  });
 }
 
 function addProfilingMiddleware(app) {


### PR DESCRIPTION
## Description

Instead of performing `JSON.stringify` we are using precalculated raw payload sizes for capturing metrics:
- `transformer_http_request_size`: using `ctx.request.rawBody` provided by [koa-bodyparser](https://github.com/koajs/bodyparser?tab=readme-ov-file#raw-body)
- `transformer_http_response_size`: using `ctx.response.length` provided by [koa](https://github.com/koajs/koa/blob/master/docs/api/response.md#responselength-1)

This has a positive impact on server's performance and cpu utilization, especially while dealing with larger payloads