### PR TITLE
fix: metrics aggregator stops collecting metrics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,7 @@
         "oauth-1.0a": "^2.2.6",
         "object-hash": "^3.0.0",
         "parse-static-imports": "^1.1.0",
-        "prom-client": "^14.2.0",
+        "prom-client": "^15.1.3",
         "qs": "^6.11.1",
         "rs-jsonpath": "^1.1.2",
         "set-value": "^4.1.0",
@@ -3779,6 +3779,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/@paralleldrive/cuid2": {
@@ -18840,15 +18849,16 @@
       }
     },
     "node_modules/prom-client": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-14.2.0.tgz",
-      "integrity": "sha512-sF308EhTenb/pDRPakm+WgiN+VdM/T1RaHj1x+MvAuT8UiQP8JmOEbxVqtkbfR4LrvOg5n7ic01kRBDGXjYikA==",
+      "version": "15.1.3",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
+      "integrity": "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==",
       "license": "Apache-2.0",
       "dependencies": {
+        "@opentelemetry/api": "^1.4.0",
         "tdigest": "^0.1.1"
       },
       "engines": {
-        "node": ">=10"
+        "node": "^16 || ^18 || >=20"
       }
     },
     "node_modules/prompts": {

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "oauth-1.0a": "^2.2.6",
     "object-hash": "^3.0.0",
     "parse-static-imports": "^1.1.0",
-    "prom-client": "^14.2.0",
+    "prom-client": "^15.1.3",
     "qs": "^6.11.1",
     "rs-jsonpath": "^1.1.2",
     "set-value": "^4.1.0",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -20,7 +20,7 @@ sonar.eslint.reportPaths=reports/eslint.json
 # Path to sources
 sonar.sources=src
 sonar.inclusions=**/*.js
-sonar.exclusions=**/*.json,**/*.html,**/*.png,**/*.jpg,**/*.gif,**/*.svg,**/*.yml,src/util/libExtractor.js,src/util/url-search-params.min.js,src/util/lodash-es-core.js,**/*.bench.js
+sonar.exclusions=**/*.json,**/*.html,**/*.png,**/*.jpg,**/*.gif,**/*.svg,**/*.yml,src/util/libExtractor.js,src/util/url-search-params.min.js,src/util/lodash-es-core.js,**/*.bench.js,src/util/worker.js
 
 # Path to tests
 sonar.tests=test

--- a/src/util/cluster.js
+++ b/src/util/cluster.js
@@ -28,6 +28,8 @@ async function shutdownWorkers() {
 }
 
 function start(port, app, metricsApp) {
+  // Enable diagnostic reporting on SIGUSR2 signal for debugging stuck processes
+  process.report.reportOnSignal = true;
 
   if (cluster.isMaster) {
     logger.info(`Master (pid: ${process.pid}) has started`);

--- a/src/util/worker.js
+++ b/src/util/worker.js
@@ -7,9 +7,17 @@ parentPort.on('message', async (message) => {
   if (message.type === MESSAGE_TYPES.AGGREGATE_METRICS_REQ) {
     try {
       const promString = await AggregatorRegistry.aggregate(message.metrics).metrics();
-      parentPort.postMessage({ type: MESSAGE_TYPES.AGGREGATE_METRICS_RES, metrics: promString });
+      parentPort.postMessage({
+        type: MESSAGE_TYPES.AGGREGATE_METRICS_RES,
+        metrics: promString,
+        requestId: message.requestId,
+      });
     } catch (error) {
-      parentPort.postMessage({ type: MESSAGE_TYPES.AGGREGATE_METRICS_RES, error: error.message });
+      parentPort.postMessage({
+        type: MESSAGE_TYPES.AGGREGATE_METRICS_RES,
+        error: error.message,
+        requestId: message.requestId,
+      });
     }
   }
 });

--- a/test/__tests__/metricsAggregator.test.js
+++ b/test/__tests__/metricsAggregator.test.js
@@ -1,9 +1,18 @@
 const { MetricsAggregator } = require('../../src/util/metricsAggregator');
+const logger = require('../../src/logger');
 const { Worker } = require('worker_threads');
 jest.mock('cluster');
 const cluster = require('cluster');
+const exp = require('constants');
+const { set } = require('lodash');
+const { error } = require('console');
+const { any } = require('is');
 
 describe('MetricsAggregator', () => {
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
   it('should create a worker thread and register callbacks on creation', async () => {
     const clusterOnSpy = jest.spyOn(cluster, 'on');
     const metricsAggregator = new MetricsAggregator();
@@ -62,10 +71,10 @@ describe('MetricsAggregator', () => {
     
     // set cluster.workers object to simulate multiple workers
     cluster.workers = { 
-      1: { send: mockSendForWorker(1) }, 
-      2: { send: mockSendForWorker(2) },
-      3: { send: mockSendForWorker(3) },
-      4: { send: mockSendForWorker(4) },
+      1: { send: mockSendForWorker(1), isConnected: () => true }, 
+      2: { send: mockSendForWorker(2), isConnected: () => true },
+      3: { send: mockSendForWorker(3), isConnected: () => true },
+      4: { send: mockSendForWorker(4), isConnected: () => true },
     };
    
     // create metrics aggregator
@@ -77,4 +86,289 @@ describe('MetricsAggregator', () => {
     // shutdown the metrics aggregator
     await metricsAggregator.shutdown();
   });
+
+  it('should handle errors during getMetricsAsJSON', async () => {
+    logger.setLogLevel('info');
+    jest.useFakeTimers();
+    // mock the getMetricsAsJSON method to return a single metric
+    const mockGetMetricsAsJSON = jest.fn().mockImplementation(() => {
+      throw new Error('Get metrics error');
+    });
+    
+    // mock master's send - this functions simulates worker -> master communication
+    // mockMasterSend(workerId) returns a function that simulates sending a message from a worker to the master
+    // workerId is used to mark which worker sent the message
+    const mockMasterSend = (workerId) => jest.fn().mockImplementation((message) => {
+      metricsAggregator.onWorkerMessage({ id: workerId }, message);
+    });
+
+    // mock worker's send - this functions simulates master -> worker communication
+    // mockSendForWorker(workerId) returns a function that simulates sending a message from the master to a worker
+    // workerId is used to mark which worker to send the message to
+    const mockSendForWorker = (workerId) => jest.fn().mockImplementation((message) => {
+      // set the cluster.worker object so that the worker can use it to send a message to the master
+      cluster.worker = { id: workerId, send: mockMasterSend(workerId) };
+      metricsAggregator.onMasterMessage(message);
+    });
+
+
+    cluster.workers = { 
+      1: { send: mockSendForWorker(1), isConnected: () => true }, 
+      2: { send: mockSendForWorker(2), isConnected: () => true },
+      3: { send: mockSendForWorker(3), isConnected: () => true },
+      4: { send: mockSendForWorker(4), isConnected: () => true },
+    };
+   
+    // create metrics aggregator
+    const metricsAggregator = new MetricsAggregator({ prometheusRegistry: {getMetricsAsJSON: mockGetMetricsAsJSON}});
+    const metrics = metricsAggregator.aggregateMetrics();
+    await expect(metrics).rejects.toBeInstanceOf(Error);
+
+    await metricsAggregator.shutdown();
+
+  });
+
+  it('should timeout a request if it takes too long', async () => {
+    logger.setLogLevel('info');
+    jest.useFakeTimers();
+    const mockResetMetrics = jest.fn()
+    // mock the getMetricsAsJSON method to return a single metric
+    const mockGetMetricsAsJSON = jest.fn().mockImplementation(() => {
+      return [{
+        help: "Total user CPU time spent in seconds.",
+        name: "process_cpu_user_seconds_total",
+        type: "counter",
+        values: [
+          {
+            value: 1,
+            labels: {
+              instanceName: "localhost",
+            },
+          },
+        ],
+        aggregator: "sum",
+      }];
+    });
+    
+    // mock master's send - this functions simulates worker -> master communication
+    // mockMasterSend(workerId) returns a function that simulates sending a message from a worker to the master
+    // workerId is used to mark which worker sent the message
+    const mockMasterSend = (workerId) => jest.fn().mockImplementation((message) => {
+      metricsAggregator.onWorkerMessage({ id: workerId }, message);
+    });
+
+    // mock worker's send - this functions simulates master -> worker communication
+    // mockSendForWorker(workerId) returns a function that simulates sending a message from the master to a worker
+    // workerId is used to mark which worker to send the message to
+    const mockSendForWorker = (workerId) => jest.fn().mockImplementation((message) => {
+      // set the cluster.worker object so that the worker can use it to send a message to the master
+      cluster.worker = { id: workerId, send: mockMasterSend(workerId) };
+      metricsAggregator.onMasterMessage(message);
+    });
+
+    const mockSendForStuckWorker = jest.fn().mockImplementation((message) => {
+      // ignore the message to simulate a stuck worker
+    });
+
+    const mockSendThatErrors = jest.fn().mockImplementation((message) => {
+      throw new Error('Send error');
+    });
+
+    const mockSendThatRespondsWithErrorMessage = (workerId) => jest.fn().mockImplementation((message) => {
+      const requestId = message.requestId;
+      metricsAggregator.onWorkerMessage({ id: workerId }, {
+        type: 'rudder-transformer:getMetricsRes',
+        error: 'Send error',
+        requestId: requestId,
+      });
+    });
+
+    cluster.workers = { 
+      1: { send: mockSendForWorker(1), isConnected: () => true }, 
+      2: { send: mockSendForWorker(2), isConnected: () => true },
+      3: { send: mockSendThatErrors, isConnected: () => true }, // this worker should be ignored because send throws an error
+      4: { send: mockSendForStuckWorker, isConnected: () => true },
+    };
+   
+    // create metrics aggregator
+    const metricsAggregator = new MetricsAggregator({ prometheusRegistry: {getMetricsAsJSON: mockGetMetricsAsJSON, resetMetrics: mockResetMetrics}});
+    // first request should timeout after 10 seconds
+    const metrics1 = metricsAggregator.aggregateMetrics();
+
+    // try to send a 2nd request at the same time
+    const metrics2 = metricsAggregator.aggregateMetrics();
+    await expect(metrics2).rejects.toBeInstanceOf(Error); // second call should throw an error since the first request is still pending
+
+    jest.advanceTimersByTime(11000); // advance time to trigger timeout
+    await expect(metrics1).rejects.toBeInstanceOf(Error);
+
+    // now fourth worker should respond with an error message
+    cluster.workers[4].send = mockSendThatRespondsWithErrorMessage(4);
+    const metrics3 = metricsAggregator.aggregateMetrics();
+    await expect(metrics3).rejects.toBeInstanceOf(Error);
+
+    // mark the problematic worker as disconnected
+    cluster.workers[4].isConnected = () => false;
+    const metrics4 = await metricsAggregator.aggregateMetrics();
+    expect(metrics4).toMatch(`process_cpu_user_seconds_total\{instanceName="localhost"\} 2`);
+    
+    metricsAggregator.resetMetrics(); // reset metrics to clear the buffer
+    metricsAggregator.resetMetrics(); // reset metrics to clear the buffer
+    
+    await metricsAggregator.shutdown();
+  });
+
+  it('should handle an error in workerThread.postMessage', async () => {
+    logger.setLogLevel('info');
+    jest.useFakeTimers();
+    // mock the getMetricsAsJSON method to return a single metric
+    const mockGetMetricsAsJSON = jest.fn().mockImplementation(() => {
+      return [{
+        help: "Total user CPU time spent in seconds.",
+        name: "process_cpu_user_seconds_total",
+        type: "counter",
+        values: [
+          {
+            value: 1,
+            labels: {
+              instanceName: "localhost",
+            },
+          },
+        ],
+        aggregator: "sum",
+      }];
+    });
+    
+    // mock master's send - this functions simulates worker -> master communication
+    // mockMasterSend(workerId) returns a function that simulates sending a message from a worker to the master
+    // workerId is used to mark which worker sent the message
+    const mockMasterSend = (workerId) => jest.fn().mockImplementation((message) => {
+      metricsAggregator.onWorkerMessage({ id: workerId }, message);
+    });
+
+    // mock worker's send - this functions simulates master -> worker communication
+    // mockSendForWorker(workerId) returns a function that simulates sending a message from the master to a worker
+    // workerId is used to mark which worker to send the message to
+    const mockSendForWorker = (workerId) => jest.fn().mockImplementation((message) => {
+      // set the cluster.worker object so that the worker can use it to send a message to the master
+      cluster.worker = { id: workerId, send: mockMasterSend(workerId) };
+      metricsAggregator.onMasterMessage(message);
+    });
+
+    cluster.workers = { 
+      1: { send: mockSendForWorker(1), isConnected: () => true }, 
+    };
+   
+    // create metrics aggregator
+    const metricsAggregator = new MetricsAggregator({ prometheusRegistry: {getMetricsAsJSON: mockGetMetricsAsJSON}});
+    // first request should timeout after 10 seconds
+    const metrics1 = await metricsAggregator.aggregateMetrics();
+    expect(metrics1).toMatch(`process_cpu_user_seconds_total\{instanceName="localhost"\} 1`);
+    
+
+    metricsAggregator.workerThread.postMessage = jest.fn().mockImplementation(() => {
+      throw new Error('Post message error');
+    });
+    
+    // it should create a new worker thread
+    const metrics2 = metricsAggregator.aggregateMetrics();
+    await expect(metrics2).rejects.toBeInstanceOf(Error);
+
+    await metricsAggregator.shutdown();
+  });
+
+  it('should handle exceptional scenarios in onWorkerThreadMessage', async () => {
+    logger.setLogLevel('info');
+    
+    // create metrics aggregator
+    const metricsAggregator = new MetricsAggregator({ prometheusRegistry: {}});
+    // it should ignore messages for different request IDs
+    metricsAggregator.onWorkerThreadMessage({
+      type: 'rudder-transformer:aggregateMetricsRes', 
+      requestId: -1
+    });
+
+    // it should ignore messages if resolveFunc is not defined
+    metricsAggregator.onWorkerThreadMessage({
+      type: 'rudder-transformer:aggregateMetricsRes', 
+      requestId: 0
+    });
+
+    metricsAggregator.resolveFunc = jest.fn();
+    mockRejectFunc = jest.fn();
+    metricsAggregator.rejectFunc = mockRejectFunc;
+    metricsAggregator.onWorkerThreadMessage({
+      type: 'rudder-transformer:aggregateMetricsRes', 
+      requestId: 0, 
+      error: 'Some error'
+    });
+    expect(mockRejectFunc).toHaveBeenCalledWith(expect.any(Error));
+    expect(metricsAggregator.resolveFunc).toBeNull();
+
+    await metricsAggregator.shutdown();
+  });
+
+  it('should restart a worker thread that dies', async () => {
+    logger.setLogLevel('info');
+    jest.useFakeTimers();
+    // mock the getMetricsAsJSON method to return a single metric
+    const mockGetMetricsAsJSON = jest.fn().mockImplementation(() => {
+      return [{
+        help: "Total user CPU time spent in seconds.",
+        name: "process_cpu_user_seconds_total",
+        type: "counter",
+        values: [
+          {
+            value: 1,
+            labels: {
+              instanceName: "localhost",
+            },
+          },
+        ],
+        aggregator: "sum",
+      }];
+    });
+    
+    // mock master's send - this functions simulates worker -> master communication
+    // mockMasterSend(workerId) returns a function that simulates sending a message from a worker to the master
+    // workerId is used to mark which worker sent the message
+    const mockMasterSend = (workerId) => jest.fn().mockImplementation((message) => {
+      metricsAggregator.onWorkerMessage({ id: workerId }, message);
+    });
+
+    // mock worker's send - this functions simulates master -> worker communication
+    // mockSendForWorker(workerId) returns a function that simulates sending a message from the master to a worker
+    // workerId is used to mark which worker to send the message to
+    const mockSendForWorker = (workerId) => jest.fn().mockImplementation((message) => {
+      // set the cluster.worker object so that the worker can use it to send a message to the master
+      cluster.worker = { id: workerId, send: mockMasterSend(workerId) };
+      metricsAggregator.onMasterMessage(message);
+    });
+
+    cluster.workers = { 
+      1: { send: mockSendForWorker(1), isConnected: () => true }, 
+    };
+   
+    // create metrics aggregator
+    const metricsAggregator = new MetricsAggregator({ prometheusRegistry: {getMetricsAsJSON: mockGetMetricsAsJSON}});
+    // first request should timeout after 10 seconds
+    const metrics1 = await metricsAggregator.aggregateMetrics();
+    expect(metrics1).toMatch(`process_cpu_user_seconds_total\{instanceName="localhost"\} 1`);
+    
+    // simulate worker thread crash
+    await metricsAggregator.workerThread.terminate();
+
+    // it should create a new worker thread
+    const metrics2 = await metricsAggregator.aggregateMetrics();
+    expect(metrics2).toMatch(`process_cpu_user_seconds_total\{instanceName="localhost"\} 1`);
+
+    // simulate worker thread crash again during shutdown
+    metricsAggregator.shuttingDown = true; 
+    await metricsAggregator.workerThread.terminate();
+
+    await metricsAggregator.shutdown();
+
+
+  });
+
 });


### PR DESCRIPTION
## What are the changes introduced in this PR?

There were a number of issues with the current metrics aggregator implementation that this pull request is fixing:
- If the running request didn't complete for whatever reason, aggregator was being stuck not trying to aggregate anymore. Now we are using a configurable `METRICS_AGGREGATOR_REQUEST_TIMEOUT_SECONDS=10`, after which a new aggregation request will be allowed.
- In case of worker errors the aggregator's state could become corrupted, since it could associate old responses with newer requests. Now we're using a requestId so that aggregator ignores responses for previous request ids.
- A lot of error conditions were being unhandled, e.g. an error while sending to a worker or the aggregator thread, or trying to send to a disconnected worker.
- Worker thread wasn't being monitored for errors/exits. Now we are recreating the worker thread if it exits unexpectedly.

Additionally, bumping **prom-client** to latest version:
- Includes a [performance improvement](https://github.com/siimon/prom-client/pull/549) which helps with [this issue](https://github.com/siimon/prom-client/issues/543).
- Includes various other performance improvements ([here](https://github.com/siimon/prom-client/pull/606), [here](https://github.com/siimon/prom-client/releases#:~:text=Refactor%20histogram%20internals%20and%20provide%20a%20fast%20path%20for%20rendering%20metrics%20to%20Prometheus%20strings%20when%20there%20are%20many%20labels%20shared%20across%20different%20values.), [here](https://github.com/siimon/prom-client/releases#:~:text=Improve%20performance%20of%20hashObject%20by%20using%20pre%2Dsorted%20array%20of%20label%20names))

After all these changes, it is still possible for metrics aggregation to fail continuously, e.g. in case there is a stuck (busy) worker. This scenario however should be handled through a future change, where we'll be introducing a cluster manager which is going to be able to detect stuck workers not responding to ping requests and restart them or even shutdown the pod.

resolves INT-3872