### PR TITLE
chore: remove logger for cdk service

### DIFF
--- a/src/cdk/v2/utils.ts
+++ b/src/cdk/v2/utils.ts
@@ -86,8 +86,6 @@ export function getErrorInfo(err: CatchErr, isProd: boolean, defTags) {
   const message = isProd ? getWorkflowEngineErrorMessage(err) : err.message;
 
   if (err instanceof WorkflowExecutionError) {
-    logger.error(`Error occurred during workflow step execution: ${message}`, err);
-
     // Determine the error instance
     let errInstance: CatchErr = err;
     if (err.originalError) {

--- a/src/cdk/v2/utils.ts
+++ b/src/cdk/v2/utils.ts
@@ -86,6 +86,7 @@ export function getErrorInfo(err: CatchErr, isProd: boolean, defTags) {
   const message = isProd ? getWorkflowEngineErrorMessage(err) : err.message;
 
   if (err instanceof WorkflowExecutionError) {
+    logger.debug(`Error occurred during workflow step execution: ${message}`, err);
     // Determine the error instance
     let errInstance: CatchErr = err;
     if (err.originalError) {


### PR DESCRIPTION
## What are the changes introduced in this PR?

This pull request includes a small change to the `getErrorInfo` function in `src/cdk/v2/utils.ts`. The change removes a logging statement that previously logged workflow step execution errors.