### PR TITLE
feat: add endpoint path to Braze response objects

### DIFF
--- a/src/v0/destinations/braze/config.js
+++ b/src/v0/destinations/braze/config.js
@@ -9,20 +9,32 @@ const ConfigCategory = {
   },
 };
 
-function getIdentifyEndpoint(endPoint) {
-  return `${endPoint}/users/identify`;
+function getIdentifyEndpoint(baseEndpoint) {
+  return {
+    endpoint: `${baseEndpoint}/users/identify`,
+    path: 'users/identify',
+  };
 }
 
-function getTrackEndPoint(endPoint) {
-  return `${endPoint}/users/track`;
+function getTrackEndPoint(baseEndpoint) {
+  return {
+    endpoint: `${baseEndpoint}/users/track`,
+    path: 'users/track',
+  };
 }
 
-function getSubscriptionGroupEndPoint(endPoint) {
-  return `${endPoint}/v2/subscription/status/set`;
+function getSubscriptionGroupEndPoint(baseEndpoint) {
+  return {
+    endpoint: `${baseEndpoint}/v2/subscription/status/set`,
+    path: 'v2/subscription/status/set',
+  };
 }
 
-function getAliasMergeEndPoint(endPoint) {
-  return `${endPoint}/users/merge`;
+function getAliasMergeEndPoint(baseEndpoint) {
+  return {
+    endpoint: `${baseEndpoint}/users/merge`,
+    path: 'users/merge',
+  };
 }
 
 const mappingConfig = getMappingConfig(ConfigCategory, __dirname);

--- a/src/v0/destinations/braze/identityResolutionUtils.test.ts
+++ b/src/v0/destinations/braze/identityResolutionUtils.test.ts
@@ -26,11 +26,21 @@ jest.mock('@rudderstack/integrations-lib', () => ({
 
 // Type the mocked functions
 const mockedHandleHttpRequest = handleHttpRequest as jest.MockedFunction<typeof handleHttpRequest>;
-const mockedGetDynamicErrorType = getDynamicErrorType as jest.MockedFunction<typeof getDynamicErrorType>;
-const mockedIsHttpStatusSuccess = isHttpStatusSuccess as jest.MockedFunction<typeof isHttpStatusSuccess>;
-const mockedCollectStatsForAliasFailure = collectStatsForAliasFailure as jest.MockedFunction<typeof collectStatsForAliasFailure>;
-const mockedGetEndpointFromConfig = getEndpointFromConfig as jest.MockedFunction<typeof getEndpointFromConfig>;
-const mockedGetIdentifyEndpoint = getIdentifyEndpoint as jest.MockedFunction<typeof getIdentifyEndpoint>;
+const mockedGetDynamicErrorType = getDynamicErrorType as jest.MockedFunction<
+  typeof getDynamicErrorType
+>;
+const mockedIsHttpStatusSuccess = isHttpStatusSuccess as jest.MockedFunction<
+  typeof isHttpStatusSuccess
+>;
+const mockedCollectStatsForAliasFailure = collectStatsForAliasFailure as jest.MockedFunction<
+  typeof collectStatsForAliasFailure
+>;
+const mockedGetEndpointFromConfig = getEndpointFromConfig as jest.MockedFunction<
+  typeof getEndpointFromConfig
+>;
+const mockedGetIdentifyEndpoint = getIdentifyEndpoint as jest.MockedFunction<
+  typeof getIdentifyEndpoint
+>;
 const mockedStatsIncrement = stats.increment as jest.MockedFunction<typeof stats.increment>;
 const mockedLoggerError = logger.error as jest.MockedFunction<typeof logger.error>;
 
@@ -78,7 +88,9 @@ interface BrazeResponse {
 }
 
 // Test fixtures
-const createMockDestination = (overrides: Partial<BrazeDestinationConfig> = {}): Destination<BrazeDestinationConfig> => ({
+const createMockDestination = (
+  overrides: Partial<BrazeDestinationConfig> = {},
+): Destination<BrazeDestinationConfig> => ({
   ID: 'test-destination-id',
   Name: 'Test Braze Destination',
   Config: {
@@ -106,14 +118,14 @@ const createMockAliasToIdentify = (overrides: Partial<AliasToIdentify> = {}): Al
 
 const createMockIdentifyCall = (
   aliasCount: number = 1,
-  destinationOverrides: Partial<BrazeDestinationConfig> = {}
+  destinationOverrides: Partial<BrazeDestinationConfig> = {},
 ): IdentifyCall => ({
   identifyPayload: {
-    aliases_to_identify: Array.from({ length: aliasCount }, (_, i) => 
+    aliases_to_identify: Array.from({ length: aliasCount }, (_, i) =>
       createMockAliasToIdentify({
         external_id: `user${i + 1}`,
         alias_name: `anon${i + 1}`,
-      })
+      }),
     ),
   },
   destination: createMockDestination(destinationOverrides),
@@ -122,7 +134,7 @@ const createMockIdentifyCall = (
 
 const createMockBrazeResponse = (
   status: number,
-  responseOverrides: Partial<BrazeResponse['response']> = {}
+  responseOverrides: Partial<BrazeResponse['response']> = {},
 ): { httpResponse: Promise<any>; processedResponse: BrazeResponse } => ({
   httpResponse: Promise.resolve({}),
   processedResponse: {
@@ -137,13 +149,16 @@ const createMockBrazeResponse = (
 describe('identityResolutionUtils', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    
+
     // Default mock implementations
     mockedGetEndpointFromConfig.mockReturnValue('https://rest.iad-03.braze.com');
-    mockedGetIdentifyEndpoint.mockReturnValue('https://rest.iad-03.braze.com/users/identify');
+    mockedGetIdentifyEndpoint.mockReturnValue({
+      endpoint: 'https://rest.iad-03.braze.com/users/identify',
+      path: 'users/identify',
+    });
     mockedGetDynamicErrorType.mockReturnValue('retryable');
     mockedIsHttpStatusSuccess.mockImplementation((status) => status >= 200 && status < 300);
-    
+
     // Mock IDENTIFY_BRAZE_MAX_REQ_COUNT
     (IDENTIFY_BRAZE_MAX_REQ_COUNT as any) = 50;
   });
@@ -153,11 +168,11 @@ describe('identityResolutionUtils', () => {
       it('should successfully process a single identify call', async () => {
         const identifyCall = createMockIdentifyCall();
         const mockResponse = createMockBrazeResponse(200);
-        
+
         mockedHandleHttpRequest.mockResolvedValue(mockResponse);
-        
+
         const result = await processSingleBatch([identifyCall], 'test-dest-id');
-        
+
         expect(result).toEqual({ success: true });
         expect(mockedHandleHttpRequest).toHaveBeenCalledWith(
           'post',
@@ -179,7 +194,7 @@ describe('identityResolutionUtils', () => {
             requestMethod: 'POST',
             module: 'router',
             endpointPath: '/users/identify',
-          }
+          },
         );
       });
 
@@ -187,19 +202,19 @@ describe('identityResolutionUtils', () => {
         const identifyCall1 = createMockIdentifyCall(2);
         const identifyCall2 = createMockIdentifyCall(1);
         const mockResponse = createMockBrazeResponse(201);
-        
+
         mockedHandleHttpRequest.mockResolvedValue(mockResponse);
-        
+
         const result = await processSingleBatch([identifyCall1, identifyCall2], 'test-dest-id');
-        
+
         expect(result).toEqual({ success: true });
-        
+
         // Verify that aliases from both calls are flattened
         const expectedAliases = [
           ...identifyCall1.identifyPayload.aliases_to_identify,
           ...identifyCall2.identifyPayload.aliases_to_identify,
         ];
-        
+
         expect(mockedHandleHttpRequest).toHaveBeenCalledWith(
           'post',
           'https://rest.iad-03.braze.com/users/identify',
@@ -208,18 +223,18 @@ describe('identityResolutionUtils', () => {
             merge_behavior: 'merge',
           },
           expect.any(Object),
-          expect.any(Object)
+          expect.any(Object),
         );
       });
 
       it('should handle maximum batch size correctly', async () => {
         const identifyCall = createMockIdentifyCall(50); // Max batch size
         const mockResponse = createMockBrazeResponse(200);
-        
+
         mockedHandleHttpRequest.mockResolvedValue(mockResponse);
-        
+
         const result = await processSingleBatch([identifyCall], 'test-dest-id');
-        
+
         expect(result).toEqual({ success: true });
         expect(identifyCall.identifyPayload.aliases_to_identify).toHaveLength(50);
       });
@@ -229,21 +244,21 @@ describe('identityResolutionUtils', () => {
       it('should handle 4xx client errors', async () => {
         const identifyCall = createMockIdentifyCall();
         const mockResponse = createMockBrazeResponse(400, { message: 'Bad Request' });
-        
+
         mockedHandleHttpRequest.mockResolvedValue(mockResponse);
-        
+
         const result = await processSingleBatch([identifyCall], 'test-dest-id');
-        
+
         expect(result.success).toBe(false);
         expect(result.error).toBeInstanceOf(NetworkError);
         expect(result.error?.message).toContain('Braze identify failed');
         expect(mockedLoggerError).toHaveBeenCalledWith(
           'Braze identity resolution failed',
-          JSON.stringify(mockResponse.processedResponse.response)
+          JSON.stringify(mockResponse.processedResponse.response),
         );
         expect(mockedCollectStatsForAliasFailure).toHaveBeenCalledWith(
           mockResponse.processedResponse.response,
-          identifyCall.destination.ID
+          identifyCall.destination.ID,
         );
         expect(mockedStatsIncrement).toHaveBeenCalledWith(
           'braze_batched_identify_func_calls_count',
@@ -251,18 +266,18 @@ describe('identityResolutionUtils', () => {
             destination_id: 'test-dest-id',
             status: 400,
             error: 'non_2xx_status',
-          }
+          },
         );
       });
 
       it('should handle 5xx server errors', async () => {
         const identifyCall = createMockIdentifyCall();
         const mockResponse = createMockBrazeResponse(500, { message: 'Internal Server Error' });
-        
+
         mockedHandleHttpRequest.mockResolvedValue(mockResponse);
-        
+
         const result = await processSingleBatch([identifyCall], 'test-dest-id');
-        
+
         expect(result.success).toBe(false);
         expect(result.error).toBeInstanceOf(NetworkError);
         expect(mockedStatsIncrement).toHaveBeenCalledWith(
@@ -271,19 +286,19 @@ describe('identityResolutionUtils', () => {
             destination_id: 'test-dest-id',
             status: 500,
             error: 'non_2xx_status',
-          }
+          },
         );
       });
 
       it('should handle 429 rate limit errors', async () => {
         const identifyCall = createMockIdentifyCall();
         const mockResponse = createMockBrazeResponse(429, { message: 'Rate Limited' });
-        
+
         mockedHandleHttpRequest.mockResolvedValue(mockResponse);
         mockedGetDynamicErrorType.mockReturnValue('throttled');
-        
+
         const result = await processSingleBatch([identifyCall], 'test-dest-id');
-        
+
         expect(result.success).toBe(false);
         expect(result.error).toBeInstanceOf(NetworkError);
         expect(mockedGetDynamicErrorType).toHaveBeenCalledWith(429);
@@ -292,10 +307,12 @@ describe('identityResolutionUtils', () => {
       it('should handle network timeout/connection errors', async () => {
         const identifyCall = createMockIdentifyCall();
         const networkError = new Error('Network timeout');
-        
+
         mockedHandleHttpRequest.mockRejectedValue(networkError);
-        
-        await expect(processSingleBatch([identifyCall], 'test-dest-id')).rejects.toThrow('Network timeout');
+
+        await expect(processSingleBatch([identifyCall], 'test-dest-id')).rejects.toThrow(
+          'Network timeout',
+        );
       });
     });
 
@@ -303,21 +320,21 @@ describe('identityResolutionUtils', () => {
       it('should handle application-level errors from Braze', async () => {
         const identifyCall = createMockIdentifyCall();
         const mockResponse = createMockBrazeResponse(200, {
-          errors: [
-            { type: 'invalid_external_id', input_array: 'aliases_to_identify', index: 0 }
-          ]
+          errors: [{ type: 'invalid_external_id', input_array: 'aliases_to_identify', index: 0 }],
         });
-        
+
         mockedHandleHttpRequest.mockResolvedValue(mockResponse);
-        
+
         const result = await processSingleBatch([identifyCall], 'test-dest-id');
-        
+
         expect(result.success).toBe(false);
         expect(result.error).toBeInstanceOf(BaseError);
-        expect(result.error?.message).toContain('[Unhandled Identify Resolution Error] invalid_external_id');
+        expect(result.error?.message).toContain(
+          '[Unhandled Identify Resolution Error] invalid_external_id',
+        );
         expect(mockedLoggerError).toHaveBeenCalledWith(
           'Braze Unhandled Identify Resolution Error',
-          JSON.stringify(mockResponse.processedResponse.response)
+          JSON.stringify(mockResponse.processedResponse.response),
         );
         expect(mockedStatsIncrement).toHaveBeenCalledWith(
           'braze_batched_identify_func_calls_count',
@@ -325,7 +342,7 @@ describe('identityResolutionUtils', () => {
             destination_id: 'test-dest-id',
             status: 200,
             error: 'unhandled_error',
-          }
+          },
         );
       });
 
@@ -334,14 +351,14 @@ describe('identityResolutionUtils', () => {
         const mockResponse = createMockBrazeResponse(200, {
           errors: [
             { type: 'invalid_external_id', input_array: 'aliases_to_identify', index: 0 },
-            { type: 'missing_alias_name', input_array: 'aliases_to_identify', index: 1 }
-          ]
+            { type: 'missing_alias_name', input_array: 'aliases_to_identify', index: 1 },
+          ],
         });
-        
+
         mockedHandleHttpRequest.mockResolvedValue(mockResponse);
-        
+
         const result = await processSingleBatch([identifyCall], 'test-dest-id');
-        
+
         expect(result.success).toBe(false);
         expect(result.error).toBeInstanceOf(BaseError);
         expect(result.error?.message).toContain('invalid_external_id'); // Should use first error
@@ -350,11 +367,11 @@ describe('identityResolutionUtils', () => {
       it('should handle empty errors array as success', async () => {
         const identifyCall = createMockIdentifyCall();
         const mockResponse = createMockBrazeResponse(200, { errors: [] });
-        
+
         mockedHandleHttpRequest.mockResolvedValue(mockResponse);
-        
+
         const result = await processSingleBatch([identifyCall], 'test-dest-id');
-        
+
         expect(result).toEqual({ success: true });
       });
 
@@ -367,11 +384,11 @@ describe('identityResolutionUtils', () => {
             response: undefined as any,
           },
         };
-        
+
         mockedHandleHttpRequest.mockResolvedValue(mockResponse);
-        
+
         const result = await processSingleBatch([identifyCall], 'test-dest-id');
-        
+
         expect(result).toEqual({ success: true });
       });
     });
@@ -383,7 +400,10 @@ describe('identityResolutionUtils', () => {
         const mockResponse = createMockBrazeResponse(200);
 
         mockedGetEndpointFromConfig.mockReturnValue('https://rest.fra-02.braze.eu');
-        mockedGetIdentifyEndpoint.mockReturnValue('https://rest.fra-02.braze.eu/users/identify');
+        mockedGetIdentifyEndpoint.mockReturnValue({
+          endpoint: 'https://rest.fra-02.braze.eu/users/identify',
+          path: 'users/identify',
+        });
         mockedHandleHttpRequest.mockResolvedValue(mockResponse);
 
         const result = await processSingleBatch([identifyCall], 'test-dest-id');
@@ -399,7 +419,10 @@ describe('identityResolutionUtils', () => {
         const mockResponse = createMockBrazeResponse(200);
 
         mockedGetEndpointFromConfig.mockReturnValue('https://rest.au-01.braze.com');
-        mockedGetIdentifyEndpoint.mockReturnValue('https://rest.au-01.braze.com/users/identify');
+        mockedGetIdentifyEndpoint.mockReturnValue({
+          endpoint: 'https://rest.au-01.braze.com/users/identify',
+          path: 'users/identify',
+        });
         mockedHandleHttpRequest.mockResolvedValue(mockResponse);
 
         const result = await processSingleBatch([identifyCall], 'test-dest-id');
@@ -417,7 +440,7 @@ describe('identityResolutionUtils', () => {
         });
 
         await expect(processSingleBatch([identifyCall], 'test-dest-id')).rejects.toThrow(
-          'Invalid Data Center: valid values are EU, US, AU'
+          'Invalid Data Center: valid values are EU, US, AU',
         );
       });
 
@@ -442,7 +465,7 @@ describe('identityResolutionUtils', () => {
               Authorization: `Bearer ${customApiKey}`,
             },
           },
-          expect.any(Object)
+          expect.any(Object),
         );
       });
     });
@@ -459,7 +482,7 @@ describe('identityResolutionUtils', () => {
         // processSingleBatch should not collect success stats - that's done in processBatchedIdentify
         expect(mockedStatsIncrement).not.toHaveBeenCalledWith(
           'braze_batched_identify_func_calls_count',
-          expect.objectContaining({ status: '2xx' })
+          expect.objectContaining({ status: '2xx' }),
         );
       });
 
@@ -478,7 +501,7 @@ describe('identityResolutionUtils', () => {
             destination_id: customDestId,
             status: 400,
             error: 'non_2xx_status',
-          }
+          },
         );
       });
     });
@@ -526,14 +549,14 @@ describe('identityResolutionUtils', () => {
 
         expect(mockedMapInBatches).toHaveBeenCalledWith(
           [identifyCalls], // Should be a single chunk
-          expect.any(Function)
+          expect.any(Function),
         );
         expect(mockedStatsIncrement).toHaveBeenCalledWith(
           'braze_batched_identify_func_calls_count',
           {
             destination_id: 'test-dest-id',
             status: '2xx',
-          }
+          },
         );
       });
 
@@ -561,7 +584,7 @@ describe('identityResolutionUtils', () => {
             expect.arrayContaining([expect.any(Object)]), // Second chunk of 50
             expect.arrayContaining([expect.any(Object)]), // Third chunk of 25
           ]),
-          expect.any(Function)
+          expect.any(Function),
         );
 
         const chunksArg = mockedMapInBatches.mock.calls[0][0];
@@ -618,7 +641,7 @@ describe('identityResolutionUtils', () => {
           {
             destination_id: 'test-dest-id',
             status: '2xx',
-          }
+          },
         );
       });
 
@@ -635,7 +658,7 @@ describe('identityResolutionUtils', () => {
               // Second batch fails
               results.push({
                 success: false,
-                error: new NetworkError('Test error', 500, {}, {})
+                error: new NetworkError('Test error', 500, {}, {}),
               });
             }
           }
@@ -647,7 +670,7 @@ describe('identityResolutionUtils', () => {
         // Should not collect success stats when any batch fails
         expect(mockedStatsIncrement).not.toHaveBeenCalledWith(
           'braze_batched_identify_func_calls_count',
-          expect.objectContaining({ status: '2xx' })
+          expect.objectContaining({ status: '2xx' }),
         );
       });
 
@@ -659,7 +682,7 @@ describe('identityResolutionUtils', () => {
           for (const chunk of chunks) {
             results.push({
               success: false,
-              error: new NetworkError('Test error', 500, {}, {})
+              error: new NetworkError('Test error', 500, {}, {}),
             });
           }
           return results;
@@ -670,7 +693,7 @@ describe('identityResolutionUtils', () => {
         // Should not collect success stats when all batches fail
         expect(mockedStatsIncrement).not.toHaveBeenCalledWith(
           'braze_batched_identify_func_calls_count',
-          expect.objectContaining({ status: '2xx' })
+          expect.objectContaining({ status: '2xx' }),
         );
       });
 
@@ -683,12 +706,12 @@ describe('identityResolutionUtils', () => {
             if (i === 0) {
               results.push({
                 success: false,
-                error: new NetworkError('Network error', 500, {}, {})
+                error: new NetworkError('Network error', 500, {}, {}),
               });
             } else {
               results.push({
                 success: false,
-                error: new BaseError('Application error')
+                error: new BaseError('Application error'),
               });
             }
           }
@@ -699,7 +722,7 @@ describe('identityResolutionUtils', () => {
 
         expect(mockedStatsIncrement).not.toHaveBeenCalledWith(
           'braze_batched_identify_func_calls_count',
-          expect.objectContaining({ status: '2xx' })
+          expect.objectContaining({ status: '2xx' }),
         );
       });
     });
@@ -725,7 +748,7 @@ describe('identityResolutionUtils', () => {
         // Should not collect success stats
         expect(mockedStatsIncrement).not.toHaveBeenCalledWith(
           'braze_batched_identify_func_calls_count',
-          expect.objectContaining({ status: '2xx' })
+          expect.objectContaining({ status: '2xx' }),
         );
       });
 
@@ -735,7 +758,7 @@ describe('identityResolutionUtils', () => {
         mockedMapInBatches.mockImplementation(async (chunks: any[], processor: any) => {
           // Simulate application error in processSingleBatch
           const mockResponse = createMockBrazeResponse(200, {
-            errors: [{ type: 'invalid_external_id', input_array: 'aliases_to_identify', index: 0 }]
+            errors: [{ type: 'invalid_external_id', input_array: 'aliases_to_identify', index: 0 }],
           });
           mockedHandleHttpRequest.mockResolvedValue(mockResponse);
 
@@ -751,7 +774,7 @@ describe('identityResolutionUtils', () => {
         // Should not collect success stats
         expect(mockedStatsIncrement).not.toHaveBeenCalledWith(
           'braze_batched_identify_func_calls_count',
-          expect.objectContaining({ status: '2xx' })
+          expect.objectContaining({ status: '2xx' }),
         );
       });
     });
@@ -776,7 +799,7 @@ describe('identityResolutionUtils', () => {
           {
             destination_id: customDestId,
             status: '2xx',
-          }
+          },
         );
         expect(mockedStatsIncrement).toHaveBeenCalledTimes(1);
       });
@@ -800,7 +823,7 @@ describe('identityResolutionUtils', () => {
 
         expect(mockedStatsIncrement).not.toHaveBeenCalledWith(
           'braze_batched_identify_func_calls_count',
-          expect.objectContaining({ status: '2xx' })
+          expect.objectContaining({ status: '2xx' }),
         );
       });
     });
@@ -855,7 +878,7 @@ describe('identityResolutionUtils', () => {
             merge_behavior: 'merge',
           },
           expect.any(Object),
-          expect.any(Object)
+          expect.any(Object),
         );
       });
 
@@ -936,7 +959,7 @@ describe('identityResolutionUtils', () => {
           {
             destination_id: 'test-dest-id',
             status: '2xx',
-          }
+          },
         );
       });
 
@@ -950,7 +973,7 @@ describe('identityResolutionUtils', () => {
               // First batch fails
               results.push({
                 success: false,
-                error: new NetworkError('First batch error', 500, {}, {})
+                error: new NetworkError('First batch error', 500, {}, {}),
               });
             } else {
               // Second batch succeeds
@@ -965,7 +988,7 @@ describe('identityResolutionUtils', () => {
         // Should not collect success stats because one batch failed
         expect(mockedStatsIncrement).not.toHaveBeenCalledWith(
           'braze_batched_identify_func_calls_count',
-          expect.objectContaining({ status: '2xx' })
+          expect.objectContaining({ status: '2xx' }),
         );
       });
     });
@@ -999,7 +1022,7 @@ describe('identityResolutionUtils', () => {
             requestMethod: 'POST',
             module: 'router',
             endpointPath: '/users/identify',
-          }
+          },
         );
       });
 
@@ -1013,7 +1036,7 @@ describe('identityResolutionUtils', () => {
 
         expect(mockedLoggerError).toHaveBeenCalledWith(
           'Braze identity resolution failed',
-          JSON.stringify(mockResponse.processedResponse.response)
+          JSON.stringify(mockResponse.processedResponse.response),
         );
       });
 
@@ -1040,7 +1063,7 @@ describe('identityResolutionUtils', () => {
 
         expect(mockedCollectStatsForAliasFailure).toHaveBeenCalledWith(
           mockResponse.processedResponse.response,
-          identifyCall.destination.ID
+          identifyCall.destination.ID,
         );
         expect(mockedStatsIncrement).toHaveBeenCalledWith(
           'braze_batched_identify_func_calls_count',
@@ -1048,7 +1071,7 @@ describe('identityResolutionUtils', () => {
             destination_id: 'test-dest-id',
             status: 500,
             error: 'non_2xx_status',
-          }
+          },
         );
       });
     });
@@ -1106,7 +1129,7 @@ describe('identityResolutionUtils', () => {
             merge_behavior: 'merge', // Should be overridden
           },
           expect.any(Object),
-          expect.any(Object)
+          expect.any(Object),
         );
       });
 
@@ -1121,7 +1144,10 @@ describe('identityResolutionUtils', () => {
           },
         };
 
-        mockedHandleHttpRequest.mockResolvedValue({ httpResponse: Promise.resolve({}), processedResponse: brazeResponse });
+        mockedHandleHttpRequest.mockResolvedValue({
+          httpResponse: Promise.resolve({}),
+          processedResponse: brazeResponse,
+        });
 
         const result = await processSingleBatch([identifyCall], 'test-dest-id');
 
@@ -1148,7 +1174,7 @@ describe('identityResolutionUtils', () => {
       it('should handle BaseError type correctly', async () => {
         const identifyCall = createMockIdentifyCall();
         const mockResponse = createMockBrazeResponse(200, {
-          errors: [{ type: 'invalid_external_id', input_array: 'aliases_to_identify', index: 0 }]
+          errors: [{ type: 'invalid_external_id', input_array: 'aliases_to_identify', index: 0 }],
         });
 
         mockedHandleHttpRequest.mockResolvedValue(mockResponse);
@@ -1159,7 +1185,9 @@ describe('identityResolutionUtils', () => {
         expect(result.error).toBeInstanceOf(BaseError);
 
         const baseError = result.error as BaseError;
-        expect(baseError.message).toContain('[Unhandled Identify Resolution Error] invalid_external_id');
+        expect(baseError.message).toContain(
+          '[Unhandled Identify Resolution Error] invalid_external_id',
+        );
       });
     });
 
@@ -1196,7 +1224,9 @@ describe('identityResolutionUtils', () => {
 
       it('should handle very large batch counts', async () => {
         const largeBatchCount = 1000;
-        const identifyCalls = Array.from({ length: largeBatchCount }, () => createMockIdentifyCall());
+        const identifyCalls = Array.from({ length: largeBatchCount }, () =>
+          createMockIdentifyCall(),
+        );
 
         mockedMapInBatches.mockImplementation(async (chunks: any[], processor: any) => {
           expect(chunks).toHaveLength(20); // 1000 / 50 = 20 chunks
@@ -1216,7 +1246,7 @@ describe('identityResolutionUtils', () => {
           {
             destination_id: 'test-dest-id',
             status: '2xx',
-          }
+          },
         );
       });
 
@@ -1237,7 +1267,7 @@ describe('identityResolutionUtils', () => {
             destination_id: 'test-dest-id',
             status: 418,
             error: 'non_2xx_status',
-          }
+          },
         );
       });
 
@@ -1283,7 +1313,7 @@ describe('identityResolutionUtils', () => {
 
       expect(mockedLoggerError).toHaveBeenCalledWith(
         'Braze identity resolution failed',
-        JSON.stringify(errorResponse)
+        JSON.stringify(errorResponse),
       );
     });
 
@@ -1293,8 +1323,8 @@ describe('identityResolutionUtils', () => {
         message: 'success',
         errors: [
           { type: 'invalid_external_id', input_array: 'aliases_to_identify', index: 0 },
-          { type: 'missing_alias_name', input_array: 'aliases_to_identify', index: 1 }
-        ]
+          { type: 'missing_alias_name', input_array: 'aliases_to_identify', index: 1 },
+        ],
       };
       const mockResponse = createMockBrazeResponse(200, errorResponse);
 
@@ -1304,7 +1334,7 @@ describe('identityResolutionUtils', () => {
 
       expect(mockedLoggerError).toHaveBeenCalledWith(
         'Braze Unhandled Identify Resolution Error',
-        JSON.stringify(errorResponse)
+        JSON.stringify(errorResponse),
       );
     });
 

--- a/src/v0/destinations/braze/identityResolutionUtils.ts
+++ b/src/v0/destinations/braze/identityResolutionUtils.ts
@@ -67,7 +67,7 @@ async function processSingleBatch(
   destinationId: string,
 ): Promise<BatchIdentifyResult> {
   const { destination } = identifyCallsChunk[0];
-  const identifyEndpoint = getIdentifyEndpoint(getEndpointFromConfig(destination));
+  const { endpoint } = getIdentifyEndpoint(getEndpointFromConfig(destination));
 
   const aliasesToIdentify = identifyCallsChunk.flatMap(
     (identifyCall) => identifyCall.identifyPayload.aliases_to_identify,
@@ -76,7 +76,7 @@ async function processSingleBatch(
   const { processedResponse: brazeIdentifyResp }: { processedResponse: BrazeResponse } =
     await handleHttpRequest(
       'post',
-      identifyEndpoint,
+      endpoint,
       { aliases_to_identify: aliasesToIdentify, merge_behavior: 'merge' },
       {
         headers: {

--- a/src/v0/destinations/braze/transform.js
+++ b/src/v0/destinations/braze/transform.js
@@ -51,9 +51,10 @@ const { getDynamicErrorType } = require('../../../adapters/utils/networkUtils');
 const { processBatchedIdentify } = require('./identityResolutionUtils');
 const { JSON_MIME_TYPE } = require('../../util/constant');
 
-function buildResponse(message, destination, properties, endpoint) {
+function buildResponse(message, destination, properties, endpointDetails) {
   const response = defaultRequestConfig();
-  response.endpoint = endpoint;
+  response.endpoint = endpointDetails.endpoint;
+  response.endpointPath = endpointDetails.path;
   response.userId = message.userId || message.anonymousId;
   response.body.JSON = removeUndefinedValues(properties);
   return {
@@ -198,10 +199,10 @@ async function processIdentify({ message, destination, metadata, identifyCallsAr
     });
     return;
   }
-  const identifyEndpoint = getIdentifyEndpoint(getEndpointFromConfig(destination));
+  const { endpoint } = getIdentifyEndpoint(getEndpointFromConfig(destination));
   const { processedResponse: brazeIdentifyResp } = await handleHttpRequest(
     'post',
-    identifyEndpoint,
+    endpoint,
     identifyPayload,
     {
       headers: {
@@ -385,7 +386,9 @@ function processGroup(message, destination) {
     // eslint-disable-next-line @typescript-eslint/naming-convention
     const subscription_groups = [subscriptionGroup];
     const response = defaultRequestConfig();
-    response.endpoint = getSubscriptionGroupEndPoint(getEndpointFromConfig(destination));
+    const { endpoint, path } = getSubscriptionGroupEndPoint(getEndpointFromConfig(destination));
+    response.endpoint = endpoint;
+    response.endpointPath = path;
     response.body.JSON = removeUndefinedValues({
       subscription_groups,
     });

--- a/src/v0/destinations/braze/util.js
+++ b/src/v0/destinations/braze/util.js
@@ -441,13 +441,17 @@ function prepareGroupAndAliasBatch(arrayChunks, responseArray, destination, type
   for (const chunk of arrayChunks) {
     const response = defaultRequestConfig();
     if (type === 'merge') {
-      response.endpoint = getAliasMergeEndPoint(getEndpointFromConfig(destination));
+      const { endpoint, path } = getAliasMergeEndPoint(getEndpointFromConfig(destination));
+      response.endpoint = endpoint;
+      response.endpointPath = path;
       const merge_updates = chunk;
       response.body.JSON = removeUndefinedAndNullValues({
         merge_updates,
       });
     } else if (type === 'subscription') {
-      response.endpoint = getSubscriptionGroupEndPoint(getEndpointFromConfig(destination));
+      const { endpoint, path } = getSubscriptionGroupEndPoint(getEndpointFromConfig(destination));
+      response.endpoint = endpoint;
+      response.endpointPath = path;
       const subscription_groups = chunk;
       // maketool transformed event
       logger.info(`braze subscription chunk ${JSON.stringify(subscription_groups)}`);
@@ -532,7 +536,7 @@ const processBatch = (transformedEvents) => {
     Authorization: `Bearer ${destination.Config.restApiKey}`,
   };
 
-  const endpoint = getTrackEndPoint(getEndpointFromConfig(destination));
+  const { endpoint, path } = getTrackEndPoint(getEndpointFromConfig(destination));
   for (let i = 0; i < maxNumberOfRequest; i += 1) {
     const attributes = attributeArrayChunks[i];
     const events = eventsArrayChunks[i];
@@ -556,6 +560,7 @@ const processBatch = (transformedEvents) => {
 
     const response = defaultRequestConfig();
     response.endpoint = endpoint;
+    response.endpointPath = path;
     response.body.JSON = removeUndefinedAndNullValues({
       partner: 'RudderStack',
       attributes,

--- a/test/integrations/destinations/braze/processor/data.ts
+++ b/test/integrations/destinations/braze/processor/data.ts
@@ -11,7 +11,7 @@ export const data = [
         body: [
           {
             destination: {
-                hasDynamicConfig: false,
+              hasDynamicConfig: false,
               Config: {
                 restApiKey: secret1,
                 prefixProperties: true,
@@ -89,6 +89,7 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: 'https://rest.au-01.braze.com/users/track',
+              endpointPath: 'users/track',
               headers: {
                 'Content-Type': 'application/json',
                 Accept: 'application/json',
@@ -136,7 +137,7 @@ export const data = [
         body: [
           {
             destination: {
-                hasDynamicConfig: false,
+              hasDynamicConfig: false,
               Config: {
                 restApiKey: secret1,
                 prefixProperties: true,
@@ -226,7 +227,7 @@ export const data = [
         body: [
           {
             destination: {
-                hasDynamicConfig: false,
+              hasDynamicConfig: false,
               Config: {
                 restApiKey: secret1,
                 prefixProperties: true,
@@ -300,6 +301,7 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: 'https://rest.fra-01.braze.eu/users/track',
+              endpointPath: 'users/track',
               headers: {
                 'Content-Type': 'application/json',
                 Accept: 'application/json',
@@ -345,7 +347,7 @@ export const data = [
         body: [
           {
             destination: {
-                hasDynamicConfig: false,
+              hasDynamicConfig: false,
               Config: {
                 restApiKey: secret1,
                 prefixProperties: true,
@@ -423,6 +425,7 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: 'https://rest.fra-01.braze.eu/users/track',
+              endpointPath: 'users/track',
               headers: {
                 'Content-Type': 'application/json',
                 Accept: 'application/json',
@@ -475,7 +478,7 @@ export const data = [
         body: [
           {
             destination: {
-                hasDynamicConfig: false,
+              hasDynamicConfig: false,
               Config: {
                 restApiKey: secret1,
                 prefixProperties: true,
@@ -552,6 +555,7 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: 'https://rest.fra-01.braze.eu/users/track',
+              endpointPath: 'users/track',
               headers: {
                 'Content-Type': 'application/json',
                 Accept: 'application/json',
@@ -604,7 +608,7 @@ export const data = [
         body: [
           {
             destination: {
-                hasDynamicConfig: false,
+              hasDynamicConfig: false,
               Config: {
                 restApiKey: secret1,
                 prefixProperties: true,
@@ -680,6 +684,7 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: 'https://rest.iad-01.braze.com/users/track',
+              endpointPath: 'users/track',
               headers: {
                 'Content-Type': 'application/json',
                 Accept: 'application/json',
@@ -725,7 +730,7 @@ export const data = [
         body: [
           {
             destination: {
-                hasDynamicConfig: false,
+              hasDynamicConfig: false,
               Config: {
                 restApiKey: secret1,
                 prefixProperties: true,
@@ -808,6 +813,7 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: 'https://rest.fra-01.braze.eu/users/track',
+              endpointPath: 'users/track',
               headers: {
                 'Content-Type': 'application/json',
                 Accept: 'application/json',
@@ -871,7 +877,7 @@ export const data = [
         body: [
           {
             destination: {
-                hasDynamicConfig: false,
+              hasDynamicConfig: false,
               Config: {
                 restApiKey: secret1,
                 prefixProperties: true,
@@ -980,6 +986,7 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: 'https://rest.fra-01.braze.eu/users/track',
+              endpointPath: 'users/track',
               headers: {
                 'Content-Type': 'application/json',
                 Accept: 'application/json',
@@ -1144,7 +1151,7 @@ export const data = [
               originalTimestamp: '2020-09-14T12:09:37.491Z',
             },
             destination: {
-                hasDynamicConfig: false,
+              hasDynamicConfig: false,
               Config: {
                 restApiKey: secret1,
                 prefixProperties: true,
@@ -1245,7 +1252,7 @@ export const data = [
               originalTimestamp: '2020-09-14T12:09:37.491Z',
             },
             destination: {
-                hasDynamicConfig: false,
+              hasDynamicConfig: false,
               Config: {
                 restApiKey: secret1,
                 prefixProperties: true,
@@ -1276,6 +1283,7 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: 'https://rest.fra-01.braze.eu/users/track',
+              endpointPath: 'users/track',
               headers: {
                 'Content-Type': 'application/json',
                 Accept: 'application/json',
@@ -1316,7 +1324,7 @@ export const data = [
         body: [
           {
             destination: {
-                hasDynamicConfig: false,
+              hasDynamicConfig: false,
               Config: {
                 restApiKey: secret1,
                 prefixProperties: true,
@@ -1398,6 +1406,7 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: 'https://rest.iad-01.braze.com/users/track',
+              endpointPath: 'users/track',
               headers: {
                 'Content-Type': 'application/json',
                 Accept: 'application/json',
@@ -1438,7 +1447,7 @@ export const data = [
         body: [
           {
             destination: {
-                hasDynamicConfig: false,
+              hasDynamicConfig: false,
               Config: {
                 restApiKey: secret1,
                 prefixProperties: true,
@@ -1547,6 +1556,7 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: 'https://rest.fra-01.braze.eu/users/track',
+              endpointPath: 'users/track',
               headers: {
                 'Content-Type': 'application/json',
                 Accept: 'application/json',
@@ -1620,7 +1630,7 @@ export const data = [
         body: [
           {
             destination: {
-                hasDynamicConfig: false,
+              hasDynamicConfig: false,
               Config: {
                 restApiKey: secret1,
                 prefixProperties: true,
@@ -1729,6 +1739,7 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: 'https://rest.fra-01.braze.eu/users/track',
+              endpointPath: 'users/track',
               headers: {
                 'Content-Type': 'application/json',
                 Accept: 'application/json',
@@ -1802,7 +1813,7 @@ export const data = [
         body: [
           {
             destination: {
-                hasDynamicConfig: false,
+              hasDynamicConfig: false,
               Config: {
                 restApiKey: secret1,
                 prefixProperties: true,
@@ -1929,6 +1940,7 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: 'https://rest.fra-01.braze.eu/users/track',
+              endpointPath: 'users/track',
               headers: {
                 'Content-Type': 'application/json',
                 Accept: 'application/json',
@@ -2035,7 +2047,7 @@ export const data = [
         body: [
           {
             destination: {
-                hasDynamicConfig: false,
+              hasDynamicConfig: false,
               Config: {
                 restApiKey: secret1,
                 prefixProperties: true,
@@ -2156,6 +2168,7 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: 'https://rest.fra-01.braze.eu/users/track',
+              endpointPath: 'users/track',
               headers: {
                 'Content-Type': 'application/json',
                 Accept: 'application/json',
@@ -2254,7 +2267,7 @@ export const data = [
         body: [
           {
             destination: {
-                hasDynamicConfig: false,
+              hasDynamicConfig: false,
               Config: {
                 restApiKey: secret1,
                 prefixProperties: true,
@@ -2334,6 +2347,7 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: 'https://rest.iad-01.braze.com/users/track',
+              endpointPath: 'users/track',
               headers: {
                 'Content-Type': 'application/json',
                 Accept: 'application/json',
@@ -2386,7 +2400,7 @@ export const data = [
         body: [
           {
             destination: {
-                hasDynamicConfig: false,
+              hasDynamicConfig: false,
               Config: {
                 restApiKey: secret1,
                 prefixProperties: true,
@@ -2466,6 +2480,7 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: 'https://rest.iad-01.braze.com/users/track',
+              endpointPath: 'users/track',
               headers: {
                 'Content-Type': 'application/json',
                 Accept: 'application/json',
@@ -2518,7 +2533,7 @@ export const data = [
         body: [
           {
             destination: {
-                hasDynamicConfig: false,
+              hasDynamicConfig: false,
               Config: {
                 restApiKey: secret1,
                 prefixProperties: true,
@@ -2582,6 +2597,7 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: 'https://rest.iad-03.braze.com/users/merge',
+              endpointPath: 'users/merge',
               headers: {
                 'Content-Type': 'application/json',
                 Accept: 'application/json',
@@ -2625,7 +2641,7 @@ export const data = [
         body: [
           {
             destination: {
-                hasDynamicConfig: false,
+              hasDynamicConfig: false,
               Config: {
                 restApiKey: secret1,
                 prefixProperties: true,
@@ -2709,7 +2725,7 @@ export const data = [
         body: [
           {
             destination: {
-                hasDynamicConfig: false,
+              hasDynamicConfig: false,
               Config: {
                 restApiKey: secret1,
                 prefixProperties: true,
@@ -2793,7 +2809,7 @@ export const data = [
         body: [
           {
             destination: {
-                hasDynamicConfig: false,
+              hasDynamicConfig: false,
               Config: {
                 restApiKey: secret1,
                 prefixProperties: true,
@@ -2874,6 +2890,7 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: 'https://rest.iad-01.braze.com/users/track',
+              endpointPath: 'users/track',
               headers: {
                 'Content-Type': 'application/json',
                 Accept: 'application/json',
@@ -2929,7 +2946,7 @@ export const data = [
         body: [
           {
             destination: {
-                hasDynamicConfig: false,
+              hasDynamicConfig: false,
               Config: {
                 restApiKey: secret1,
                 prefixProperties: true,
@@ -3035,6 +3052,7 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: 'https://rest.iad-01.braze.com/users/track',
+              endpointPath: 'users/track',
               headers: {
                 'Content-Type': 'application/json',
                 Accept: 'application/json',
@@ -3151,7 +3169,7 @@ export const data = [
               originalTimestamp: '2020-09-14T12:09:37.491Z',
             },
             destination: {
-                hasDynamicConfig: false,
+              hasDynamicConfig: false,
               Config: {
                 restApiKey: secret1,
                 prefixProperties: true,
@@ -3183,6 +3201,7 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: 'https://rest.fra-01.braze.eu/v2/subscription/status/set',
+              endpointPath: 'v2/subscription/status/set',
               headers: {
                 'Content-Type': 'application/json',
                 Accept: 'application/json',
@@ -3274,7 +3293,7 @@ export const data = [
               originalTimestamp: '2020-09-14T12:09:37.491Z',
             },
             destination: {
-                hasDynamicConfig: false,
+              hasDynamicConfig: false,
               Config: {
                 restApiKey: secret1,
                 prefixProperties: true,
@@ -3306,6 +3325,7 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: 'https://rest.fra-01.braze.eu/v2/subscription/status/set',
+              endpointPath: 'v2/subscription/status/set',
               headers: {
                 'Content-Type': 'application/json',
                 Accept: 'application/json',
@@ -3347,7 +3367,7 @@ export const data = [
         body: [
           {
             destination: {
-                hasDynamicConfig: false,
+              hasDynamicConfig: false,
               Config: {
                 restApiKey: secret1,
                 prefixProperties: true,
@@ -3429,6 +3449,7 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: 'https://rest.fra-01.braze.eu/users/track',
+              endpointPath: 'users/track',
               headers: {
                 'Content-Type': 'application/json',
                 Accept: 'application/json',
@@ -3480,7 +3501,7 @@ export const data = [
         body: [
           {
             destination: {
-                hasDynamicConfig: false,
+              hasDynamicConfig: false,
               Config: {
                 restApiKey: secret1,
                 prefixProperties: true,
@@ -3590,6 +3611,7 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: 'https://rest.fra-01.braze.eu/users/track',
+              endpointPath: 'users/track',
               headers: {
                 'Content-Type': 'application/json',
                 Accept: 'application/json',
@@ -3673,7 +3695,7 @@ export const data = [
         body: [
           {
             destination: {
-                hasDynamicConfig: false,
+              hasDynamicConfig: false,
               Config: {
                 restApiKey: secret1,
                 prefixProperties: true,
@@ -3752,7 +3774,7 @@ export const data = [
         body: [
           {
             destination: {
-                hasDynamicConfig: false,
+              hasDynamicConfig: false,
               Config: {
                 restApiKey: secret1,
                 prefixProperties: true,
@@ -3897,6 +3919,7 @@ export const data = [
                 XML: {},
               },
               endpoint: 'https://rest.fra-01.braze.eu/users/track',
+              endpointPath: 'users/track',
               files: {},
               headers: {
                 Accept: 'application/json',
@@ -3926,7 +3949,7 @@ export const data = [
         body: [
           {
             destination: {
-                hasDynamicConfig: false,
+              hasDynamicConfig: false,
               Config: {
                 restApiKey: secret1,
                 prefixProperties: true,
@@ -4002,6 +4025,7 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: 'https://rest.fra-01.braze.eu/users/track',
+              endpointPath: 'users/track',
               headers: {
                 'Content-Type': 'application/json',
                 Accept: 'application/json',
@@ -4074,7 +4098,7 @@ export const data = [
         body: [
           {
             destination: {
-                hasDynamicConfig: false,
+              hasDynamicConfig: false,
               Config: {
                 restApiKey: secret1,
                 prefixProperties: true,
@@ -4135,6 +4159,7 @@ export const data = [
               type: 'REST',
               method: 'POST',
               endpoint: 'https://rest.iad-01.braze.com/users/track',
+              endpointPath: 'users/track',
               headers: {
                 'Content-Type': 'application/json',
                 Accept: 'application/json',
@@ -4242,7 +4267,7 @@ export const data = [
               originalTimestamp: '2020-09-14T12:09:37.491Z',
             },
             destination: {
-                hasDynamicConfig: false,
+              hasDynamicConfig: false,
               Config: {
                 restApiKey: secret1,
                 prefixProperties: true,
@@ -4343,7 +4368,7 @@ export const data = [
               originalTimestamp: '2020-09-14T12:09:37.491Z',
             },
             destination: {
-                hasDynamicConfig: false,
+              hasDynamicConfig: false,
               Config: {
                 restApiKey: secret1,
                 prefixProperties: true,

--- a/test/integrations/destinations/braze/router/data.ts
+++ b/test/integrations/destinations/braze/router/data.ts
@@ -275,6 +275,7 @@ const basicRouterTests = [
                   type: 'REST',
                   method: 'POST',
                   endpoint: 'https://rest.fra-01.braze.eu/users/track',
+                  endpointPath: 'users/track',
                   headers: {
                     'Content-Type': 'application/json',
                     Accept: 'application/json',
@@ -327,6 +328,7 @@ const basicRouterTests = [
                   type: 'REST',
                   method: 'POST',
                   endpoint: 'https://rest.fra-01.braze.eu/v2/subscription/status/set',
+                  endpointPath: 'v2/subscription/status/set',
                   headers: {
                     'Content-Type': 'application/json',
                     Accept: 'application/json',
@@ -361,6 +363,7 @@ const basicRouterTests = [
                   type: 'REST',
                   method: 'POST',
                   endpoint: 'https://rest.fra-01.braze.eu/users/merge',
+                  endpointPath: 'users/merge',
                   headers: {
                     'Content-Type': 'application/json',
                     Accept: 'application/json',
@@ -423,7 +426,7 @@ const basicRouterTests = [
     },
     envOverrides: {
       BRAZE_BATCH_IDENTIFY_RESOLUTION: 'false',
-    }
+    },
   },
   {
     name: 'braze',
@@ -754,6 +757,7 @@ const basicRouterTests = [
                   type: 'REST',
                   method: 'POST',
                   endpoint: 'https://rest.iad-03.braze.com/users/track',
+                  endpointPath: 'users/track',
                   headers: {
                     'Content-Type': 'application/json',
                     Accept: 'application/json',
@@ -902,7 +906,7 @@ const basicRouterTests = [
     },
     envOverrides: {
       BRAZE_BATCH_IDENTIFY_RESOLUTION: 'false',
-    }
+    },
   },
 ];
 
@@ -911,7 +915,7 @@ const basicRouterTestsWithBatchIdentityResolutionEnabled = basicRouterTests.map(
     ...test,
     envOverrides: {
       BRAZE_BATCH_IDENTIFY_RESOLUTION: 'true',
-    }
+    },
   };
 });
 

--- a/test/integrations/destinations/braze/router/identityResolution.ts
+++ b/test/integrations/destinations/braze/router/identityResolution.ts
@@ -144,6 +144,7 @@ export const identityResolution = [
                   type: 'REST',
                   method: 'POST',
                   endpoint: 'https://rest.fra-01.braze.eu/users/track',
+                  endpointPath: 'users/track',
                   headers: {
                     'Content-Type': 'application/json',
                     Accept: 'application/json',
@@ -291,6 +292,7 @@ export const identityResolution = [
                   type: 'REST',
                   method: 'POST',
                   endpoint: 'https://rest.fra-01.braze.eu/users/track',
+                  endpointPath: 'users/track',
                   headers: {
                     'Content-Type': 'application/json',
                     Accept: 'application/json',
@@ -483,6 +485,7 @@ export const identityResolution = [
                   type: 'REST',
                   method: 'POST',
                   endpoint: 'https://rest.fra-01.braze.eu/users/track',
+                  endpointPath: 'users/track',
                   headers: {
                     'Content-Type': 'application/json',
                     Accept: 'application/json',
@@ -684,6 +687,7 @@ export const identityResolution = [
                   type: 'REST',
                   method: 'POST',
                   endpoint: 'https://rest.fra-01.braze.eu/users/track',
+                  endpointPath: 'users/track',
                   headers: {
                     'Content-Type': 'application/json',
                     Accept: 'application/json',


### PR DESCRIPTION
## What are the changes introduced in this PR?

Enhanced Braze destination endpoint functions to return both the full endpoint URL and the path component for better debugging and monitoring capabilities.

## What is the related Linear task?

Resolves https://linear.app/rudderstack/issue/INT-4102/add-endpoint-path-details-in-rudder-transformer-for-top-15

## Please explain the objectives of your changes below

Modified endpoint functions (identify, track, subscription group, and alias merge) to return structured objects containing both the complete endpoint URL and the path component. This improves debugging capabilities and provides better visibility into which specific Braze API endpoints are being called.

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

The endpoint functions now return objects with `endpoint` and `path` properties instead of just the URL string. This is a non-breaking change as the `endpoint` property contains the same URL that was previously returned.

### Any new dependencies introduced with this change?

N/A

### Any new generic utility introduced or modified. Please explain the changes.

Modified endpoint utility functions in `config.js` to return structured response objects.

### Any technical or performance related pointers to consider with the change?

No performance impact. The change only affects the structure of returned data, not the actual API calls.

@coderabbitai review

<hr>

### Developer checklist

- [x] My code follows the style guidelines of this project
- [x] **No breaking changes are being introduced.**
- [x] All related docs linked with the PR?
- [x] All changes manually tested?
- [x] Any documentation changes needed with this change?
- [x] Is the PR limited to 10 file changes?
- [x] Is the PR limited to one linear task?
- [x] Are relevant unit and component test-cases added in **new readability format**?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?
- [ ] Verified that there are no credentials or confidential data exposed with the changes.