### PR TITLE
chore: disable pyroscope for primary process in cluster mode

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import bodyParser from 'koa-bodyparser';
 import { configureBatchProcessingDefaults } from '@rudderstack/integrations-lib';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { init as pyroscopeInit, start as pyroscopeStart } from '@pyroscope/nodejs';
+import cluster from 'cluster';
 import {
   addRequestSizeMiddleware,
   addStatMiddleware,
@@ -15,7 +16,6 @@ import { metricsRouter } from './routes/metricsRouter';
 import * as clusterUtil from './util/cluster';
 import { RedisDB } from './util/redis/redisConnector';
 import { logProcessInfo } from './util/utils';
-import cluster from 'cluster';
 
 // eslint-disable-next-line import/first
 import logger from './logger';


### PR DESCRIPTION
## Summary

Disables Pyroscope profiling for the primary (master) process when running in cluster mode, while keeping it enabled for worker processes.

## Changes

- Modified Pyroscope initialization logic to skip profiling on the primary process when clustering is enabled
- Renamed `cluster` import to `clusterUtil` to avoid naming conflict with Node.js native `cluster` module
- Added explicit import of Node.js `cluster` module to check `cluster.isPrimary`

## Motivation

In cluster mode, the primary process acts as a coordinator and doesn't handle actual requests - only worker processes do. Profiling the primary process provides no useful performance insights and wastes resources. This change ensures Pyroscope only profiles the worker processes that actually handle application traffic.

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

N/A

### Any new dependencies introduced with this change?

N/A

### Any new generic utility introduced or modified. Please explain the changes.

N/A

### Any technical or performance related pointers to consider with the change?

N/A

@coderabbitai review

<hr>

### Developer checklist

- [ ] My code follows the style guidelines of this project

- [ ] **No breaking changes are being introduced.**

- [ ] All related docs linked with the PR?

- [ ] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [ ] Is the PR limited to 10 file changes?

- [ ] Is the PR limited to one linear task?

- [ ] Are relevant unit and component test-cases added in **new readability format**?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.
