### PR TITLE
fix: handle empty commits in UT deploy workflow

### DIFF
--- a/.github/workflows/prepare-for-prod-ut-deploy.yml
+++ b/.github/workflows/prepare-for-prod-ut-deploy.yml
@@ -188,11 +188,17 @@ jobs:
             git add $customer
           done
 
-          git commit -m "chore: upgrade dedicated user transformers to $TAG_NAME"
-          git push -u origin dedicated-user-transformer-$TAG_NAME
+          # Check if there are any changes to commit
+          if git diff --cached --quiet; then
+            echo "No changes to commit for dedicated user transformers"
+            echo "DEDICATED_PR_URL=NA" >> $GITHUB_ENV
+          else
+            git commit -m "chore: upgrade dedicated user transformers to $TAG_NAME"
+            git push -u origin dedicated-user-transformer-$TAG_NAME
 
-          PR_URL=$(gh pr create --fill | grep -o 'https://github.com/[^/]*/[^/]*/pull/[0-9]*')
-          echo "DEDICATED_PR_URL=$PR_URL" >> $GITHUB_ENV
+            PR_URL=$(gh pr create --fill | grep -o 'https://github.com/[^/]*/[^/]*/pull/[0-9]*')
+            echo "DEDICATED_PR_URL=$PR_URL" >> $GITHUB_ENV
+          fi
 
       - name: Notify Control Plane Team
         uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a  # v2.1.1


### PR DESCRIPTION
## Problem
The UT deploy workflow was failing when there were no files to commit, causing the `git commit` command to error out and break the pipeline.

## Solution
- Added conditional check using `git diff --cached --quiet` before attempting to commit
- Only commit and push if there are actual changes to be committed
- Set `DEDICATED_PR_URL=NA` when no changes are present to maintain consistency
- Ensures the workflow continues gracefully in both scenarios

## Changes
- Modified `.github/workflows/prepare-for-prod-ut-deploy.yml`
- Added conditional logic around git commit and push operations
- Proper handling of environment variables for downstream steps

## Testing
- Workflow will now handle both cases:
  - ✅ When there are changes: commits, pushes, and creates PR as before
  - ✅ When there are no changes: logs message and continues without error

Fixes the issue where empty commits would cause the workflow to fail.