### PR TITLE
fix: add mapping of advertiser_tracking_enabled and enable extInfo with empty string

### DIFF
--- a/src/v0/destinations/snapchat_conversion/transformV3.js
+++ b/src/v0/destinations/snapchat_conversion/transformV3.js
@@ -220,6 +220,12 @@ const trackResponseBuilder = (message, { Config }, mappedEvent) => {
       ...commonProperties.custom_data,
     };
   }
+  if (commonProperties.app_data) {
+    payload.data[0].app_data = {
+      ...payload.data[0]?.app_data,
+      ...commonProperties.app_data,
+    };
+  }
 
   // Process and validate payload
   const processedPayload = processPayload(payload, message, {

--- a/src/v0/destinations/snapchat_conversion/utilsV3.js
+++ b/src/v0/destinations/snapchat_conversion/utilsV3.js
@@ -128,8 +128,7 @@ const getExtInfo = (message) => {
     deviceInfo.freeStorage,
     environmentInfo.timezone,
   ];
-
-  return extInfo.some((value) => value == null) ? null : extInfo;
+  return extInfo.map((value) => (value == null ? '' : value));
 };
 
 module.exports = {

--- a/test/integrations/destinations/snapchat_conversion/processor/dataV3.ts
+++ b/test/integrations/destinations/snapchat_conversion/processor/dataV3.ts
@@ -503,6 +503,24 @@ export const dataV3: ProcessorTestData[] = [
                     {
                       action_source: 'MOBILE_APP',
                       app_data: {
+                        extinfo: [
+                          'i2',
+                          'com.rudderlabs.javascript',
+                          '1.0.0',
+                          '1.0.0',
+                          '14.4.1',
+                          'AOSP on IA Emulator',
+                          'en-US',
+                          '',
+                          '',
+                          '',
+                          '',
+                          '2',
+                          '',
+                          '',
+                          '',
+                          '',
+                        ],
                         app_id: 'dhfeih44f',
                       },
                       custom_data: {
@@ -583,7 +601,6 @@ export const dataV3: ProcessorTestData[] = [
                 },
                 network: {
                   bluetooth: false,
-                  carrier: 'Android',
                   cellular: true,
                   wifi: true,
                 },
@@ -615,6 +632,7 @@ export const dataV3: ProcessorTestData[] = [
                 storage: 128,
                 free_storage: 8,
                 cpu_cores: 2,
+                att_status: 0,
               },
               integrations: {
                 All: true,
@@ -653,7 +671,6 @@ export const dataV3: ProcessorTestData[] = [
                     {
                       action_source: 'MOBILE_APP',
                       app_data: {
-                        app_id: 'dhfeih44f',
                         extinfo: [
                           'i2',
                           'com.rudderlabs.javascript',
@@ -663,7 +680,7 @@ export const dataV3: ProcessorTestData[] = [
                           'AOSP on IA Emulator',
                           'en-US',
                           'IST',
-                          'Android',
+                          '',
                           '1080',
                           '1794',
                           '420',
@@ -672,6 +689,8 @@ export const dataV3: ProcessorTestData[] = [
                           '8',
                           'Asia/Kolkata',
                         ],
+                        advertiser_tracking_enabled: 0,
+                        app_id: 'dhfeih44f',
                       },
                       custom_data: {
                         search_string: 't-shirts',
@@ -819,6 +838,24 @@ export const dataV3: ProcessorTestData[] = [
                     {
                       action_source: 'MOBILE_APP',
                       app_data: {
+                        extinfo: [
+                          'i2',
+                          'com.rudderlabs.javascript',
+                          '1.0.0',
+                          '1.0.0',
+                          '14.4.1',
+                          '',
+                          'en-US',
+                          '',
+                          '',
+                          '',
+                          '',
+                          '2',
+                          '',
+                          '',
+                          '',
+                          '',
+                        ],
                         app_id: 'dhfeih44f',
                       },
                       custom_data: {
@@ -967,6 +1004,24 @@ export const dataV3: ProcessorTestData[] = [
                     {
                       action_source: 'MOBILE_APP',
                       app_data: {
+                        extinfo: [
+                          'i2',
+                          'com.rudderlabs.javascript',
+                          '1.0.0',
+                          '1.0.0',
+                          '14.4.1',
+                          '',
+                          'en-US',
+                          '',
+                          '',
+                          '',
+                          '',
+                          '2',
+                          '',
+                          '',
+                          '',
+                          '',
+                        ],
                         app_id: 'dhfeih44f',
                       },
                       custom_data: {
@@ -1115,6 +1170,24 @@ export const dataV3: ProcessorTestData[] = [
                     {
                       action_source: 'MOBILE_APP',
                       app_data: {
+                        extinfo: [
+                          'i2',
+                          'com.rudderlabs.javascript',
+                          '1.0.0',
+                          '1.0.0',
+                          '14.4.1',
+                          '',
+                          'en-US',
+                          '',
+                          '',
+                          '',
+                          '',
+                          '2',
+                          '',
+                          '',
+                          '',
+                          '',
+                        ],
                         app_id: 'dhfeih44f',
                       },
                       custom_data: {
@@ -1254,6 +1327,24 @@ export const dataV3: ProcessorTestData[] = [
                     {
                       action_source: 'MOBILE_APP',
                       app_data: {
+                        extinfo: [
+                          'i2',
+                          'com.rudderlabs.javascript',
+                          '1.0.0',
+                          '1.0.0',
+                          '14.4.1',
+                          '',
+                          'en-US',
+                          '',
+                          '',
+                          '',
+                          '',
+                          '2',
+                          '',
+                          '',
+                          '',
+                          '',
+                        ],
                         app_id: 'dhfeih44f',
                       },
                       custom_data: {
@@ -2715,6 +2806,24 @@ export const dataV3: ProcessorTestData[] = [
                     {
                       action_source: 'MOBILE_APP',
                       app_data: {
+                        extinfo: [
+                          'i2',
+                          'com.rudderlabs.javascript',
+                          '1.0.0',
+                          '1.0.0',
+                          '14.4.1',
+                          '',
+                          'en-US',
+                          '',
+                          '',
+                          '',
+                          '',
+                          '2',
+                          '',
+                          '',
+                          '',
+                          '',
+                        ],
                         app_id: 'dhfeih44f',
                       },
                       custom_data: {
@@ -3263,6 +3372,24 @@ export const dataV3: ProcessorTestData[] = [
                     {
                       action_source: 'MOBILE_APP',
                       app_data: {
+                        extinfo: [
+                          'i2',
+                          'com.rudderlabs.javascript',
+                          '1.0.0',
+                          '1.0.0',
+                          '14.4.1',
+                          '',
+                          'en-US',
+                          '',
+                          '',
+                          '',
+                          '',
+                          '2',
+                          '',
+                          '',
+                          '',
+                          '',
+                        ],
                         app_id: 'dhfeih44f',
                       },
                       custom_data: {
@@ -3411,6 +3538,24 @@ export const dataV3: ProcessorTestData[] = [
                     {
                       action_source: 'MOBILE_APP',
                       app_data: {
+                        extinfo: [
+                          'i2',
+                          'com.rudderlabs.javascript',
+                          '1.0.0',
+                          '1.0.0',
+                          '14.4.1',
+                          '',
+                          'en-US',
+                          '',
+                          '',
+                          '',
+                          '',
+                          '2',
+                          '',
+                          '',
+                          '',
+                          '',
+                        ],
                         app_id: 'dhfeih44f',
                       },
                       custom_data: {
@@ -3557,6 +3702,24 @@ export const dataV3: ProcessorTestData[] = [
                     {
                       action_source: 'MOBILE_APP',
                       app_data: {
+                        extinfo: [
+                          'i2',
+                          'com.rudderlabs.javascript',
+                          '1.0.0',
+                          '1.0.0',
+                          '14.4.1',
+                          '',
+                          'en-US',
+                          '',
+                          '',
+                          '',
+                          '',
+                          '2',
+                          '',
+                          '',
+                          '',
+                          '',
+                        ],
                         app_id: 'dhfeih44f',
                       },
                       custom_data: {
@@ -3705,6 +3868,24 @@ export const dataV3: ProcessorTestData[] = [
                     {
                       action_source: 'MOBILE_APP',
                       app_data: {
+                        extinfo: [
+                          'i2',
+                          'com.rudderlabs.javascript',
+                          '1.0.0',
+                          '1.0.0',
+                          '14.4.1',
+                          '',
+                          'en-US',
+                          '',
+                          '',
+                          '',
+                          '',
+                          '2',
+                          '',
+                          '',
+                          '',
+                          '',
+                        ],
                         app_id: 'dhfeih44f',
                       },
                       custom_data: {
@@ -3857,6 +4038,24 @@ export const dataV3: ProcessorTestData[] = [
                     {
                       action_source: 'MOBILE_APP',
                       app_data: {
+                        extinfo: [
+                          'i2',
+                          'com.rudderlabs.javascript',
+                          '1.0.0',
+                          '1.0.0',
+                          '14.4.1',
+                          '',
+                          'en-US',
+                          '',
+                          '',
+                          '',
+                          '',
+                          '2',
+                          '',
+                          '',
+                          '',
+                          '',
+                        ],
                         app_id: 'dhfeih44f',
                       },
                       custom_data: {

--- a/test/integrations/destinations/snapchat_conversion/router/dataV3.ts
+++ b/test/integrations/destinations/snapchat_conversion/router/dataV3.ts
@@ -470,6 +470,24 @@ export const dataV3: RouterTestData[] = [
                       {
                         action_source: 'MOBILE_APP',
                         app_data: {
+                          extinfo: [
+                            'i2',
+                            'com.rudderlabs.javascript',
+                            '1.0.0',
+                            '1.0.0',
+                            '14.4.1',
+                            'AOSP on IA Emulator',
+                            'en-US',
+                            '',
+                            '',
+                            '',
+                            '',
+                            '2',
+                            '',
+                            '',
+                            '',
+                            '',
+                          ],
                           app_id: 'dhfeih44f',
                         },
                         custom_data: {
@@ -489,6 +507,24 @@ export const dataV3: RouterTestData[] = [
                       {
                         action_source: 'MOBILE_APP',
                         app_data: {
+                          extinfo: [
+                            'i2',
+                            'com.rudderlabs.javascript',
+                            '1.0.0',
+                            '1.0.0',
+                            '14.4.1',
+                            '',
+                            'en-US',
+                            '',
+                            '',
+                            '',
+                            '',
+                            '2',
+                            '',
+                            '',
+                            '',
+                            '',
+                          ],
                           app_id: 'dhfeih44f',
                         },
                         custom_data: {


### PR DESCRIPTION
## What are the changes introduced in this PR?

Fix the logic of populating extInfo, setting an empty string for null values, apart from dropping the entire extInfo and use advertiser_tracking_enabled.

## What is the related Linear task?

Resolves INT-3910

## Please explain the objectives of your changes below

Put down any required details on the broader aspect of your changes. If there are any dependent changes, **mandatorily** mention them here

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

N/A

### Any new dependencies introduced with this change?

N/A

### Any new generic utility introduced or modified. Please explain the changes.

N/A

### Any technical or performance related pointers to consider with the change?

N/A

@coderabbitai review

<hr>

### Developer checklist

- [ ] My code follows the style guidelines of this project

- [ ] **No breaking changes are being introduced.**

- [ ] All related docs linked with the PR?

- [ ] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [ ] Is the PR limited to 10 file changes?

- [ ] Is the PR limited to one linear task?

- [ ] Are relevant unit and component test-cases added in **new readability format**?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.
