### PR TITLE
chore: remove promise.all from iterable delete users to process calls synchronously

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@datadog/pprof": "^5.5.1",
         "@koa/router": "^12.0.0",
         "@ndhoule/extend": "^2.0.0",
-        "@rudderstack/integrations-lib": "^0.2.31",
+        "@rudderstack/integrations-lib": "^0.2.35",
         "@rudderstack/json-template-engine": "^0.19.5",
         "@rudderstack/pyroscope-nodejs": "^0.4.6-fork.1",
         "@rudderstack/workflow-engine": "^0.8.13",
@@ -1499,14 +1499,14 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.26.2",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
-      "integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
+      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.27.1",
         "js-tokens": "^4.0.0",
-        "picocolors": "^1.0.0"
+        "picocolors": "^1.1.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1650,9 +1650,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
-      "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1660,9 +1660,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
-      "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -1679,27 +1679,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.9.tgz",
-      "integrity": "sha512-Mz/4+y8udxBKdmzt/UjPACs4G3j5SshJJEFFKxlCGPydG4JAHXxjWjAwjd09tf6oINvl1VfMJo+nB7H2YKQ0dA==",
+      "version": "7.27.4",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.4.tgz",
+      "integrity": "sha512-Y+bO6U+I7ZKaM5G5rDUZiYfUvQPUibYmAFe7EnKdnKBbVXDZxvp+MWOH5gYciY0EPk4EScsuFMQBbEfpdRKSCQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.26.9",
-        "@babel/types": "^7.26.9"
+        "@babel/template": "^7.27.2",
+        "@babel/types": "^7.27.3"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.9.tgz",
-      "integrity": "sha512-81NWa1njQblgZbQHxWHpxxCzNsa3ZwvFqpUg7P+NNUU6f3UU2jBEg4OlF/J6rl8+PQGh1q6/zWScd001YwcA5A==",
+      "version": "7.27.5",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.5.tgz",
+      "integrity": "sha512-OsQd175SxWkGlzbny8J3K8TnnDD0N3lrIUtB92xwyRpzaenGZhxDvxN/JgU00U3CDZNj9tPuDJ5H0WS4Nt3vKg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.26.9"
+        "@babel/types": "^7.27.3"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -1948,15 +1948,15 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.26.9.tgz",
-      "integrity": "sha512-qyRplbeIpNZhmzOysF/wFMuP9sctmh2cFzRAZOn1YapxBsE1i9bJIY586R/WBLfLcmcBlM8ROBiQURnnNy+zfA==",
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
+      "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.26.2",
-        "@babel/parser": "^7.26.9",
-        "@babel/types": "^7.26.9"
+        "@babel/code-frame": "^7.27.1",
+        "@babel/parser": "^7.27.2",
+        "@babel/types": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1992,14 +1992,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.9.tgz",
-      "integrity": "sha512-Y3IR1cRnOxOCDvMmNiym7XpXQ93iGDDPHx+Zj+NM+rg0fBaShfQLkg+hKPaZCEvg5N/LeCo4+Rj/i3FuJsIQaw==",
+      "version": "7.27.3",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.3.tgz",
+      "integrity": "sha512-Y1GkI4ktrtvmawoSq+4FCVHNryea6uR+qUQy0AGxLSsjCX0nVmkYQMBLHDkXZuo5hGx7eYdnIaslsdBFm7zbUw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.25.9",
-        "@babel/helper-validator-identifier": "^7.25.9"
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -3732,6 +3732,19 @@
       "integrity": "sha512-xb77tVVGDGwjy25a6RmBiiBQ9uvxhkG0OEpVkQ74oNFsy9u+4PGp5BIIblmJZmJBMgXiKxZtkr4GcmHCNVubBQ==",
       "license": "MIT"
     },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -3767,6 +3780,16 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.2.2.tgz",
