### PR TITLE
feat(splitio): add endpoint path details

### DIFF
--- a/src/v0/destinations/splitio/config.js
+++ b/src/v0/destinations/splitio/config.js
@@ -7,7 +7,7 @@ const endpoints = {
 };
 
 const CONFIG_CATEGORIES = {
-  EVENT: { endPoint: endpoints.eventUrl, name: 'EventConfig' },
+  EVENT: { endPoint: endpoints.eventUrl, name: 'EventConfig', endpointPath: '/events' },
 };
 
 const MAPPING_CONFIG = getMappingConfig(CONFIG_CATEGORIES, __dirname);

--- a/src/v0/destinations/splitio/transform.js
+++ b/src/v0/destinations/splitio/transform.js
@@ -26,6 +26,7 @@ function responseBuilderSimple(payload, category, destination) {
     const responseBody = payload;
     const response = defaultRequestConfig();
     response.endpoint = category.endPoint;
+    response.endpointPath = category.endpointPath;
     response.method = defaultPostRequestConfig.requestMethod;
     response.headers = {
       'Content-Type': JSON_MIME_TYPE,

--- a/test/integrations/destinations/splitio/processor/data.ts
+++ b/test/integrations/destinations/splitio/processor/data.ts
@@ -61,6 +61,7 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: 'https://events.split.io/api/events',
+              endpointPath: '/events',
               headers: {
                 'Content-Type': 'application/json',
                 Authorization: authHeader1,
@@ -162,6 +163,7 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: 'https://events.split.io/api/events',
+              endpointPath: '/events',
               headers: {
                 'Content-Type': 'application/json',
                 Authorization: authHeader1,
@@ -264,6 +266,7 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: 'https://events.split.io/api/events',
+              endpointPath: '/events',
               headers: {
                 'Content-Type': 'application/json',
                 Authorization: authHeader1,
@@ -354,6 +357,7 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: 'https://events.split.io/api/events',
+              endpointPath: '/events',
               headers: {
                 'Content-Type': 'application/json',
                 Authorization: authHeader1,
@@ -438,6 +442,7 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: 'https://events.split.io/api/events',
+              endpointPath: '/events',
               headers: {
                 'Content-Type': 'application/json',
                 Authorization: authHeader1,
@@ -526,6 +531,7 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: 'https://events.split.io/api/events',
+              endpointPath: '/events',
               headers: {
                 'Content-Type': 'application/json',
                 Authorization: authHeader1,
@@ -795,6 +801,7 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: 'https://events.split.io/api/events',
+              endpointPath: '/events',
               headers: {
                 'Content-Type': 'application/json',
                 Authorization: authHeader1,
@@ -879,6 +886,7 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: 'https://events.split.io/api/events',
+              endpointPath: '/events',
               headers: {
                 'Content-Type': 'application/json',
                 Authorization: authHeader1,

--- a/test/integrations/destinations/splitio/router/data.ts
+++ b/test/integrations/destinations/splitio/router/data.ts
@@ -57,6 +57,7 @@ export const data = [
                 type: 'REST',
                 method: 'POST',
                 endpoint: 'https://events.split.io/api/events',
+                endpointPath: '/events',
                 headers: { 'Content-Type': 'application/json', Authorization: authHeader1 },
                 params: {},
                 body: {
@@ -140,6 +141,7 @@ export const data = [
                 type: 'REST',
                 method: 'POST',
                 endpoint: 'https://events.split.io/api/events',
+                endpointPath: '/events',
                 headers: { 'Content-Type': 'application/json', Authorization: authHeader1 },
                 params: {},
                 body: {


### PR DESCRIPTION
## What are the changes introduced in this PR?

Added endpoint path details to Split.io destination configuration to support the top 15 destinations initiative. This change adds the `endpointPath` field to the configuration categories and ensures it's included in the response transformation.

## What is the related Linear task?

Resolves INT-4102

## Please explain the objectives of your changes below

This change is part of the initiative to add endpoint path details for the top 15 destinations in RudderStack. The `endpointPath` field provides additional metadata about the API endpoint being used, which can be useful for monitoring, debugging, and analytics purposes.

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

- Added `endpointPath: '/events'` to the EVENT configuration category in Split.io config
- Updated the transform function to include `endpointPath` in the response object
- Updated test data files to include the new `endpointPath` field in expected outputs

### Any new dependencies introduced with this change?

N/A

### Any new generic utility introduced or modified. Please explain the changes.

N/A

### Any technical or performance related pointers to consider with the change?

This is a non-breaking change that only adds additional metadata to the response. No performance impact is expected.

@coderabbitai review

<hr>

### Developer checklist

- [x] My code follows the style guidelines of this project
- [x] **No breaking changes are being introduced.**
- [x] All related docs linked with the PR?
- [x] All changes manually tested?
- [ ] Any documentation changes needed with this change?
- [x] Is the PR limited to 10 file changes?
- [x] Is the PR limited to one linear task?
- [x] Are relevant unit and component test-cases added in **new readability format**?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?
- [ ] Verified that there are no credentials or confidential data exposed with the changes.