### PR TITLE
fix: fireHTTPStats to emit metrics about requests only

### DIFF
--- a/src/adapters/network.test.js
+++ b/src/adapters/network.test.js
@@ -84,6 +84,7 @@ describe('fireHTTPStats tests', () => {
     stats.timing.mockClear();
     stats.counter.mockClear();
   });
+
   it('should not throw error when metadata is sent as correctly defined object', () => {
     const clientResponse = {
       success: true,
@@ -135,23 +136,24 @@ describe('fireHTTPStats tests', () => {
       },
     };
     const startTime = new Date();
+    const metadataArray = [
+      {
+        destType: 'DT',
+        destinationId: 'd1',
+        workspaceId: 'w1',
+        jobId: 1,
+        sourceId: 's1',
+      },
+      {
+        destType: 'DT',
+        jobId: 2,
+        destinationId: 'd1',
+        workspaceId: 'w2',
+        sourceId: 's2',
+      },
+    ];
     const statTags = {
-      metadata: [
-        {
-          destType: 'DT',
-          destinationId: 'd1',
-          workspaceId: 'w1',
-          jobId: 1,
-          sourceId: 's1',
-        },
-        {
-          destType: 'DT',
-          jobId: 2,
-          destinationId: 'd1',
-          workspaceId: 'w2',
-          sourceId: 's2',
-        },
-      ],
+      metadata: metadataArray,
       destType: 'DT',
       feature: 'feat',
       endpointPath: '/some/url',
@@ -161,24 +163,14 @@ describe('fireHTTPStats tests', () => {
       fireHTTPStats(clientResponse, startTime, statTags);
     }).not.toThrow(Error);
 
-    expect(stats.timing).toHaveBeenCalledTimes(2);
+    expect(stats.timing).toHaveBeenCalledTimes(1);
     expect(stats.timing).toHaveBeenNthCalledWith(1, 'outgoing_request_latency', startTime, {
+      destType: 'DT',
       destinationId: 'd1',
       workspaceId: 'w1',
       sourceId: 's1',
-      destType: 'DT',
       feature: 'feat',
       module: '',
-      endpointPath: '/some/url',
-      requestMethod: 'post',
-    });
-    expect(stats.timing).toHaveBeenNthCalledWith(2, 'outgoing_request_latency', startTime, {
-      destinationId: 'd1',
-      workspaceId: 'w2',
-      sourceId: 's2',
-      destType: 'DT',
-      module: '',
-      feature: 'feat',
       endpointPath: '/some/url',
       requestMethod: 'post',
     });
@@ -241,7 +233,14 @@ describe('fireHTTPStats tests', () => {
       fireHTTPStats(clientResponse, startTime, statTags);
     }).not.toThrow(Error);
 
-    expect(stats.timing).toHaveBeenCalledTimes(0);
+    expect(stats.timing).toHaveBeenCalledTimes(1);
+    expect(stats.timing).toHaveBeenNthCalledWith(1, 'outgoing_request_latency', startTime, {
+      destType: 'DT',
+      feature: 'feat',
+      module: '',
+      endpointPath: '/some/url',
+      requestMethod: 'post',
+    });
   });
   it('should not throw error when metadata is sent as empty object', () => {
     const clientResponse = {
@@ -302,7 +301,14 @@ describe('fireHTTPStats tests', () => {
       fireHTTPStats(clientResponse, startTime, statTags);
     }).not.toThrow(Error);
 
-    expect(stats.timing).toHaveBeenCalledTimes(0);
+    expect(stats.timing).toHaveBeenCalledTimes(1);
+    expect(stats.timing).toHaveBeenNthCalledWith(1, 'outgoing_request_latency', startTime, {
+      destType: 'DT',
+      feature: 'feat',
+      module: '',
+      endpointPath: '/some/url',
+      requestMethod: 'post',
+    });
   });
   it('should not throw error when metadata is sent as [1, 2]', () => {
     const clientResponse = {
@@ -329,15 +335,8 @@ describe('fireHTTPStats tests', () => {
       fireHTTPStats(clientResponse, startTime, statTags);
     }).not.toThrow(Error);
 
-    expect(stats.timing).toHaveBeenCalledTimes(2);
+    expect(stats.timing).toHaveBeenCalledTimes(1);
     expect(stats.timing).toHaveBeenNthCalledWith(1, 'outgoing_request_latency', startTime, {
-      destType: 'DT',
-      feature: 'feat',
-      module: '',
-      endpointPath: '/some/url',
-      requestMethod: 'post',
-    });
-    expect(stats.timing).toHaveBeenNthCalledWith(2, 'outgoing_request_latency', startTime, {
       destType: 'DT',
       feature: 'feat',
       module: '',
@@ -361,6 +360,184 @@ describe('fireHTTPStats tests', () => {
     const startTime = new Date();
     const statTags = {
       metadata: 1,
+      destType: 'DT',
+      feature: 'feat',
+      endpointPath: '/some/url',
+      requestMethod: 'post',
+    };
+    expect(() => {
+      fireHTTPStats(clientResponse, startTime, statTags);
+    }).not.toThrow(Error);
+
+    expect(stats.timing).toHaveBeenCalledTimes(1);
+    expect(stats.timing).toHaveBeenNthCalledWith(1, 'outgoing_request_latency', startTime, {
+      destType: 'DT',
+      feature: 'feat',
+      module: '',
+      endpointPath: '/some/url',
+      requestMethod: 'post',
+    });
+  });
+
+  // Additional tests for the simplified fireHTTPStats function
+  it('should handle null metadata correctly', () => {
+    const clientResponse = {
+      success: true,
+      response: {
+        data: { a: 1, b: 2 },
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      },
+    };
+    const startTime = new Date();
+    const statTags = {
+      metadata: null,
+      destType: 'DT',
+      feature: 'feat',
+      endpointPath: '/some/url',
+      requestMethod: 'post',
+    };
+    expect(() => {
+      fireHTTPStats(clientResponse, startTime, statTags);
+    }).not.toThrow(Error);
+
+    expect(stats.timing).toHaveBeenCalledTimes(1);
+    expect(stats.timing).toHaveBeenNthCalledWith(1, 'outgoing_request_latency', startTime, {
+      destType: 'DT',
+      feature: 'feat',
+      module: '',
+      endpointPath: '/some/url',
+      requestMethod: 'post',
+    });
+  });
+
+  it('should handle string metadata correctly', () => {
+    const clientResponse = {
+      success: true,
+      response: {
+        data: { a: 1, b: 2 },
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      },
+    };
+    const startTime = new Date();
+    const statTags = {
+      metadata: 'test-metadata',
+      destType: 'DT',
+      feature: 'feat',
+      endpointPath: '/some/url',
+      requestMethod: 'post',
+    };
+    expect(() => {
+      fireHTTPStats(clientResponse, startTime, statTags);
+    }).not.toThrow(Error);
+
+    expect(stats.timing).toHaveBeenCalledTimes(1);
+    expect(stats.timing).toHaveBeenNthCalledWith(1, 'outgoing_request_latency', startTime, {
+      destType: 'DT',
+      feature: 'feat',
+      module: '',
+      endpointPath: '/some/url',
+      requestMethod: 'post',
+    });
+  });
+
+  it('should handle boolean metadata correctly', () => {
+    const clientResponse = {
+      success: true,
+      response: {
+        data: { a: 1, b: 2 },
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      },
+    };
+    const startTime = new Date();
+    const statTags = {
+      metadata: true,
+      destType: 'DT',
+      feature: 'feat',
+      endpointPath: '/some/url',
+      requestMethod: 'post',
+    };
+    expect(() => {
+      fireHTTPStats(clientResponse, startTime, statTags);
+    }).not.toThrow(Error);
+
+    expect(stats.timing).toHaveBeenCalledTimes(1);
+    expect(stats.timing).toHaveBeenNthCalledWith(1, 'outgoing_request_latency', startTime, {
+      destType: 'DT',
+      feature: 'feat',
+      module: '',
+      endpointPath: '/some/url',
+      requestMethod: 'post',
+    });
+  });
+
+  it('should handle complex nested object metadata correctly', () => {
+    const clientResponse = {
+      success: true,
+      response: {
+        data: { a: 1, b: 2 },
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      },
+    };
+    const startTime = new Date();
+    const complexMetadata = {
+      destType: 'DT',
+      destinationId: 'd1',
+      workspaceId: 'w1',
+      sourceId: 's1',
+      nested: {
+        level1: {
+          level2: 'deep-value',
+        },
+      },
+      array: [1, 2, { nested: 'value' }],
+    };
+    const statTags = {
+      metadata: complexMetadata,
+      destType: 'DT',
+      feature: 'feat',
+      endpointPath: '/some/url',
+      requestMethod: 'post',
+    };
+    expect(() => {
+      fireHTTPStats(clientResponse, startTime, statTags);
+    }).not.toThrow(Error);
+
+    expect(stats.timing).toHaveBeenCalledTimes(1);
+    expect(stats.timing).toHaveBeenNthCalledWith(1, 'outgoing_request_latency', startTime, {
+      destType: 'DT',
+      destinationId: 'd1',
+      workspaceId: 'w1',
+      sourceId: 's1',
+      feature: 'feat',
+      module: '',
+      endpointPath: '/some/url',
+      requestMethod: 'post',
+    });
+  });
+
+  it('should handle mixed array metadata correctly', () => {
+    const clientResponse = {
+      success: true,
+      response: {
+        data: { a: 1, b: 2 },
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      },
+    };
+    const startTime = new Date();
+    const mixedMetadata = [
+      { destType: 'DT', id: 1 },
+      'string-value',
+      42,
+      null,
+      { nested: { value: 'test' } },
+    ];
+    const statTags = {
+      metadata: mixedMetadata,
       destType: 'DT',
       feature: 'feat',
       endpointPath: '/some/url',

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,5 +1,9 @@
 /* istanbul ignore file */
-const { LOGLEVELS, structuredLogger } = require('@rudderstack/integrations-lib');
+const {
+  LOGLEVELS,
+  structuredLogger,
+  isDefinedAndNotNull,
+} = require('@rudderstack/integrations-lib');
 const { getMatchedMetadata } = require('./util/logger');
 // LOGGER_IMPL can be `console` or `winston`
 const loggerImpl = process.env.LOGGER_IMPL ?? 'winston';
@@ -44,7 +48,7 @@ const setLogLevel = (level) => {
 const getLogMetadata = (metadata) => {
   let reqMeta = metadata;
   if (Array.isArray(metadata)) {
-    [reqMeta] = metadata;
+    [reqMeta] = metadata.filter(isDefinedAndNotNull);
   }
   const destType = reqMeta?.destType || reqMeta?.destinationType;
   return {


### PR DESCRIPTION
## What are the changes introduced in this PR?

Fixed fireHTTPStats to fire only once per request instead of for each job. The function was incorrectly processing metadata arrays and calling fireOutgoingReqStats multiple times per request.

## What is the related Linear task?

N/A

## Please explain the objectives of your changes below

The fireHTTPStats function was incorrectly firing stats for each job in the metadata array instead of once per request. This change fixes the behavior by:

- Removing the complex metadata array processing logic that was causing multiple stats calls
- Passing metadata directly to fireOutgoingReqStats as a single value
- Ensuring fireHTTPStats fires only once per request, not per job
- Updating all related tests to reflect the corrected behavior
- Adding comprehensive test coverage for various metadata types (null, string, boolean, complex objects, mixed arrays)

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

**Bug Fix**: The function now correctly calls fireOutgoingReqStats only once per request instead of multiple times for each job in the metadata array. This fixes the incorrect stats reporting behavior.

### Any new dependencies introduced with this change?

N/A

### Any new generic utility introduced or modified. Please explain the changes.

N/A

### Any technical or performance related pointers to consider with the change?

- Fixed incorrect stats reporting (was firing per job, now fires per request)
- Reduced function complexity and improved maintainability
- Single call to fireOutgoingReqStats instead of multiple calls for array metadata
- Better test coverage for edge cases

@coderabbitai review

<hr>

### Developer checklist

- [x] My code follows the style guidelines of this project
- [x] **No breaking changes are being introduced.**
- [x] All related docs linked with the PR?
- [x] All changes manually tested?
- [ ] Any documentation changes needed with this change?
- [x] Is the PR limited to 10 file changes?
- [x] Is the PR limited to one linear task?
- [x] Are relevant unit and component test-cases added in **new readability format**?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?
- [ ] Verified that there are no credentials or confidential data exposed with the changes.