+      "integrity": "sha512-ZOBkgDwEdoYVlSeRbYYXs0S9MejQofiVYoTbKzy/6GQa39/q5tQU2IX46+shYnUkpEl3wc+J6wRlar7r2EK2xA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -3798,9 +3821,10 @@
       "license": "MIT"
     },
     "node_modules/@rudderstack/integrations-lib": {
-      "version": "0.2.31",
-      "resolved": "https://registry.npmjs.org/@rudderstack/integrations-lib/-/integrations-lib-0.2.31.tgz",
-      "integrity": "sha512-6izcQDvAjOhJTog4Y6etQZvGc4UqEMt0IT0Mf5yDAzM54P/4PHXKxmVeUV1MWK7dKZabSF4sUjFPDVKsZS4zqQ==",
+      "version": "0.2.35",
+      "resolved": "https://registry.npmjs.org/@rudderstack/integrations-lib/-/integrations-lib-0.2.35.tgz",
+      "integrity": "sha512-Pg/yeSfWm52QDTh7V4CoY4NKB19jpPn7K1OGBuG/7metfWJH15w0BHens8wMhk9dK/jX1Vh/qHDXoUQjNNJg5Q==",
+      "license": "MIT",
       "dependencies": {
         "axios": "^1.4.0",
         "eslint-config-airbnb-base": "^15.0.0",
@@ -10570,14 +10594,14 @@
       }
     },
     "node_modules/formidable": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.1.2.tgz",
-      "integrity": "sha512-CM3GuJ57US06mlpQ47YcunuUZ9jpm8Vx+P2CGt2j7HpgkKZO/DJYQ0Bobim8G6PFQmK5lOqOOdUXboU+h73A4g==",
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.1.5.tgz",
+      "integrity": "sha512-Oz5Hwvwak/DCaXVVUtPn4oLMLLy1CdclLKO1LFgU7XzDpVMUU5UjlSLpGMocyQNNk8F6IJW9M/YdooSn2MRI+Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
         "dezalgo": "^1.0.4",
-        "hexoid": "^1.0.0",
         "once": "^1.4.0",
         "qs": "^6.11.0"
       },
@@ -11740,16 +11764,6 @@
       "resolved": "https://registry.npmjs.org/heap/-/heap-0.2.7.tgz",
       "integrity": "sha512-2bsegYkkHO+h/9MGbn6KWcE45cHZgPANo5LXF7EvWdT0yT2EguSVO1nDgU5c8+ZOPwp2vMNa7YFsJhVcDR9Sdg==",
       "license": "MIT"
-    },
-    "node_modules/hexoid": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/hexoid/-/hexoid-1.0.0.tgz",
-      "integrity": "sha512-QFLV0taWQOZtvIRIAdBChesmogZrtuXvVWsFHZTk2SU+anspqZ2vMnoLg7IE1+Uk16N19APic1BuF8bC8c2m5g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/homedir-polyfill": {
       "version": "1.0.3",
@@ -21212,9 +21226,9 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.2.tgz",
-      "integrity": "sha512-EsaAXwxmx8UB7FRKqeozqEPop69DXcmYwTQwXvyAPF352HJsPdkVhvTaDPYqfNgruveJIJy3TA2l+2zj8LJIJA==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.3.tgz",
+      "integrity": "sha512-090nwYJDmlhwFwEW3QQl+vaNnxsO2yVsd45eTKRBzSzu+hlb1w2K9inVq5b0ngXuLVqQ4ApvsUHHnu/zQNkWAg==",
       "license": "MIT",
       "dependencies": {
         "chownr": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@datadog/pprof": "^5.5.1",
     "@koa/router": "^12.0.0",
     "@ndhoule/extend": "^2.0.0",
-    "@rudderstack/integrations-lib": "^0.2.31",
+    "@rudderstack/integrations-lib": "^0.2.35",
     "@rudderstack/json-template-engine": "^0.19.5",
     "@rudderstack/pyroscope-nodejs": "^0.4.6-fork.1",
     "@rudderstack/workflow-engine": "^0.8.13",

--- a/src/v0/destinations/iterable/deleteUsers.js
+++ b/src/v0/destinations/iterable/deleteUsers.js
@@ -1,4 +1,8 @@
-const { NetworkError, ConfigurationError } = require('@rudderstack/integrations-lib');
+const {
+  NetworkError,
+  ConfigurationError,
+  forEachInBatches,
+} = require('@rudderstack/integrations-lib');
 const { httpDELETE } = require('../../../adapters/network');
 const { processAxiosResponse } = require('../../../adapters/utils/networkUtils');
 const { isHttpStatusSuccess } = require('../../util');
@@ -25,43 +29,48 @@ const userDeletionHandler = async (userAttributes, config) => {
     }
   });
   const failedUserDeletions = [];
