### PR TITLE
chore: groupEventsByType function optimization

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -3,3 +3,6 @@ coverage:
     patch:
       default:
         informational: true
+ignore:
+  - '**/*.bench.js'
+  - '**/*.bench.ts'

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -20,7 +20,7 @@ sonar.eslint.reportPaths=reports/eslint.json
 # Path to sources
 sonar.sources=src
 sonar.inclusions=**/*.js
-sonar.exclusions=**/*.json,**/*.html,**/*.png,**/*.jpg,**/*.gif,**/*.svg,**/*.yml,src/util/libExtractor.js,src/util/url-search-params.min.js,src/util/lodash-es-core.js
+sonar.exclusions=**/*.json,**/*.html,**/*.png,**/*.jpg,**/*.gif,**/*.svg,**/*.yml,src/util/libExtractor.js,src/util/url-search-params.min.js,src/util/lodash-es-core.js,**/*.bench.js
 
 # Path to tests
 sonar.tests=test

--- a/src/v0/util/index.groupEvents.bench.js
+++ b/src/v0/util/index.groupEvents.bench.js
@@ -1,0 +1,163 @@
+/* eslint-disable no-console */
+const { performance } = require('perf_hooks');
+// Import the util module
+const { groupEventsByType } = require('./index');
+
+/**
+ * Groups events with the same message type together in batches.
+ * Each batch contains events that have the same message type and are from different users.
+ * @param {*} inputs - An array of events
+ * @returns {*} - An array of batches
+ */
+const groupEventsByTypeOld = (inputs) => {
+  const batches = [];
+  let currentInputsArray = inputs;
+  while (currentInputsArray.length > 0) {
+    const remainingInputsArray = [];
+    const userOrderTracker = {};
+    const event = currentInputsArray.shift();
+    const messageType = event.message.type;
+    const batch = [event];
+    currentInputsArray.forEach((currentInput) => {
+      const currentMessageType = currentInput.message.type;
+      const currentUser = currentInput.metadata.userId;
+      if (currentMessageType === messageType && !userOrderTracker[currentUser]) {
+        batch.push(currentInput);
+      } else {
+        remainingInputsArray.push(currentInput);
+        userOrderTracker[currentUser] = true;
+      }
+    });
+    batches.push(batch);
+    currentInputsArray = remainingInputsArray;
+  }
+
+  return batches;
+};
+
+// Utility function to generate random test data
+function generateTestData(count) {
+  const messageTypes = ['track', 'identify', 'page', 'screen', 'group', 'alias'];
+  const userIds = Array.from({ length: 20 }, (_, i) => `user-${i}`);
+
+  return Array.from({ length: count }, () => {
+    const messageType = messageTypes[Math.floor(Math.random() * messageTypes.length)];
+    const userId = userIds[Math.floor(Math.random() * userIds.length)];
+
+    return {
+      message: {
+        type: messageType,
+      },
+      metadata: {
+        userId,
+        jobId: Math.floor(Math.random() * 1000),
+      },
+    };
+  });
+}
+
+// Generate skewed data - lots of same message types and users
+function generateSkewedData(count) {
+  const messageTypes = ['track', 'identify'];
+  const userIds = Array.from({ length: 5 }, (_, i) => `user-${i}`);
+
+  return Array.from({ length: count }, () => {
+    const messageType = messageTypes[Math.floor(Math.random() * messageTypes.length)];
+    const userId = userIds[Math.floor(Math.random() * userIds.length)];
+
+    return {
+      message: {
+        type: messageType,
+      },
+      metadata: {
+        userId,
+        jobId: Math.floor(Math.random() * 1000),
+      },
+    };
+  });
+}
+
+// Function to run a benchmark
+function runBenchmark(fn, input, iterations = 5) {
+  // Warm-up run
+  fn([...input]);
+
+  let result;
+  const times = [];
+  for (let i = 0; i < iterations; i += 1) {
+    const start = performance.now();
+    result = fn([...input]);
+    const end = performance.now();
+    times.push(end - start);
+
+    // Print info about the result to verify correctness
+    if (i === 0) {
+      console.log(`${fn.name} generated ${result.length} batches`);
+    }
+  }
+
+  const average = times.reduce((sum, time) => sum + time, 0) / times.length;
+  const min = Math.min(...times);
+  const max = Math.max(...times);
+
+  return { average, min, max, times, resultLength: result.length };
+}
+
+// Run all benchmarks
+function runAllBenchmarks() {
+  // Generate test data once
+  const testData = generateTestData(1000);
+
+  // Run benchmarks
+  console.log(`Running benchmarks with ${testData.length} messages...`);
+
+  console.log('\nBenchmarking groupEventsByType:');
+  const results = runBenchmark(groupEventsByType, testData);
+  console.log(`Average time: ${results.average.toFixed(2)}ms`);
+  console.log(`Min time: ${results.min.toFixed(2)}ms`);
+  console.log(`Max time: ${results.max.toFixed(2)}ms`);
+
+  console.log('\nBenchmarking groupEventsByTypeOld:');
+  const v1Results = runBenchmark(groupEventsByTypeOld, testData);
+  console.log(`Average time: ${v1Results.average.toFixed(2)}ms`);
+  console.log(`Min time: ${v1Results.min.toFixed(2)}ms`);
+  console.log(`Max time: ${v1Results.max.toFixed(2)}ms`);
+
+  // Compare results
+  const speedup = v1Results.average / results.average;
+  console.log(
+    `\nComparison: groupEventsByType is ${speedup.toFixed(2)}x ${speedup > 1 ? 'faster' : 'slower'} than groupEventsByTypeOld`,
+  );
+
+  // More detailed comparison with different dataset sizes
+  console.log('\n\n===== Testing with different dataset sizes =====');
+  [10, 100, 500, 1000, 2000, 5000].forEach((size) => {
+    console.log(`\nTesting with ${size} messages:`);
+    const data = generateTestData(size);
+
+    const result = runBenchmark(groupEventsByType, data, 3);
+    const v1Result = runBenchmark(groupEventsByTypeOld, data, 3);
+
+    const speedupFactor = v1Result.average / result.average;
+    console.log(
+      `groupEventsByType: ${result.average.toFixed(2)}ms, groupEventsByTypeOld: ${v1Result.average.toFixed(2)}ms`,
+    );
+    console.log(`Speedup: ${speedupFactor.toFixed(2)}x ${speedupFactor > 1 ? 'faster' : 'slower'}`);
+  });
+
+  // Test with skewed data
+  console.log('\n\n===== Testing with skewed data (fewer types, more duplicates) =====');
+  const skewedData = generateSkewedData(1000);
+  console.log(`\nTesting with 1000 skewed messages (fewer types, more duplicates):`);
+  const skewedResult = runBenchmark(groupEventsByType, skewedData, 3);
+  const v1SkewedResult = runBenchmark(groupEventsByTypeOld, skewedData, 3);
+
+  const skewedSpeedup = v1SkewedResult.average / skewedResult.average;
+  console.log(
+    `groupEventsByType: ${skewedResult.average.toFixed(2)}ms, groupEventsByTypeOld: ${v1SkewedResult.average.toFixed(2)}ms`,
+  );
+  console.log(`Speedup: ${skewedSpeedup.toFixed(2)}x ${skewedSpeedup > 1 ? 'faster' : 'slower'}`);
+}
+
+// Run the benchmarks
+runAllBenchmarks();


