### PR TITLE
chore: add slack notification for UT deployment PRs

### DIFF
--- a/.github/workflows/prepare-for-prod-ut-deploy.yml
+++ b/.github/workflows/prepare-for-prod-ut-deploy.yml
@@ -135,7 +135,8 @@ jobs:
           git commit -m "chore: upgrade shared user-transformers to $UT_TAG_NAME"
           git push -u origin shared-user-transformer-$UT_TAG_NAME
 
-          gh pr create --fill
+          PR_URL=$(gh pr create --fill --json url --jq '.url')
+          echo "SHARED_PR_URL=$PR_URL" >> $GITHUB_ENV
 
       - name: Update Helm Chart and Raise Pull Request For Hosted Transformer
         env:
@@ -152,7 +153,8 @@ jobs:
           git commit -m "chore: upgrade hosted user-transformer to $UT_TAG_NAME"
           git push -u origin hosted-user-transformer-$UT_TAG_NAME
 
-          gh pr create --fill
+          PR_URL=$(gh pr create --fill --json url --jq '.url')
+          echo "HOSTED_PR_URL=$PR_URL" >> $GITHUB_ENV
 
       - name: Update helm charts and raise pull request for enterprise customers on dedicated transformers
         env:
@@ -188,4 +190,34 @@ jobs:
           git commit -m "chore: upgrade dedicated user transformers to $TAG_NAME"
           git push -u origin dedicated-user-transformer-$TAG_NAME
 
-          gh pr create --fill
+          PR_URL=$(gh pr create --fill --json url --jq '.url')
+          echo "DEDICATED_PR_URL=$PR_URL" >> $GITHUB_ENV
+
+      - name: Notify Control Plane Team
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a  # v2.1.1
+        continue-on-error: true
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        with:
+          method: chat.postMessage
+          payload: |
+            {
+              "channel": "${{ secrets.SLACK_CONTROL_PLANE_CHANNEL_ID }}",
+              "text": "*UT Deployment PRs Created*\nCC: @control-plane-on-call",
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text", 
+                    "text": "🚀 User Transformer Deployment - DevOps PRs Ready"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Version: `${{ needs.generate-tag-names.outputs.tag_name_ut }}`\n\nPRs created for review:\n• <${{ env.SHARED_PR_URL }}|Shared User Transformer>\n• <${{ env.HOSTED_PR_URL }}|Hosted User Transformer>\n• <${{ env.DEDICATED_PR_URL }}|Dedicated User Transformer>\n\nPlease review and merge the DevOps PRs."
+                  }
+                }
+              ]
+            }

--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -166,7 +166,7 @@ jobs:
 
       - name: Notify Slack Channel
         id: slack
-        uses: slackapi/slack-github-action@v2.1.1
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a  # v2.1.1
         continue-on-error: true
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v4.2.1
 
       - name: notify
-        uses: slackapi/slack-github-action@v2.1.1
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a  # v2.1.1
         continue-on-error: true
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}


### PR DESCRIPTION
## What are the changes introduced in this PR?

Added Slack notification functionality to the UT deployment workflow to notify the Control Plane team when DevOps PRs are created.

## What is the related Linear task?

Resolves INT-3976

## Please explain the objectives of your changes below

This PR implements Slack notifications for UT deployment as requested in the Linear issue. The changes include:

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

- **Modified UT deployment workflow**: Added PR URL capture for all three types of DevOps PRs (shared, hosted, dedicated transformers)
- **Added Slack notification step**: New step that sends a notification with PR links to the Control Plane team
- **Updated Slack action security**: Updated all Slack actions to use specific commit hash for security

### Any new dependencies introduced with this change?

N/A - Uses existing Slack action with security update

### Any new generic utility introduced or modified. Please explain the changes.

N/A

### Any technical or performance related pointers to consider with the change?

- Uses  to prevent notification failures from blocking deployment
- Captures PR URLs using  for direct linking
- Requires  secret to be configured

### Developer checklist

- [x] My code follows the style guidelines of this project
- [x] **No breaking changes are being introduced.**
- [x] All related docs linked with the PR?
- [x] All changes manually tested?
- [x] Any documentation changes needed with this change?
- [x] Is the PR limited to 10 file changes?
- [x] Is the PR limited to one linear task?
- [x] Are relevant unit and component test-cases added in **new readability format**?