### PR TITLE
fix: replace --json flag with grep for gh pr create compatibility

### DIFF
--- a/.github/workflows/prepare-for-prod-ut-deploy.yml
+++ b/.github/workflows/prepare-for-prod-ut-deploy.yml
@@ -135,7 +135,7 @@ jobs:
           git commit -m "chore: upgrade shared user-transformers to $UT_TAG_NAME"
           git push -u origin shared-user-transformer-$UT_TAG_NAME
 
-          PR_URL=$(gh pr create --fill --json url --jq '.url')
+          PR_URL=$(gh pr create --fill | grep -o 'https://github.com/[^/]*/[^/]*/pull/[0-9]*')
           echo "SHARED_PR_URL=$PR_URL" >> $GITHUB_ENV
 
       - name: Update Helm Chart and Raise Pull Request For Hosted Transformer
@@ -153,7 +153,7 @@ jobs:
           git commit -m "chore: upgrade hosted user-transformer to $UT_TAG_NAME"
           git push -u origin hosted-user-transformer-$UT_TAG_NAME
 
-          PR_URL=$(gh pr create --fill --json url --jq '.url')
+          PR_URL=$(gh pr create --fill | grep -o 'https://github.com/[^/]*/[^/]*/pull/[0-9]*')
           echo "HOSTED_PR_URL=$PR_URL" >> $GITHUB_ENV
 
       - name: Update helm charts and raise pull request for enterprise customers on dedicated transformers
@@ -190,7 +190,7 @@ jobs:
           git commit -m "chore: upgrade dedicated user transformers to $TAG_NAME"
           git push -u origin dedicated-user-transformer-$TAG_NAME
 
-          PR_URL=$(gh pr create --fill --json url --jq '.url')
+          PR_URL=$(gh pr create --fill | grep -o 'https://github.com/[^/]*/[^/]*/pull/[0-9]*')
           echo "DEDICATED_PR_URL=$PR_URL" >> $GITHUB_ENV
 
       - name: Notify Control Plane Team


### PR DESCRIPTION
## What are the changes introduced in this PR?

Fixed GitHub CLI compatibility issue in the prepare-for-prod-ut-deploy.yml workflow by replacing the --json flag with grep for extracting PR URLs.

## What is the related Linear task?

N/A - Bug fix for workflow compatibility

## Please explain the objectives of your changes below

The --json flag is not available for write operations like gh pr create in older versions of GitHub CLI, causing workflow failures. This fix ensures compatibility across different GitHub CLI versions.

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

**Change**: Replaced gh pr create --fill --json url --jq '.url' with gh pr create --fill | grep -o 'https://github.com/[^/]*/[^/]*/pull/[0-9]*'

**Reason**: The --json flag is only available for read operations (like gh release view) but not for write operations (like gh pr create) in older GitHub CLI versions.

### Any new dependencies introduced with this change?

N/A

### Any new generic utility introduced or modified. Please explain the changes.

N/A

### Any technical or performance related pointers to consider with the change?

The new approach uses grep with regex to extract PR URLs, which is more compatible but slightly less robust than JSON parsing. However, it works reliably for GitHub PR URLs.

@coderabbitai review