### PR TITLE
feat: add endpointPath to Google AdWords Remarketing Lists destination

### DIFF
--- a/src/v0/destinations/google_adwords_remarketing_lists/config.js
+++ b/src/v0/destinations/google_adwords_remarketing_lists/config.js
@@ -2,6 +2,7 @@ const { getMappingConfig } = require('../../util');
 
 const API_VERSION = 'v19';
 
+const OFFLINE_USER_DATA_JOBS_ENDPOINT = 'offlineUserDataJobs';
 const BASE_ENDPOINT = `https://googleads.googleapis.com/${API_VERSION}/customers`;
 const CONFIG_CATEGORIES = {
   AUDIENCE_LIST: { type: 'audienceList', name: 'offlineDataJobs' },
@@ -26,6 +27,7 @@ const consentConfigMap = {
 
 module.exports = {
   API_VERSION,
+  OFFLINE_USER_DATA_JOBS_ENDPOINT,
   BASE_ENDPOINT,
   TYPEOFLIST,
   attributeMapping,

--- a/src/v0/destinations/google_adwords_remarketing_lists/util.js
+++ b/src/v0/destinations/google_adwords_remarketing_lists/util.js
@@ -16,6 +16,7 @@ const {
   addressInfoMapping,
   attributeMapping,
   TYPEOFLIST,
+  OFFLINE_USER_DATA_JOBS_ENDPOINT,
   BASE_ENDPOINT,
   hashAttributes,
   ADDRESS_INFO_ATTRIBUTES,
@@ -41,7 +42,8 @@ const responseBuilder = (
   const payload = body;
   const response = defaultRequestConfig();
   const filteredCustomerId = removeHyphens(Config.customerId);
-  response.endpoint = `${BASE_ENDPOINT}/${filteredCustomerId}/offlineUserDataJobs`;
+  response.endpointPath = OFFLINE_USER_DATA_JOBS_ENDPOINT;
+  response.endpoint = `${BASE_ENDPOINT}/${filteredCustomerId}/${OFFLINE_USER_DATA_JOBS_ENDPOINT}`;
   response.body.JSON = removeUndefinedAndNullValues(payload);
   if (!isDefinedAndNotNullAndNotEmpty(audienceId)) {
     throw new ConfigurationError('List ID is a mandatory field');

--- a/src/v0/destinations/google_adwords_remarketing_lists/util.test.js
+++ b/src/v0/destinations/google_adwords_remarketing_lists/util.test.js
@@ -69,6 +69,7 @@ const expectedResponse = {
   type: 'REST',
   method: 'POST',
   endpoint: `https://googleads.googleapis.com/${API_VERSION}/customers/7693729833/offlineUserDataJobs`,
+  endpointPath: 'offlineUserDataJobs',
   headers: {
     Authorization: `Bearer ${accessToken}`,
     'Content-Type': 'application/json',

--- a/test/integrations/destinations/google_adwords_remarketing_lists/processor/data.ts
+++ b/test/integrations/destinations/google_adwords_remarketing_lists/processor/data.ts
@@ -73,6 +73,7 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: `https://googleads.googleapis.com/${API_VERSION}/customers/7693729833/offlineUserDataJobs`,
+              endpointPath: 'offlineUserDataJobs',
               headers: {
                 Authorization: authHeader1,
                 'Content-Type': 'application/json',
@@ -205,6 +206,7 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: `https://googleads.googleapis.com/${API_VERSION}/customers/7693729833/offlineUserDataJobs`,
+              endpointPath: 'offlineUserDataJobs',
               headers: {
                 Authorization: authHeader1,
                 'Content-Type': 'application/json',
@@ -324,6 +326,7 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: `https://googleads.googleapis.com/${API_VERSION}/customers/7693729833/offlineUserDataJobs`,
+              endpointPath: 'offlineUserDataJobs',
               headers: {
                 Authorization: authHeader1,
                 'Content-Type': 'application/json',
@@ -1425,6 +1428,7 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: `https://googleads.googleapis.com/${API_VERSION}/customers/7693729833/offlineUserDataJobs`,
+              endpointPath: 'offlineUserDataJobs',
               headers: {
                 Authorization: authHeader1,
                 'Content-Type': 'application/json',
@@ -2819,6 +2823,7 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: `https://googleads.googleapis.com/${API_VERSION}/customers/7693729833/offlineUserDataJobs`,
+              endpointPath: 'offlineUserDataJobs',
               headers: {
                 Authorization: authHeader1,
                 'Content-Type': 'application/json',
@@ -2898,6 +2903,7 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: `https://googleads.googleapis.com/${API_VERSION}/customers/7693729833/offlineUserDataJobs`,
+              endpointPath: 'offlineUserDataJobs',
               headers: {
                 Authorization: authHeader1,
                 'Content-Type': 'application/json',
@@ -4110,6 +4116,7 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: `https://googleads.googleapis.com/${API_VERSION}/customers/7693729833/offlineUserDataJobs`,
+              endpointPath: 'offlineUserDataJobs',
               headers: {
                 Authorization: authHeader1,
                 'Content-Type': 'application/json',
@@ -5409,6 +5416,7 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: `https://googleads.googleapis.com/${API_VERSION}/customers/7693729833/offlineUserDataJobs`,
+              endpointPath: 'offlineUserDataJobs',
               headers: {
                 Authorization: authHeader1,
                 'Content-Type': 'application/json',
@@ -6785,6 +6793,7 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: `https://googleads.googleapis.com/${API_VERSION}/customers/7693729833/offlineUserDataJobs`,
+              endpointPath: 'offlineUserDataJobs',
               headers: {
                 Authorization: authHeader1,
                 'Content-Type': 'application/json',
@@ -8094,6 +8103,7 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: `https://googleads.googleapis.com/${API_VERSION}/customers/7693729833/offlineUserDataJobs`,
+              endpointPath: 'offlineUserDataJobs',
               headers: {
                 Authorization: authHeader1,
                 'Content-Type': 'application/json',
@@ -9393,6 +9403,7 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: `https://googleads.googleapis.com/${API_VERSION}/customers/7693729833/offlineUserDataJobs`,
+              endpointPath: 'offlineUserDataJobs',
               headers: {
                 Authorization: authHeader1,
                 'Content-Type': 'application/json',
@@ -10787,6 +10798,7 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: `https://googleads.googleapis.com/${API_VERSION}/customers/7693729833/offlineUserDataJobs`,
+              endpointPath: 'offlineUserDataJobs',
               headers: {
                 Authorization: authHeader1,
                 'Content-Type': 'application/json',
@@ -10866,6 +10878,7 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: `https://googleads.googleapis.com/${API_VERSION}/customers/7693729833/offlineUserDataJobs`,
+              endpointPath: 'offlineUserDataJobs',
               headers: {
                 Authorization: authHeader1,
                 'Content-Type': 'application/json',
@@ -11040,6 +11053,7 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: `https://googleads.googleapis.com/${API_VERSION}/customers/7693729833/offlineUserDataJobs`,
+              endpointPath: 'offlineUserDataJobs',
               headers: {
                 Authorization: authHeader1,
                 'Content-Type': 'application/json',
@@ -11117,6 +11131,7 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: `https://googleads.googleapis.com/${API_VERSION}/customers/7693729833/offlineUserDataJobs`,
+              endpointPath: 'offlineUserDataJobs',
               headers: {
                 Authorization: authHeader1,
                 'Content-Type': 'application/json',
@@ -11260,6 +11275,7 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: `https://googleads.googleapis.com/${API_VERSION}/customers/7693729833/offlineUserDataJobs`,
+              endpointPath: 'offlineUserDataJobs',
               headers: {
                 Authorization: authHeader1,
                 'Content-Type': 'application/json',
@@ -11466,6 +11482,7 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: `https://googleads.googleapis.com/${API_VERSION}/customers/7693729833/offlineUserDataJobs`,
+              endpointPath: 'offlineUserDataJobs',
               headers: {
                 Authorization: authHeader1,
                 'Content-Type': 'application/json',
@@ -11604,6 +11621,7 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: `https://googleads.googleapis.com/${API_VERSION}/customers/7693729833/offlineUserDataJobs`,
+              endpointPath: 'offlineUserDataJobs',
               headers: {
                 Authorization: authHeader1,
                 'Content-Type': 'application/json',
@@ -11741,6 +11759,7 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: `https://googleads.googleapis.com/${API_VERSION}/customers/7693729833/offlineUserDataJobs`,
+              endpointPath: 'offlineUserDataJobs',
               headers: {
                 Authorization: authHeader1,
                 'Content-Type': 'application/json',
@@ -11880,6 +11899,7 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: `https://googleads.googleapis.com/${API_VERSION}/customers/7693729833/offlineUserDataJobs`,
+              endpointPath: 'offlineUserDataJobs',
               headers: {
                 Authorization: authHeader1,
                 'Content-Type': 'application/json',
@@ -12022,6 +12042,7 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: `https://googleads.googleapis.com/${API_VERSION}/customers/7693729833/offlineUserDataJobs`,
+              endpointPath: 'offlineUserDataJobs',
               headers: {
                 Authorization: authHeader1,
                 'Content-Type': 'application/json',

--- a/test/integrations/destinations/google_adwords_remarketing_lists/router/data.ts
+++ b/test/integrations/destinations/google_adwords_remarketing_lists/router/data.ts
@@ -36,6 +36,7 @@ export const data = [
                   type: 'REST',
                   method: 'POST',
                   endpoint: `https://googleads.googleapis.com/${API_VERSION}/customers/7693729833/offlineUserDataJobs`,
+                  endpointPath: 'offlineUserDataJobs',
                   headers: {
                     Authorization: authHeader3,
                     'Content-Type': 'application/json',
@@ -155,6 +156,7 @@ export const data = [
                   type: 'REST',
                   method: 'POST',
                   endpoint: `https://googleads.googleapis.com/${API_VERSION}/customers/7693729833/offlineUserDataJobs`,
+                  endpointPath: 'offlineUserDataJobs',
                   headers: {
                     Authorization: authHeader3,
                     'Content-Type': 'application/json',
@@ -274,6 +276,7 @@ export const data = [
                   type: 'REST',
                   method: 'POST',
                   endpoint: `https://googleads.googleapis.com/${API_VERSION}/customers/7693729833/offlineUserDataJobs`,
+                  endpointPath: 'offlineUserDataJobs',
                   headers: {
                     Authorization: authHeader3,
                     'Content-Type': 'application/json',
@@ -369,6 +372,7 @@ export const data = [
                   type: 'REST',
                   method: 'POST',
                   endpoint: `https://googleads.googleapis.com/${API_VERSION}/customers/7693729833/offlineUserDataJobs`,
+                  endpointPath: 'offlineUserDataJobs',
                   headers: {
                     Authorization: authHeader3,
                     'Content-Type': 'application/json',
@@ -464,6 +468,7 @@ export const data = [
                   type: 'REST',
                   method: 'POST',
                   endpoint: `https://googleads.googleapis.com/${API_VERSION}/customers/7693729833/offlineUserDataJobs`,
+                  endpointPath: 'offlineUserDataJobs',
                   headers: {
                     Authorization: authHeader3,
                     'Content-Type': 'application/json',
@@ -514,6 +519,7 @@ export const data = [
                   type: 'REST',
                   method: 'POST',
                   endpoint: `https://googleads.googleapis.com/${API_VERSION}/customers/7693729833/offlineUserDataJobs`,
+                  endpointPath: 'offlineUserDataJobs',
                   headers: {
                     Authorization: authHeader3,
                     'Content-Type': 'application/json',
@@ -631,6 +637,7 @@ export const data = [
                   type: 'REST',
                   method: 'POST',
                   endpoint: `https://googleads.googleapis.com/${API_VERSION}/customers/7693729833/offlineUserDataJobs`,
+                  endpointPath: 'offlineUserDataJobs',
                   headers: {
                     Authorization: authHeader3,
                     'Content-Type': 'application/json',
@@ -728,6 +735,7 @@ export const data = [
                   type: 'REST',
                   method: 'POST',
                   endpoint: `https://googleads.googleapis.com/${API_VERSION}/customers/7693729833/offlineUserDataJobs`,
+                  endpointPath: 'offlineUserDataJobs',
                   headers: {
                     Authorization: authHeader3,
                     'Content-Type': 'application/json',
@@ -855,6 +863,7 @@ export const data = [
                   type: 'REST',
                   method: 'POST',
                   endpoint: `https://googleads.googleapis.com/${API_VERSION}/customers/7693729833/offlineUserDataJobs`,
+                  endpointPath: 'offlineUserDataJobs',
                   headers: {
                     Authorization: authHeader3,
                     'Content-Type': 'application/json',
@@ -1003,6 +1012,7 @@ export const data = [
                   type: 'REST',
                   method: 'POST',
                   endpoint: `https://googleads.googleapis.com/${API_VERSION}/customers/7693729833/offlineUserDataJobs`,
+                  endpointPath: 'offlineUserDataJobs',
                   headers: {
                     Authorization: authHeader3,
                     'Content-Type': 'application/json',
@@ -1119,6 +1129,7 @@ export const data = [
                   type: 'REST',
                   method: 'POST',
                   endpoint: `https://googleads.googleapis.com/${API_VERSION}/customers/7693729833/offlineUserDataJobs`,
+                  endpointPath: 'offlineUserDataJobs',
                   headers: {
                     Authorization: authHeader3,
                     'Content-Type': 'application/json',
@@ -1220,6 +1231,7 @@ export const data = [
                   type: 'REST',
                   method: 'POST',
                   endpoint: `https://googleads.googleapis.com/${API_VERSION}/customers/7693729833/offlineUserDataJobs`,
+                  endpointPath: 'offlineUserDataJobs',
                   headers: {
                     Authorization: 'Bearer commonAccessToken',
                     'Content-Type': 'application/json',
@@ -1317,6 +1329,7 @@ export const data = [
                   type: 'REST',
                   method: 'POST',
                   endpoint: `https://googleads.googleapis.com/${API_VERSION}/customers/7693729833/offlineUserDataJobs`,
+                  endpointPath: 'offlineUserDataJobs',
                   headers: {
                     Authorization: 'Bearer commonAccessToken',
                     'Content-Type': 'application/json',
@@ -1444,6 +1457,7 @@ export const data = [
                   type: 'REST',
                   method: 'POST',
                   endpoint: `https://googleads.googleapis.com/${API_VERSION}/customers/7693729833/offlineUserDataJobs`,
+                  endpointPath: 'offlineUserDataJobs',
                   headers: {
                     Authorization: 'Bearer commonAccessToken',
                     'Content-Type': 'application/json',


### PR DESCRIPTION
## Summary

This PR adds the  property to the Google AdWords Remarketing Lists destination response configuration.

## Changes

- **config.js**: Added  constant and exported it
- **util.js**: Updated  function to include  in the response
- **util.test.js**: Updated test expectations to include 
- **Test data files**: Updated all processor and router test data files to include  in expected responses

## Technical Details

The  property provides better traceability and debugging capabilities by clearly identifying the specific API endpoint being used in the response object. This change ensures consistency with other destinations that include endpoint paths in their responses.

## Testing

- All existing tests pass
- Test data has been updated to reflect the new  property
- No breaking changes to existing functionality

## Files Modified

- `src/v0/destinations/google_adwords_remarketing_lists/config.js`
- `src/v0/destinations/google_adwords_remarketing_lists/util.js`
- `src/v0/destinations/google_adwords_remarketing_lists/util.test.js`
- `test/integrations/destinations/google_adwords_remarketing_lists/processor/data.ts`
- `test/integrations/destinations/google_adwords_remarketing_lists/router/data.ts`