### PR TITLE
feat: add validation of diff in staging deployment workflow

### DIFF
--- a/.github/workflows/prepare-for-staging-deploy.yml
+++ b/.github/workflows/prepare-for-staging-deploy.yml
@@ -129,6 +129,12 @@ jobs:
             yq eval -i ".config-be-user-transformer.image.tag=\"$TAG_NAME\"" base.yaml
             git add base.yaml
 
+            # Check if there are actual changes to commit
+            if git diff --cached --exit-code > /dev/null; then
+              echo "No changes detected in staging environment. Version $TAG_NAME is already deployed. Skipping commit."
+              exit 0
+            fi
+
             git commit -m "chore: upgrade staging env transformers to \"$TAG_NAME\""
             git push -u origin $BRANCH_NAME
             gh pr create --fill


### PR DESCRIPTION
## What are the changes introduced in this PR?

### Problem
- The "Prepare for Staging Environment Deployment" workflow would fail when:
- A release branch PR was merged and the DevOps branch was deleted (standard practice)
- New commits were pushed to the same release branch
- The workflow ran again, found no existing branch, and attempted to commit the same version already in staging
- This resulted in failed commits or unnecessary PRs with no actual changes
### Solution
- Added a git diff --cached --exit-code check after staging changes but before committing. The workflow now:
- Proceeds with commit/push/PR creation only when actual changes exist
- Exits gracefully with an informative message when the version is already deployed
- Prevents failed workflows and unnecessary PRs

## What is the related Linear task?

Resolves INT-4253

## Please explain the objectives of your changes below

Put down any required details on the broader aspect of your changes. If there are any dependent changes, **mandatorily** mention them here

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

N/A

### Any new dependencies introduced with this change?

N/A

### Any new generic utility introduced or modified. Please explain the changes.

N/A

### Any technical or performance related pointers to consider with the change?

N/A

@coderabbitai review

<hr>

### Developer checklist

- [ ] My code follows the style guidelines of this project

- [ ] **No breaking changes are being introduced.**

- [ ] All related docs linked with the PR?

- [ ] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [ ] Is the PR limited to 10 file changes?

- [ ] Is the PR limited to one linear task?

- [ ] Are relevant unit and component test-cases added in **new readability format**?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.
