### PR TITLE
chore: add safe batch processing to avoid blocking in highly batched destinations

### DIFF
--- a/src/cdk/v2/destinations/bloomreach_catalog/rtWorkflow.yaml
+++ b/src/cdk/v2/destinations/bloomreach_catalog/rtWorkflow.yaml
@@ -24,7 +24,7 @@ steps:
 
   - name: processRecordEvents
     template: |
-      $.processRecordInputs(^.{.message.type === $.EventType.RECORD}[], ^[0].destination)
+      await $.processRecordInputs(^.{.message.type === $.EventType.RECORD}[], ^[0].destination)
 
   - name: failOtherEvents
     template: |

--- a/src/cdk/v2/destinations/bloomreach_catalog/transformRecord.ts
+++ b/src/cdk/v2/destinations/bloomreach_catalog/transformRecord.ts
@@ -1,4 +1,4 @@
-import { InstrumentationError } from '@rudderstack/integrations-lib';
+import { forEachInBatches, InstrumentationError } from '@rudderstack/integrations-lib';
 import { CatalogAction } from './config';
 import { batchResponseBuilder } from './utils';
 
@@ -56,7 +56,7 @@ const getEventChunks = (
   }
 };
 
-export const processRecordInputs = (inputs: any[], destination: any) => {
+export const processRecordInputs = async (inputs: any[], destination: any) => {
   const insertItemRespList: any[] = [];
   const updateItemRespList: any[] = [];
   const deleteItemRespList: any[] = [];
@@ -66,7 +66,7 @@ export const processRecordInputs = (inputs: any[], destination: any) => {
     return [];
   }
 
-  inputs.forEach((input) => {
+  await forEachInBatches(inputs, async (input) => {
     try {
       getEventChunks(
         {

--- a/src/v0/destinations/customerio_audience/transform.ts
+++ b/src/v0/destinations/customerio_audience/transform.ts
@@ -1,3 +1,4 @@
+import { mapInBatches } from '@rudderstack/integrations-lib';
 import {
   CustomerIOConnection,
   CustomerIODestination,
@@ -17,7 +18,7 @@ const processRouterDest = async (inputs: CustomerIORouterRequest[], reqMetadata:
   const customerIOConnection = connection as CustomerIOConnection;
 
   // Process events and separate valid and error cases
-  const processedEvents = inputs.map((event) => {
+  const processedEvents = await mapInBatches(inputs, (event) => {
     try {
       return {
         success: true,

--- a/src/v0/destinations/fb_custom_audience/transform.js
+++ b/src/v0/destinations/fb_custom_audience/transform.js
@@ -1,5 +1,9 @@
 const lodash = require('lodash');
-const { InstrumentationError, ConfigurationError } = require('@rudderstack/integrations-lib');
+const {
+  InstrumentationError,
+  ConfigurationError,
+  groupByInBatches,
+} = require('@rudderstack/integrations-lib');
 const {
   checkSubsetOfArray,
   isDefinedAndNotNullAndNotEmpty,
@@ -214,7 +218,9 @@ const process = (event) => processEvent(event.message, event.destination);
 
 const processRouterDest = async (inputs, reqMetadata) => {
   const respList = [];
-  const groupedInputs = lodash.groupBy(inputs, (input) => input.message.type?.toLowerCase());
+  const groupedInputs = await groupByInBatches(inputs, (input) =>
+    input.message.type?.toLowerCase(),
+  );
   let transformedRecordEvent = [];
   let transformedAudienceEvent = [];
 
@@ -226,7 +232,7 @@ const processRouterDest = async (inputs, reqMetadata) => {
   }
 
   if (groupedInputs.record) {
-    transformedRecordEvent = processRecordInputs(groupedInputs.record);
+    transformedRecordEvent = await processRecordInputs(groupedInputs.record);
   }
 
   if (groupedInputs.audiencelist) {

--- a/src/v0/destinations/google_adwords_remarketing_lists/transform.js
+++ b/src/v0/destinations/google_adwords_remarketing_lists/transform.js
@@ -1,5 +1,8 @@
-const lodash = require('lodash');
-const { InstrumentationError, ConfigurationError } = require('@rudderstack/integrations-lib');
+const {
+  InstrumentationError,
+  ConfigurationError,
+  groupByInBatches,
+} = require('@rudderstack/integrations-lib');
 const logger = require('../../../logger');
 const {
   returnArrayOfSubarrays,
@@ -141,7 +144,9 @@ const process = async (event) => processEvent(event.metadata, event.message, eve
 
 const processRouterDest = async (inputs, reqMetadata) => {
   const respList = [];
-  const groupedInputs = lodash.groupBy(inputs, (input) => input.message.type?.toLowerCase());
+  const groupedInputs = await groupByInBatches(inputs, (input) =>
+    input.message.type?.toLowerCase(),
+  );
   let transformedRecordEvent = [];
   let transformedAudienceEvent = [];
 

--- a/src/v0/util/index.test.js
+++ b/src/v0/util/index.test.js
@@ -342,7 +342,7 @@ describe('Unit test cases for combineBatchRequestsWithSameJobIds', () => {
         },
       },
     ];
-    expect(combineBatchRequestsWithSameJobIds(input)).toEqual(expectedOutput);
+    expect(await combineBatchRequestsWithSameJobIds(input)).toEqual(expectedOutput);
   });
 
   it('Each batchRequest contains unique jobIds (no event multiplexing)', async () => {
@@ -460,7 +460,7 @@ describe('Unit test cases for combineBatchRequestsWithSameJobIds', () => {
         },
       },
     ];
-    expect(combineBatchRequestsWithSameJobIds(input)).toEqual(expectedOutput);
+    expect(await combineBatchRequestsWithSameJobIds(input)).toEqual(expectedOutput);
   });
 });
 

--- a/test/integrations/destinations/mailchimp/router/data.ts
+++ b/test/integrations/destinations/mailchimp/router/data.ts
@@ -465,10 +465,11 @@ export const data = [
                 Enabled: true,
                 Transformations: [],
               },
-              metadata: [{ jobId: 6, userId: 'u1' }],
+              metadata: [{ jobId: 4, userId: 'u1' }],
               batched: false,
               statusCode: 400,
-              error: 'Missing required value from "event"',
+              error:
+                'The status must be one of [subscribed, unsubscribed, cleaned, pending, transactional]',
               statTags: {
                 destType: 'MAILCHIMP',
                 errorCategory: 'dataValidation',
@@ -496,11 +497,10 @@ export const data = [
                 Enabled: true,
                 Transformations: [],
               },
-              metadata: [{ jobId: 4, userId: 'u1' }],
+              metadata: [{ jobId: 6, userId: 'u1' }],
               batched: false,
               statusCode: 400,
-              error:
-                'The status must be one of [subscribed, unsubscribed, cleaned, pending, transactional]',
+              error: 'Missing required value from "event"',
               statTags: {
                 destType: 'MAILCHIMP',
                 errorCategory: 'dataValidation',


### PR DESCRIPTION
This pull request focuses on improving batch processing efficiency across various destination integrations - which are using high batch numbers - by introducing asynchronous utilities (`forEachInBatches`, `mapInBatches`, `groupByInBatches`, and `reduceInBatches`) from the `@rudderstack/integrations-lib`. 

### Enhancements to Batch Processing:

* **Bloomreach Catalog Integration:**
  - Updated `processRecordInputs` to use `await forEachInBatches` for processing inputs asynchronously in batches.
  - Modified the workflow YAML file to call `processRecordInputs` as an asynchronous function.

* **Facebook Custom Audience Integration:**
  - Refactored `processRecordEventArray`, `preparePayload`, and related methods to utilize `mapInBatches`, `forEachInBatches`, and `groupByInBatches` for concurrent processing. [[1]](diffhunk://#diff-801fe4c03e60dbe190d208b245548b0ff9332084d7fd7fafd2b6c6a8fef21428L73-R91) [[2]](diffhunk://#diff-801fe4c03e60dbe190d208b245548b0ff9332084d7fd7fafd2b6c6a8fef21428L120-R132) [[3]](diffhunk://#diff-801fe4c03e60dbe190d208b245548b0ff9332084d7fd7fafd2b6c6a8fef21428L154-R170)
  - Converted `processRecordInputs` methods (`V1`, `V2`, and combined) to asynchronous functions for improved batch handling. [[1]](diffhunk://#diff-801fe4c03e60dbe190d208b245548b0ff9332084d7fd7fafd2b6c6a8fef21428L206-R218) [[2]](diffhunk://#diff-801fe4c03e60dbe190d208b245548b0ff9332084d7fd7fafd2b6c6a8fef21428L236-R248) [[3]](diffhunk://#diff-801fe4c03e60dbe190d208b245548b0ff9332084d7fd7fafd2b6c6a8fef21428L268-R280)

* **Google AdWords Integrations:**
  - Updated batch processing logic in `google_adwords_offline_conversions` and `google_adwords_remarketing_lists` integrations to use `forEachInBatches` and `mapInBatches` for asynchronous event handling. [[1]](diffhunk://#diff-6a6991d5fb9b903397045e78d3cd6ed4713e392d15ad66ffb533b0bb48fb5c86L169-R173) [[2]](diffhunk://#diff-4b5e71b0d12d75ef5bc92261b107d20b6d0a54ee1a37e0db8591dbea22063adfL48-R52)
  - Refactored payload preparation methods to handle batched data asynchronously. [[1]](diffhunk://#diff-6a6991d5fb9b903397045e78d3cd6ed4713e392d15ad66ffb533b0bb48fb5c86L157-R161) [[2]](diffhunk://#diff-4b5e71b0d12d75ef5bc92261b107d20b6d0a54ee1a37e0db8591dbea22063adfL64-R68)

### Introduction of Concurrent Processing Options:

* **Native Integration Source Service:**
  - Replaced `Promise.all` with `mapInBatches` for concurrent processing of source events, enabling better scalability. Added an option for non-sequential processing. [[1]](diffhunk://#diff-7cfab78229a734230049e4d48fe8c6dfb19de187314e10e1b0b531f966442d18L45-R52) [[2]](diffhunk://#diff-7cfab78229a734230049e4d48fe8c6dfb19de187314e10e1b0b531f966442d18L73-R80)

* **Customer.io Audience Integration:**
  - Updated `processRouterDest` to use `mapInBatches` for asynchronous batch processing of inputs.

These changes collectively improve the performance and scalability of batch processing in the codebase while ensuring compatibility with existing workflows.