### PR TITLE
fix: correct tag variable usage in UT deploy workflow

### DIFF
--- a/.github/workflows/prepare-for-prod-ut-deploy.yml
+++ b/.github/workflows/prepare-for-prod-ut-deploy.yml
@@ -116,19 +116,20 @@ jobs:
           git checkout -b shared-user-transformer-$UT_TAG_NAME
 
           cd helm-charts/shared-services/per-az/environment/production
-          yq eval -i ".user-transformer.image.tag=\"$TAG_NAME\"" production.yaml
+          yq eval -i ".user-transformer.image.tag=\"$UT_TAG_NAME\"" production.yaml
           yq eval -i ".user-transformer.image.repository=\"$TF_IMAGE_REPOSITORY\"" production.yaml
           git add production.yaml
 
-          yq eval -i ".user-transformer.image.tag=\"$TAG_NAME\"" enterprise/enterprise.yaml
+          yq eval -i ".user-transformer.image.tag=\"$UT_TAG_NAME\"" enterprise/enterprise.yaml
           yq eval -i ".user-transformer.image.repository=\"$TF_IMAGE_REPOSITORY\"" enterprise/enterprise.yaml
           git add enterprise/enterprise.yaml
 
-          yq eval -i ".user-transformer.image.tag=\"$TAG_NAME\"" multi-tenant/multi-tenant.yaml
+          yq eval -i ".user-transformer.image.tag=\"$UT_TAG_NAME\"" multi-tenant/multi-tenant.yaml
           yq eval -i ".user-transformer.image.repository=\"$TF_IMAGE_REPOSITORY\"" multi-tenant/multi-tenant.yaml
           git add multi-tenant/multi-tenant.yaml
 
-          cd ../../../../config-be-rudder-transformer/environment/prod
+          cd -
+          cd helm-charts/config-be-rudder-transformer/environment/prod
           yq eval -i ".config-be-user-transformer.image.tag=\"$UT_TAG_NAME\"" base.yaml
           git add base.yaml
 
@@ -146,8 +147,8 @@ jobs:
           git checkout -b hosted-user-transformer-$UT_TAG_NAME ${{steps.extract_branch_name.outputs.branch_name}}
 
           cd customer-objects/multi-tenant-us
-          yq eval -i ".user-transformer.image.tag=\"$UT_TAG_NAME\"" hostedmtedmt.yaml
-          yq eval -i ".user-transformer.image.repository=\"$TF_IMAGE_REPOSITORY\"" hostedmtedmt.yaml
+          yq eval -i ".spec.user-transformer.image.version=\"$UT_TAG_NAME\"" hostedmtedmt.yaml
+          yq eval -i ".spec.user-transformer.image.repository=\"$TF_IMAGE_REPOSITORY\"" hostedmtedmt.yaml
           git add hostedmtedmt.yaml
 
           git commit -m "chore: upgrade hosted user-transformer to $UT_TAG_NAME"
@@ -173,7 +174,7 @@ jobs:
             for f in "./$directory"/*; do
               [[ -f $f ]] || continue
 
-              enabled="$(yq e '.spec.user_transformer.enabled' $f)"
+              enabled="$(yq e '.spec.user-transformer.enabled' $f)"
               if [ $enabled == "true" ]; then
                   enabled_ut_customers+=( $f )
               fi
@@ -182,8 +183,8 @@ jobs:
 
           # bump up the customers version and repository information
           for customer in "${enabled_ut_customers[@]}"; do
-            yq eval -i ".spec.user_transformer.image.version=\"$TAG_NAME\"" $customer
-            yq eval -i ".spec.user_transformer.image.repository=\"$TF_IMAGE_REPOSITORY\"" $customer
+            yq eval -i ".spec.user-transformer.image.version=\"$UT_TAG_NAME\"" $customer
+            yq eval -i ".spec.user-transformer.image.repository=\"$TF_IMAGE_REPOSITORY\"" $customer
             git add $customer
           done
 


### PR DESCRIPTION
## What are the changes introduced in this PR?

Fixed inconsistent tag variable usage in the prepare-for-prod-ut-deploy.yml workflow file to ensure proper UT (User Transformer) deployment.

## What is the related Linear task?
Resolves https://linear.app/rudderstack/issue/INT-4108/on-call-sep-10-16-dilip-progress-on-following-tasks

## Please explain the objectives of your changes below

This PR fixes several inconsistencies in the UT deployment workflow:

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

- **Shared services**: Changed from using `TAG_NAME` to `UT_TAG_NAME` for proper UT-specific tagging
- **Hosted transformer**: Fixed yq path from `.user-transformer.image.tag` to `.spec.user-transformer.image.version`
- **Dedicated transformer**: Fixed yq path from `.spec.user_transformer.enabled` to `.spec.user-transformer.enabled` and updated image version to use `UT_TAG_NAME`
- **Directory navigation**: Fixed relative path navigation in the workflow

### Any new dependencies introduced with this change?

N/A

### Any new generic utility introduced or modified. Please explain the changes.

N/A

### Any technical or performance related pointers to consider with the change?

This ensures that UT deployments use the correct tag naming convention and proper YAML paths, preventing deployment failures.

@coderabbitai review

<hr>

### Developer checklist

- [x] My code follows the style guidelines of this project
- [x] **No breaking changes are being introduced.**
- [x] All related docs linked with the PR?
- [x] All changes manually tested?
- [x] Any documentation changes needed with this change?
- [x] Is the PR limited to 10 file changes?
- [x] Is the PR limited to one linear task?
- [x] Are relevant unit and component test-cases added in **new readability format**?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?
- [ ] Verified that there are no credentials or confidential data exposed with the changes.