### PR TITLE
fix: update GitHub Actions checkout to v4 for compatibility

### DIFF
--- a/.github/workflows/build-pr-artifacts.yml
+++ b/.github/workflows/build-pr-artifacts.yml
@@ -26,7 +26,7 @@ jobs:
       tag_name_ut: ${{ steps.gen_tag_names.outputs.tag_name_ut }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
 


### PR DESCRIPTION
## Description
This PR updates the GitHub Actions checkout action from v5 to v4 in the build-pr-artifacts.yml workflow.

Resolves https://linear.app/rudderstack/issue/INT-4108/on-call-sep-10-16-dilip-progress-on-following-tasks

## Problem
- GitHub Actions executions are failing due to runner version mismatches
- Not all action executions are getting the latest GitHub runner
- actions/checkout@v5 requires newer runners that aren't available everywhere

## Solution
- Downgrade actions/checkout from v5 to v4 for better compatibility
- This ensures the workflow can run on older GitHub runners
- Addresses the failing action executions

## Changes
- Updated  to use 

## Testing
- [ ] Verify the workflow runs successfully on PR creation
- [ ] Ensure no breaking changes to existing functionality