### PR TITLE
fix: resolve Prometheus metric label mismatches

### DIFF
--- a/src/services/destination/cdkV2Integration.ts
+++ b/src/services/destination/cdkV2Integration.ts
@@ -98,7 +98,16 @@ export class CDKV2DestinationService implements DestinationService {
               metaTo,
             );
 
-          stats.increment('event_transform_failure', metaTo.errorDetails);
+          stats.increment('event_transform_failure', {
+            destType: metaTo.errorDetails.destType,
+            module: metaTo.errorDetails.module,
+            destinationId: metaTo.errorDetails.destinationId,
+            workspaceId: metaTo.errorDetails.workspaceId,
+            feature: metaTo.errorDetails.feature,
+            implementation: metaTo.errorDetails.implementation,
+            errorCategory: metaTo.errorDetails.errorCategory,
+            errorType: metaTo.errorDetails.errorType,
+          });
 
           return [erroredResp];
         }

--- a/src/services/destination/postTransformation.ts
+++ b/src/services/destination/postTransformation.ts
@@ -108,7 +108,16 @@ export class DestinationPostTransformationService {
           ...resp.statTags,
           ...metaTo.errorDetails,
         };
-        stats.increment('event_transform_failure', metaTo.errorDetails);
+        stats.increment('event_transform_failure', {
+          destType: metaTo.errorDetails.destType,
+          module: metaTo.errorDetails.module,
+          destinationId: metaTo.errorDetails.destinationId,
+          workspaceId: metaTo.errorDetails.workspaceId,
+          feature: metaTo.errorDetails.feature,
+          implementation: metaTo.errorDetails.implementation,
+          errorCategory: metaTo.errorDetails.errorCategory,
+          errorType: metaTo.errorDetails.errorType,
+        });
       } else {
         stats.increment('event_transform_success', {
           destType: destinationType,
@@ -137,7 +146,17 @@ export class DestinationPostTransformationService {
       statTags: errObj.statTags,
     } as RouterTransformationResponse;
     ErrorReportingService.reportError(error, metaTo.errorContext, resp);
-    stats.increment('event_transform_failure', metaTo.errorDetails);
+
+    stats.increment('event_transform_failure', {
+      destType: metaTo.errorDetails.destType,
+      module: metaTo.errorDetails.module,
+      destinationId: metaTo.errorDetails.destinationId,
+      workspaceId: metaTo.errorDetails.workspaceId,
+      feature: metaTo.errorDetails.feature,
+      implementation: metaTo.errorDetails.implementation,
+      errorCategory: metaTo.errorDetails.errorCategory,
+      errorType: metaTo.errorDetails.errorType,
+    });
     return resp;
   }
 
@@ -216,7 +235,16 @@ export class DestinationPostTransformationService {
     metaTo: MetaTransferObject,
   ): UserDeletionResponse {
     const errObj = generateErrorObject(error, metaTo.errorDetails, false);
-    stats.increment('regulation_worker_user_deletion_failure', metaTo.errorDetails);
+
+    stats.increment('regulation_worker_user_deletion_failure', {
+      destType: metaTo.errorDetails.destType,
+      module: metaTo.errorDetails.module,
+      implementation: metaTo.errorDetails.implementation,
+      feature: metaTo.errorDetails.feature,
+      destinationId: metaTo.errorDetails.destinationId,
+      errorCategory: metaTo.errorDetails.errorCategory,
+      errorType: metaTo.errorDetails.errorType,
+    });
     const resp = {
       statusCode: errObj.status,
       error: errObj.message,

--- a/src/util/prometheus.js
+++ b/src/util/prometheus.js
@@ -262,6 +262,8 @@ class Prometheus {
           'workspaceId',
           'feature',
           'implementation',
+          'errorCategory',
+          'errorType',
         ],
       },
       {
@@ -389,7 +391,15 @@ class Prometheus {
         name: 'regulation_worker_user_deletion_failure',
         help: 'regulation_worker_user_deletion_failure',
         type: 'counter',
-        labelNames: ['destType', 'module', 'implementation', 'feature'],
+        labelNames: [
+          'destType',
+          'module',
+          'implementation',
+          'feature',
+          'destinationId',
+          'errorCategory',
+          'errorType',
+        ],
       },
       {
         name: 'shopify_server_side_identifier_event',


### PR DESCRIPTION
## What are the changes introduced in this PR?

### **Problem**
- Code was passing entire `metaTo.errorDetails` objects instead of filtering to only allowed labels
- Missing labels: `destinationId`, `errorCategory`, `errorType` in metric definitions

### **Solution**
1. **Updated metric definitions** in `src/util/prometheus.js`:
   - Added missing labels to `regulation_worker_user_deletion_failure`
   - Added missing labels to `event_transform_failure`

2. **Fixed tag filtering** in metric usage:
   - Replaced passing entire `metaTo.errorDetails` with filtered inline objects
   - Only include labels that match metric definitions
   - Applied consistent pattern across all usage locations

## What is the related Linear task?

Resolves INT-XXX

## Please explain the objectives of your changes below

Put down any required details on the broader aspect of your changes. If there are any dependent changes, **mandatorily** mention them here

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

N/A

### Any new dependencies introduced with this change?

N/A

### Any new generic utility introduced or modified. Please explain the changes.

N/A

### Any technical or performance related pointers to consider with the change?

N/A

@coderabbitai review

<hr>

### Developer checklist

- [ ] My code follows the style guidelines of this project

- [ ] **No breaking changes are being introduced.**

- [ ] All related docs linked with the PR?

- [ ] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [ ] Is the PR limited to 10 file changes?

- [ ] Is the PR limited to one linear task?

- [ ] Are relevant unit and component test-cases added in **new readability format**?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.