-  // eslint-disable-next-line no-restricted-syntax
-  for (const uId of validUserIds) {
-    const endpointCategory = { endpoint: `users/byUserId/${uId}` };
-    const url = constructEndpoint(dataCenter, endpointCategory);
-    const requestOptions = {
-      headers: {
-        'Content-Type': JSON_MIME_TYPE,
-        api_key: apiKey,
-      },
-    };
-    // eslint-disable-next-line no-await-in-loop
-    const resp = await httpDELETE(url, requestOptions, {
-      destType: 'iterable',
-      feature: 'deleteUsers',
-      endpointPath: '/users/byUserId/uId',
-      requestMethod: 'DELETE',
-      module: 'deletion',
-    });
-    const handledDelResponse = processAxiosResponse(resp);
-    if (!isHttpStatusSuccess(handledDelResponse.status) && handledDelResponse.status !== 404) {
-      if (handledDelResponse.status !== 400) {
-        // Generic errors such as invalid api key
-        throw new NetworkError(
-          `User deletion request failed : ${handledDelResponse.response.msg}`,
-          handledDelResponse.status,
-          {
-            [tags.TAG_NAMES.ERROR_TYPE]: getDynamicErrorType(handledDelResponse.status),
-            [tags.TAG_NAMES.STATUS]: handledDelResponse.status,
-          },
-          handledDelResponse,
-        );
-      } else {
-        // Specific errors such as user is not found
-        failedUserDeletions.push({ userId: uId, Reason: handledDelResponse.response.msg });
+  await forEachInBatches(
+    validUserIds,
+    async (uId) => {
+      const endpointCategory = { endpoint: `users/byUserId/${uId}` };
+      const url = constructEndpoint(dataCenter, endpointCategory);
+      const requestOptions = {
+        headers: {
+          'Content-Type': JSON_MIME_TYPE,
+          api_key: apiKey,
+        },
+      };
+      const resp = await httpDELETE(url, requestOptions, {
+        destType: 'iterable',
+        feature: 'deleteUsers',
+        endpointPath: '/users/byUserId/uId',
+        requestMethod: 'DELETE',
+        module: 'deletion',
+      });
+      const handledDelResponse = processAxiosResponse(resp);
+      if (!isHttpStatusSuccess(handledDelResponse.status) && handledDelResponse.status !== 404) {
+        if (handledDelResponse.status !== 400) {
+          // Generic errors such as invalid api key
+          throw new NetworkError(
+            `User deletion request failed : ${handledDelResponse.response.msg}`,
+            handledDelResponse.status,
+            {
+              [tags.TAG_NAMES.ERROR_TYPE]: getDynamicErrorType(handledDelResponse.status),
+              [tags.TAG_NAMES.STATUS]: handledDelResponse.status,
+            },
+            handledDelResponse,
+          );
+        } else {
+          // Specific errors such as user is not found
+          failedUserDeletions.push({ userId: uId, Reason: handledDelResponse.response.msg });
+        }
       }
-    }
-  }
+    },
+    {
+      batchSize: 10,
+      sequentialProcessing: false,
+    },
+  );
 
   if (failedUserDeletions.length > 0) {
     throw new NetworkError(

--- a/src/v0/destinations/iterable/deleteUsers.js
+++ b/src/v0/destinations/iterable/deleteUsers.js
@@ -25,43 +25,43 @@ const userDeletionHandler = async (userAttributes, config) => {
     }
   });
   const failedUserDeletions = [];
-  await Promise.all(
-    validUserIds.map(async (uId) => {
-      const endpointCategory = { endpoint: `users/byUserId/${uId}` };
-      const url = constructEndpoint(dataCenter, endpointCategory);
-      const requestOptions = {
-        headers: {
-          'Content-Type': JSON_MIME_TYPE,
-          api_key: apiKey,
-        },
-      };
-      const resp = await httpDELETE(url, requestOptions, {
-        destType: 'iterable',
-        feature: 'deleteUsers',
-        endpointPath: '/users/byUserId/uId',
-        requestMethod: 'DELETE',
-        module: 'deletion',
-      });
-      const handledDelResponse = processAxiosResponse(resp);
-      if (!isHttpStatusSuccess(handledDelResponse.status) && handledDelResponse.status !== 404) {
-        if (handledDelResponse.status !== 400) {
-          // Generic errors such as invalid api key
-          throw new NetworkError(
-            `User deletion request failed : ${handledDelResponse.response.msg}`,
-            handledDelResponse.status,
-            {
-              [tags.TAG_NAMES.ERROR_TYPE]: getDynamicErrorType(handledDelResponse.status),
-              [tags.TAG_NAMES.STATUS]: handledDelResponse.status,
-            },
-            handledDelResponse,
-          );
-        } else {
-          // Specific errors such as user is not found
-          failedUserDeletions.push({ userId: uId, Reason: handledDelResponse.response.msg });
-        }
+  // eslint-disable-next-line no-restricted-syntax
+  for (const uId of validUserIds) {
+    const endpointCategory = { endpoint: `users/byUserId/${uId}` };
+    const url = constructEndpoint(dataCenter, endpointCategory);
+    const requestOptions = {
+      headers: {
+        'Content-Type': JSON_MIME_TYPE,
+        api_key: apiKey,
+      },
+    };
+    // eslint-disable-next-line no-await-in-loop
+    const resp = await httpDELETE(url, requestOptions, {
+      destType: 'iterable',
+      feature: 'deleteUsers',
+      endpointPath: '/users/byUserId/uId',
+      requestMethod: 'DELETE',
+      module: 'deletion',
+    });
+    const handledDelResponse = processAxiosResponse(resp);
+    if (!isHttpStatusSuccess(handledDelResponse.status) && handledDelResponse.status !== 404) {
+      if (handledDelResponse.status !== 400) {
+        // Generic errors such as invalid api key
+        throw new NetworkError(
+          `User deletion request failed : ${handledDelResponse.response.msg}`,
+          handledDelResponse.status,
+          {
+            [tags.TAG_NAMES.ERROR_TYPE]: getDynamicErrorType(handledDelResponse.status),
+            [tags.TAG_NAMES.STATUS]: handledDelResponse.status,
+          },
+          handledDelResponse,
+        );
+      } else {
+        // Specific errors such as user is not found
+        failedUserDeletions.push({ userId: uId, Reason: handledDelResponse.response.msg });
       }
-    }),
-  );
+    }
+  }
 
   if (failedUserDeletions.length > 0) {
     throw new NetworkError(


### PR DESCRIPTION
## What are the changes introduced in this PR?

We are removing promise.all from the Iterable deleteUser so that all the requests can be processed sequentially.

## What is the related Linear task?

Resolves INT-XXX

## Please explain the objectives of your changes below

Put down any required details on the broader aspect of your changes. If there are any dependent changes, **mandatorily** mention them here

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

N/A

### Any new dependencies introduced with this change?

N/A

### Any new generic utility introduced or modified. Please explain the changes.

N/A

### Any technical or performance related pointers to consider with the change?

N/A

@coderabbitai review

<hr>

### Developer checklist

- [ ] My code follows the style guidelines of this project

- [ ] **No breaking changes are being introduced.**

- [ ] All related docs linked with the PR?

- [ ] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [ ] Is the PR limited to 10 file changes?

- [ ] Is the PR limited to one linear task?

- [ ] Are relevant unit and component test-cases added in **new readability format**?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.