### PR DESCRIPTION
This pull request refactors the `groupEventsByType` function to **improve performance drastically**, especially with larger batch sizes, and maintain user-specific ordering. It also introduces a new benchmarking script for comparing the performance of two implementations of the `groupEventsByType` function.

### Performance Benchmarking Enhancements:
* Added a new benchmarking script in `src/v0/util/index.groupEvents.bench.js` to compare the performance of the old and new `groupEventsByType` implementations. It includes utilities for generating test data, running benchmarks, and analyzing results across different dataset sizes and skewed data scenarios.

### Refactoring for Efficiency:
* Refactored the `groupEventsByType` function in `src/v0/util/index.js` to improve performance and ensure user-specific ordering in batches. The new implementation uses chunk objects and a `Map` to track the last chunk index for each user, reducing redundant iterations and enhancing scalability.


resolves PIPE-2139

```sh
Running benchmarks with 1000 messages...

Benchmarking groupEventsByType:
groupEventsByType generated 155 batches
Average time: 0.20ms
Min time: 0.17ms
Max time: 0.29ms

Benchmarking groupEventsByTypeOld:
groupEventsByTypeOld generated 155 batches
Average time: 2.51ms
Min time: 2.17ms
Max time: 3.06ms

Comparison: groupEventsByType is 12.59x faster than groupEventsByTypeOld


===== Testing with different dataset sizes =====

Testing with 10 messages:
groupEventsByType generated 6 batches
groupEventsByTypeOld generated 6 batches
groupEventsByType: 0.00ms, groupEventsByTypeOld: 0.00ms
Speedup: 0.81x slower

Testing with 100 messages:
groupEventsByType generated 23 batches
groupEventsByTypeOld generated 23 batches
groupEventsByType: 0.02ms, groupEventsByTypeOld: 0.03ms
Speedup: 1.94x faster

Testing with 500 messages:
groupEventsByType generated 85 batches
groupEventsByTypeOld generated 85 batches
groupEventsByType: 0.09ms, groupEventsByTypeOld: 0.61ms
Speedup: 6.84x faster

Testing with 1000 messages:
groupEventsByType generated 159 batches
groupEventsByTypeOld generated 159 batches
groupEventsByType: 0.06ms, groupEventsByTypeOld: 2.54ms
Speedup: 44.83x faster

Testing with 2000 messages:
groupEventsByType generated 290 batches
groupEventsByTypeOld generated 290 batches
groupEventsByType: 0.12ms, groupEventsByTypeOld: 9.88ms
Speedup: 80.48x faster

Testing with 5000 messages:
groupEventsByType generated 721 batches
groupEventsByTypeOld generated 721 batches
groupEventsByType: 0.39ms, groupEventsByTypeOld: 44.80ms
Speedup: 113.75x faster


===== Testing with skewed data (fewer types, more duplicates) =====

Testing with 1000 skewed messages (fewer types, more duplicates):
groupEventsByType generated 116 batches
groupEventsByTypeOld generated 116 batches
groupEventsByType: 0.04ms, groupEventsByTypeOld: 1.21ms
Speedup: 29.93x faster
```