### PR TITLE
fix: resolve Prometheus metric label mismatches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [1.105.0](https://github.com/rudderlabs/rudder-transformer/compare/v1.104.8...v1.105.0) (2025-07-22)
+
+
+### Features
+
+* add new identify flow and subscription event in track call for attentive tag ([#4468](https://github.com/rudderlabs/rudder-transformer/issues/4468)) ([004401a](https://github.com/rudderlabs/rudder-transformer/commit/004401aac81dbbe8884585d23c7eb315d4238e86))
+* update test cases for customer io audience ([#4428](https://github.com/rudderlabs/rudder-transformer/issues/4428)) ([01aa484](https://github.com/rudderlabs/rudder-transformer/commit/01aa484758600eb2b59cee6693355d9d2fa9a6f9))
+
+
+### Bug Fixes
+
+* add cloning of operator repo in workflow ([#4475](https://github.com/rudderlabs/rudder-transformer/issues/4475)) ([b5f239c](https://github.com/rudderlabs/rudder-transformer/commit/b5f239cadad7038e352492ad74b255837f3b6db1))
+* add object type check ([b1f3584](https://github.com/rudderlabs/rudder-transformer/commit/b1f35840fa6e2f0fc050066901c8ad37bee98af5))
+* **attentive_tag:** correct identity resolution logic and add test cases ([#4513](https://github.com/rudderlabs/rudder-transformer/issues/4513)) ([b105b72](https://github.com/rudderlabs/rudder-transformer/commit/b105b72936e16d5d0c9d58f40d6330b75f88f4f9))
+* google sheets metadata maintenance ([#4463](https://github.com/rudderlabs/rudder-transformer/issues/4463)) ([b23d9a8](https://github.com/rudderlabs/rudder-transformer/commit/b23d9a8f601a8695c3d5646dc39f43852116f7d3))
+* handle throttled_devices in AM network handler response ([b90b0f5](https://github.com/rudderlabs/rudder-transformer/commit/b90b0f544e6ba3fa1ee262c712e03bacea19c93b))
+* handle throttled_devices in AM network handler response ([#4508](https://github.com/rudderlabs/rudder-transformer/issues/4508)) ([ded932f](https://github.com/rudderlabs/rudder-transformer/commit/ded932f0dd449c0614f5a4e64c65e650e37c898e))
+* stream dest test type fix ([8de1054](https://github.com/rudderlabs/rudder-transformer/commit/8de10544d8543a3374e46f970bb4ce81a3d6fcbb))
+
 ### [1.104.8](https://github.com/rudderlabs/rudder-transformer/compare/v1.104.7...v1.104.8) (2025-07-22)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rudder-transformer",
-  "version": "1.104.8",
+  "version": "1.105.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rudder-transformer",
-      "version": "1.104.8",
+      "version": "1.105.0",
       "license": "ISC",
       "dependencies": {
         "@amplitude/ua-parser-js": "0.7.24",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rudder-transformer",
-  "version": "1.104.8",
+  "version": "1.105.0",
   "description": "",
   "homepage": "https://github.com/rudderlabs/rudder-transformer#readme",
   "bugs": {

--- a/src/services/destination/cdkV2Integration.ts
+++ b/src/services/destination/cdkV2Integration.ts
@@ -98,7 +98,16 @@ export class CDKV2DestinationService implements DestinationService {
               metaTo,
             );
 
-          stats.increment('event_transform_failure', metaTo.errorDetails);
+          stats.increment('event_transform_failure', {
+            destType: metaTo.errorDetails.destType,
+            module: metaTo.errorDetails.module,
+            destinationId: metaTo.errorDetails.destinationId,
+            workspaceId: metaTo.errorDetails.workspaceId,
+            feature: metaTo.errorDetails.feature,
+            implementation: metaTo.errorDetails.implementation,
+            errorCategory: metaTo.errorDetails.errorCategory,
+            errorType: metaTo.errorDetails.errorType,
+          });
 
           return [erroredResp];
         }

--- a/src/services/destination/postTransformation.ts
+++ b/src/services/destination/postTransformation.ts
@@ -108,7 +108,16 @@ export class DestinationPostTransformationService {
           ...resp.statTags,
           ...metaTo.errorDetails,
         };
-        stats.increment('event_transform_failure', metaTo.errorDetails);
+        stats.increment('event_transform_failure', {
+          destType: metaTo.errorDetails.destType,
+          module: metaTo.errorDetails.module,
+          destinationId: metaTo.errorDetails.destinationId,
+          workspaceId: metaTo.errorDetails.workspaceId,
+          feature: metaTo.errorDetails.feature,
+          implementation: metaTo.errorDetails.implementation,
+          errorCategory: metaTo.errorDetails.errorCategory,
+          errorType: metaTo.errorDetails.errorType,
+        });
       } else {
         stats.increment('event_transform_success', {
           destType: destinationType,
@@ -137,7 +146,17 @@ export class DestinationPostTransformationService {
       statTags: errObj.statTags,
     } as RouterTransformationResponse;
     ErrorReportingService.reportError(error, metaTo.errorContext, resp);
-    stats.increment('event_transform_failure', metaTo.errorDetails);
+
+    stats.increment('event_transform_failure', {
+      destType: metaTo.errorDetails.destType,
+      module: metaTo.errorDetails.module,
+      destinationId: metaTo.errorDetails.destinationId,
+      workspaceId: metaTo.errorDetails.workspaceId,
+      feature: metaTo.errorDetails.feature,
+      implementation: metaTo.errorDetails.implementation,
+      errorCategory: metaTo.errorDetails.errorCategory,
+      errorType: metaTo.errorDetails.errorType,
+    });
     return resp;
   }
 
@@ -216,7 +235,16 @@ export class DestinationPostTransformationService {
     metaTo: MetaTransferObject,
   ): UserDeletionResponse {
     const errObj = generateErrorObject(error, metaTo.errorDetails, false);
-    stats.increment('regulation_worker_user_deletion_failure', metaTo.errorDetails);
+
+    stats.increment('regulation_worker_user_deletion_failure', {
+      destType: metaTo.errorDetails.destType,
+      module: metaTo.errorDetails.module,
+      implementation: metaTo.errorDetails.implementation,
+      feature: metaTo.errorDetails.feature,
+      destinationId: metaTo.errorDetails.destinationId,
+      errorCategory: metaTo.errorDetails.errorCategory,
+      errorType: metaTo.errorDetails.errorType,
+    });
     const resp = {
       statusCode: errObj.status,
       error: errObj.message,

--- a/src/util/prometheus.js
+++ b/src/util/prometheus.js
@@ -262,6 +262,8 @@ class Prometheus {
           'workspaceId',
           'feature',
           'implementation',
+          'errorCategory',
+          'errorType',
         ],
       },
       {
@@ -389,7 +391,15 @@ class Prometheus {
         name: 'regulation_worker_user_deletion_failure',
         help: 'regulation_worker_user_deletion_failure',
         type: 'counter',
-        labelNames: ['destType', 'module', 'implementation', 'feature'],
+        labelNames: [
+          'destType',
+          'module',
+          'implementation',
+          'feature',
+          'destinationId',
+          'errorCategory',
+          'errorType',
+        ],
       },
       {
         name: 'shopify_server_side_identifier_event',


### PR DESCRIPTION
## What are the changes introduced in this PR?

### **Problem**
- Code was passing entire `metaTo.errorDetails` objects instead of filtering to only allowed labels
- Missing labels: `destinationId`, `errorCategory`, `errorType` in metric definitions

### **Solution**
1. **Updated metric definitions** in `src/util/prometheus.js`:
   - Added missing labels to `regulation_worker_user_deletion_failure`
   - Added missing labels to `event_transform_failure`

2. **Fixed tag filtering** in metric usage:
   - Replaced passing entire `metaTo.errorDetails` with filtered inline objects
   - Only include labels that match metric definitions
   - Applied consistent pattern across all usage locations

## What is the related Linear task?

Resolves INT-3940

## Please explain the objectives of your changes below

Put down any required details on the broader aspect of your changes. If there are any dependent changes, **mandatorily** mention them here

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

N/A

### Any new dependencies introduced with this change?

N/A

### Any new generic utility introduced or modified. Please explain the changes.

N/A

### Any technical or performance related pointers to consider with the change?

N/A

@coderabbitai review

<hr>

### Developer checklist

- [ ] My code follows the style guidelines of this project

- [ ] **No breaking changes are being introduced.**

- [ ] All related docs linked with the PR?

- [ ] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [ ] Is the PR limited to 10 file changes?

- [ ] Is the PR limited to one linear task?

- [ ] Are relevant unit and component test-cases added in **new readability format**?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.
