### PR TITLE
fix: move continue-on-error to specific test step in ingestion-service-test workflow

### DIFF
--- a/.github/workflows/ingestion-service-test.yml
+++ b/.github/workflows/ingestion-service-test.yml
@@ -19,7 +19,6 @@ jobs:
   ingestion-service-test:
     name: ingestion-service-test
     runs-on: ubuntu-latest
-    continue-on-error: true
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       TRANSFORMER_IMAGE_NAME_FOR_TEST: ${{ inputs.build_tag }}
@@ -48,6 +47,7 @@ jobs:
           cd rudder-ingestion-svc
           go mod download
       - name: 'Run tests'
+        continue-on-error: true
         run: |
           cd rudder-ingestion-svc
           pwd


### PR DESCRIPTION
## Description
This PR fixes the GitHub workflow configuration for the ingestion-service-test by moving the `continue-on-error: true` from the job level to the specific 'Run tests' step level.

## Changes
- Moved `continue-on-error: true` from job level to the 'Run tests' step level
- This allows the job to fail properly while still allowing test failures to not block the workflow
- Improves workflow reliability and error handling

## Why this change?
Previously, having `continue-on-error: true` at the job level meant that the entire job would continue even if there were critical failures. By moving it to the specific test step, we ensure that:
1. The job can fail properly for critical issues
2. Test failures don't block the workflow unnecessarily
3. Better error handling and debugging capabilities

## Testing
- [x] Workflow syntax validated
- [x] Changes tested locally