### PR TITLE
feat: update TikTok Ads to include endpointPath

### DIFF
--- a/src/v0/destinations/tiktok_ads/config.js
+++ b/src/v0/destinations/tiktok_ads/config.js
@@ -1,7 +1,10 @@
 const { getMappingConfig } = require('../../util');
 
-const TRACK_ENDPOINT = 'https://business-api.tiktok.com/open_api/v1.3/pixel/track/';
-const BATCH_ENDPOINT = 'https://business-api.tiktok.com/open_api/v1.3/pixel/batch/';
+const BASE_URL = 'https://business-api.tiktok.com/open_api/v1.3';
+const TRACK_ENDPOINT_PATH = '/pixel/track';
+const TRACK_ENDPOINT = `${BASE_URL}${TRACK_ENDPOINT_PATH}/`;
+const BATCH_ENDPOINT_PATH = '/pixel/batch';
+const BATCH_ENDPOINT = `${BASE_URL}${BATCH_ENDPOINT_PATH}/`;
 const MAX_BATCH_SIZE = 50;
 
 const ConfigCategory = {
@@ -50,12 +53,15 @@ const mappingConfig = getMappingConfig(ConfigCategory, __dirname);
 
 // tiktok docs for max batch size for events 2.0: https://business-api.tiktok.com/portal/docs?id=1771100779668482
 const maxBatchSizeV2 = 1000;
-const trackEndpointV2 = 'https://business-api.tiktok.com/open_api/v1.3/event/track/';
+const trackEndpointV2Path = '/event/track';
+const trackEndpointV2 = `${BASE_URL}${trackEndpointV2Path}/`;
 // Following is the list of standard events for which some parameters are recommended
 // Ref: https://business-api.tiktok.com/portal/docs?id=1771101186666498
 const eventsWithRecommendedParams = ['AddToCart', 'CompletePayment', 'PlaceAnOrder', 'ViewContent'];
 module.exports = {
+  TRACK_ENDPOINT_PATH,
   TRACK_ENDPOINT,
+  BATCH_ENDPOINT_PATH,
   BATCH_ENDPOINT,
   MAX_BATCH_SIZE,
   PARTNER_NAME,
@@ -63,6 +69,7 @@ module.exports = {
   trackMappingV2: mappingConfig[ConfigCategory.TRACK_V2.name],
   eventNameMapping,
   DESTINATION: 'TIKTOK_ADS',
+  trackEndpointV2Path,
   trackEndpointV2,
   maxBatchSizeV2,
   eventsWithRecommendedParams,

--- a/src/v0/destinations/tiktok_ads/transform.js
+++ b/src/v0/destinations/tiktok_ads/transform.js
@@ -31,6 +31,8 @@ const {
   eventNameMapping,
   MAX_BATCH_SIZE,
   PARTNER_NAME,
+  TRACK_ENDPOINT_PATH,
+  BATCH_ENDPOINT_PATH,
 } = require('./config');
 const { JSON_MIME_TYPE } = require('../../util/constant');
 
@@ -121,6 +123,7 @@ const getTrackResponse = (message, Config, event) => {
 
   response.method = defaultPostRequestConfig.requestMethod;
   response.endpoint = TRACK_ENDPOINT;
+  response.endpointPath = TRACK_ENDPOINT_PATH;
   // add partner name
   response.body.JSON = removeUndefinedAndNullValues({
     ...payload,
@@ -213,6 +216,7 @@ function batchEvents(eventsChunk) {
   };
 
   batchedRequest.endpoint = BATCH_ENDPOINT;
+  batchedRequest.endpointPath = BATCH_ENDPOINT_PATH;
   batchedRequest.headers = {
     'Access-Token': accessToken,
     'Content-Type': 'application/json',

--- a/src/v0/destinations/tiktok_ads/transform.test.js
+++ b/src/v0/destinations/tiktok_ads/transform.test.js
@@ -1,6 +1,7 @@
 const { InstrumentationError } = require('@rudderstack/integrations-lib');
 
 const { trackResponseBuilder } = require('./transform');
+const { TRACK_ENDPOINT, TRACK_ENDPOINT_PATH } = require('./config');
 
 describe('trackResponseBuilder', () => {
   const baseConfig = {
@@ -23,7 +24,8 @@ describe('trackResponseBuilder', () => {
       'Content-Type': 'application/json',
     },
     method: 'POST',
-    endpoint: 'https://business-api.tiktok.com/open_api/v1.3/pixel/track/',
+    endpoint: TRACK_ENDPOINT,
+    endpointPath: TRACK_ENDPOINT_PATH,
   };
 
   const testCases = [
@@ -121,6 +123,7 @@ describe('trackResponseBuilder', () => {
         expect(resp.headers).toMatchObject(expectedResponse.headers);
         expect(resp.method).toBe(expectedResponse.method);
         expect(resp.endpoint).toBe(expectedResponse.endpoint);
+        expect(resp.endpointPath).toBe(expectedResponse.endpointPath);
         expect(resp.body.JSON).toMatchObject({
           pixel_code: expectedResponse.body.pixel_code,
           partner_name: expectedResponse.body.partner_name,

--- a/src/v0/destinations/tiktok_ads/transformV2.js
+++ b/src/v0/destinations/tiktok_ads/transformV2.js
@@ -29,6 +29,7 @@ const config = require('./config');
 
 const {
   trackMappingV2,
+  trackEndpointV2Path,
   trackEndpointV2,
   eventNameMapping,
   PARTNER_NAME,
@@ -128,6 +129,7 @@ const trackResponseBuilder = async (message, { Config }) => {
   // tiktok doc for request: https://business-api.tiktok.com/portal/docs?id=1771100865818625
   response.method = defaultPostRequestConfig.requestMethod;
   response.endpoint = trackEndpointV2;
+  response.endpointPath = trackEndpointV2Path;
   const responseList = [];
   if (standardEventsMap[event]) {
     Object.keys(standardEventsMap).forEach((key) => {
@@ -412,6 +414,7 @@ const buildBatchResponseForEvent = (batch) => {
   const { batchedRequest } = defaultBatchRequestConfig();
   batchedRequest.body.JSON = event;
   batchedRequest.endpoint = trackEndpointV2;
+  batchedRequest.endpointPath = trackEndpointV2Path;
   batchedRequest.headers = {
     'Access-Token': accessToken,
     'Content-Type': 'application/json',

--- a/src/v0/destinations/tiktok_ads/transformV2.test.js
+++ b/src/v0/destinations/tiktok_ads/transformV2.test.js
@@ -1,6 +1,7 @@
 const { InstrumentationError } = require('@rudderstack/integrations-lib');
 
 const { trackResponseBuilder } = require('./transformV2');
+const { trackEndpointV2, trackEndpointV2Path } = require('./config');
 
 describe('trackResponseBuilder', () => {
   const baseConfig = {
@@ -23,7 +24,8 @@ describe('trackResponseBuilder', () => {
       'Content-Type': 'application/json',
     },
     method: 'POST',
-    endpoint: 'https://business-api.tiktok.com/open_api/v1.3/event/track/',
+    endpoint: trackEndpointV2,
+    endpointPath: trackEndpointV2Path,
   };
 
   const testCases = [
@@ -123,6 +125,7 @@ describe('trackResponseBuilder', () => {
         expect(resp.headers).toMatchObject(expectedResponse.headers);
         expect(resp.method).toBe(expectedResponse.method);
         expect(resp.endpoint).toBe(expectedResponse.endpoint);
+        expect(resp.endpointPath).toBe(expectedResponse.endpointPath);
         expect(resp.body.JSON).toMatchObject({
           event_source: expectedResponse.body.event_source,
           event_source_id: expectedResponse.body.event_source_id,

--- a/test/integrations/destinations/tiktok_ads/dataDelivery/business.ts
+++ b/test/integrations/destinations/tiktok_ads/dataDelivery/business.ts
@@ -1,3 +1,4 @@
+import { BATCH_ENDPOINT } from '../../../../../src/v0/destinations/tiktok_ads/config';
 import { ProxyV1TestData } from '../../../testTypes';
 import { generateMetadata, generateProxyV1Payload } from '../../../testUtils';
 
@@ -64,7 +65,7 @@ export const V1BusinessTestScenarion: ProxyV1TestData[] = [
               'test-dest-response-key': 'successResponse',
             },
             params,
-            endpoint: 'https://business-api.tiktok.com/open_api/v1.2/pixel/batch/',
+            endpoint: BATCH_ENDPOINT,
             JSON: {
               ...commonParts,
               properties: {
@@ -130,7 +131,7 @@ export const V1BusinessTestScenarion: ProxyV1TestData[] = [
               ...commonHeaderPart,
               'test-dest-response-key': 'invalidDataTypeResponse',
             },
-            endpoint: 'https://business-api.tiktok.com/open_api/v1.2/pixel/batch/',
+            endpoint: BATCH_ENDPOINT,
             JSON: {
               properties: {
                 contents: [
@@ -195,7 +196,7 @@ export const V1BusinessTestScenarion: ProxyV1TestData[] = [
         body: generateProxyV1Payload(
           {
             params,
-            endpoint: 'https://business-api.tiktok.com/open_api/v1.2/pixel/batch/',
+            endpoint: BATCH_ENDPOINT,
             headers: {
               ...commonHeaderPart,
               'test-dest-response-key': 'invalidPermissionsResponse',

--- a/test/integrations/destinations/tiktok_ads/dataDelivery/data.ts
+++ b/test/integrations/destinations/tiktok_ads/dataDelivery/data.ts
@@ -4,6 +4,7 @@ import lodash from 'lodash';
 import { V1BusinessTestScenarion } from './business';
 import { v1OtherScenarios } from './other';
 import { generateProxyV0Payload } from '../../../testUtils';
+import { BATCH_ENDPOINT } from '../../../../../src/v0/destinations/tiktok_ads/config';
 
 const oldV0TestCases = [
   {
@@ -62,7 +63,7 @@ const oldV0TestCases = [
                 'Mozilla/5.0 (platform; rv:geckoversion) Gecko/geckotrail Firefox/firefoxversion',
             },
           },
-          endpoint: 'https://business-api.tiktok.com/open_api/v1.2/pixel/batch/',
+          endpoint: BATCH_ENDPOINT,
           method: 'POST',
           params: {
             destination: 'tiktok_ads',
@@ -146,7 +147,7 @@ const oldV0TestCases = [
                 'Mozilla/5.0 (platform; rv:geckoversion) Gecko/geckotrail Firefox/firefoxversion',
             },
           },
-          endpoint: 'https://business-api.tiktok.com/open_api/v1.2/pixel/batch/',
+          endpoint: BATCH_ENDPOINT,
           method: 'POST',
           params: {
             destination: 'tiktok_ads',
@@ -240,7 +241,7 @@ const oldV0TestCases = [
                 'Mozilla/5.0 (platform; rv:geckoversion) Gecko/geckotrail Firefox/firefoxversion',
             },
           },
-          endpoint: 'https://business-api.tiktok.com/open_api/v1.2/pixel/batch/',
+          endpoint: BATCH_ENDPOINT,
           method: 'POST',
           params: {
             destination: 'tiktok_ads',
@@ -335,7 +336,7 @@ const oldV0TestCases = [
                 'Mozilla/5.0 (platform; rv:geckoversion) Gecko/geckotrail Firefox/firefoxversion',
             },
           },
-          endpoint: 'https://business-api.tiktok.com/open_api/v1.2/pixel/batch/',
+          endpoint: BATCH_ENDPOINT,
           method: 'POST',
           params: {
             destination: 'tiktok_ads',
@@ -429,7 +430,7 @@ const oldV0TestCases = [
                 'Mozilla/5.0 (platform; rv:geckoversion) Gecko/geckotrail Firefox/firefoxversion',
             },
           },
-          endpoint: 'https://business-api.tiktok.com/open_api/v1.2/pixel/batch/',
+          endpoint: BATCH_ENDPOINT,
           method: 'POST',
           params: {
             destination: 'tiktok_ads',
@@ -520,7 +521,7 @@ const oldV0TestCases = [
                 'Mozilla/5.0 (platform; rv:geckoversion) Gecko/geckotrail Firefox/firefoxversion',
             },
           },
-          endpoint: 'https://business-api.tiktok.com/open_api/v1.2/pixel/batch/',
+          endpoint: BATCH_ENDPOINT,
           method: 'POST',
           params: {
             destination: 'tiktok_ads',
@@ -557,7 +558,7 @@ const oldV0TestCases = [
     mockFns: (mockAdapter: MockAxiosAdapter) => {
       mockAdapter
         .onPost(
-          'https://business-api.tiktok.com/open_api/v1.2/pixel/batch/',
+          BATCH_ENDPOINT,
           {
             asymmetricMatch: (actual) => {
               const expected = {

--- a/test/integrations/destinations/tiktok_ads/dataDelivery/other.ts
+++ b/test/integrations/destinations/tiktok_ads/dataDelivery/other.ts
@@ -1,3 +1,4 @@
+import { BATCH_ENDPOINT } from '../../../../../src/v0/destinations/tiktok_ads/config';
 import { ProxyV1TestData } from '../../../testTypes';
 import { generateMetadata, generateProxyV1Payload } from '../../../testUtils';
 import { commonHeaderPart, params, statTags, commonParts } from './business';
@@ -36,7 +37,7 @@ export const v1OtherScenarios: ProxyV1TestData[] = [
         body: generateProxyV1Payload(
           {
             params,
-            endpoint: 'https://business-api.tiktok.com/open_api/v1.2/pixel/batch/',
+            endpoint: BATCH_ENDPOINT,
             headers: { ...commonHeaderPart, 'test-dest-response-key': 'tooManyRequests' },
             JSON: {
               ...commonParts,
@@ -88,7 +89,7 @@ export const v1OtherScenarios: ProxyV1TestData[] = [
         body: generateProxyV1Payload(
           {
             params,
-            endpoint: 'https://business-api.tiktok.com/open_api/v1.2/pixel/batch/',
+            endpoint: BATCH_ENDPOINT,
             headers: { ...commonHeaderPart, 'test-dest-response-key': '502-BadGateway' },
             JSON: {
               ...commonParts,

--- a/test/integrations/destinations/tiktok_ads/network.ts
+++ b/test/integrations/destinations/tiktok_ads/network.ts
@@ -1,7 +1,9 @@
+import { BATCH_ENDPOINT } from '../../../../src/v0/destinations/tiktok_ads/config';
+
 export const networkCallsData = [
   {
     httpReq: {
-      url: 'https://business-api.tiktok.com/open_api/v1.2/pixel/batch/',
+      url: BATCH_ENDPOINT,
       data: {
         pixel_code: 'A1T8T4UYGVIQA8ORZMX9',
         partner_name: 'RudderStack',
@@ -45,7 +47,7 @@ export const networkCallsData = [
   },
   {
     httpReq: {
-      url: 'https://business-api.tiktok.com/open_api/v1.2/pixel/batch/',
+      url: BATCH_ENDPOINT,
       data: {
         pixel_code: 'A1T8T4UYGVIQA8ORZMX9',
         partner_name: 'RudderStack',
@@ -95,7 +97,7 @@ export const networkCallsData = [
   },
   {
     httpReq: {
-      url: 'https://business-api.tiktok.com/open_api/v1.2/pixel/batch/',
+      url: BATCH_ENDPOINT,
       data: {
         pixel_code: 'A1T8T4UYGVIQA8ORZMX9',
         partner_name: 'RudderStack',
@@ -146,7 +148,7 @@ export const networkCallsData = [
   },
   {
     httpReq: {
-      url: 'https://business-api.tiktok.com/open_api/v1.2/pixel/batch/',
+      url: BATCH_ENDPOINT,
       data: {
         pixel_code: 'A1T8T4UYGVIQA8ORZMX9',
         partner_name: 'RudderStack',
@@ -193,7 +195,7 @@ export const networkCallsData = [
   },
   {
     httpReq: {
-      url: 'https://business-api.tiktok.com/open_api/v1.2/pixel/batch/',
+      url: BATCH_ENDPOINT,
       data: {
         pixel_code: 'A1T8T4UYGVIQA8ORZMX9',
         partner_name: 'RudderStack',

--- a/test/integrations/destinations/tiktok_ads/processor/data.ts
+++ b/test/integrations/destinations/tiktok_ads/processor/data.ts
@@ -7,6 +7,12 @@ import { ProcessorTestData } from '../../../testTypes';
 import { MessageType } from '../../../../../src/types';
 import { generateMetadata, overrideDestination } from '../../../testUtils';
 import { destinationConfig } from '../common';
+import {
+  TRACK_ENDPOINT,
+  TRACK_ENDPOINT_PATH,
+  trackEndpointV2,
+  trackEndpointV2Path,
+} from '../../../../../src/v0/destinations/tiktok_ads/config';
 
 const commonContents = [
   {
@@ -130,7 +136,8 @@ export const data: ProcessorTestData[] = [
               version: '1',
               type: 'REST',
               method: 'POST',
-              endpoint: 'https://business-api.tiktok.com/open_api/v1.3/pixel/track/',
+              endpoint: TRACK_ENDPOINT,
+              endpointPath: TRACK_ENDPOINT_PATH,
               headers: {
                 'Access-Token': 'dummyAccessToken',
                 'Content-Type': 'application/json',
@@ -232,7 +239,8 @@ export const data: ProcessorTestData[] = [
               version: '1',
               type: 'REST',
               method: 'POST',
-              endpoint: 'https://business-api.tiktok.com/open_api/v1.3/pixel/track/',
+              endpoint: TRACK_ENDPOINT,
+              endpointPath: TRACK_ENDPOINT_PATH,
               headers: {
                 'Access-Token': 'dummyAccessToken',
                 'Content-Type': 'application/json',
@@ -368,7 +376,8 @@ export const data: ProcessorTestData[] = [
               version: '1',
               type: 'REST',
               method: 'POST',
-              endpoint: 'https://business-api.tiktok.com/open_api/v1.3/pixel/track/',
+              endpoint: TRACK_ENDPOINT,
+              endpointPath: TRACK_ENDPOINT_PATH,
               headers: {
                 'Access-Token': 'dummyAccessToken',
                 'Content-Type': 'application/json',
@@ -536,7 +545,8 @@ export const data: ProcessorTestData[] = [
               version: '1',
               type: 'REST',
               method: 'POST',
-              endpoint: 'https://business-api.tiktok.com/open_api/v1.3/pixel/track/',
+              endpoint: TRACK_ENDPOINT,
+              endpointPath: TRACK_ENDPOINT_PATH,
               headers: {
                 'Access-Token': 'dummyAccessToken',
                 'Content-Type': 'application/json',
@@ -637,7 +647,8 @@ export const data: ProcessorTestData[] = [
               version: '1',
               type: 'REST',
               method: 'POST',
-              endpoint: 'https://business-api.tiktok.com/open_api/v1.3/pixel/track/',
+              endpoint: TRACK_ENDPOINT,
+              endpointPath: TRACK_ENDPOINT_PATH,
               headers: {
                 'Access-Token': 'dummyAccessToken',
                 'Content-Type': 'application/json',
@@ -776,7 +787,8 @@ export const data: ProcessorTestData[] = [
               version: '1',
               type: 'REST',
               method: 'POST',
-              endpoint: 'https://business-api.tiktok.com/open_api/v1.3/pixel/track/',
+              endpoint: TRACK_ENDPOINT,
+              endpointPath: TRACK_ENDPOINT_PATH,
               headers: {
                 'Access-Token': 'dummyAccessToken',
                 'Content-Type': 'application/json',
@@ -875,7 +887,8 @@ export const data: ProcessorTestData[] = [
               version: '1',
               type: 'REST',
               method: 'POST',
-              endpoint: 'https://business-api.tiktok.com/open_api/v1.3/pixel/track/',
+              endpoint: TRACK_ENDPOINT,
+              endpointPath: TRACK_ENDPOINT_PATH,
               headers: {
                 'Access-Token': 'dummyAccessToken',
                 'Content-Type': 'application/json',
@@ -1184,7 +1197,8 @@ export const data: ProcessorTestData[] = [
               version: '1',
               type: 'REST',
               method: 'POST',
-              endpoint: 'https://business-api.tiktok.com/open_api/v1.3/pixel/track/',
+              endpoint: TRACK_ENDPOINT,
+              endpointPath: TRACK_ENDPOINT_PATH,
               headers: {
                 'Access-Token': 'dummyAccessToken',
                 'Content-Type': 'application/json',
@@ -1282,7 +1296,8 @@ export const data: ProcessorTestData[] = [
               version: '1',
               type: 'REST',
               method: 'POST',
-              endpoint: 'https://business-api.tiktok.com/open_api/v1.3/pixel/track/',
+              endpoint: TRACK_ENDPOINT,
+              endpointPath: TRACK_ENDPOINT_PATH,
               headers: {
                 'Access-Token': 'dummyAccessToken',
                 'Content-Type': 'application/json',
@@ -1381,7 +1396,8 @@ export const data: ProcessorTestData[] = [
               version: '1',
               type: 'REST',
               method: 'POST',
-              endpoint: 'https://business-api.tiktok.com/open_api/v1.3/pixel/track/',
+              endpoint: TRACK_ENDPOINT,
+              endpointPath: TRACK_ENDPOINT_PATH,
               headers: {
                 'Access-Token': 'dummyAccessToken',
                 'Content-Type': 'application/json',
@@ -1479,7 +1495,8 @@ export const data: ProcessorTestData[] = [
               version: '1',
               type: 'REST',
               method: 'POST',
-              endpoint: 'https://business-api.tiktok.com/open_api/v1.3/pixel/track/',
+              endpoint: TRACK_ENDPOINT,
+              endpointPath: TRACK_ENDPOINT_PATH,
               headers: {
                 'Access-Token': 'dummyAccessToken',
                 'Content-Type': 'application/json',
@@ -1685,7 +1702,8 @@ export const data: ProcessorTestData[] = [
               version: '1',
               type: 'REST',
               method: 'POST',
-              endpoint: 'https://business-api.tiktok.com/open_api/v1.3/pixel/track/',
+              endpoint: TRACK_ENDPOINT,
+              endpointPath: TRACK_ENDPOINT_PATH,
               headers: {
                 'Access-Token': 'dummyAccessToken',
                 'Content-Type': 'application/json',
@@ -1784,7 +1802,8 @@ export const data: ProcessorTestData[] = [
               version: '1',
               type: 'REST',
               method: 'POST',
-              endpoint: 'https://business-api.tiktok.com/open_api/v1.3/pixel/track/',
+              endpoint: TRACK_ENDPOINT,
+              endpointPath: TRACK_ENDPOINT_PATH,
               headers: {
                 'Access-Token': 'dummyAccessToken',
                 'Content-Type': 'application/json',
@@ -1883,7 +1902,8 @@ export const data: ProcessorTestData[] = [
               version: '1',
               type: 'REST',
               method: 'POST',
-              endpoint: 'https://business-api.tiktok.com/open_api/v1.3/pixel/track/',
+              endpoint: TRACK_ENDPOINT,
+              endpointPath: TRACK_ENDPOINT_PATH,
               headers: {
                 'Access-Token': 'dummyAccessToken',
                 'Content-Type': 'application/json',
@@ -2026,7 +2046,8 @@ export const data: ProcessorTestData[] = [
               version: '1',
               type: 'REST',
               method: 'POST',
-              endpoint: 'https://business-api.tiktok.com/open_api/v1.3/pixel/track/',
+              endpoint: TRACK_ENDPOINT,
+              endpointPath: TRACK_ENDPOINT_PATH,
               headers: {
                 'Access-Token': 'dummyAccessToken',
                 'Content-Type': 'application/json',
@@ -2165,7 +2186,8 @@ export const data: ProcessorTestData[] = [
               version: '1',
               type: 'REST',
               method: 'POST',
-              endpoint: 'https://business-api.tiktok.com/open_api/v1.3/pixel/track/',
+              endpoint: TRACK_ENDPOINT,
+              endpointPath: TRACK_ENDPOINT_PATH,
               headers: {
                 'Access-Token': 'dummyAccessToken',
                 'Content-Type': 'application/json',
@@ -2317,7 +2339,8 @@ export const data: ProcessorTestData[] = [
               version: '1',
               type: 'REST',
               method: 'POST',
-              endpoint: 'https://business-api.tiktok.com/open_api/v1.3/pixel/track/',
+              endpoint: TRACK_ENDPOINT,
+              endpointPath: TRACK_ENDPOINT_PATH,
               headers: {
                 'Access-Token': 'dummyAccessToken',
                 'Content-Type': 'application/json',
@@ -2363,7 +2386,8 @@ export const data: ProcessorTestData[] = [
               version: '1',
               type: 'REST',
               method: 'POST',
-              endpoint: 'https://business-api.tiktok.com/open_api/v1.3/pixel/track/',
+              endpoint: TRACK_ENDPOINT,
+              endpointPath: TRACK_ENDPOINT_PATH,
               headers: {
                 'Access-Token': 'dummyAccessToken',
                 'Content-Type': 'application/json',
@@ -2546,7 +2570,8 @@ export const data: ProcessorTestData[] = [
               version: '1',
               type: 'REST',
               method: 'POST',
-              endpoint: 'https://business-api.tiktok.com/open_api/v1.3/pixel/track/',
+              endpoint: TRACK_ENDPOINT,
+              endpointPath: TRACK_ENDPOINT_PATH,
               headers: {
                 'Access-Token': 'dummyAccessToken',
                 'Content-Type': 'application/json',
@@ -2654,7 +2679,8 @@ export const data: ProcessorTestData[] = [
               version: '1',
               type: 'REST',
               method: 'POST',
-              endpoint: 'https://business-api.tiktok.com/open_api/v1.3/pixel/track/',
+              endpoint: TRACK_ENDPOINT,
+              endpointPath: TRACK_ENDPOINT_PATH,
               headers: {
                 'Access-Token': 'dummyAccessToken',
                 'Content-Type': 'application/json',
@@ -2762,7 +2788,8 @@ export const data: ProcessorTestData[] = [
               version: '1',
               type: 'REST',
               method: 'POST',
-              endpoint: 'https://business-api.tiktok.com/open_api/v1.3/pixel/track/',
+              endpoint: TRACK_ENDPOINT,
+              endpointPath: TRACK_ENDPOINT_PATH,
               headers: {
                 'Access-Token': 'dummyAccessToken',
                 'Content-Type': 'application/json',
@@ -2881,7 +2908,8 @@ export const data: ProcessorTestData[] = [
               version: '1',
               type: 'REST',
               method: 'POST',
-              endpoint: 'https://business-api.tiktok.com/open_api/v1.3/pixel/track/',
+              endpoint: TRACK_ENDPOINT,
+              endpointPath: TRACK_ENDPOINT_PATH,
               headers: {
                 'Access-Token': 'dummyAccessToken',
                 'Content-Type': 'application/json',
@@ -3000,7 +3028,8 @@ export const data: ProcessorTestData[] = [
               version: '1',
               type: 'REST',
               method: 'POST',
-              endpoint: 'https://business-api.tiktok.com/open_api/v1.3/pixel/track/',
+              endpoint: TRACK_ENDPOINT,
+              endpointPath: TRACK_ENDPOINT_PATH,
               headers: {
                 'Access-Token': 'dummyAccessToken',
                 'Content-Type': 'application/json',
@@ -3140,7 +3169,8 @@ export const data: ProcessorTestData[] = [
               version: '1',
               type: 'REST',
               method: 'POST',
-              endpoint: 'https://business-api.tiktok.com/open_api/v1.3/pixel/track/',
+              endpoint: TRACK_ENDPOINT,
+              endpointPath: TRACK_ENDPOINT_PATH,
               headers: {
                 'Access-Token': 'dummyAccessToken',
                 'Content-Type': 'application/json',
@@ -3285,7 +3315,8 @@ export const data: ProcessorTestData[] = [
               version: '1',
               type: 'REST',
               method: 'POST',
-              endpoint: 'https://business-api.tiktok.com/open_api/v1.3/pixel/track/',
+              endpoint: TRACK_ENDPOINT,
+              endpointPath: TRACK_ENDPOINT_PATH,
               headers: {
                 'Access-Token': 'dummyAccessToken',
                 'Content-Type': 'application/json',
@@ -3416,7 +3447,8 @@ export const data: ProcessorTestData[] = [
               version: '1',
               type: 'REST',
               method: 'POST',
-              endpoint: 'https://business-api.tiktok.com/open_api/v1.3/pixel/track/',
+              endpoint: TRACK_ENDPOINT,
+              endpointPath: TRACK_ENDPOINT_PATH,
               headers: {
                 'Access-Token': 'dummyAccessToken',
                 'Content-Type': 'application/json',
@@ -3597,7 +3629,8 @@ export const data: ProcessorTestData[] = [
               version: '1',
               type: 'REST',
               method: 'POST',
-              endpoint: 'https://business-api.tiktok.com/open_api/v1.3/pixel/track/',
+              endpoint: TRACK_ENDPOINT,
+              endpointPath: TRACK_ENDPOINT_PATH,
               headers: {
                 'Access-Token': 'dummyAccessToken',
                 'Content-Type': 'application/json',
@@ -3717,7 +3750,8 @@ export const data: ProcessorTestData[] = [
               version: '1',
               type: 'REST',
               method: 'POST',
-              endpoint: 'https://business-api.tiktok.com/open_api/v1.3/event/track/',
+              endpoint: trackEndpointV2,
+              endpointPath: trackEndpointV2Path,
               headers: {
                 'Access-Token': 'dummyAccessToken',
                 'Content-Type': 'application/json',
@@ -3871,7 +3905,8 @@ export const data: ProcessorTestData[] = [
               version: '1',
               type: 'REST',
               method: 'POST',
-              endpoint: 'https://business-api.tiktok.com/open_api/v1.3/event/track/',
+              endpoint: trackEndpointV2,
+              endpointPath: trackEndpointV2Path,
               headers: {
                 'Access-Token': 'dummyAccessToken',
                 'Content-Type': 'application/json',
@@ -4028,7 +4063,8 @@ export const data: ProcessorTestData[] = [
               version: '1',
               type: 'REST',
               method: 'POST',
-              endpoint: 'https://business-api.tiktok.com/open_api/v1.3/event/track/',
+              endpoint: trackEndpointV2,
+              endpointPath: trackEndpointV2Path,
               headers: {
                 'Access-Token': 'dummyAccessToken',
                 'Content-Type': 'application/json',
@@ -4216,7 +4252,8 @@ export const data: ProcessorTestData[] = [
               version: '1',
               type: 'REST',
               method: 'POST',
-              endpoint: 'https://business-api.tiktok.com/open_api/v1.3/event/track/',
+              endpoint: trackEndpointV2,
+              endpointPath: trackEndpointV2Path,
               headers: {
                 'Access-Token': 'dummyAccessToken',
                 'Content-Type': 'application/json',
@@ -4725,7 +4762,8 @@ export const data: ProcessorTestData[] = [
               version: '1',
               type: 'REST',
               method: 'POST',
-              endpoint: 'https://business-api.tiktok.com/open_api/v1.3/event/track/',
+              endpoint: trackEndpointV2,
+              endpointPath: trackEndpointV2Path,
               headers: {
                 'Access-Token': 'dummyAccessToken',
                 'Content-Type': 'application/json',
@@ -4916,7 +4954,8 @@ export const data: ProcessorTestData[] = [
               version: '1',
               type: 'REST',
               method: 'POST',
-              endpoint: 'https://business-api.tiktok.com/open_api/v1.3/event/track/',
+              endpoint: trackEndpointV2,
+              endpointPath: trackEndpointV2Path,
               headers: {
                 'Access-Token': 'dummyAccessToken',
                 'Content-Type': 'application/json',
@@ -5090,7 +5129,8 @@ export const data: ProcessorTestData[] = [
               version: '1',
               type: 'REST',
               method: 'POST',
-              endpoint: 'https://business-api.tiktok.com/open_api/v1.3/event/track/',
+              endpoint: trackEndpointV2,
+              endpointPath: trackEndpointV2Path,
               headers: {
                 'Access-Token': 'dummyAccessToken',
                 'Content-Type': 'application/json',
@@ -5273,7 +5313,8 @@ export const data: ProcessorTestData[] = [
               version: '1',
               type: 'REST',
               method: 'POST',
-              endpoint: 'https://business-api.tiktok.com/open_api/v1.3/pixel/track/',
+              endpoint: TRACK_ENDPOINT,
+              endpointPath: TRACK_ENDPOINT_PATH,
               headers: {
                 'Access-Token': 'dummyAccessToken',
                 'Content-Type': 'application/json',
@@ -5386,7 +5427,8 @@ export const data: ProcessorTestData[] = [
               version: '1',
               type: 'REST',
               method: 'POST',
-              endpoint: 'https://business-api.tiktok.com/open_api/v1.3/event/track/',
+              endpoint: trackEndpointV2,
+              endpointPath: trackEndpointV2Path,
               headers: {
                 'Access-Token': 'dummyAccessToken',
                 'Content-Type': 'application/json',
@@ -5492,7 +5534,8 @@ export const data: ProcessorTestData[] = [
               version: '1',
               type: 'REST',
               method: 'POST',
-              endpoint: 'https://business-api.tiktok.com/open_api/v1.3/event/track/',
+              endpoint: trackEndpointV2,
+              endpointPath: trackEndpointV2Path,
               headers: {
                 'Access-Token': 'dummyAccessToken',
                 'Content-Type': 'application/json',
@@ -5643,7 +5686,8 @@ export const data: ProcessorTestData[] = [
               version: '1',
               type: 'REST',
               method: 'POST',
-              endpoint: 'https://business-api.tiktok.com/open_api/v1.3/pixel/track/',
+              endpoint: TRACK_ENDPOINT,
+              endpointPath: TRACK_ENDPOINT_PATH,
               headers: {
                 'Access-Token': 'dummyAccessToken',
                 'Content-Type': 'application/json',
@@ -5745,7 +5789,8 @@ export const data: ProcessorTestData[] = [
               version: '1',
               type: 'REST',
               method: 'POST',
-              endpoint: 'https://business-api.tiktok.com/open_api/v1.3/pixel/track/',
+              endpoint: TRACK_ENDPOINT,
+              endpointPath: TRACK_ENDPOINT_PATH,
               headers: {
                 'Access-Token': 'dummyAccessToken',
                 'Content-Type': 'application/json',
@@ -5844,7 +5889,8 @@ export const data: ProcessorTestData[] = [
               version: '1',
               type: 'REST',
               method: 'POST',
-              endpoint: 'https://business-api.tiktok.com/open_api/v1.3/pixel/track/',
+              endpoint: TRACK_ENDPOINT,
+              endpointPath: TRACK_ENDPOINT_PATH,
               headers: {
                 'Access-Token': 'dummyAccessToken',
                 'Content-Type': 'application/json',

--- a/test/integrations/destinations/tiktok_ads/router/data.ts
+++ b/test/integrations/destinations/tiktok_ads/router/data.ts
@@ -3,6 +3,14 @@ import { RouterTestData } from '../../../testTypes';
 import { defaultMockFns } from '../mocks';
 import { overrideDestination } from '../../../testUtils';
 import { destinationConfig } from '../common';
+import {
+  TRACK_ENDPOINT,
+  TRACK_ENDPOINT_PATH,
+  trackEndpointV2,
+  trackEndpointV2Path,
+  BATCH_ENDPOINT_PATH,
+  BATCH_ENDPOINT,
+} from '../../../../../src/v0/destinations/tiktok_ads/config';
 
 export const data: RouterTestData[] = [
   {
@@ -305,7 +313,8 @@ export const data: RouterTestData[] = [
                 version: '1',
                 type: 'REST',
                 method: 'POST',
-                endpoint: 'https://business-api.tiktok.com/open_api/v1.3/pixel/batch/',
+                endpoint: BATCH_ENDPOINT,
+                endpointPath: BATCH_ENDPOINT_PATH,
                 headers: {
                   'Access-Token': 'dummyAccessToken',
                   'Content-Type': 'application/json',
@@ -805,7 +814,8 @@ export const data: RouterTestData[] = [
                 version: '1',
                 type: 'REST',
                 method: 'POST',
-                endpoint: 'https://business-api.tiktok.com/open_api/v1.3/pixel/batch/',
+                endpoint: BATCH_ENDPOINT,
+                endpointPath: BATCH_ENDPOINT_PATH,
                 headers: { 'Access-Token': 'dummyAccessToken', 'Content-Type': 'application/json' },
                 params: {},
                 body: {
@@ -1109,7 +1119,8 @@ export const data: RouterTestData[] = [
                     JSON_ARRAY: {},
                     XML: {},
                   },
-                  endpoint: 'https://business-api.tiktok.com/open_api/v1.3/pixel/track/',
+                  endpoint: TRACK_ENDPOINT,
+                  endpointPath: TRACK_ENDPOINT_PATH,
                   files: {},
                   headers: {
                     'Access-Token': 'dummyAccessToken',
@@ -1368,7 +1379,8 @@ export const data: RouterTestData[] = [
                 version: '1',
                 type: 'REST',
                 method: 'POST',
-                endpoint: 'https://business-api.tiktok.com/open_api/v1.3/event/track/',
+                endpoint: trackEndpointV2,
+                endpointPath: trackEndpointV2Path,
                 headers: {
                   'Access-Token': 'dummyAccessToken',
                   'Content-Type': 'application/json',
@@ -1511,7 +1523,8 @@ export const data: RouterTestData[] = [
                 version: '1',
                 type: 'REST',
                 method: 'POST',
-                endpoint: 'https://business-api.tiktok.com/open_api/v1.3/event/track/',
+                endpoint: trackEndpointV2,
+                endpointPath: trackEndpointV2Path,
                 headers: {
                   'Access-Token': 'dummyAccessToken',
                   'Content-Type': 'application/json',
@@ -1839,7 +1852,8 @@ export const data: RouterTestData[] = [
                 version: '1',
                 type: 'REST',
                 method: 'POST',
-                endpoint: 'https://business-api.tiktok.com/open_api/v1.3/event/track/',
+                endpoint: trackEndpointV2,
+                endpointPath: trackEndpointV2Path,
                 headers: {
                   'Access-Token': 'dummyAccessToken',
                   'Content-Type': 'application/json',
@@ -1983,7 +1997,8 @@ export const data: RouterTestData[] = [
                 version: '1',
                 type: 'REST',
                 method: 'POST',
-                endpoint: 'https://business-api.tiktok.com/open_api/v1.3/event/track/',
+                endpoint: trackEndpointV2,
+                endpointPath: trackEndpointV2Path,
                 headers: {
                   'Access-Token': 'dummyAccessToken',
                   'Content-Type': 'application/json',
@@ -2279,7 +2294,8 @@ export const data: RouterTestData[] = [
                 version: '1',
                 type: 'REST',
                 method: 'POST',
-                endpoint: 'https://business-api.tiktok.com/open_api/v1.3/event/track/',
+                endpoint: trackEndpointV2,
+                endpointPath: trackEndpointV2Path,
                 headers: {
                   'Access-Token': 'dummyAccessToken',
                   'Content-Type': 'application/json',
@@ -2738,7 +2754,8 @@ export const data: RouterTestData[] = [
                 version: '1',
                 type: 'REST',
                 method: 'POST',
-                endpoint: 'https://business-api.tiktok.com/open_api/v1.3/event/track/',
+                endpoint: trackEndpointV2,
+                endpointPath: trackEndpointV2Path,
                 headers: {
                   'Access-Token': 'dummyAccessToken',
                   'Content-Type': 'application/json',
@@ -2910,7 +2927,8 @@ export const data: RouterTestData[] = [
                   version: '1',
                   type: 'REST',
                   method: 'POST',
-                  endpoint: 'https://business-api.tiktok.com/open_api/v1.3/event/track/',
+                  endpoint: trackEndpointV2,
+                  endpointPath: trackEndpointV2Path,
                   headers: {
                     'Access-Token': 'dummyAccessToken',
                     'Content-Type': 'application/json',
@@ -2990,7 +3008,8 @@ export const data: RouterTestData[] = [
                 version: '1',
                 type: 'REST',
                 method: 'POST',
-                endpoint: 'https://business-api.tiktok.com/open_api/v1.3/event/track/',
+                endpoint: trackEndpointV2,
+                endpointPath: trackEndpointV2Path,
                 headers: {
                   'Access-Token': 'dummyAccessToken',
                   'Content-Type': 'application/json',
@@ -3194,7 +3213,8 @@ export const data: RouterTestData[] = [
                   version: '1',
                   type: 'REST',
                   method: 'POST',
-                  endpoint: 'https://business-api.tiktok.com/open_api/v1.3/event/track/',
+                  endpoint: trackEndpointV2,
+                  endpointPath: trackEndpointV2Path,
                   headers: {
                     'Access-Token': 'dummyAccessToken',
                     'Content-Type': 'application/json',
@@ -3279,7 +3299,8 @@ export const data: RouterTestData[] = [
                   version: '1',
                   type: 'REST',
                   method: 'POST',
-                  endpoint: 'https://business-api.tiktok.com/open_api/v1.3/event/track/',
+                  endpoint: trackEndpointV2,
+                  endpointPath: trackEndpointV2Path,
                   headers: {
                     'Access-Token': 'dummyAccessToken',
                     'Content-Type': 'application/json',


### PR DESCRIPTION
## What are the changes introduced in this PR?

Updated TikTok Ads to include the new `endpointPath` property that was added to the destination transformation responses.

## What is the related Linear task?

Resolves https://linear.app/rudderstack/issue/INT-4102/add-endpoint-path-details-in-rudder-transformer-for-top-15

## Please explain the objectives of your changes below

The TikTok Ads destination was updated to include `endpointPath` properties in the response objects. This PR updates all related tests to expect these new properties:

- **Unit Tests**: Updated `transform.test.js` and `transformV2.test.js` to include `endpointPath` in expected responses
- **Component Tests**: Updated `processor/data.ts` and `router/data.ts` to include `endpointPath` for all endpoint configurations

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

No changes to existing capabilities. This is purely a test update to match the new `endpointPath` property that was added to the TikTok Ads destination responses.

### Any new dependencies introduced with this change?

N/A

### Any new generic utility introduced or modified. Please explain the changes.

N/A

### Any technical or performance related pointers to consider with the change?

N/A

@coderabbitai review

<hr>

### Developer checklist

- [x] My code follows the style guidelines of this project
- [x] **No breaking changes are being introduced.**
- [x] All related docs linked with the PR?
- [x] All changes manually tested?
- [x] Any documentation changes needed with this change?
- [x] Is the PR limited to 10 file changes?
- [x] Is the PR limited to one linear task?
- [x] Are relevant unit and component test-cases added in **new readability format**?

### Reviewer checklist

- [x] Is the type of change in the PR title appropriate as per the changes?
- [x] Verified that there are no credentials or confidential data exposed with the changes.