### PR TITLE
chore: run global git pre-commits with husky

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,7 +1,15 @@
 
-# run global hook if exists
-if [ -x "$HOME/.git-hooks/pre-commit.d/gitleaks" ]; then
-  "$HOME/.git-hooks/pre-commit.d/gitleaks"
+# run global hook
+GITLEAKS_HOOK="$HOME/.git-hooks/pre-commit.d/gitleaks"
+
+if [ -x "$GITLEAKS_HOOK" ]; then
+  if ! "$GITLEAKS_HOOK"; then
+    printf 'Global gitleaks pre-commit hook failed. Aborting commit.\n' >&2
+    exit 1
+  fi
+else
+  printf 'Error: Global gitleaks hook is not a file or not executable: %s\n' "$GITLEAKS_HOOK" >&2
+  exit 1
 fi
 
 # Get changed files in test/integrations/sources/


### PR DESCRIPTION
## What are the changes introduced in this PR?

Husky overrides globally configured git pre-commit hooks. Secret scanning global pre-commit hooks will not run because of this. We are forcing husky to run this in this PR. This is only a temporary solution. Ideal scenario is to completely avoid using husky as we want to avoid running npm lifecycle scripts as well which husky relies on.

## What is the related Linear task?

Resolves INT-4168

## Please explain the objectives of your changes below

Put down any required details on the broader aspect of your changes. If there are any dependent changes, **mandatorily** mention them here

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

N/A

### Any new dependencies introduced with this change?

N/A

### Any new generic utility introduced or modified. Please explain the changes.

N/A

### Any technical or performance related pointers to consider with the change?

N/A

@coderabbitai review

<hr>

### Developer checklist

- [ ] My code follows the style guidelines of this project

- [ ] **No breaking changes are being introduced.**

- [ ] All related docs linked with the PR?

- [ ] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [ ] Is the PR limited to 10 file changes?

- [ ] Is the PR limited to one linear task?

- [ ] Are relevant unit and component test-cases added in **new readability format**?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.
