### PR TITLE
chore: mp add content type header to all apis

### DIFF
--- a/src/v0/destinations/mp/transform.js
+++ b/src/v0/destinations/mp/transform.js
@@ -43,13 +43,11 @@ const { CommonUtils } = require('../../../util/common');
 // ref: https://help.mixpanel.com/hc/en-us/articles/115004613766-Default-Properties-Collected-by-Mixpanel
 const mPEventPropertiesConfigJson = mappingConfig[ConfigCategory.EVENT_PROPERTIES.name];
 
-const setStrictMode = (destConfig) => ({
-  strict: destConfig.strictMode ? 1 : 0,
-});
-
 const setImportCredentials = (destConfig) => {
   const endpoint = `${getBaseEndpoint(destConfig)}/import/`;
-  const params = setStrictMode(destConfig);
+  const params = {
+    strict: destConfig.strictMode ? 1 : 0,
+  };
   const { serviceAccountUserName, serviceAccountSecret, projectId, token } = destConfig;
   let credentials;
   if (token) {
@@ -102,7 +100,6 @@ const responseBuilderSimple = (payload, message, eventType, destConfig) => {
       response.headers = {
         'Content-Type': 'application/json',
       };
-      response.params = setStrictMode(destConfig);
   }
   return response;
 };

--- a/src/v0/destinations/mp/transform.js
+++ b/src/v0/destinations/mp/transform.js
@@ -43,9 +43,13 @@ const { CommonUtils } = require('../../../util/common');
 // ref: https://help.mixpanel.com/hc/en-us/articles/115004613766-Default-Properties-Collected-by-Mixpanel
 const mPEventPropertiesConfigJson = mappingConfig[ConfigCategory.EVENT_PROPERTIES.name];
 
+const setStrictMode = (destConfig) => ({
+  strict: destConfig.strictMode ? 1 : 0,
+});
+
 const setImportCredentials = (destConfig) => {
   const endpoint = `${getBaseEndpoint(destConfig)}/import/`;
-  const params = { strict: destConfig.strictMode ? 1 : 0 };
+  const params = setStrictMode(destConfig);
   const { serviceAccountUserName, serviceAccountSecret, projectId, token } = destConfig;
   let credentials;
   if (token) {
@@ -95,7 +99,10 @@ const responseBuilderSimple = (payload, message, eventType, destConfig) => {
     }
     default:
       response.endpoint = `${getBaseEndpoint(destConfig)}/engage/`;
-      response.headers = {};
+      response.headers = {
+        'Content-Type': 'application/json',
+      };
+      response.params = setStrictMode(destConfig);
   }
   return response;
 };

--- a/test/integrations/destinations/mp/processor/data.ts
+++ b/test/integrations/destinations/mp/processor/data.ts
@@ -684,9 +684,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {
-                strict: 0,
-              },
+              params: {},
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -821,9 +819,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {
-                strict: 0,
-              },
+              params: {},
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -854,9 +850,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {
-                strict: 0,
-              },
+              params: {},
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -1162,9 +1156,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {
-                strict: 0,
-              },
+              params: {},
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -1388,9 +1380,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {
-                strict: 0,
-              },
+              params: {},
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -2050,9 +2040,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {
-                strict: 0,
-              },
+              params: {},
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -2157,9 +2145,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {
-                strict: 0,
-              },
+              params: {},
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -2189,9 +2175,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {
-                strict: 0,
-              },
+              params: {},
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -2286,9 +2270,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {
-                strict: 0,
-              },
+              params: {},
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -2318,9 +2300,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {
-                strict: 0,
-              },
+              params: {},
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -2350,9 +2330,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {
-                strict: 0,
-              },
+              params: {},
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -2448,9 +2426,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {
-                strict: 0,
-              },
+              params: {},
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -2480,9 +2456,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {
-                strict: 0,
-              },
+              params: {},
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -2618,9 +2592,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {
-                strict: 0,
-              },
+              params: {},
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -2799,9 +2771,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {
-                strict: 0,
-              },
+              params: {},
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -2912,9 +2882,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {
-                strict: 0,
-              },
+              params: {},
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -3293,9 +3261,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {
-                strict: 0,
-              },
+              params: {},
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -3442,9 +3408,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {
-                strict: 0,
-              },
+              params: {},
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -3556,9 +3520,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {
-                strict: 0,
-              },
+              params: {},
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -3669,9 +3631,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {
-                strict: 0,
-              },
+              params: {},
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -3790,9 +3750,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {
-                strict: 0,
-              },
+              params: {},
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -3908,9 +3866,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {
-                strict: 0,
-              },
+              params: {},
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -4025,9 +3981,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {
-                strict: 0,
-              },
+              params: {},
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -4141,9 +4095,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {
-                strict: 0,
-              },
+              params: {},
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -4256,9 +4208,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {
-                strict: 0,
-              },
+              params: {},
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -4380,9 +4330,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {
-                strict: 0,
-              },
+              params: {},
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -5052,9 +5000,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {
-                strict: 0,
-              },
+              params: {},
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -5182,9 +5128,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {
-                strict: 0,
-              },
+              params: {},
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -5410,9 +5354,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {
-                strict: 0,
-              },
+              params: {},
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -5796,9 +5738,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {
-                strict: 0,
-              },
+              params: {},
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -5828,9 +5768,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {
-                strict: 0,
-              },
+              params: {},
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -6070,9 +6008,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {
-                strict: 0,
-              },
+              params: {},
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -6201,9 +6137,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {
-                strict: 0,
-              },
+              params: {},
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -6411,9 +6345,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {
-                strict: 0,
-              },
+              params: {},
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -6699,9 +6631,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {
-                strict: 0,
-              },
+              params: {},
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -6731,9 +6661,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {
-                strict: 0,
-              },
+              params: {},
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -6912,9 +6840,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {
-                strict: 0,
-              },
+              params: {},
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -7069,9 +6995,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {
-                strict: 0,
-              },
+              params: {},
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -7227,9 +7151,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {
-                strict: 1,
-              },
+              params: {},
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -7481,9 +7403,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {
-                strict: 0,
-              },
+              params: {},
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -7516,9 +7436,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {
-                strict: 0,
-              },
+              params: {},
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -7649,9 +7567,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {
-                strict: 0,
-              },
+              params: {},
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -7684,9 +7600,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {
-                strict: 0,
-              },
+              params: {},
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -8037,9 +7951,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {
-                strict: 0,
-              },
+              params: {},
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -8072,9 +7984,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {
-                strict: 0,
-              },
+              params: {},
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -8113,9 +8023,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {
-                strict: 0,
-              },
+              params: {},
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -8153,9 +8061,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {
-                strict: 0,
-              },
+              params: {},
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -8293,9 +8199,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {
-                strict: 0,
-              },
+              params: {},
               body: {
                 JSON: {},
                 JSON_ARRAY: {

--- a/test/integrations/destinations/mp/processor/data.ts
+++ b/test/integrations/destinations/mp/processor/data.ts
@@ -681,8 +681,12 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: 'https://api.mixpanel.com/engage/',
-              headers: {},
-              params: {},
+              headers: {
+                'Content-Type': 'application/json',
+              },
+              params: {
+                strict: 0,
+              },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -814,8 +818,12 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: 'https://api.mixpanel.com/engage/',
-              headers: {},
-              params: {},
+              headers: {
+                'Content-Type': 'application/json',
+              },
+              params: {
+                strict: 0,
+              },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -843,8 +851,12 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: 'https://api.mixpanel.com/engage/',
-              headers: {},
-              params: {},
+              headers: {
+                'Content-Type': 'application/json',
+              },
+              params: {
+                strict: 0,
+              },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -1147,8 +1159,12 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: 'https://api.mixpanel.com/engage/',
-              headers: {},
-              params: {},
+              headers: {
+                'Content-Type': 'application/json',
+              },
+              params: {
+                strict: 0,
+              },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -1369,8 +1385,12 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: 'https://api.mixpanel.com/engage/',
-              headers: {},
-              params: {},
+              headers: {
+                'Content-Type': 'application/json',
+              },
+              params: {
+                strict: 0,
+              },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -2027,8 +2047,12 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: 'https://api.mixpanel.com/engage/',
-              headers: {},
-              params: {},
+              headers: {
+                'Content-Type': 'application/json',
+              },
+              params: {
+                strict: 0,
+              },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -2130,8 +2154,12 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: 'https://api.mixpanel.com/engage/',
-              headers: {},
-              params: {},
+              headers: {
+                'Content-Type': 'application/json',
+              },
+              params: {
+                strict: 0,
+              },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -2158,8 +2186,12 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: 'https://api.mixpanel.com/groups/',
-              headers: {},
-              params: {},
+              headers: {
+                'Content-Type': 'application/json',
+              },
+              params: {
+                strict: 0,
+              },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -2251,8 +2283,12 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: 'https://api.mixpanel.com/engage/',
-              headers: {},
-              params: {},
+              headers: {
+                'Content-Type': 'application/json',
+              },
+              params: {
+                strict: 0,
+              },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -2279,8 +2315,12 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: 'https://api.mixpanel.com/groups/',
-              headers: {},
-              params: {},
+              headers: {
+                'Content-Type': 'application/json',
+              },
+              params: {
+                strict: 0,
+              },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -2307,8 +2347,12 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: 'https://api.mixpanel.com/groups/',
-              headers: {},
-              params: {},
+              headers: {
+                'Content-Type': 'application/json',
+              },
+              params: {
+                strict: 0,
+              },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -2401,8 +2445,12 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: 'https://api-eu.mixpanel.com/engage/',
-              headers: {},
-              params: {},
+              headers: {
+                'Content-Type': 'application/json',
+              },
+              params: {
+                strict: 0,
+              },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -2429,8 +2477,12 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: 'https://api-eu.mixpanel.com/groups/',
-              headers: {},
-              params: {},
+              headers: {
+                'Content-Type': 'application/json',
+              },
+              params: {
+                strict: 0,
+              },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -2563,8 +2615,12 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: 'https://api-eu.mixpanel.com/engage/',
-              headers: {},
-              params: {},
+              headers: {
+                'Content-Type': 'application/json',
+              },
+              params: {
+                strict: 0,
+              },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -2740,8 +2796,12 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: 'https://api-eu.mixpanel.com/engage/',
-              headers: {},
-              params: {},
+              headers: {
+                'Content-Type': 'application/json',
+              },
+              params: {
+                strict: 0,
+              },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -2849,8 +2909,12 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: 'https://api-eu.mixpanel.com/engage/',
-              headers: {},
-              params: {},
+              headers: {
+                'Content-Type': 'application/json',
+              },
+              params: {
+                strict: 0,
+              },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -3226,8 +3290,12 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: 'https://api-eu.mixpanel.com/engage/',
-              headers: {},
-              params: {},
+              headers: {
+                'Content-Type': 'application/json',
+              },
+              params: {
+                strict: 0,
+              },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -3371,8 +3439,12 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: 'https://api.mixpanel.com/engage/',
-              headers: {},
-              params: {},
+              headers: {
+                'Content-Type': 'application/json',
+              },
+              params: {
+                strict: 0,
+              },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -3481,8 +3553,12 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: 'https://api.mixpanel.com/engage/',
-              headers: {},
-              params: {},
+              headers: {
+                'Content-Type': 'application/json',
+              },
+              params: {
+                strict: 0,
+              },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -3590,8 +3666,12 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: 'https://api.mixpanel.com/engage/',
-              headers: {},
-              params: {},
+              headers: {
+                'Content-Type': 'application/json',
+              },
+              params: {
+                strict: 0,
+              },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -3707,8 +3787,12 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: 'https://api.mixpanel.com/engage/',
-              headers: {},
-              params: {},
+              headers: {
+                'Content-Type': 'application/json',
+              },
+              params: {
+                strict: 0,
+              },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -3821,8 +3905,12 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: 'https://api.mixpanel.com/engage/',
-              headers: {},
-              params: {},
+              headers: {
+                'Content-Type': 'application/json',
+              },
+              params: {
+                strict: 0,
+              },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -3934,8 +4022,12 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: 'https://api.mixpanel.com/engage/',
-              headers: {},
-              params: {},
+              headers: {
+                'Content-Type': 'application/json',
+              },
+              params: {
+                strict: 0,
+              },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -4046,8 +4138,12 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: 'https://api.mixpanel.com/engage/',
-              headers: {},
-              params: {},
+              headers: {
+                'Content-Type': 'application/json',
+              },
+              params: {
+                strict: 0,
+              },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -4157,8 +4253,12 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: 'https://api.mixpanel.com/engage/',
-              headers: {},
-              params: {},
+              headers: {
+                'Content-Type': 'application/json',
+              },
+              params: {
+                strict: 0,
+              },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -4277,8 +4377,12 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: 'https://api.mixpanel.com/engage/',
-              headers: {},
-              params: {},
+              headers: {
+                'Content-Type': 'application/json',
+              },
+              params: {
+                strict: 0,
+              },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -4945,8 +5049,12 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: 'https://api.mixpanel.com/engage/',
-              headers: {},
-              params: {},
+              headers: {
+                'Content-Type': 'application/json',
+              },
+              params: {
+                strict: 0,
+              },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -5071,8 +5179,12 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: 'https://api.mixpanel.com/engage/',
-              headers: {},
-              params: {},
+              headers: {
+                'Content-Type': 'application/json',
+              },
+              params: {
+                strict: 0,
+              },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -5295,8 +5407,12 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: 'https://api.mixpanel.com/engage/',
-              headers: {},
-              params: {},
+              headers: {
+                'Content-Type': 'application/json',
+              },
+              params: {
+                strict: 0,
+              },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -5677,8 +5793,12 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: 'https://api.mixpanel.com/engage/',
-              headers: {},
-              params: {},
+              headers: {
+                'Content-Type': 'application/json',
+              },
+              params: {
+                strict: 0,
+              },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -5705,8 +5825,12 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: 'https://api.mixpanel.com/groups/',
-              headers: {},
-              params: {},
+              headers: {
+                'Content-Type': 'application/json',
+              },
+              params: {
+                strict: 0,
+              },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -5943,8 +6067,12 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: 'https://api.mixpanel.com/engage/',
-              headers: {},
-              params: {},
+              headers: {
+                'Content-Type': 'application/json',
+              },
+              params: {
+                strict: 0,
+              },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -6070,8 +6198,12 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: 'https://api.mixpanel.com/engage/',
-              headers: {},
-              params: {},
+              headers: {
+                'Content-Type': 'application/json',
+              },
+              params: {
+                strict: 0,
+              },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -6276,8 +6408,12 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: 'https://api.mixpanel.com/engage/',
-              headers: {},
-              params: {},
+              headers: {
+                'Content-Type': 'application/json',
+              },
+              params: {
+                strict: 0,
+              },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -6560,8 +6696,12 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: 'https://api.mixpanel.com/engage/',
-              headers: {},
-              params: {},
+              headers: {
+                'Content-Type': 'application/json',
+              },
+              params: {
+                strict: 0,
+              },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -6588,8 +6728,12 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: 'https://api.mixpanel.com/groups/',
-              headers: {},
-              params: {},
+              headers: {
+                'Content-Type': 'application/json',
+              },
+              params: {
+                strict: 0,
+              },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -6765,8 +6909,12 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: 'https://api.mixpanel.com/engage/',
-              headers: {},
-              params: {},
+              headers: {
+                'Content-Type': 'application/json',
+              },
+              params: {
+                strict: 0,
+              },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -6918,8 +7066,12 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: 'https://api.mixpanel.com/engage/',
-              headers: {},
-              params: {},
+              headers: {
+                'Content-Type': 'application/json',
+              },
+              params: {
+                strict: 0,
+              },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -7072,8 +7224,12 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: 'https://api-eu.mixpanel.com/engage/',
-              headers: {},
-              params: {},
+              headers: {
+                'Content-Type': 'application/json',
+              },
+              params: {
+                strict: 1,
+              },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -7322,8 +7478,12 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: 'https://api.mixpanel.com/engage/',
-              headers: {},
-              params: {},
+              headers: {
+                'Content-Type': 'application/json',
+              },
+              params: {
+                strict: 0,
+              },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -7353,8 +7513,12 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: 'https://api.mixpanel.com/engage/',
-              headers: {},
-              params: {},
+              headers: {
+                'Content-Type': 'application/json',
+              },
+              params: {
+                strict: 0,
+              },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -7482,8 +7646,12 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: 'https://api.mixpanel.com/engage/',
-              headers: {},
-              params: {},
+              headers: {
+                'Content-Type': 'application/json',
+              },
+              params: {
+                strict: 0,
+              },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -7513,8 +7681,12 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: 'https://api.mixpanel.com/engage/',
-              headers: {},
-              params: {},
+              headers: {
+                'Content-Type': 'application/json',
+              },
+              params: {
+                strict: 0,
+              },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -7862,8 +8034,12 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: 'https://api.mixpanel.com/engage/',
-              headers: {},
-              params: {},
+              headers: {
+                'Content-Type': 'application/json',
+              },
+              params: {
+                strict: 0,
+              },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -7893,8 +8069,12 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: 'https://api.mixpanel.com/engage/',
-              headers: {},
-              params: {},
+              headers: {
+                'Content-Type': 'application/json',
+              },
+              params: {
+                strict: 0,
+              },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -7930,8 +8110,12 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: 'https://api.mixpanel.com/engage/',
-              headers: {},
-              params: {},
+              headers: {
+                'Content-Type': 'application/json',
+              },
+              params: {
+                strict: 0,
+              },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -7966,8 +8150,12 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: 'https://api.mixpanel.com/engage/',
-              headers: {},
-              params: {},
+              headers: {
+                'Content-Type': 'application/json',
+              },
+              params: {
+                strict: 0,
+              },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -8102,8 +8290,12 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: 'https://api.mixpanel.com/engage/',
-              headers: {},
-              params: {},
+              headers: {
+                'Content-Type': 'application/json',
+              },
+              params: {
+                strict: 0,
+              },
               body: {
                 JSON: {},
                 JSON_ARRAY: {

--- a/test/integrations/destinations/mp/router/data.ts
+++ b/test/integrations/destinations/mp/router/data.ts
@@ -514,8 +514,12 @@ export const data = [
                   type: 'REST',
                   method: 'POST',
                   endpoint: 'https://api.mixpanel.com/engage/',
-                  headers: {},
-                  params: {},
+                  headers: {
+                    'Content-Type': 'application/json',
+                  },
+                  params: {
+                    strict: 1,
+                  },
                   body: {
                     JSON: {},
                     JSON_ARRAY: {
@@ -620,8 +624,12 @@ export const data = [
                   type: 'REST',
                   method: 'POST',
                   endpoint: 'https://api.mixpanel.com/engage/',
-                  headers: {},
-                  params: {},
+                  headers: {
+                    'Content-Type': 'application/json',
+                  },
+                  params: {
+                    strict: 1,
+                  },
                   body: {
                     JSON: {},
                     JSON_ARRAY: {
@@ -756,8 +764,12 @@ export const data = [
                   type: 'REST',
                   method: 'POST',
                   endpoint: 'https://api.mixpanel.com/engage/',
-                  headers: {},
-                  params: {},
+                  headers: {
+                    'Content-Type': 'application/json',
+                  },
+                  params: {
+                    strict: 1,
+                  },
                   body: {
                     JSON: {},
                     JSON_ARRAY: {
@@ -780,8 +792,12 @@ export const data = [
                   type: 'REST',
                   method: 'POST',
                   endpoint: 'https://api.mixpanel.com/groups/',
-                  headers: {},
-                  params: {},
+                  headers: {
+                    'Content-Type': 'application/json',
+                  },
+                  params: {
+                    strict: 1,
+                  },
                   body: {
                     JSON: {},
                     JSON_ARRAY: {
@@ -1376,8 +1392,12 @@ export const data = [
                   type: 'REST',
                   method: 'POST',
                   endpoint: 'https://api.mixpanel.com/engage/',
-                  headers: {},
-                  params: {},
+                  headers: {
+                    'Content-Type': 'application/json',
+                  },
+                  params: {
+                    strict: 1,
+                  },
                   body: {
                     JSON: {},
                     JSON_ARRAY: {
@@ -1481,8 +1501,12 @@ export const data = [
                   type: 'REST',
                   method: 'POST',
                   endpoint: 'https://api.mixpanel.com/engage/',
-                  headers: {},
-                  params: {},
+                  headers: {
+                    'Content-Type': 'application/json',
+                  },
+                  params: {
+                    strict: 1,
+                  },
                   body: {
                     JSON: {},
                     JSON_ARRAY: {
@@ -1616,8 +1640,12 @@ export const data = [
                   type: 'REST',
                   method: 'POST',
                   endpoint: 'https://api.mixpanel.com/engage/',
-                  headers: {},
-                  params: {},
+                  headers: {
+                    'Content-Type': 'application/json',
+                  },
+                  params: {
+                    strict: 1,
+                  },
                   body: {
                     JSON: {},
                     JSON_ARRAY: {
@@ -1640,8 +1668,12 @@ export const data = [
                   type: 'REST',
                   method: 'POST',
                   endpoint: 'https://api.mixpanel.com/groups/',
-                  headers: {},
-                  params: {},
+                  headers: {
+                    'Content-Type': 'application/json',
+                  },
+                  params: {
+                    strict: 1,
+                  },
                   body: {
                     JSON: {},
                     JSON_ARRAY: {

--- a/test/integrations/destinations/mp/router/data.ts
+++ b/test/integrations/destinations/mp/router/data.ts
@@ -517,9 +517,7 @@ export const data = [
                   headers: {
                     'Content-Type': 'application/json',
                   },
-                  params: {
-                    strict: 1,
-                  },
+                  params: {},
                   body: {
                     JSON: {},
                     JSON_ARRAY: {
@@ -627,9 +625,7 @@ export const data = [
                   headers: {
                     'Content-Type': 'application/json',
                   },
-                  params: {
-                    strict: 1,
-                  },
+                  params: {},
                   body: {
                     JSON: {},
                     JSON_ARRAY: {
@@ -767,9 +763,7 @@ export const data = [
                   headers: {
                     'Content-Type': 'application/json',
                   },
-                  params: {
-                    strict: 1,
-                  },
+                  params: {},
                   body: {
                     JSON: {},
                     JSON_ARRAY: {
@@ -795,9 +789,7 @@ export const data = [
                   headers: {
                     'Content-Type': 'application/json',
                   },
-                  params: {
-                    strict: 1,
-                  },
+                  params: {},
                   body: {
                     JSON: {},
                     JSON_ARRAY: {
@@ -1395,9 +1387,7 @@ export const data = [
                   headers: {
                     'Content-Type': 'application/json',
                   },
-                  params: {
-                    strict: 1,
-                  },
+                  params: {},
                   body: {
                     JSON: {},
                     JSON_ARRAY: {
@@ -1504,9 +1494,7 @@ export const data = [
                   headers: {
                     'Content-Type': 'application/json',
                   },
-                  params: {
-                    strict: 1,
-                  },
+                  params: {},
                   body: {
                     JSON: {},
                     JSON_ARRAY: {
@@ -1643,9 +1631,7 @@ export const data = [
                   headers: {
                     'Content-Type': 'application/json',
                   },
-                  params: {
-                    strict: 1,
-                  },
+                  params: {},
                   body: {
                     JSON: {},
                     JSON_ARRAY: {
@@ -1671,9 +1657,7 @@ export const data = [
                   headers: {
                     'Content-Type': 'application/json',
                   },
-                  params: {
-                    strict: 1,
-                  },
+                  params: {},
                   body: {
                     JSON: {},
                     JSON_ARRAY: {


### PR DESCRIPTION
## What are the changes introduced in this PR?
**Summary:**

This PR adds `Content-Type` headers to the `/engage` and `/group` API requests.

**Reason:**

Mixpanel recommends explicitly setting the `Content-Type` for these endpoints to avoid unexpected errors. This change ensures that `transformerProxy` can correctly interpret and forward the content with the appropriate headers.

`engage` api
<img width="1248" alt="image" src="https://github.com/user-attachments/assets/f93871d1-8bca-463f-bf60-2c3dfcbaa96d" />
https://developer.mixpanel.com/reference/profile-set

`/group` api
<img width="1253" alt="image" src="https://github.com/user-attachments/assets/994c456e-cecf-455b-8d64-ac2d2a78122b" />
https://developer.mixpanel.com/reference/group-set-property

## What is the related Linear task?

Resolves INT-3639

## Please explain the objectives of your changes below

Put down any required details on the broader aspect of your changes. If there are any dependent changes, **mandatorily** mention them here

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

N/A

### Any new dependencies introduced with this change?

N/A

### Any new generic utility introduced or modified. Please explain the changes.

N/A

### Any technical or performance related pointers to consider with the change?

N/A

@coderabbitai review

<hr>

### Developer checklist

- [x] My code follows the style guidelines of this project

- [x] **No breaking changes are being introduced.**

- [ ] All related docs linked with the PR?

- [x] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [x] Is the PR limited to 10 file changes?

- [ ] Is the PR limited to one linear task?

- [ ] Are relevant unit and component test-cases added in **new readability format**?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.
