### PR TITLE
fix: response parsing for adobe analytics

### DIFF
--- a/src/v0/destinations/adobe_analytics/networkHandler.js
+++ b/src/v0/destinations/adobe_analytics/networkHandler.js
@@ -21,6 +21,15 @@ const responseHandler = (responseParams) => {
   const message = `[${DESTINATION}] - Request Processed Successfully`;
   const { response, status } = destinationResponse;
 
+  // Check if the response is string
+  if (typeof response !== 'string') {
+    return {
+      status,
+      message: `[${DESTINATION}] - Response is not a string response: ${JSON.stringify(response)}`,
+      destinationResponse,
+    };
+  }
+
   // Extract values between different tags
   const responseStatus = extractContent(response, 'status');
   const reason = extractContent(response, 'reason');


### PR DESCRIPTION
## What are the changes introduced in this PR?

This pull request includes an update to the `responseHandler` function in `src/v0/destinations/adobe_analytics/networkHandler.js` to improve error handling for non-string responses.

### Error handling improvements:
* Added a check to verify if the `response` is a string. If not, it returns an error message along with the original `destinationResponse` object, ensuring better handling of unexpected response types.

## What is the related Linear task?

Resolves INT-3941
