### PR TITLE
chore: add type for requestMetadata

### DIFF
--- a/src/cdk/v2/handler.ts
+++ b/src/cdk/v2/handler.ts
@@ -5,7 +5,7 @@ import {
   WorkflowEngine,
   WorkflowEngineFactory,
 } from '@rudderstack/workflow-engine';
-import { FixMe } from '../../types';
+import { FixMe, RequestMetadata } from '../../types';
 
 import tags from '../../v0/util/tags';
 
@@ -73,7 +73,7 @@ export async function getCachedWorkflowEngine(
 export async function executeWorkflow(
   workflowEngine: WorkflowEngine,
   parsedEvent: FixMe,
-  requestMetadata: NonNullable<unknown> = {},
+  requestMetadata: RequestMetadata,
 ) {
   const result = await workflowEngine.execute(parsedEvent, { requestMetadata });
   // TODO: Handle remaining output scenarios
@@ -84,7 +84,7 @@ export async function processCdkV2Workflow(
   destType: string,
   parsedEvent: FixMe,
   feature: string,
-  requestMetadata: NonNullable<unknown> = {},
+  requestMetadata: RequestMetadata,
   bindings: Record<string, FixMe> = {},
 ) {
   try {

--- a/src/interfaces/DestinationService.ts
+++ b/src/interfaces/DestinationService.ts
@@ -9,6 +9,7 @@ import {
   RouterTransformationResponse,
   UserDeletionRequest,
   UserDeletionResponse,
+  RequestMetadata,
 } from '../types/index';
 
 export interface DestinationService {
@@ -27,27 +28,27 @@ export interface DestinationService {
     events: ProcessorTransformationRequest[],
     destinationType: string,
     version: string,
-    requestMetadata: NonNullable<unknown>,
+    requestMetadata: RequestMetadata,
   ): Promise<ProcessorTransformationResponse[]>;
 
   doRouterTransformation(
     events: RouterTransformationRequestData[],
     destinationType: string,
     version: string,
-    requestMetadata: NonNullable<unknown>,
+    requestMetadata: RequestMetadata,
   ): Promise<RouterTransformationResponse[]>;
 
   doBatchTransformation(
     events: RouterTransformationRequestData[],
     destinationType: string,
     version: string,
-    requestMetadata: NonNullable<unknown>,
+    requestMetadata: RequestMetadata,
   ): RouterTransformationResponse[];
 
   deliver(
     event: ProxyRequest,
     destinationType: string,
-    requestMetadata: NonNullable<unknown>,
+    requestMetadata: RequestMetadata,
     version: string,
   ): Promise<DeliveryV0Response | DeliveryV1Response>;
 

--- a/src/interfaces/SourceService.ts
+++ b/src/interfaces/SourceService.ts
@@ -1,4 +1,9 @@
-import { MetaTransferObject, SourceInputV2, SourceTransformationResponse } from '../types/index';
+import {
+  MetaTransferObject,
+  SourceInputV2,
+  SourceTransformationResponse,
+  RequestMetadata,
+} from '../types/index';
 
 export interface SourceService {
   getTags(): MetaTransferObject;
@@ -6,6 +11,6 @@ export interface SourceService {
   sourceTransformRoutine(
     sourceEvents: NonNullable<SourceInputV2>[],
     sourceType: string,
-    requestMetadata: NonNullable<unknown>,
+    requestMetadata: RequestMetadata,
   ): Promise<SourceTransformationResponse[]>;
 }

--- a/src/services/destination/__tests__/nativeIntegration.test.ts
+++ b/src/services/destination/__tests__/nativeIntegration.test.ts
@@ -3,6 +3,7 @@ import {
   ProcessorTransformationOutput,
   ProcessorTransformationRequest,
   ProcessorTransformationResponse,
+  RequestMetadata,
 } from '../../../types/index';
 import { NativeIntegrationDestinationService } from '../nativeIntegration';
 import { DestinationPostTransformationService } from '../postTransformation';
@@ -15,7 +16,14 @@ describe('NativeIntegration Service', () => {
   test('doProcessorTransformation - success', async () => {
     const destType = '__rudder_test__';
     const version = 'v0';
-    const requestMetadata = {};
+    const requestMetadata: RequestMetadata = {
+      namespace: 'Unknown',
+      cluster: 'Unknown',
+      features: {
+        'filter-code': true,
+        'gzip-support': true,
+      },
+    };
     const event = { message: { a: 'b' } } as unknown as ProcessorTransformationRequest;
     const events: ProcessorTransformationRequest[] = [event, event];
 
@@ -57,7 +65,14 @@ describe('NativeIntegration Service', () => {
   test('doProcessorTransformation - failure', async () => {
     const destType = '__rudder_test__';
     const version = 'v0';
-    const requestMetadata = {};
+    const requestMetadata: RequestMetadata = {
+      namespace: 'Unknown',
+      cluster: 'Unknown',
+      features: {
+        'filter-code': true,
+        'gzip-support': false,
+      },
+    };
     const event = { message: { a: 'b' } } as unknown as ProcessorTransformationRequest;
     const events: ProcessorTransformationRequest[] = [event, event];
 

--- a/src/services/destination/cdkV2Integration.ts
+++ b/src/services/destination/cdkV2Integration.ts
@@ -17,6 +17,7 @@ import {
   UserDeletionRequest,
   UserDeletionResponse,
   CatchErr,
+  RequestMetadata,
 } from '../../types';
 import stats from '../../util/stats';
 import { groupRouterTransformEvents } from '../../v0/util';
@@ -54,7 +55,7 @@ export class CDKV2DestinationService implements DestinationService {
     events: ProcessorTransformationRequest[],
     destinationType: string,
     _version: string,
-    requestMetadata: NonNullable<unknown>,
+    requestMetadata: RequestMetadata,
   ): Promise<ProcessorTransformationResponse[]> {
     // TODO: Change the promise type
     const respList: ProcessorTransformationResponse[][] = await mapInBatches(
@@ -121,7 +122,7 @@ export class CDKV2DestinationService implements DestinationService {
     events: RouterTransformationRequestData[],
     destinationType: string,
     _version: string,
-    requestMetadata: NonNullable<unknown>,
+    requestMetadata: RequestMetadata,
   ): Promise<RouterTransformationResponse[]> {
     const groupedEvents: RouterTransformationRequestData[][] =
       await groupRouterTransformEvents(events);
@@ -166,7 +167,7 @@ export class CDKV2DestinationService implements DestinationService {
     _events: RouterTransformationRequestData[],
     _destinationType: string,
     _version: string,
-    _requestMetadata: NonNullable<unknown>,
+    _requestMetadata: RequestMetadata,
   ): RouterTransformationResponse[] {
     throw new TransformationError('CDKV2 Does not Implement Batch Transform Routine');
   }
@@ -174,7 +175,7 @@ export class CDKV2DestinationService implements DestinationService {
   public deliver(
     _event: ProxyRequest,
     _destinationType: string,
-    _requestMetadata: NonNullable<unknown>,
+    _requestMetadata: RequestMetadata,
   ): Promise<DeliveryV0Response | DeliveryV1Response> {
     throw new TransformationError('CDKV2 Does not Implement Delivery Routine');
   }

--- a/src/services/destination/nativeIntegration.ts
+++ b/src/services/destination/nativeIntegration.ts
@@ -183,7 +183,7 @@ export class NativeIntegrationDestinationService implements DestinationService {
   public async deliver(
     deliveryRequest: ProxyRequest,
     destinationType: string,
-    _requestMetadata: NonNullable<unknown>,
+    _requestMetadata: RequestMetadata,
     version: string,
   ): Promise<DeliveryV0Response | DeliveryV1Response> {
     try {

--- a/src/services/destination/nativeIntegration.ts
+++ b/src/services/destination/nativeIntegration.ts
@@ -19,6 +19,7 @@ import {
   ProxyRequest,
   ProxyV0Request,
   ProxyV1Request,
+  RequestMetadata,
   RouterTransformationRequestData,
   RouterTransformationResponse,
   UserDeletionRequest,
@@ -60,7 +61,7 @@ export class NativeIntegrationDestinationService implements DestinationService {
     events: ProcessorTransformationRequest[],
     destinationType: string,
     version: string,
-    requestMetadata: NonNullable<unknown>,
+    requestMetadata: RequestMetadata,
   ): Promise<ProcessorTransformationResponse[]> {
     const destHandler = FetchHandler.getDestHandler(destinationType, version);
     const respList = await mapInBatches(
@@ -100,7 +101,7 @@ export class NativeIntegrationDestinationService implements DestinationService {
     events: RouterTransformationRequestData[],
     destinationType: string,
     version: string,
-    requestMetadata: NonNullable<unknown>,
+    requestMetadata: RequestMetadata,
   ): Promise<RouterTransformationResponse[]> {
     const destHandler = FetchHandler.getDestHandler(destinationType, version);
     const groupedEvents: RouterTransformationRequestData[][] =
@@ -143,7 +144,7 @@ export class NativeIntegrationDestinationService implements DestinationService {
     events: RouterTransformationRequestData[],
     destinationType: string,
     version: any,
-    requestMetadata: NonNullable<unknown>,
+    requestMetadata: RequestMetadata,
   ): RouterTransformationResponse[] {
     const destHandler = FetchHandler.getDestHandler(destinationType, version);
     if (!destHandler.batch) {

--- a/src/services/source/__tests__/nativeIntegration.test.ts
+++ b/src/services/source/__tests__/nativeIntegration.test.ts
@@ -1,5 +1,6 @@
 import { FetchHandler } from '../../../helpers/fetchHandlers';
 import {
+  RequestMetadata,
   SourceTransformationResponse,
   SourceTransformationSuccessResponse,
 } from '../../../types/index';
@@ -16,9 +17,18 @@ const headers = {
 };
 
 describe('NativeIntegration Source Service', () => {
+  const createMockRequestMetadata = (): RequestMetadata => ({
+    namespace: 'Test',
+    cluster: 'Test',
+    features: {
+      'source-transformation': true,
+      'batch-processing': true,
+    },
+  });
+
   test('sourceTransformRoutine - success', async () => {
     const sourceType = '__rudder_test__';
-    const requestMetadata = {};
+    const requestMetadata = createMockRequestMetadata();
 
     const event = {
       request: { body: JSON.stringify({ message: { a: 'b' } }) },
@@ -61,7 +71,7 @@ describe('NativeIntegration Source Service', () => {
   describe('sourceTransformRoutine - failure', () => {
     test('integration failure', async () => {
       const sourceType = '__rudder_test__';
-      const requestMetadata = {};
+      const requestMetadata = createMockRequestMetadata();
 
       const event = {
         request: { body: JSON.stringify({ message: { a: 'b' } }) },
@@ -99,7 +109,7 @@ describe('NativeIntegration Source Service', () => {
 
     test('invalid source events', async () => {
       const sourceType = '__rudder_test__';
-      const requestMetadata = {};
+      const requestMetadata = createMockRequestMetadata();
 
       const service = new NativeIntegrationSourceService();
       await expect(

--- a/src/services/source/nativeIntegration.ts
+++ b/src/services/source/nativeIntegration.ts
@@ -12,6 +12,7 @@ import {
   RudderMessage,
   SourceInputV2,
   SourceTransformationResponse,
+  RequestMetadata,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   FixMe,
 } from '../../types';
@@ -40,7 +41,7 @@ export class NativeIntegrationSourceService implements SourceService {
     sourceEvents: NonNullable<SourceInputV2>[],
     sourceType: string,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    _requestMetadata: NonNullable<unknown>,
+    _requestMetadata: RequestMetadata,
   ): Promise<SourceTransformationResponse[]> {
     if (!Array.isArray(sourceEvents)) {
       throw new TransformationError('Invalid source events');

--- a/src/types/destinationTransformation.ts
+++ b/src/types/destinationTransformation.ts
@@ -34,6 +34,8 @@ export type RequestMetadata = {
   namespace: string;
   cluster: string;
   features: Record<string, boolean>;
+  // Allow additional metadata fields for future extensibility
+  [key: string]: unknown;
 };
 
 export type BatchedRequestBody<T = Record<string, unknown>> = {

--- a/src/types/destinationTransformation.ts
+++ b/src/types/destinationTransformation.ts
@@ -30,6 +30,12 @@ export type ProcessorTransformationRequest<
   credentials?: Credential[];
 };
 
+export type RequestMetadata = {
+  namespace: string;
+  cluster: string;
+  features: Record<string, boolean>;
+};
+
 export type BatchedRequestBody<T = Record<string, unknown>> = {
   JSON?: T;
   JSON_ARRAY?: Record<string, unknown>;


### PR DESCRIPTION
## What are the changes introduced in this PR?

This pull request introduces changes to improve type safety and enhance functionality in the `NativeIntegrationDestinationService` by defining and integrating a new `RequestMetadata` type. The updates ensure consistent handling of metadata across various transformation methods and tests.

### Type Safety Enhancements:

* [`src/types/destinationTransformation.ts`](diffhunk://#diff-15371642c532c1209ec4b6d53a9571942788a5e6c9ba41b05107d1298b30707bR33-R38): Added a new `RequestMetadata` type to represent metadata with `namespace`, `cluster`, and `features` fields for improved type safety.


## What is the related Linear task?

Resolves INT-3921

## Please explain the objectives of your changes below

Put down any required details on the broader aspect of your changes. If there are any dependent changes, **mandatorily** mention them here

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

N/A

### Any new dependencies introduced with this change?

N/A

### Any new generic utility introduced or modified. Please explain the changes.

N/A

### Any technical or performance related pointers to consider with the change?

N/A

@coderabbitai review

<hr>

### Developer checklist

- [ ] My code follows the style guidelines of this project

- [ ] **No breaking changes are being introduced.**

- [ ] All related docs linked with the PR?

- [ ] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [ ] Is the PR limited to 10 file changes?

- [ ] Is the PR limited to one linear task?

- [ ] Are relevant unit and component test-cases added in **new readability format**?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.
