### PR TITLE
fix: transformBatch reporting metrics issue

### DIFF
--- a/src/services/userTransform.ts
+++ b/src/services/userTransform.ts
@@ -1,6 +1,7 @@
 import groupBy from 'lodash/groupBy';
 import isEmpty from 'lodash/isEmpty';
 import { isNil } from 'lodash';
+import { v4 as uuidv4 } from 'uuid';
 import { userTransformHandler } from '../routerUtils';
 import {
   UserTransformationLibrary,
@@ -73,6 +74,13 @@ export class UserTransformService {
           messageIds,
         };
 
+        const generateNewMetadata = (response: UserTransformationResponse) => ({
+          ...eventsToProcess[0]?.metadata,
+          messageId: uuidv4(),
+          eventName: response.transformedEvent.event,
+          eventType: response.transformedEvent.type,
+        });
+
         const metaTags =
           eventsToProcess.length > 0 && eventsToProcess[0].metadata
             ? getMetadata(eventsToProcess[0].metadata)
@@ -109,6 +117,8 @@ export class UserTransformService {
               messageIdsInOutputSet.add(ev.metadata.messageId);
             } else if (ev.metadata?.messageIds) {
               ev.metadata.messageIds.forEach((id) => messageIdsInOutputSet.add(id));
+            } else if (ev.error) {
+              commonMetadata.messageIds.forEach((id) => messageIdsInOutputSet.add(id));
             }
             if (ev.error) {
               transformedEventsWithMetadata.push({
@@ -130,7 +140,10 @@ export class UserTransformService {
             }
             transformedEventsWithMetadata.push({
               output: ev.transformedEvent,
-              metadata: isEmpty(ev.metadata) ? commonMetadata : ev.metadata,
+              metadata:
+                isEmpty(ev.metadata) || !ev.metadata.messageId
+                  ? generateNewMetadata(ev)
+                  : ev.metadata,
               statusCode: 200,
             } as ProcessorTransformationResponse);
           });

--- a/src/services/userTransform.ts
+++ b/src/services/userTransform.ts
@@ -109,9 +109,6 @@ export class UserTransformService {
               messageIdsInOutputSet.add(ev.metadata.messageId);
             } else if (ev.metadata?.messageIds) {
               ev.metadata.messageIds.forEach((id) => messageIdsInOutputSet.add(id));
-            } else if (ev.error && isEmpty(ev.metadata)) {
-              // incase of error, add messageIds to output set so that they are not marked as dropped
-              commonMetadata.messageIds.forEach((id) => messageIdsInOutputSet.add(id));
             }
             if (ev.error) {
               transformedEventsWithMetadata.push({

--- a/src/services/userTransform.ts
+++ b/src/services/userTransform.ts
@@ -109,7 +109,8 @@ export class UserTransformService {
               messageIdsInOutputSet.add(ev.metadata.messageId);
             } else if (ev.metadata?.messageIds) {
               ev.metadata.messageIds.forEach((id) => messageIdsInOutputSet.add(id));
-            } else if (isEmpty(ev.metadata)) {
+            } else if (ev.error && isEmpty(ev.metadata)) {
+              // incase of error, add messageIds to output set so that are not marked as dropped
               commonMetadata.messageIds.forEach((id) => messageIdsInOutputSet.add(id));
             }
             if (ev.error) {

--- a/src/services/userTransform.ts
+++ b/src/services/userTransform.ts
@@ -110,7 +110,7 @@ export class UserTransformService {
             } else if (ev.metadata?.messageIds) {
               ev.metadata.messageIds.forEach((id) => messageIdsInOutputSet.add(id));
             } else if (ev.error && isEmpty(ev.metadata)) {
-              // incase of error, add messageIds to output set so that are not marked as dropped
+              // incase of error, add messageIds to output set so that they are not marked as dropped
               commonMetadata.messageIds.forEach((id) => messageIdsInOutputSet.add(id));
             }
             if (ev.error) {

--- a/src/services/userTransform.ts
+++ b/src/services/userTransform.ts
@@ -1,7 +1,7 @@
 import groupBy from 'lodash/groupBy';
 import isEmpty from 'lodash/isEmpty';
 import { isNil } from 'lodash';
-import { v4 as uuidv4 } from 'uuid';
+import { generateUUID } from '@rudderstack/integrations-lib';
 import { userTransformHandler } from '../routerUtils';
 import {
   UserTransformationLibrary,
@@ -76,7 +76,7 @@ export class UserTransformService {
 
         const generateNewMetadata = (response: UserTransformationResponse) => ({
           ...eventsToProcess[0]?.metadata,
-          messageId: uuidv4(),
+          messageId: generateUUID(),
           eventName: response.transformedEvent.event,
           eventType: response.transformedEvent.type,
         });

--- a/src/services/userTransform.ts
+++ b/src/services/userTransform.ts
@@ -109,6 +109,8 @@ export class UserTransformService {
               messageIdsInOutputSet.add(ev.metadata.messageId);
             } else if (ev.metadata?.messageIds) {
               ev.metadata.messageIds.forEach((id) => messageIdsInOutputSet.add(id));
+            } else if (isEmpty(ev.metadata)) {
+              commonMetadata.messageIds.forEach((id) => messageIdsInOutputSet.add(id));
             }
             if (ev.error) {
               transformedEventsWithMetadata.push({

--- a/src/util/ivmFactory.js
+++ b/src/util/ivmFactory.js
@@ -152,7 +152,7 @@ async function createIvm(
             break;
           }
           outputEvents = transformedEventsBatch.map(transformedEvent => {
-            const eventMetadata = eventsMetadata[transformedEvent?.messageId] ?? eventsMetadata[firstInputEventMessageId] ?? {};
+            const eventMetadata = eventsMetadata[transformedEvent?.messageId] || eventsMetadata[firstInputEventMessageId] || {};
             if (!isObject(transformedEvent)) {
               return {error: "returned event in events array from transformBatch(events) is not an object", metadata: eventMetadata};
             }

--- a/src/util/ivmFactory.js
+++ b/src/util/ivmFactory.js
@@ -118,10 +118,10 @@ async function createIvm(
           }
           outputEvents = transformedEventsBatch.map(transformedEvent => {
             if (!isObject(transformedEvent)) {
-              return{error: "returned event in events array from transformBatch(events) is not an object", metadata: getMetadata(transformedEvent, firstInputEventMessageId)};
+              return {error: "returned event in events array from transformBatch(events) is not an object", metadata: getMetadata(transformedEvent, firstInputEventMessageId)};
             }
-            return{transformedEvent, metadata: getMetadata(transformedEvent, firstInputEventMessageId)};
-          })
+            return {transformedEvent, metadata: getMetadata(transformedEvent, firstInputEventMessageId)};
+          });
           break;
         case "transformEvent":
           await Promise.all(eventMessages.map(async ev => {

--- a/src/util/ivmFactory.js
+++ b/src/util/ivmFactory.js
@@ -11,7 +11,6 @@ const { fetchWithDnsWrapper } = require('./utils');
 const ISOLATE_VM_MEMORY = parseInt(process.env.ISOLATE_VM_MEMORY || '128', 10);
 const RUDDER_LIBRARY_REGEX = /^@rs\/[A-Za-z]+\/v[0-9]{1,3}$/;
 const GEOLOCATION_TIMEOUT_IN_MS = parseInt(process.env.GEOLOCATION_TIMEOUT_IN_MS || '1000', 10);
-const IS_TRANSFORM_BATCH_V2_ENABLED = process.env.IS_TRANSFORM_BATCH_V2_ENABLED === 'true';
 
 const SUPPORTED_FUNC_NAMES = ['transformEvent', 'transformBatch'];
 
@@ -80,7 +79,7 @@ async function createIvm(
     });
   }
 
-  let codeWithWrapper =
+  const codeWithWrapper =
     // eslint-disable-next-line prefer-template
     code +
     `
@@ -191,127 +190,6 @@ async function createIvm(
       return outputEvents
     }
   `;
-
-  if (IS_TRANSFORM_BATCH_V2_ENABLED) {
-    codeWithWrapper =
-      // eslint-disable-next-line prefer-template
-      code +
-      `
-    export async function transformWrapper(transformationPayload) {
-      let events = transformationPayload.events
-      let transformType = transformationPayload.transformationType
-      let outputEvents = []
-      const eventMessages = events.map(event => event.message);
-      const eventsMetadata = {};
-      events.forEach(ev => {
-        eventsMetadata[ev.message.messageId] = ev.metadata;
-      });
-
-      const isObject = (o) => Object.prototype.toString.call(o) === '[object Object]';
-
-      var metadata = function(event) {
-        const eventMetadata = event ? eventsMetadata[event.messageId] || {} : {};
-        return {
-          sourceId: eventMetadata.sourceId,
-          sourceName: eventMetadata.sourceName,
-          workspaceId: eventMetadata.workspaceId,
-          sourceType: eventMetadata.sourceType,
-          sourceCategory: eventMetadata.sourceCategory,
-          destinationId: eventMetadata.destinationId,
-          destinationType: eventMetadata.destinationType,
-          destinationName: eventMetadata.destinationName,
-
-          // TODO: remove non required fields
-
-          namespace: eventMetadata.namespace,
-          originalSourceId: eventMetadata.originalSourceId,
-          trackingPlanId: eventMetadata.trackingPlanId,
-          trackingPlanVersion: eventMetadata.trackingPlanVersion,
-          sourceTpConfig: eventMetadata.sourceTpConfig,
-          mergedTpConfig: eventMetadata.mergedTpConfig,
-          jobId: eventMetadata.jobId,
-          sourceJobId: eventMetadata.sourceJobId,
-          sourceJobRunId: eventMetadata.sourceJobRunId,
-          sourceTaskRunId: eventMetadata.sourceTaskRunId,
-          recordId: eventMetadata.recordId,
-          messageId: eventMetadata.messageId,
-          messageIds: eventMetadata.messageIds,
-          rudderId: eventMetadata.rudderId,
-          receivedAt: eventMetadata.receivedAt,
-          eventName: eventMetadata.eventName,
-          eventType: eventMetadata.eventType,
-          sourceDefinitionId: eventMetadata.sourceDefinitionId,
-          destinationDefinitionId: eventMetadata.destinationDefinitionId,
-          transformationId: eventMetadata.transformationId,
-          transformationVersionId: eventMetadata.transformationVersionId,
-        };
-      }
-      switch(transformType) {
-        case "transformBatch":
-          const firstInputEventMessageId = eventMessages.length > 0 ? eventMessages[0].messageId : null;
-          let transformedEventsBatch;
-          try {
-            // create a new array with the same elements as eventMessages, this is done to avoid mutating the original array
-            transformedEventsBatch = await transformBatch([...eventMessages], metadata);
-          } catch (error) {
-            outputEvents.push(...eventMessages.map(ev => (
-              {error: extractStackTrace(error.stack, [transformType]), metadata: eventsMetadata[ev?.messageId] || {}}
-            )));
-            return outputEvents;
-          }
-          if (!Array.isArray(transformedEventsBatch)) {
-            outputEvents.push(...eventMessages.map(ev => (
-              {error: "returned events from transformBatch(event) is not an array", metadata: eventsMetadata[ev?.messageId] || {}}
-            )));
-            break;
-          }
-          outputEvents = transformedEventsBatch.map(transformedEvent => {
-            const eventMetadata = eventsMetadata[transformedEvent?.messageId] || eventsMetadata[firstInputEventMessageId] || {};
-            if (!isObject(transformedEvent)) {
-              return {error: "returned event in events array from transformBatch(events) is not an object", metadata: eventMetadata};
-            }
-            return {transformedEvent, metadata: eventMetadata};
-          });
-          break;
-        case "transformEvent":
-          await Promise.all(eventMessages.map(async ev => {
-            const currMsgId = ev.messageId;
-            try{
-              let transformedOutput = await transformEvent(ev, metadata);
-              // if func returns null/undefined drop event
-              if (transformedOutput === null || transformedOutput === undefined) return;
-              if (Array.isArray(transformedOutput)) {
-                const producedEvents = [];
-                const encounteredError = !transformedOutput.every(e => {
-                  if (isObject(e)) {
-                    producedEvents.push({transformedEvent: e, metadata: eventsMetadata[currMsgId] || {}});
-                    return true;
-                  } else {
-                    outputEvents.push({error: "returned event in events array from transformEvent(event) is not an object", metadata: eventsMetadata[currMsgId] || {}});
-                    return false;
-                  }
-                })
-                if (!encounteredError) {
-                  outputEvents.push(...producedEvents);
-                }
-                return;
-              }
-              if (!isObject(transformedOutput)) {
-                return outputEvents.push({error: "returned event from transformEvent(event) is not an object", metadata: eventsMetadata[currMsgId] || {}});
-              }
-              outputEvents.push({transformedEvent: transformedOutput, metadata: eventsMetadata[currMsgId] || {}});
-              return;
-            } catch (error) {
-              // Handling the errors in versionedRouter.js
-              return outputEvents.push({error: extractStackTrace(error.stack, [transformType]), metadata: eventsMetadata[currMsgId] || {}});
-            }
-          }));
-          break;
-      }
-      return outputEvents
-    }
-  `;
-  }
   const isolate = new ivm.Isolate({ memoryLimit: ISOLATE_VM_MEMORY });
   const isolateStartWallTime = isolate.wallTime;
   const isolateStartCPUTime = isolate.cpuTime;

--- a/src/util/ivmFactory.js
+++ b/src/util/ivmFactory.js
@@ -141,13 +141,13 @@ async function createIvm(
             transformedEventsBatch = await transformBatch([...eventMessages], metadata);
           } catch (error) {
             outputEvents.push(...eventMessages.map(ev => (
-              {error: extractStackTrace(error.stack, [transformType]), metadata: eventsMetadata[ev.messageId] || {}}
+              {error: extractStackTrace(error.stack, [transformType]), metadata: eventsMetadata[ev?.messageId] || {}}
             )));
             return outputEvents;
           }
           if (!Array.isArray(transformedEventsBatch)) {
             outputEvents.push(...eventMessages.map(ev => (
-              {error: "returned events from transformBatch(event) is not an array", metadata: eventsMetadata[ev.messageId] || {}}
+              {error: "returned events from transformBatch(event) is not an array", metadata: eventsMetadata[ev?.messageId] || {}}
             )));
             break;
           }

--- a/src/util/ivmFactory.js
+++ b/src/util/ivmFactory.js
@@ -95,8 +95,8 @@ async function createIvm(
 
       const isObject = (o) => Object.prototype.toString.call(o) === '[object Object]';
 
-      var metadata = function(event) {
-        const eventMetadata = event ? eventsMetadata[event.messageId] || {} : {};
+      var metadata = function(event, firstInputEventMessageId) {
+       const eventMetadata = eventsMetadata[event?.messageId] ?? eventsMetadata[firstInputEventMessageId] ?? {};
         return {
           sourceId: eventMetadata.sourceId,
           sourceName: eventMetadata.sourceName,
@@ -134,6 +134,7 @@ async function createIvm(
       }
       switch(transformType) {
         case "transformBatch":
+          const firstInputEventMessageId = eventMessages.length > 0 ? eventMessages[0].messageId : null;
           let transformedEventsBatch;
           try {
             transformedEventsBatch = await transformBatch(eventMessages, metadata);
@@ -149,7 +150,7 @@ async function createIvm(
             if (!isObject(transformedEvent)) {
               return{error: "returned event in events array from transformBatch(events) is not an object", metadata: {}};
             }
-            return{transformedEvent, metadata: metadata(transformedEvent)};
+            return{transformedEvent, metadata: metadata(transformedEvent, firstInputEventMessageId)};
           })
           break;
         case "transformEvent":

--- a/src/util/ivmFactory.js
+++ b/src/util/ivmFactory.js
@@ -95,8 +95,43 @@ async function createIvm(
 
       const isObject = (o) => Object.prototype.toString.call(o) === '[object Object]';
 
-      const getMetadata = (event, firstInputEventMessageId) => eventsMetadata[event?.messageId] ?? eventsMetadata[firstInputEventMessageId] ?? {};
+      var metadata = function(event) {
+        const eventMetadata = event ? eventsMetadata[event.messageId] || {} : {};
+        return {
+          sourceId: eventMetadata.sourceId,
+          sourceName: eventMetadata.sourceName,
+          workspaceId: eventMetadata.workspaceId,
+          sourceType: eventMetadata.sourceType,
+          sourceCategory: eventMetadata.sourceCategory,
+          destinationId: eventMetadata.destinationId,
+          destinationType: eventMetadata.destinationType,
+          destinationName: eventMetadata.destinationName,
 
+          // TODO: remove non required fields
+
+          namespace: eventMetadata.namespace,
+          originalSourceId: eventMetadata.originalSourceId,
+          trackingPlanId: eventMetadata.trackingPlanId,
+          trackingPlanVersion: eventMetadata.trackingPlanVersion,
+          sourceTpConfig: eventMetadata.sourceTpConfig,
+          mergedTpConfig: eventMetadata.mergedTpConfig,
+          jobId: eventMetadata.jobId,
+          sourceJobId: eventMetadata.sourceJobId,
+          sourceJobRunId: eventMetadata.sourceJobRunId,
+          sourceTaskRunId: eventMetadata.sourceTaskRunId,
+          recordId: eventMetadata.recordId,
+          messageId: eventMetadata.messageId,
+          messageIds: eventMetadata.messageIds,
+          rudderId: eventMetadata.rudderId,
+          receivedAt: eventMetadata.receivedAt,
+          eventName: eventMetadata.eventName,
+          eventType: eventMetadata.eventType,
+          sourceDefinitionId: eventMetadata.sourceDefinitionId,
+          destinationDefinitionId: eventMetadata.destinationDefinitionId,
+          transformationId: eventMetadata.transformationId,
+          transformationVersionId: eventMetadata.transformationVersionId,
+        };
+      }
       switch(transformType) {
         case "transformBatch":
           const firstInputEventMessageId = eventMessages.length > 0 ? eventMessages[0].messageId : null;
@@ -117,10 +152,11 @@ async function createIvm(
             break;
           }
           outputEvents = transformedEventsBatch.map(transformedEvent => {
+            const eventMetadata = eventsMetadata[transformedEvent?.messageId] ?? eventsMetadata[firstInputEventMessageId] ?? {};
             if (!isObject(transformedEvent)) {
-              return {error: "returned event in events array from transformBatch(events) is not an object", metadata: getMetadata(transformedEvent, firstInputEventMessageId)};
+              return {error: "returned event in events array from transformBatch(events) is not an object", metadata: eventMetadata};
             }
-            return {transformedEvent, metadata: getMetadata(transformedEvent, firstInputEventMessageId)};
+            return {transformedEvent, metadata: eventMetadata};
           });
           break;
         case "transformEvent":


### PR DESCRIPTION
## What are the changes introduced in this PR?

This PR fixes the issue with reporting metrics generated when transformBatch is used.

## What is the related Linear task?

Resolves OBS-828

## Please explain the objectives of your changes below

Currently, there are two issues with the UT response when transformBatch is used:
- Newly added events in UT do not contain a messageId. As a result, these events are not tracked in reporting metrics.
- When UT fails, all input events are incorrectly marked as filtered. This causes rudder-transformer to return N + 1 events (where N is the number of input events marked as filtered, plus one additional event indicating the UT failure). However, the expected behavior is to return only a single event—the failed UT event—without any filtered events.

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

N/A

### Any new dependencies introduced with this change?

N/A

### Any new generic utility introduced or modified. Please explain the changes.

N/A

### Any technical or performance related pointers to consider with the change?

N/A

@coderabbitai review

<hr>

### Developer checklist

- [ ] My code follows the style guidelines of this project

- [ ] **No breaking changes are being introduced.**

- [ ] All related docs linked with the PR?

- [ ] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [ ] Is the PR limited to 10 file changes?

- [ ] Is the PR limited to one linear task?

- [ ] Are relevant unit and component test-cases added in **new readability format**?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.
