### PR TITLE
chore: disable lifecycle hooks

### DIFF
--- a/.github/workflows/allure-test-reporter.yml
+++ b/.github/workflows/allure-test-reporter.yml
@@ -30,7 +30,7 @@ jobs:
           cache: 'npm'
 
       - name: Install Dependencies
-        run: npm ci
+        run: npm ci && npm run prepare
 
       - name: Run Tests and Generate Report
         run: |

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -25,7 +25,7 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci && npm run prepare
 
       - name: Print versions
         run: |

--- a/.github/workflows/dt-test-and-report-code-coverage.yml
+++ b/.github/workflows/dt-test-and-report-code-coverage.yml
@@ -45,7 +45,7 @@ jobs:
           cache: 'npm'
 
       - name: Install Dependencies
-        run: npm ci
+        run: npm ci && npm run prepare
 
       - name: Run Tests
         id: run_tests

--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -46,7 +46,7 @@ jobs:
         env:
           HUSKY: 0
         run: |
-          npm ci
+          npm ci && npm run prepare
 
       # In order to make a commit, we need to initialize a user.
       # You may choose to write something less generic here if you want, it doesn't matter functionality wise.
@@ -166,7 +166,7 @@ jobs:
 
       - name: Notify Slack Channel
         id: slack
-        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a  # v2.1.1
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
         continue-on-error: true
         env:
           PROJECT_NAME: 'Rudder Transformer'

--- a/.github/workflows/ut-tests.yml
+++ b/.github/workflows/ut-tests.yml
@@ -39,7 +39,7 @@ jobs:
           cache: 'npm'
 
       - name: Install Dependencies
-        run: npm ci
+        run: npm ci && npm run prepare
 
       - name: Create Kind cluster
         run: kind create cluster --name kind-cluster --config=test/__tests__/data/worker-nodes-kind.yml

--- a/.github/workflows/verify-server-start.yml
+++ b/.github/workflows/verify-server-start.yml
@@ -28,7 +28,7 @@ jobs:
           cache: 'npm'
 
       - name: Install Dependencies
-        run: npm ci
+        run: npm ci && npm run prepare
 
       - name: Build Project
         run: npm run build

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -30,7 +30,7 @@ jobs:
           cache: 'npm'
 
       - name: Install Dependencies
-        run: npm ci
+        run: npm ci && npm run prepare
 
       - id: files
         uses: Ana06/get-changed-files@v1.2

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,10 @@ RUN chown -R node:node /home/node/app
 USER node
 
 COPY package*.json ./
-COPY scripts/skipPrepareScript.js ./scripts/skipPrepareScript.js
-RUN npm ci --no-audit --cache .npm
+
+RUN npm ci --ignore-scripts --no-audit --cache .npm && \
+    npm run prepare
+
 COPY --chown=node:node . .
 RUN npm run build:ci -- --sourceMap false
 RUN npm run copy
@@ -44,12 +46,9 @@ FROM base AS prodDepsBuilder
 WORKDIR /home/node/app
 USER node
 COPY --chown=node:node --from=development /home/node/app/package*.json ./
-COPY --chown=node:node --from=development /home/node/app/scripts/skipPrepareScript.js ./scripts/skipPrepareScript.js
 
-ENV SKIP_PREPARE_SCRIPT='true'
-
-RUN npm ci --omit=dev --no-audit --cache .npm
-RUN npm run clean:node
+RUN npm ci --ignore-scripts --omit=dev --no-audit --cache .npm && \
+    npm run clean:node
 
 FROM base as production
 ENV HUSKY 0

--- a/Dockerfile-ut-func
+++ b/Dockerfile-ut-func
@@ -31,8 +31,9 @@ RUN chown -R node:node /home/node/app
 USER node
 
 COPY package*.json ./
-COPY scripts/skipPrepareScript.js ./scripts/skipPrepareScript.js
-RUN npm ci --no-audit --cache .npm
+RUN npm ci --ignore-scripts --no-audit --cache .npm && \
+  npm run prepare
+
 COPY --chown=node:node . .
 RUN npm run build:ci -- --sourceMap false
 RUN npm run copy
@@ -49,12 +50,9 @@ FROM base AS prodDepsBuilder
 WORKDIR /home/node/app
 USER node
 COPY --chown=node:node --from=development /home/node/app/package*.json ./
-COPY --chown=node:node --from=development /home/node/app/scripts/skipPrepareScript.js ./scripts/skipPrepareScript.js
 
-ENV SKIP_PREPARE_SCRIPT='true'
-
-RUN npm ci --omit=dev --no-audit --cache .npm
-RUN npm run clean:node
+RUN npm ci --ignore-scripts --omit=dev --no-audit --cache .npm && \
+  npm run clean:node
 
 FROM base as production
 ENV HUSKY 0

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "test:ut:integration:ci": "npm run test:ut:integration -- --expand --maxWorkers=50%",
     "pre-commit": "npm run test:ts:silent && npm run test:js:silent && npx lint-staged",
     "commit-msg": "commitlint --edit",
-    "prepare": "node ./scripts/skipPrepareScript.js || husky install",
+    "prepare": "npm --prefix ./node_modules/isolated-vm run rebuild",
     "release": "npx standard-version",
     "release:github": "echo '⚠️  DEPRECATED: Use release:github:modern instead' && DEBUG=conventional-github-releaser npx conventional-github-releaser -p angular --config github-release.config.js",
     "release:github:modern": "node scripts/create-github-release.js",

--- a/scripts/skipPrepareScript.js
+++ b/scripts/skipPrepareScript.js
@@ -1,5 +1,0 @@
-if (process.env.SKIP_PREPARE_SCRIPT === 'true') {
-  process.exit(0);
-} else {
-  process.exit(1);
-}


### PR DESCRIPTION
## What are the changes introduced in this PR?

Introduced `.npmrc` with ignore-scripts=true to prevent lifecycle hooks. The rest of the changes are to accommodate `isolated-vm` manual build as well as Dockerfile adjustments to manually call `npm run prepare` which builds `isolated-vm` from source.