### PR TITLE
fix: remove request ip from context for auth0 source

### DIFF
--- a/go/webhook/testcases/testdata/testcases/auth0/add_member_to_an_organization_0.json
+++ b/go/webhook/testcases/testdata/testcases/auth0/add_member_to_an_organization_0.json
@@ -35,7 +35,6 @@
           },
           "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/105.0.0.0 Safari/537.36",
           "ip": "35.167.74.121",
-          "request_ip": "35.167.74.121",
           "integration": {
             "name": "Auth0"
           }

--- a/go/webhook/testcases/testdata/testcases/auth0/missing_user_id_0.json
+++ b/go/webhook/testcases/testdata/testcases/auth0/missing_user_id_0.json
@@ -40,7 +40,6 @@
           },
           "userAgent": "unknown",
           "ip": "35.166.202.113",
-          "request_ip": "35.166.202.113",
           "integration": {
             "name": "Auth0"
           }

--- a/go/webhook/testcases/testdata/testcases/auth0/missing_user_id_for_all_the_requests_in_a_batch_0.json
+++ b/go/webhook/testcases/testdata/testcases/auth0/missing_user_id_for_all_the_requests_in_a_batch_0.json
@@ -40,7 +40,6 @@
           },
           "userAgent": "unknown",
           "ip": "35.166.202.113",
-          "request_ip": "35.166.202.113",
           "integration": {
             "name": "Auth0"
           }

--- a/go/webhook/testcases/testdata/testcases/auth0/missing_user_id_for_all_the_requests_in_a_batch_1.json
+++ b/go/webhook/testcases/testdata/testcases/auth0/missing_user_id_for_all_the_requests_in_a_batch_1.json
@@ -32,7 +32,6 @@
           },
           "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/105.0.0.0 Safari/537.36",
           "ip": "35.166.202.113",
-          "request_ip": "35.166.202.113",
           "integration": {
             "name": "Auth0"
           }

--- a/go/webhook/testcases/testdata/testcases/auth0/successful_signup_0.json
+++ b/go/webhook/testcases/testdata/testcases/auth0/successful_signup_0.json
@@ -40,7 +40,6 @@
           },
           "userAgent": "unknown",
           "ip": "35.166.202.113",
-          "request_ip": "35.166.202.113",
           "integration": {
             "name": "Auth0"
           }

--- a/go/webhook/testcases/testdata/testcases/auth0/successful_signup_1.json
+++ b/go/webhook/testcases/testdata/testcases/auth0/successful_signup_1.json
@@ -36,7 +36,6 @@
           },
           "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/105.0.0.0 Safari/537.36",
           "ip": "35.166.202.113",
-          "request_ip": "35.166.202.113",
           "integration": {
             "name": "Auth0"
           }

--- a/go/webhook/testcases/testdata/testcases/auth0/update_tenant_settings_0.json
+++ b/go/webhook/testcases/testdata/testcases/auth0/update_tenant_settings_0.json
@@ -36,7 +36,6 @@
           },
           "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/105.0.0.0 Safari/537.36",
           "ip": "35.160.3.103",
-          "request_ip": "35.160.3.103",
           "integration": {
             "name": "Auth0"
           }

--- a/go/webhook/testcases/testdata/testcases/auth0/update_tenant_settings_1.json
+++ b/go/webhook/testcases/testdata/testcases/auth0/update_tenant_settings_1.json
@@ -35,7 +35,6 @@
             "userId": "google-oauth2|123456"
           },
           "ip": "35.160.3.103",
-          "request_ip": "35.160.3.103",
           "integration": {
             "name": "Auth0"
           }

--- a/src/sources/auth0/mapping.json
+++ b/src/sources/auth0/mapping.json
@@ -29,7 +29,7 @@
   },
   {
     "sourceKeys": "ip",
-    "destKeys": ["context.ip", "context.request_ip"]
+    "destKeys": ["context.ip"]
   },
   {
     "sourceKeys": "details.auth.user.email",

--- a/test/integrations/sources/auth0/data.ts
+++ b/test/integrations/sources/auth0/data.ts
@@ -146,7 +146,6 @@ export const data = [
                     library: { name: 'unknown', version: 'unknown' },
                     userAgent: 'unknown',
                     ip: '35.166.202.113',
-                    request_ip: '35.166.202.113',
                     integration: { name: 'Auth0' },
                   },
                   properties: {
@@ -186,7 +185,6 @@ export const data = [
                     userAgent:
                       'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/105.0.0.0 Safari/537.36',
                     ip: '35.166.202.113',
-                    request_ip: '35.166.202.113',
                     integration: { name: 'Auth0' },
                   },
                   properties: {
@@ -330,7 +328,6 @@ export const data = [
                     userAgent:
                       'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/105.0.0.0 Safari/537.36',
                     ip: '35.167.74.121',
-                    request_ip: '35.167.74.121',
                     integration: { name: 'Auth0' },
                   },
                   groupId: 'org_eoe8p2atZ7furBxg',
@@ -520,7 +517,6 @@ export const data = [
                     userAgent:
                       'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/105.0.0.0 Safari/537.36',
                     ip: '35.160.3.103',
-                    request_ip: '35.160.3.103',
                     integration: { name: 'Auth0' },
                   },
                   properties: {
@@ -601,7 +597,6 @@ export const data = [
                     library: { name: 'unknown', version: 'unknown' },
                     traits: { userId: 'google-oauth2|123456' },
                     ip: '35.160.3.103',
-                    request_ip: '35.160.3.103',
                     integration: { name: 'Auth0' },
                   },
                   properties: {
@@ -716,7 +711,6 @@ export const data = [
                     library: { name: 'unknown', version: 'unknown' },
                     userAgent: 'unknown',
                     ip: '35.166.202.113',
-                    request_ip: '35.166.202.113',
                     integration: { name: 'Auth0' },
                   },
                   properties: {
@@ -835,7 +829,6 @@ export const data = [
                     library: { name: 'unknown', version: 'unknown' },
                     userAgent: 'unknown',
                     ip: '35.166.202.113',
-                    request_ip: '35.166.202.113',
                     integration: { name: 'Auth0' },
                   },
                   properties: {
@@ -873,7 +866,7 @@ export const data = [
                     userAgent:
                       'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/105.0.0.0 Safari/537.36',
                     ip: '35.166.202.113',
-                    request_ip: '35.166.202.113',
+
                     integration: { name: 'Auth0' },
                   },
                   properties: {


### PR DESCRIPTION
## What are the changes introduced in this PR?

This pull request focuses on removing the `request_ip` field from various test case files and mappings related to the Auth0 integration. The changes streamline data handling by consolidating IP-related information under the `ip` field and updating associated test cases and mappings accordingly.


## What is the related Linear task?

Resolves INT-3887

## Please explain the objectives of your changes below

Put down any required details on the broader aspect of your changes. If there are any dependent changes, **mandatorily** mention them here

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

N/A

### Any new dependencies introduced with this change?

N/A

### Any new generic utility introduced or modified. Please explain the changes.

N/A

### Any technical or performance related pointers to consider with the change?

N/A

@coderabbitai review

<hr>

### Developer checklist

- [ ] My code follows the style guidelines of this project

- [ ] **No breaking changes are being introduced.**

- [ ] All related docs linked with the PR?

- [ ] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [ ] Is the PR limited to 10 file changes?

- [ ] Is the PR limited to one linear task?

- [ ] Are relevant unit and component test-cases added in **new readability format**?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.
