### PR TITLE
fix: handle throttled_devices in AM network handler response

### DIFF
--- a/src/v0/destinations/am/networkHandler.js
+++ b/src/v0/destinations/am/networkHandler.js
@@ -30,7 +30,8 @@ class NetworkHandler {
         throttled_devices: throttledDevices,
       } = response;
 
-      const hasThrottledItems = (obj) => obj && Object.keys(obj).length > 0;
+      const hasThrottledItems = (obj) =>
+        typeof obj === 'object' && obj !== null && Object.keys(obj).length > 0;
 
       if (hasThrottledItems(throttledUsers) || hasThrottledItems(throttledDevices)) {
         logger.error('Too many requests for some devices or users.');

--- a/src/v0/destinations/am/networkHandler.js
+++ b/src/v0/destinations/am/networkHandler.js
@@ -24,9 +24,16 @@ class NetworkHandler {
       };
     }
     if (isHttpStatusThrottled(status)) {
-      const { error, throttled_users: throttledUsers } = response;
-      if (Object.keys(throttledUsers).length > 0) {
-        logger.error('Too many requests for some devices and users.');
+      const {
+        error,
+        throttled_users: throttledUsers,
+        throttled_devices: throttledDevices,
+      } = response;
+
+      const hasThrottledItems = (obj) => obj && Object.keys(obj).length > 0;
+
+      if (hasThrottledItems(throttledUsers) || hasThrottledItems(throttledDevices)) {
+        logger.error('Too many requests for some devices or users.');
         throw new RetryableError(
           `Request Failed during ${DESTINATION} response transformation: ${error} - due to Request Limit exceeded, (Retryable)`,
           500,

--- a/test/integrations/destinations/am/dataDelivery/data.ts
+++ b/test/integrations/destinations/am/dataDelivery/data.ts
@@ -551,7 +551,239 @@ export const data = [
   },
   {
     name: 'am',
-    description: 'Test 6: for 429 Rate Limit Handling',
+    description: 'Test 6: for 429 Rate Limit Handling (ThrottledUsers)',
+    feature: 'dataDelivery',
+    module: 'destination',
+    version: 'v0',
+    input: {
+      request: {
+        body: {
+          type: 'REST',
+          endpoint: 'https://api.amplitude.com/2/httpapi/rate-limited',
+          method: 'POST',
+          userId: 'test_user_123',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: {
+            FORM: {},
+            JSON: {
+              api_key: 'dummy-api-key',
+              events: [
+                {
+                  app_name: 'Rudder-Amplitude_Example',
+                  app_version: '1.0',
+                  time: 1619006730330,
+                  user_id: 'testrluser@email.com',
+                  user_properties: {
+                    city: 'San Francisco',
+                    country: 'US',
+                    email: 'testrluser@email.com',
+                  },
+                },
+              ],
+              options: {
+                min_id_length: 1,
+              },
+            },
+            JSON_ARRAY: {},
+            XML: {},
+          },
+          files: {},
+          params: {
+            destination: 'am',
+          },
+        },
+        method: 'POST',
+      },
+    },
+    output: {
+      response: {
+        status: 500, // Expected status is 500 (RetryableError)
+        body: {
+          output: {
+            status: 500,
+            message:
+              'Request Failed during amplitude response transformation: Too many requests for some devices and users - due to Request Limit exceeded, (Retryable)',
+            destinationResponse: {
+              headers: {
+                'access-control-allow-methods': 'GET, POST',
+                'access-control-allow-origin': '*',
+                'content-type': 'application/json',
+                'retry-after': '120',
+              },
+              response: {
+                code: 429,
+                error: 'Too many requests for some devices and users',
+                eps_threshold: 30,
+                throttled_users: {
+                  'testrluser@email.com': 32,
+                },
+                throttled_events: [3, 4, 7],
+              },
+              status: 429,
+            },
+            statTags: {
+              destType: 'AM',
+              errorCategory: 'network',
+              destinationId: 'Non-determininable',
+              workspaceId: 'Non-determininable',
+              errorType: 'retryable',
+              feature: 'dataDelivery',
+              implementation: 'native',
+              module: 'destination',
+            },
+          },
+        },
+      },
+    },
+    mockFns: (mockAdapter: MockAdapter) => {
+      mockAdapter
+        .onPost('https://api.amplitude.com/2/httpapi/rate-limited', {
+          asymmetricMatch: (actual) => {
+            // Simple check to match the request body
+            return actual.api_key === 'dummy-api-key';
+          },
+        })
+        .replyOnce(
+          429,
+          {
+            code: 429,
+            error: 'Too many requests for some devices and users',
+            eps_threshold: 30,
+            throttled_users: {
+              'testrluser@email.com': 32,
+            },
+            throttled_events: [3, 4, 7],
+          },
+          {
+            'access-control-allow-methods': 'GET, POST',
+            'access-control-allow-origin': '*',
+            'content-type': 'application/json',
+            'retry-after': '120',
+          },
+        );
+    },
+  },
+  {
+    name: 'am',
+    description: 'Test 7: for 429 Rate Limit Handling (ThrottledDevices)',
+    feature: 'dataDelivery',
+    module: 'destination',
+    version: 'v0',
+    input: {
+      request: {
+        body: {
+          type: 'REST',
+          endpoint: 'https://api.amplitude.com/2/httpapi/rate-limited',
+          method: 'POST',
+          userId: 'test_user_123',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: {
+            FORM: {},
+            JSON: {
+              api_key: 'dummy-api-key',
+              events: [
+                {
+                  app_name: 'Rudder-Amplitude_Example',
+                  app_version: '1.0',
+                  time: 1619006730330,
+                  user_id: 'testrluser@email.com',
+                  user_properties: {
+                    city: 'San Francisco',
+                    country: 'US',
+                    email: 'testrluser@email.com',
+                  },
+                },
+              ],
+              options: {
+                min_id_length: 1,
+              },
+            },
+            JSON_ARRAY: {},
+            XML: {},
+          },
+          files: {},
+          params: {
+            destination: 'am',
+          },
+        },
+        method: 'POST',
+      },
+    },
+    output: {
+      response: {
+        status: 500, // Expected status is 500 (RetryableError)
+        body: {
+          output: {
+            status: 500,
+            message:
+              'Request Failed during amplitude response transformation: Too many requests for some devices and users - due to Request Limit exceeded, (Retryable)',
+            destinationResponse: {
+              headers: {
+                'access-control-allow-methods': 'GET, POST',
+                'access-control-allow-origin': '*',
+                'content-type': 'application/json',
+                'retry-after': '120',
+              },
+              response: {
+                code: 429,
+                error: 'Too many requests for some devices and users',
+                eps_threshold: 30,
+                throttled_devices: {
+                  'HIJ3L821-F01A-2GY5-2C81-7F03X7DS291D': 31,
+                },
+                throttled_events: [3, 4, 7],
+              },
+              status: 429,
+            },
+            statTags: {
+              destType: 'AM',
+              errorCategory: 'network',
+              destinationId: 'Non-determininable',
+              workspaceId: 'Non-determininable',
+              errorType: 'retryable',
+              feature: 'dataDelivery',
+              implementation: 'native',
+              module: 'destination',
+            },
+          },
+        },
+      },
+    },
+    mockFns: (mockAdapter: MockAdapter) => {
+      mockAdapter
+        .onPost('https://api.amplitude.com/2/httpapi/rate-limited', {
+          asymmetricMatch: (actual) => {
+            // Simple check to match the request body
+            return actual.api_key === 'dummy-api-key';
+          },
+        })
+        .replyOnce(
+          429,
+          {
+            code: 429,
+            error: 'Too many requests for some devices and users',
+            eps_threshold: 30,
+            throttled_devices: {
+              'HIJ3L821-F01A-2GY5-2C81-7F03X7DS291D': 31,
+            },
+            throttled_events: [3, 4, 7],
+          },
+          {
+            'access-control-allow-methods': 'GET, POST',
+            'access-control-allow-origin': '*',
+            'content-type': 'application/json',
+            'retry-after': '120',
+          },
+        );
+    },
+  },
+  {
+    name: 'am',
+    description: 'Test 8: for 429 Rate Limit Handling (ThrottledUsers and ThrottledDevices)',
     feature: 'dataDelivery',
     module: 'destination',
     version: 'v0',
@@ -673,7 +905,7 @@ export const data = [
   },
   {
     name: 'am',
-    description: 'Test 7: for standard 429 Rate Limit Handling (ThrottledError)',
+    description: 'Test 9: for standard 429 Rate Limit Handling (ThrottledError)',
     feature: 'dataDelivery',
     module: 'destination',
     version: 'v0',


### PR DESCRIPTION
## What are the changes introduced in this PR?

Enhanced the AM network handler to properly handle both  and  in the response when a 429 status is received. Previously, the code only checked for , but now it also checks for  and throws appropriate retryable errors when either is present.

## What is the related Linear task?
Resolves https://linear.app/rudderstack/issue/INT-3215/amplitude-post-proxy-migration-analysis

## Please explain the objectives of your changes below

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

**Reason**: The AM destination API can return both  and  in the response when rate limits are exceeded. The previous implementation only handled , which could lead to missed throttling scenarios.

**Changes**:
- Added support for  in the response handler
- Created a helper function  to check if either object has throttled items
- Updated the condition to check both  and 
- Updated test data to remove  entries to match the new logic

### Any new dependencies introduced with this change?

N/A

### Any new generic utility introduced or modified. Please explain the changes.

N/A

### Any technical or performance related pointers to consider with the change?

N/A

@coderabbitai review

<hr>

### Developer checklist

- [x] My code follows the style guidelines of this project
- [x] **No breaking changes are being introduced.**
- [x] All related docs linked with the PR?
- [x] All changes manually tested?
- [x] Any documentation changes needed with this change?
- [x] Is the PR limited to 10 file changes?
- [x] Is the PR limited to one linear task?
- [x] Are relevant unit and component test-cases added in **new readability format**?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?
- [ ] Verified that there are no credentials or confidential data exposed with the changes.