### PR TITLE
refactor: remove unused marketo bulk upload metrics

### DIFF
--- a/src/util/prometheus.js
+++ b/src/util/prometheus.js
@@ -296,12 +296,7 @@ class Prometheus {
         type: 'counter',
         labelNames: ['destination', 'success'],
       },
-      {
-        name: 'marketo_bulk_upload_upload_file_jobs',
-        help: 'marketo_bulk_upload_upload_file_jobs',
-        type: 'counter',
-        labelNames: ['success'],
-      },
+
       {
         name: 'proxy_test_error',
         help: 'proxy_test_error',
@@ -344,24 +339,7 @@ class Prometheus {
         type: 'counter',
         labelNames: ['source', 'version'],
       },
-      {
-        name: 'marketo_bulk_upload_get_job_status',
-        help: 'marketo_bulk_upload_get_job_status',
-        type: 'counter',
-        labelNames: ['status', 'state'],
-      },
-      {
-        name: 'marketo_bulk_upload_upload_file',
-        help: 'marketo_bulk_upload_upload_file',
-        type: 'counter',
-        labelNames: ['status', 'state'],
-      },
-      {
-        name: 'marketo_bulk_upload_polling',
-        help: 'marketo_bulk_upload_polling',
-        type: 'counter',
-        labelNames: ['status', 'state', 'requestTime'],
-      },
+
       {
         name: 'marketo_fetch_token',
         help: 'marketo_fetch_token',
@@ -651,18 +629,7 @@ class Prometheus {
         type: 'histogram',
         labelNames: ['destination', 'version'],
       },
-      {
-        name: 'marketo_bulk_upload_process_time',
-        help: 'marketo_bulk_upload_process_time',
-        type: 'histogram',
-        labelNames: ['action'],
-      },
-      {
-        name: 'marketo_bulk_upload_upload_file_size',
-        help: 'marketo_bulk_upload_upload_file_size',
-        type: 'histogram',
-        labelNames: [],
-      },
+
       {
         name: 'braze_partial_failure',
         help: 'braze_partial_failure',
@@ -693,18 +660,7 @@ class Prometheus {
         type: 'counter',
         labelNames: ['http_status', 'destination_id'],
       },
-      {
-        name: 'marketo_bulk_upload_upload_file_succJobs',
-        help: 'marketo_bulk_upload_upload_file_succJobs',
-        type: 'counter',
-        labelNames: [],
-      },
-      {
-        name: 'marketo_bulk_upload_upload_file_unsuccJobs',
-        help: 'marketo_bulk_upload_upload_file_unsuccJobs',
-        type: 'counter',
-        labelNames: [],
-      },
+
       {
         name: 'braze_lookup_time',
         help: 'braze look-up time',
@@ -776,42 +732,7 @@ class Prometheus {
         labelNames: ['destination', 'version', 'sourceType', 'destinationType', 'k8_namespace'],
         buckets: [10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 150, 200],
       },
-      {
-        name: 'marketo_bulk_upload_create_header_time',
-        help: 'marketo_bulk_upload_create_header_time',
-        type: 'histogram',
-        labelNames: [],
-      },
-      {
-        name: 'marketo_bulk_upload_fetch_job_time',
-        help: 'marketo_bulk_upload_fetch_job_time',
-        type: 'histogram',
-        labelNames: [],
-      },
-      {
-        name: 'marketo_bulk_upload_fetch_job_create_response_time',
-        help: 'marketo_bulk_upload_fetch_job_create_response_time',
-        type: 'histogram',
-        labelNames: [],
-      },
-      {
-        name: 'marketo_bulk_upload_create_file_time',
-        help: 'marketo_bulk_upload_create_file_time',
-        type: 'histogram',
-        labelNames: [],
-      },
-      {
-        name: 'marketo_bulk_upload_upload_file_time',
-        help: 'marketo_bulk_upload_upload_file_time',
-        type: 'histogram',
-        labelNames: [],
-      },
-      {
-        name: 'marketo_bulk_upload_create_csvloop_time',
-        help: 'marketo_bulk_upload_create_csvloop_time',
-        type: 'histogram',
-        labelNames: [],
-      },
+
       // tracking plan metrics:
       // counter
       {


### PR DESCRIPTION
## What are the changes introduced in this PR?

Remove 13 unused Marketo bulk upload metrics that were defined but not collected in the transformer service.

## What is the related Linear task?

Resolves INT-3978

## Please explain the objectives of your changes below

### Background
During metrics analysis, it was discovered that several Marketo bulk upload metrics were defined in the Prometheus configuration but never actually collected or used in the codebase. These metrics were likely created for one-time implementation purposes but are no longer needed.

### Changes Made
- Removed 13 unused Marketo bulk upload metrics from :
  - 
  - 
  - 
  - 
  - 
  - 
  - 
  - 
  - 
  - 
  - 
  - 
  - 
  - 

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes?

**No breaking changes.** These metrics were never collected, so removing their definitions has no impact on functionality. Only the actively used Marketo metrics remain:
- 
- 
- 

### Any new dependencies introduced with this change?

N/A

### Any new generic utility introduced or modified. Please explain the changes.

N/A

### Any technical or performance related pointers to consider with the change?

**Performance Improvement:** Reduces Prometheus metric cardinality by removing 13 unused metric definitions, which improves Prometheus performance and reduces memory usage.

### Developer checklist

- [x] My code follows the style guidelines of this project
- [x] **No breaking changes are being introduced.**
- [x] All related docs linked with the PR?
- [x] All changes manually tested?
- [x] Any documentation changes needed with this change?
- [x] Is the PR limited to 10 file changes?
- [x] Is the PR limited to one linear task?
- [x] Are relevant unit and component test-cases added in **new readability format**?

@coderabbitai review