### PR TITLE
fix(braze): add type checking for gender string in formatGender

### DIFF
--- a/src/v0/destinations/braze/braze.util.test.js
+++ b/src/v0/destinations/braze/braze.util.test.js
@@ -3,6 +3,7 @@ const { handleHttpRequest } = require('../../../adapters/network');
 const {
   BrazeDedupUtility,
   addAppId,
+  formatGender,
   getPurchaseObjs,
   setAliasObject,
   handleReservedProperties,
@@ -1933,5 +1934,44 @@ describe('getEndpointFromConfig', () => {
         expect(getEndpointFromConfig(input)).toBe(expected);
       }
     });
+  });
+});
+
+describe('formatGender', () => {
+  it('should return "F" for female variations', () => {
+    expect(formatGender('woman')).toBe('F');
+    expect(formatGender('female')).toBe('F');
+    expect(formatGender('w')).toBe('F');
+    expect(formatGender('f')).toBe('F');
+    expect(formatGender('WOMAN')).toBe('F');
+    expect(formatGender('FEMALE')).toBe('F');
+    expect(formatGender('W')).toBe('F');
+    expect(formatGender('F')).toBe('F');
+  });
+
+  it('should return "M" for male variations', () => {
+    expect(formatGender('man')).toBe('M');
+    expect(formatGender('male')).toBe('M');
+    expect(formatGender('m')).toBe('M');
+    expect(formatGender('MAN')).toBe('M');
+    expect(formatGender('MALE')).toBe('M');
+    expect(formatGender('M')).toBe('M');
+  });
+
+  it('should return "O" for other variations', () => {
+    expect(formatGender('other')).toBe('O');
+    expect(formatGender('o')).toBe('O');
+    expect(formatGender('OTHER')).toBe('O');
+    expect(formatGender('O')).toBe('O');
+  });
+
+  it('should return null for invalid inputs', () => {
+    expect(formatGender('invalid')).toBeNull();
+    expect(formatGender('')).toBeNull();
+    expect(formatGender(null)).toBeNull();
+    expect(formatGender(undefined)).toBeNull();
+    expect(formatGender(123)).toBeNull();
+    expect(formatGender({})).toBeNull();
+    expect(formatGender([])).toBeNull();
   });
 });

--- a/src/v0/destinations/braze/transform.js
+++ b/src/v0/destinations/braze/transform.js
@@ -44,29 +44,10 @@ const {
 } = require('./config');
 
 const logger = require('../../../logger');
-const { getEndpointFromConfig } = require('./util');
+const { getEndpointFromConfig, formatGender } = require('./util');
 const { handleHttpRequest } = require('../../../adapters/network');
 const { getDynamicErrorType } = require('../../../adapters/utils/networkUtils');
 const { JSON_MIME_TYPE } = require('../../util/constant');
-
-function formatGender(gender) {
-  // few possible cases of woman
-  if (['woman', 'female', 'w', 'f'].includes(gender?.toLowerCase())) {
-    return 'F';
-  }
-
-  // few possible cases of man
-  if (['man', 'male', 'm'].includes(gender?.toLowerCase())) {
-    return 'M';
-  }
-
-  // few possible cases of other
-  if (['other', 'o'].includes(gender?.toLowerCase())) {
-    return 'O';
-  }
-
-  return null;
-}
 
 function buildResponse(message, destination, properties, endpoint) {
   const response = defaultRequestConfig();

--- a/src/v0/destinations/braze/util.js
+++ b/src/v0/destinations/braze/util.js
@@ -29,6 +29,29 @@ const { isObject } = require('../../util');
 const { removeUndefinedValues, getIntegrationsObj } = require('../../util');
 const { InstrumentationError, isDefined } = require('@rudderstack/integrations-lib');
 
+const formatGender = (gender) => {
+  if (typeof gender !== 'string') {
+    return null;
+  }
+
+  // few possible cases of woman
+  if (['woman', 'female', 'w', 'f'].includes(gender.toLowerCase())) {
+    return 'F';
+  }
+
+  // few possible cases of man
+  if (['man', 'male', 'm'].includes(gender.toLowerCase())) {
+    return 'M';
+  }
+
+  // few possible cases of other
+  if (['other', 'o'].includes(gender.toLowerCase())) {
+    return 'O';
+  }
+
+  return null;
+};
+
 const getEndpointFromConfig = (destination) => {
   if (!destination.Config?.dataCenter || typeof destination.Config.dataCenter !== 'string') {
     throw new InstrumentationError('Invalid Data Center: valid values are EU, US, AU');
@@ -807,6 +830,7 @@ module.exports = {
   processDeduplication,
   processBatch,
   addAppId,
+  formatGender,
   getPurchaseObjs,
   setExternalIdOrAliasObject,
   setExternalId,


### PR DESCRIPTION
## What are the changes introduced in this PR?

Added type checking in the `formatGender` function to ensure proper handling of gender input strings and added comprehensive test coverage.
Grafana Alert https://rudderstack.grafana.net/a/grafana-irm-app/alert-groups/I1QQA67CM9IF2

## What is the related Linear task?

Resolves INT-3843

## Please explain the objectives of your changes below

The `formatGender` function in the Braze destination needed proper type checking to handle non-string inputs gracefully. This change ensures that:
- Only string inputs are processed
- Non-string inputs return null
- Case-insensitive gender mapping works correctly

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

Yes, the function now explicitly checks for string type input and returns null for non-string inputs. This prevents potential issues with invalid gender values.

### Any new dependencies introduced with this change?

No new dependencies introduced.

### Any new generic utility introduced or modified. Please explain the changes.

No new utilities introduced. Modified the existing `formatGender` function in the Braze destination.

### Any technical or performance related pointers to consider with the change?

No performance impact. The type checking is a lightweight operation.

### Developer checklist

- [x] My code follows the style guidelines of this project
- [x] No breaking changes are being introduced
- [x] All changes manually tested
- [x] Is the PR limited to 10 file changes
- [x] Are relevant unit and component test-cases added in new readability format