### PR TITLE
feat: isolated vm refactor

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -32,6 +32,7 @@ reviews:
     - '!**/test/**'
     - '!**/tests/**'
     - '!docs/**'
+    - '!loadtest/**'
     - '!**/*.json'
     - '!**/*.lock'
   path_instructions:

--- a/.eslintignore
+++ b/.eslintignore
@@ -32,3 +32,4 @@ Dockerfile*
 *.properties
 *.go
 CODEOWNERS
+loadtest/

--- a/.gitignore
+++ b/.gitignore
@@ -154,3 +154,5 @@ allure-report/
 
 # git conflict files
 *.orig
+
+loadtest/results_*.json

--- a/loadtest/benchmark.sh
+++ b/loadtest/benchmark.sh
@@ -13,7 +13,7 @@ MODE="${MODE:-simple}"
 # Function to kill server on ports
 kill_server() {
   lsof -t -i:9091 | xargs kill -9 2>/dev/null || true
-  lsof -t -i:9190 | xargs kill -9 2>/dev/null || true
+  lsof -t -i:9090 | xargs kill -9 2>/dev/null || true
 }
 
 # Function to run benchmark
@@ -49,8 +49,8 @@ run_benchmark() {
 }
 
 # Run all 3
-run_benchmark "new"
 run_benchmark "legacy"
+run_benchmark "new"
 
 echo ""
 echo "========================================"

--- a/loadtest/benchmark.sh
+++ b/loadtest/benchmark.sh
@@ -1,0 +1,160 @@
+#!/bin/bash
+set -e
+
+# Usage:
+#   ./benchmark.sh              # defaults to MODE=simple
+#   MODE=stress ./benchmark.sh  # stress mode (constant 200 rps)
+#   MODE=exhaust ./benchmark.sh    # exhaust mode (2m)
+#
+# Produces: results_<scenario>_<mode>.json
+
+MODE="${MODE:-simple}"
+
+# Function to kill server on ports
+kill_server() {
+  lsof -t -i:9091 | xargs kill -9 2>/dev/null || true
+  lsof -t -i:9190 | xargs kill -9 2>/dev/null || true
+}
+
+# Function to run benchmark
+run_benchmark() {
+  SCENARIO=$1
+  echo "========================================"
+  echo "Running Benchmark: $SCENARIO (MODE=$MODE)"
+  echo "========================================"
+
+  kill_server
+
+  # Start Server (Background)
+  echo "Starting Server..."
+  TRANSFORMER_TEST_MODE=true npm run start:dev > /dev/null 2>&1 &
+
+  # Wait for server to be ready
+  echo "Waiting 10s for server..."
+  sleep 10s
+
+  # Run k6
+  echo "Running k6..."
+  OUTFILE="results_${SCENARIO}_${MODE}.json"
+  rm -f "$OUTFILE"
+
+  # Run k6 and ignore exit code to ensure we proceed to comparison even if one fails thresholds
+  k6 run -e SCENARIO="$SCENARIO" -e MODE="$MODE" loadtest.js --summary-export="$OUTFILE" || true
+
+  # Kill Server
+  echo "Stopping Server..."
+  kill_server
+  echo "Run Complete."
+  sleep 2s
+}
+
+# Run all 3
+run_benchmark "new"
+run_benchmark "legacy"
+
+echo ""
+echo "========================================"
+echo "       BENCHMARK RESULTS (MODE=$MODE)"
+echo "========================================"
+# Use node to parse JSON and print a clean markdown table
+node -e '
+const fs = require("fs");
+
+const scenarios = ["legacy", "new"];
+const MODE = process.env.MODE || "simple";
+
+function fmt(n, digits = 2) {
+  return (typeof n === "number") ? n.toFixed(digits) : "NA";
+}
+
+const results = {};
+
+const printResults = (header,valueRows,result) => {
+  const allRows = [header, ...valueRows,result];
+
+  const whiteSpacePerCol = allRows.reduce((maxes, row) => {
+    row.forEach((cell, colIndex) => {
+      const len = String(cell).length;
+      maxes[colIndex] = Math.max(maxes[colIndex] ?? 0, len);
+    });
+    return maxes;
+  }, []);
+  const printRow = (row) => {
+    const text = row.map((s, i) => {
+        const whitespace = whiteSpacePerCol[i] - String(s).length;
+        return `${" ".repeat(Math.floor(whitespace/2))}${s}${" ".repeat(Math.ceil(whitespace/2))}`;
+    }).join(" | ");
+    console.log(text);
+  }
+allRows.forEach(row => printRow(row));
+};
+const valueRows = [];
+scenarios.forEach(sc => {
+  try {
+    const file = `results_${sc}_${MODE}.json`;
+    if (!fs.existsSync(file)) {
+      console.log(`${sc} ${file} not found`);
+      return;
+    }
+
+    const data = JSON.parse(fs.readFileSync(file, "utf8"));
+    const httpReq = data.metrics.http_req_duration;
+
+    const metrics = {
+      avg: httpReq.avg,
+      med: httpReq.med,
+      p90: httpReq["p(90)"],
+      p95: httpReq["p(95)"],
+      max: httpReq.max,
+      rps: data.metrics.http_reqs?.rate,
+      vusMax: (data.metrics.vus && typeof data.metrics.vus.max === "number") ? data.metrics.vus.max : null,
+      dropped: data.metrics.dropped_iterations ? data.metrics.dropped_iterations.count : 0
+    };
+    results[sc] = metrics;
+    valueRows.push([sc,...Object.values(metrics).map(v => fmt(v, 2))]);
+  } catch (e) {
+    console.log(`| ${sc} | ERROR | ${String(e.message).slice(0, 40)} | - | - | - | - | - |`);
+  }
+});
+
+const header=["Scenario", "Average (ms)", "Median (ms)", "P90 (ms)", "P95 (ms)", "Max (ms)", " RPS ", "VUs(max)", "Dropped"];
+
+// Calculate Comparison
+if (results.legacy && results.new) {
+  const diff = (n, l) => {
+    if (typeof n !== "number" || typeof l !== "number" || l === 0){ return "NA";}
+    const d = Math.abs(((n - l) / l) * 100);
+    return d.toFixed(2) + "%";
+  };
+
+  const getWinner = (n, l, type) => {
+    let winner;
+
+    if (typeof n !== "number" || typeof l !== "number") { return "-"; }
+    if (Math.abs(n - l) < 0.001) { return "Tie"; }
+    if (type === "lower") { winner = n < l ? "New" : "Legacy" };
+    if (type === "higher") { winner = n > l ? "New" : "Legacy" };
+    const percentDiff = diff(n, l);
+    return `${winner} (${percentDiff})`;
+  };
+
+  const l = results.legacy;
+  const n = results.new;
+
+  const compareValues = [
+    "Winners",
+    getWinner(n.avg, l.avg,"lower"),
+    getWinner(n.med, l.med,"lower"),
+    getWinner(n.p90, l.p90,"lower"),
+    getWinner(n.p95, l.p95,"lower"),
+    getWinner(n.max, l.max,"lower"),
+    getWinner(n.rps, l.rps,"higher"),
+    getWinner(n.vusMax, l.vusMax,"lower"),
+    getWinner(n.dropped, l.dropped,"lower")
+  ];
+  printResults(header,valueRows,compareValues);
+}
+
+
+console.log("\n");
+'

--- a/loadtest/loadtest.js
+++ b/loadtest/loadtest.js
@@ -226,7 +226,7 @@ export const options = {
 // -----------------------
 
 export function newTest() {
-  const res = http.post('http://localhost:9190/transformation/testRun', JSON.stringify(payload), {
+  const res = http.post('http://localhost:9090/transformation/testRun', JSON.stringify(payload), {
     headers: { 'Content-Type': 'application/json' },
   });
 
@@ -247,7 +247,7 @@ export function legacyTest() {
   };
 
   const res = http.post(
-    'http://localhost:9190/transformation/test',
+    'http://localhost:9090/transformation/test',
     JSON.stringify(requestPayload),
     {
       headers: { 'Content-Type': 'application/json' },

--- a/loadtest/loadtest.js
+++ b/loadtest/loadtest.js
@@ -1,0 +1,259 @@
+import http from 'k6/http';
+import { check } from 'k6';
+import { Trend } from 'k6/metrics';
+
+const legacyTrend = new Trend('legacy_duration');
+const newImplTrend = new Trend('new_impl_duration');
+
+const MODE = __ENV.MODE || 'simple';
+
+const getEventsPayload = (count) => {
+  return Array.from({ length: count }, () => ({
+    message: {
+      type: 'track',
+      event: 'Content Playback Completed',
+      sentAt: '2024-05-17T02:44:36.778Z',
+      userId: 'user-id',
+      channel: 'mobile',
+      context: {
+        os: { name: 'Android', version: '12' },
+        app: { name: 'The Chosen', build: '50', version: '2.5.0', namespace: 'namespace' },
+        device: {
+          id: 'device-id',
+          name: 'lisbon',
+          type: 'Android',
+          model: 'moto g(60)s',
+          manufacturer: 'motorola',
+        },
+        locale: 'pt-BR',
+        screen: { width: 1080, height: 2211, density: 446 },
+        traits: {
+          id: 'trait-id',
+          email: '',
+          phone: '',
+          userId: 'user-id',
+          language: 'pt',
+          channel_id: 'channel-id',
+          anonymousId: 'anonymous-id',
+        },
+        library: { name: 'com.rudderstack.android.sdk.core', version: '1.21.0' },
+        network: { wifi: true, carrier: 'TIM', cellular: true },
+        timezone: 'America/Sao_Paulo',
+        sessionId: 1715913841,
+        userAgent: 'Dalvik/2.1.0 (Linux; U; Android 12; moto g(60)s Build/S3RLS32.114-25-13)',
+      },
+      rudderId: 'rudder-id',
+      messageId: 'message-id',
+      properties: {
+        bitrate: 3200000,
+        is_live: false,
+        language: 'PT_BR',
+        content_id: '184683594335',
+        full_screen: false,
+        video_width: 854,
+        content_type: 'VIDEO',
+        video_height: 480,
+        audio_language: '',
+        content_duration: 2339804,
+        accumulative_time: 0,
+        playback_position: 2339,
+        subtitle_language: '',
+        new_property: 'true',
+      },
+      anonymousId: 'anonymous-id',
+      integrations: { All: true },
+      originalTimestamp: '2024-05-17T02:44:29.521Z',
+    },
+    metadata: {
+      sourceId: '',
+      workspaceId: '1lLaDQS1mdax6dbR08wOUgBJBk1',
+      namespace: '',
+      instanceId: '',
+      sourceType: 'Android',
+      sourceCategory: '',
+      trackingPlanId: 'tp_27gIzarrRWhkxscAxskVPfY7m1l',
+      trackingPlanVersion: 1,
+      sourceTpConfig: {
+        global: {
+          allowUnplannedEvents: true,
+          anyOtherViolation: 'forward',
+          propagateValidationErrors: true,
+          sendViolatedEventsTo: 'procErrors',
+          unplannedProperties: 'forward',
+        },
+        group: {},
+        identify: {
+          allowUnplannedEvents: true,
+          anyOtherViolation: 'forward',
+          propagateValidationErrors: true,
+          sendViolatedEventsTo: 'procErrors',
+          unplannedProperties: 'forward',
+        },
+      },
+      mergedTpConfig: {
+        allowUnplannedEvents: true,
+        anyOtherViolation: 'forward',
+        propagateValidationErrors: true,
+        sendViolatedEventsTo: 'procErrors',
+        unplannedProperties: 'forward',
+      },
+      destinationId: '',
+      jobId: 92,
+      sourceJobId: '',
+      sourceJobRunId: '',
+      sourceTaskRunId: '',
+      recordId: null,
+      destinationType: '',
+      messageId: '45a8d4be-ea87-4fc7-8b8b-e2604982da20',
+      oauthAccessToken: '',
+      messageIds: null,
+      rudderId: '<<>>anon-id-new2<<>>identified user id2',
+      receivedAt: '2023-04-18T15:54:51.711+05:30',
+      eventName: 'Content Playback Completed',
+      eventType: 'track',
+      sourceDefinitionId: '1QGzOQGVLM35GgtteFH1vYCE0WT',
+      destinationDefinitionId: '',
+      transformationId: '',
+      transformationVersionId: '',
+    },
+    destination: {},
+    libraries: null,
+  }));
+};
+
+const getRequestPayload = (count) => ({
+  input: getEventsPayload(count),
+  code: `
+export function transformEvent(event, metadata) { return event; }
+`,
+  language: 'javascript',
+  dependencies: {
+    libraries: [],
+    credentials: [],
+  },
+});
+
+const getConfigByMode = () => {
+  switch (MODE) {
+    case 'exhaust':
+      return {
+        config: {
+          executor: 'ramping-arrival-rate',
+          startRate: 50,
+          timeUnit: '1s',
+          preAllocatedVUs: 100,
+          maxVUs: 400,
+          stages: [
+            { target: 50, duration: '30s' },
+            { target: 100, duration: '30s' },
+            { target: 150, duration: '30s' },
+            { target: 200, duration: '30s' },
+            { target: 50, duration: '30s' },
+            { target: 20, duration: '30s' },
+          ],
+        },
+        payload: getRequestPayload(300),
+      };
+    case 'stress':
+      return {
+        config: {
+          executor: 'ramping-arrival-rate',
+          startRate: 20,
+          timeUnit: '1s',
+          preAllocatedVUs: 50,
+          maxVUs: 300,
+          stages: [
+            { target: 50, duration: '30s' },
+            { target: 100, duration: '30s' },
+            { target: 150, duration: '30s' },
+            { target: 50, duration: '30s' },
+          ],
+        },
+        payload: getRequestPayload(200),
+      };
+    case 'simple':
+    default:
+      return {
+        config: {
+          executor: 'constant-arrival-rate',
+          duration: '2m',
+          rate: 50,
+          timeUnit: '1s',
+          preAllocatedVUs: 50,
+          maxVUs: 50,
+        },
+        payload: getRequestPayload(100),
+      };
+  }
+};
+
+// -----------------------
+// Configs
+// -----------------------
+
+const { config, payload } = getConfigByMode();
+// -----------------------
+// Scenario selection
+// -----------------------
+
+const scenario = __ENV.SCENARIO || 'legacy';
+
+const scenarios = {
+  legacy: {
+    legacy: Object.assign({}, config, {
+      exec: 'legacyTest',
+      startTime: '0s',
+    }),
+  },
+  new: {
+    new_impl: Object.assign({}, config, {
+      exec: 'newTest',
+      startTime: '0s',
+    }),
+  },
+};
+
+// Optional: force per-stage series to appear in summary-export by referencing them in thresholds.
+// Keep these loose, they are mostly for producing tagged sub-metrics.
+
+export const options = {
+  discardResponseBodies: true,
+  scenarios: scenarios[scenario],
+};
+
+// -----------------------
+// Tests
+// -----------------------
+
+export function newTest() {
+  const res = http.post('http://localhost:9190/transformation/testRun', JSON.stringify(payload), {
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+  check(res, { 'status is 200': (r) => r.status === 200 });
+  newImplTrend.add(res.timings.duration);
+}
+
+export function legacyTest() {
+  const requestPayload = {
+    events: payload.input,
+    trRevCode: {
+      codeVersion: '1',
+      code: payload.code,
+      language: payload.language,
+    },
+    libraryVersionIDs: payload.dependencies.libraries.map((lib) => lib.versionId),
+    credentials: payload.dependencies.credentials,
+  };
+
+  const res = http.post(
+    'http://localhost:9190/transformation/test',
+    JSON.stringify(requestPayload),
+    {
+      headers: { 'Content-Type': 'application/json' },
+    },
+  );
+
+  check(res, { 'status is 200': (r) => r.status === 200 });
+  legacyTrend.add(res.timings.duration);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "component-each": "^0.2.6",
         "crypto-js": "^4.2.0",
         "dotenv": "^16.0.3",
+        "es-module-lexer": "^2.0.0",
         "fast-json-stable-stringify": "^2.1.0",
         "fast-xml-parser": "^4.5.1",
         "flat": "^5.0.2",
@@ -8779,6 +8780,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "component-each": "^0.2.6",
     "crypto-js": "^4.2.0",
     "dotenv": "^16.0.3",
+    "es-module-lexer": "^2.0.0",
     "fast-json-stable-stringify": "^2.1.0",
     "fast-xml-parser": "^4.5.1",
     "flat": "^5.0.2",

--- a/src/routes/userTransform.ts
+++ b/src/routes/userTransform.ts
@@ -3,6 +3,7 @@ import { UserTransformController } from '../controllers/userTransform';
 import { FeatureFlagMiddleware } from '../middlewares/featureFlag';
 import { RouteActivationMiddleware } from '../middlewares/routeActivation';
 import { StatsMiddleware } from '../middlewares/stats';
+import { UserTransformerV1Controller } from '../userTransformerV1/userTransformerV1.controller';
 
 const router = new Router();
 
@@ -23,6 +24,11 @@ router.post(
   '/transformation/test',
   RouteActivationMiddleware.isUserTransformTestRouteActive,
   UserTransformController.testTransform,
+);
+router.post(
+  '/transformation/testRun',
+  RouteActivationMiddleware.isUserTransformTestRouteActive,
+  UserTransformerV1Controller.testRun,
 );
 router.post(
   '/transformationLibrary/test',

--- a/src/userTransformerV1/codeRunner/__tests__/isolatedVm.test.ts
+++ b/src/userTransformerV1/codeRunner/__tests__/isolatedVm.test.ts
@@ -1,0 +1,139 @@
+import { IsolatedVMEngine } from '../isolatedVm';
+
+describe('IsolatedVMEngine', () => {
+  let engine: IsolatedVMEngine;
+
+  beforeEach(() => {
+    engine = new IsolatedVMEngine();
+  });
+
+  afterEach(async () => {
+    await engine.dispose();
+  });
+
+  describe('Global Functions', () => {
+    it('should register and call a synchronous global function', async () => {
+      const mockFn = jest.fn((msg: string) => `Hello ${msg}`);
+      await engine.registerGlobalFunctions([{ name: 'greet', fn: mockFn }]);
+
+      const result = await engine.runScript('greet("World")');
+      expect(result).toBe('Hello World');
+      expect(mockFn).toHaveBeenCalledWith('World');
+    });
+
+    it('should register and call an asynchronous global function', async () => {
+      const mockAsyncFn = jest.fn(async (x: number) => {
+        return new Promise((resolve) => setTimeout(() => resolve(x * 2), 10));
+      });
+
+      await engine.registerGlobalFunctions([{ name: 'double', fn: mockAsyncFn, isAsync: true }]);
+
+      const code = `
+        export async function run(val) {
+          return await double(val);
+        }
+      `;
+      await engine.registerModule('asyncTest', code, { evaluate: true });
+      const result = await engine.runModuleFunction('asyncTest', 'run', [21], { promise: true });
+
+      expect(result).toBe(42);
+      expect(mockAsyncFn).toHaveBeenCalledWith(21);
+    });
+
+    it('should handle errors in async global functions', async () => {
+      const errorFn = () => Promise.reject(new Error('Async Boom'));
+      await engine.registerGlobalFunctions([{ name: 'boom', fn: errorFn, isAsync: true }]);
+
+      const code = `
+        export async function run() {
+          await boom();
+        }
+      `;
+      await engine.registerModule('boomTest', code, { evaluate: true });
+      // Expect the rejection reason to contain the error message
+      await expect(
+        engine.runModuleFunction('boomTest', 'run', [], { promise: true }),
+      ).rejects.toThrow(/Async Boom/);
+    });
+  });
+
+  describe('Modules', () => {
+    it('should register and run a module function', async () => {
+      const code = `
+        export function add(a, b) { return a+b }
+      `;
+      await engine.registerModule('math', code, { evaluate: true });
+      const result = await engine.runModuleFunction('math', 'add', [5, 3]);
+      expect(result).toBe(8);
+    });
+
+    it('should handle module throwing error', async () => {
+      const code = `
+        export function fail() { throw new Error("Module Error"); }
+      `;
+      await engine.registerModule('faulty', code, { evaluate: true });
+      await expect(engine.runModuleFunction('faulty', 'fail', [])).rejects.toThrow('Module Error');
+    });
+
+    it('should list exports from a module', async () => {
+      const code = `
+        export function one() {}
+        export const two = 2;
+      `;
+      await engine.registerModule('exportsTest', code, { evaluate: true });
+      const exports = await engine.listExportsFromModule('exportsTest');
+      expect(exports.sort()).toEqual(['one', 'two'].sort());
+    });
+  });
+
+  describe('Dependencies and State', () => {
+    it('should reset context and clear modules', async () => {
+      const code = `export function test() { return 1; }`;
+      await engine.registerModule('temp', code, { evaluate: true });
+
+      expect(await engine.runModuleFunction('temp', 'test', [])).toBe(1);
+
+      engine.resetContext();
+
+      // After reset, calling the old module should fail or need re-registration
+      // `registerModule` would throw if we try to access a module handled by the old context/isolate state
+      // specifically `runModuleFunction` tries `resolveModule` which checks the Map.
+      // `resetContext` clears the map.ivm
+      await expect(engine.runModuleFunction('temp', 'test', [])).rejects.toThrow(
+        "Module 'temp' not found",
+      );
+    });
+  });
+
+  describe('Timeout Handling', () => {
+    it('should throw timeout error when execution exceeds limit', async () => {
+      const code = `
+        export function infiniteLoop() {
+           while(true) {}
+        }
+      `;
+      await engine.registerModule('timeoutTest', code, { evaluate: true });
+      // Use short timeout to verify exception
+      await expect(
+        engine.runModuleFunction('timeoutTest', 'infiniteLoop', [], { timeout: 100 }),
+      ).rejects.toThrow(/timed out/i);
+    });
+
+    it('should throw timeout error for async functions exceeding limit', async () => {
+      const slowFn = () => new Promise((resolve) => setTimeout(resolve, 200));
+
+      await engine.registerGlobalFunctions([{ name: 'slow', fn: slowFn, isAsync: true }]);
+
+      const code = `
+        export async function runSlow() {
+          await slow();
+        }
+      `;
+      await engine.registerModule('asyncTimeoutTest', code, { evaluate: true });
+
+      await expect(
+        engine.runModuleFunction('asyncTimeoutTest', 'runSlow', [], { timeout: 50, promise: true }),
+      ).rejects.toThrow(/timed out/i);
+    });
+  });
+});

--- a/src/userTransformerV1/codeRunner/isolatedVm.ts
+++ b/src/userTransformerV1/codeRunner/isolatedVm.ts
@@ -1,0 +1,378 @@
+import ivm from 'isolated-vm';
+
+/**
+ * Wraps a promise with a timeout. If the promise does not resolve within the specified
+ * timeout, it rejects with a timeout error.
+ *
+ * @param p The promise to wrap.
+ * @param timeoutMs The timeout in milliseconds.
+ * @param onTimeout Optional callback to execute when the timeout occurs.
+ * @returns The result of the promise `p`.
+ */
+async function withHostTimeout<T>(
+  p: Promise<T>,
+  timeoutMs: number,
+  onTimeout?: () => void,
+): Promise<T> {
+  let timer: NodeJS.Timeout | undefined;
+
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      try {
+        onTimeout?.();
+      } catch {
+        // ignore
+      }
+      reject(new Error(`Execution timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+  });
+
+  try {
+    return await Promise.race([p, timeoutPromise]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+interface GlobalFunction {
+  name: string;
+  fn: (...args: any[]) => any;
+  isAsync?: boolean;
+}
+/**
+ * Engine for running JavaScript code safely using `isolated-vm`.
+ * Manages the isolate, context, module caching, and function execution.
+ */
+export class IsolatedVMEngine {
+  private isolate: ivm.Isolate;
+
+  private context?: ivm.Context;
+
+  private jail?: ivm.Reference;
+
+  private modules: Map<string, ivm.Module> = new Map();
+
+  private fnCache: Map<string, ivm.Reference> = new Map();
+
+  constructor(private memoryLimit = 128) {
+    this.isolate = new ivm.Isolate({ memoryLimit: this.memoryLimit });
+  }
+
+  /**
+   * Resolves a module from the internal cache.
+   *
+   * @param specifier The name/specifier of the module to resolve.
+   * @returns The resolved `ivm.Module`.
+   * @throws Error if the module is not found.
+   */
+  private resolveModule(specifier: string): ivm.Module {
+    const module = this.modules.get(specifier);
+    if (module) {
+      return module;
+    }
+    throw new Error(`Module '${specifier}' not found.`);
+  }
+
+  /**
+   * Gets the current context, creating it if it doesn't exist.
+   * Also ensures the global 'jail' is set up properly.
+   *
+   * @returns An object containing the context and the global reference (jail).
+   */
+  private async getContext() {
+    if (!this.context) {
+      this.context = await this.isolate.createContext();
+    }
+    if (!this.jail) {
+      this.jail = this.context.global;
+      await this.jail.set('global', this.jail.derefInto());
+    }
+    return { context: this.context, jail: this.jail };
+  }
+
+  /**
+   * Registers global functions into the isolate's context.
+   *
+   * Handles both synchronous and asynchronous functions.
+   * - Async functions are bridged using a temporary host reference and a wrapper function
+   *   inside the isolate to handle the promise bridging correctly.
+   * - Synchronous functions are registered directly as callbacks.
+   *
+   * @param globalFns An array of `GlobalFunction` objects to register.
+   */
+  async registerGlobalFunctions(globalFns: GlobalFunction[]) {
+    const { jail } = await this.getContext();
+
+    const asyncFnNames: string[] = [];
+
+    // 1) Register bridges
+    await Promise.all(
+      globalFns.map(async ({ name, fn, isAsync }) => {
+        const isAsyncFn = isAsync ?? fn.constructor.name === 'AsyncFunction';
+
+        if (isAsyncFn) {
+          asyncFnNames.push(name);
+
+          // Store a host reference temporarily on global, then bootstrap will wrap it
+          await jail.set(
+            `__host_${name}`,
+            new ivm.Reference(async (...args: any[]) => {
+              // eslint-disable-next-line no-useless-catch
+              try {
+                // eslint-disable-next-line @typescript-eslint/return-await
+                return await (fn as (...args: any[]) => Promise<any>)(...args);
+                // eslint-disable-next-line sonarjs/no-useless-catch
+              } catch (err) {
+                throw err;
+              }
+            }),
+            { copy: true },
+          );
+        } else {
+          // Use Callback for sync functions
+          await jail.set(name, new ivm.Callback((...args: any[]) => fn(...args)), { copy: true });
+        }
+      }),
+    );
+
+    // 2) Bootstrap wrappers for async functions inside the isolate
+    if (asyncFnNames.length > 0) {
+      const wrappers = asyncFnNames
+        .map(
+          (name) => `
+          {
+            const hostRef = global.__host_${name};
+            delete global.__host_${name};
+
+            if (!hostRef || typeof hostRef.apply !== 'function') {
+              throw new Error('Async host bridge for "${name}" not available');
+            }
+
+            global.${name} = function(...args) {
+              return hostRef.apply(
+                undefined,
+                args,
+                {
+                  arguments: { copy: true },
+                  result: { promise: true, copy: true }
+                }
+              );
+            };
+          }
+        `,
+        )
+        .join('\n');
+
+      const bootstrapCode = `
+      (function () {
+        ${wrappers}
+      })();
+    `;
+
+      await this.runScript(bootstrapCode);
+    }
+  }
+
+  /**
+   * Compiles and registers a module in the isolate.
+   * Invalidates any cached function references for this module.
+   *
+   * @param name The name of the module.
+   * @param code The source code of the module.
+   * @param options Options for registration.
+   * @param options.allowImports Whether the module is allowed to import other modules.
+   * @param options.evaluate Whether to evaluate the module immediately after instantiation.
+   */
+  async registerModule(
+    name: string,
+    code: string,
+    options?: { allowImports?: boolean; evaluate?: boolean },
+  ): Promise<void> {
+    this.modules.get(name)?.release();
+    this.modules.delete(name);
+
+    // Invalidate function cache for this module
+    for (const key of this.fnCache.keys()) {
+      if (key.startsWith(`${name}:`)) {
+        this.fnCache.get(key)?.release();
+        this.fnCache.delete(key);
+      }
+    }
+    const { context } = await this.getContext();
+    const module = await this.isolate.compileModule(code, { filename: name });
+    await module.instantiate(context, (specifier) => {
+      if (!options?.allowImports) {
+        throw new Error(`Module '${specifier}' not found.`);
+      }
+      return this.resolveModule(specifier);
+    });
+    try {
+      if (options?.evaluate) {
+        await module.evaluate({ timeout: 1000 });
+      }
+      this.modules.set(name, module);
+    } catch (e: any) {
+      module.release();
+      throw new Error(`Evaluation failed for module ${name}: ${e.message}`);
+    }
+  }
+
+  /**
+   * Runs a specific function exported by a registered module.
+   * Caches the function reference for future calls to improve performance.
+   *
+   * @param moduleName The name of the module containing the function.
+   * @param functionName The name of the function to run.
+   * @param args The arguments to pass to the function.
+   * @param options Execution options.
+   * @param options.timeout Execution timeout in milliseconds.
+   * @param options.promise Whether to treat the result as a promise (async execution).
+   * @param options.args.transferIn Whether to transfer arguments (e.g., ArrayBuffers) into the isolate instead of copying.
+   * @returns The result of the function execution.
+   */
+  async runModuleFunction<RT, AT extends unknown[] = unknown[]>(
+    moduleName: string,
+    functionName: string,
+    args: AT,
+    options?: {
+      timeout?: number;
+      promise?: boolean;
+      args?: {
+        /* NOTE: transferIn moves (detaches) the underlying buffer instead of copying it.
+        Only useful for large ArrayBuffer / TypedArray payloads where the source buffer
+        is no longer needed. Never use for normal objects or event data.
+        For arrays of objects, transferIn has NO effect unless the array contains
+        TypedArrays / ArrayBuffers inside
+        */
+        transferIn?: boolean;
+      };
+    },
+  ): Promise<RT> {
+    const key = `${moduleName}:${functionName}`;
+    let fnRef = this.fnCache.get(key);
+
+    if (!fnRef) {
+      const module = this.resolveModule(moduleName);
+      fnRef = await module.namespace.get(functionName, { reference: true });
+
+      if (fnRef.typeof !== 'function') {
+        fnRef.release();
+        throw new Error(`Export '${functionName}' in module '${moduleName}' is not a function`);
+      }
+      this.fnCache.set(key, fnRef);
+    }
+
+    const isAsync = options?.promise || fnRef.typeof === 'AsyncFunction' || false;
+
+    const fnArgs = options?.args?.transferIn
+      ? args.map((arg) =>
+          new ivm.ExternalCopy(arg).copyInto({ transferIn: options?.args?.transferIn || false }),
+        )
+      : args;
+
+    const applyPromise = fnRef.apply(undefined, fnArgs, {
+      timeout: options?.timeout ?? 4000,
+      arguments: { copy: !options?.args?.transferIn || undefined },
+      result: { copy: true, promise: isAsync },
+    }) as Promise<RT>;
+    if (isAsync) {
+      return withHostTimeout(applyPromise, options?.timeout ?? 60000);
+    }
+    return applyPromise;
+  }
+
+  /**
+   * Compiles and runs a script in the isolate's context.
+   *
+   * @param code The script code to run.
+   * @param options.timeout Timeout in milliseconds.
+   * @returns The result of the script execution.
+   */
+  async runScript(code: string, options?: { timeout?: number }): Promise<unknown> {
+    const { context } = await this.getContext();
+    const script = await this.isolate.compileScript(code);
+    return script.run(context, { release: true, timeout: options?.timeout ?? 4000 });
+  }
+
+  /**
+   * Lists the names of all exports from a registered module.
+   *
+   * @param name The name of the module.
+   * @returns An array of exported names.
+   */
+  async listExportsFromModule(name: string): Promise<string[]> {
+    const { context } = await this.getContext();
+    const module = this.resolveModule(name);
+    // Return export names as plain strings (transferable)
+    const names = await context.evalClosure(
+      'return Object.getOwnPropertyNames($0.deref());',
+      [module.namespace],
+
+      {
+        result: { copy: true },
+      },
+    );
+    return names;
+  }
+
+  /**
+   * Disposes the isolate, freeing up all associated resources.
+   * Safe to call multiple times.
+   */
+  async dispose() {
+    // Destroys isolate instance and invalidates all references obtained from it.
+    this.isolate?.dispose();
+  }
+
+  /**
+   * Gets heap statistics for the isolate.
+   *
+   * @returns Heap statistics object.
+   */
+  getHeapStatistics(): Promise<ivm.HeapStatistics> {
+    return this.isolate.getHeapStatistics();
+  }
+
+  /**
+   * Resets the context by releasing all modules, function caches,
+   * the global jail, and the context itself.
+   * The isolate instance remains active.
+   */
+  resetContext() {
+    this.modules.forEach((module) => {
+      try {
+        module.release();
+      } catch {
+        // ignore
+      }
+    });
+    this.modules.clear();
+
+    this.fnCache.forEach((ref) => {
+      try {
+        ref.release();
+      } catch {
+        // ignore
+      }
+    });
+    this.fnCache.clear();
+
+    if (this.jail) {
+      try {
+        this.jail.release();
+      } catch {
+        // ignore
+      }
+      this.jail = undefined;
+    }
+
+    if (this.context) {
+      try {
+        this.context.release();
+      } catch {
+        // ignore
+      }
+      this.context = undefined;
+    }
+  }
+}

--- a/src/userTransformerV1/codeRunner/transformationsJSEnvironment.ts
+++ b/src/userTransformerV1/codeRunner/transformationsJSEnvironment.ts
@@ -1,0 +1,282 @@
+/* eslint-disable max-classes-per-file */
+import fetch from 'node-fetch';
+import { IsolatedVMEngine } from './isolatedVm';
+import { fetchWithDnsWrapper, extractStackTraceUptoLastSubstringMatch } from '../../util/utils';
+import logger from '../../logger';
+import stats from '../../util/stats';
+
+interface Credential {
+  key: string;
+  value: string;
+  isSecret: boolean;
+}
+
+interface Dependency {
+  importName: string;
+  code: string;
+}
+
+interface TransformationCodeRunnerOptions {
+  code: string;
+  credentials?: Credential[];
+  dependencies?: Dependency[];
+  testMode?: boolean;
+}
+
+class ExecutionContext {
+  logs: string[] = [];
+
+  private async registerContextFunctions() {
+    if (this.options.testMode) {
+      await this.engine.registerGlobalFunctions([
+        {
+          name: 'log',
+          fn: (...args: any[]) => {
+            let logString = 'Log:';
+            args.forEach((arg) => {
+              logString = logString.concat(
+                ` ${typeof arg === 'object' ? JSON.stringify(arg) : arg}`,
+              );
+            });
+            this.logs.push(logString);
+          },
+        },
+      ]);
+    }
+  }
+
+  constructor(
+    readonly engine: IsolatedVMEngine,
+    readonly options: { testMode?: boolean },
+  ) {}
+
+  async run<RT>(fnName: string, args: any[], options?: { timeout?: number; promise?: boolean }) {
+    await this.registerContextFunctions();
+    const result = await this.engine.runModuleFunction<RT>('main', fnName, args, options);
+    return { result, logs: this.logs };
+  }
+}
+
+export class TransformationsJSEnvironment {
+  private engine: IsolatedVMEngine;
+
+  private initialized: boolean = false;
+
+  private credentialsMap!: Map<string, any>;
+
+  private dependencies!: Dependency[];
+
+  private testMode?: boolean;
+
+  private mainCode: string;
+
+  constructor(
+    options: TransformationCodeRunnerOptions,
+    readonly metadata: Record<string, any> = {},
+  ) {
+    this.engine = new IsolatedVMEngine();
+    this.setCredentialsMap(options.credentials || []);
+    this.setDependencies(options.dependencies || []);
+    this.testMode = options.testMode;
+    this.mainCode = options.code;
+  }
+
+  setCredentialsMap(credentials: Credential[]) {
+    this.credentialsMap = new Map(credentials?.map((cred) => [cred.key, cred.value]) || []);
+  }
+
+  setDependencies(dependencies: Dependency[]) {
+    this.dependencies = dependencies || [];
+  }
+
+  private async registerGlobalFunctions() {
+    const trTags = { identifier: 'V1', ...this.metadata };
+    await this.engine.registerGlobalFunctions([
+      {
+        name: 'fetch',
+        fn: async (...args: any[]) => {
+          const fetchStartTime = new Date();
+          const fetchTags = { ...trTags } as Record<string, any>;
+          try {
+            const res = await fetchWithDnsWrapper(trTags, ...args);
+            const data = await res.json();
+            fetchTags.isSuccess = 'true';
+            return data;
+          } catch (error) {
+            logger.debug('Error fetching data', error);
+            fetchTags.isSuccess = 'false';
+            return 'ERROR';
+          } finally {
+            stats.timing('fetch_call_duration', fetchStartTime, fetchTags);
+          }
+        },
+        isAsync: true,
+      },
+      {
+        name: 'fetchV2',
+        fn: async (...args: any[]) => {
+          const fetchStartTime = new Date();
+          const fetchTags = { ...trTags } as Record<string, any>;
+          try {
+            const res = await fetchWithDnsWrapper(fetchTags, ...args);
+            const headersContent: Record<string, string> = {};
+            res.headers.forEach((value: string, header: string) => {
+              headersContent[header] = value;
+            });
+
+            let body = await res.text();
+            try {
+              body = JSON.parse(body);
+            } catch (e) {
+              /* fail silently */
+            }
+
+            const data = {
+              url: res.url,
+              status: res.status,
+              headers: headersContent,
+              body,
+            };
+            fetchTags.isSuccess = 'true';
+            return data;
+          } catch (error) {
+            const err = JSON.parse(JSON.stringify(error, Object.getOwnPropertyNames(error)));
+            logger.debug('Error fetching data in fetchV2', err);
+            fetchTags.isSuccess = 'false';
+            throw err;
+          } finally {
+            stats.timing('fetchV2_call_duration', fetchStartTime, fetchTags);
+          }
+        },
+        isAsync: true,
+      },
+      {
+        name: 'geolocation',
+        fn: async (...args: any[]) => {
+          const geoStartTime = new Date();
+          const geoTags = { ...trTags } as Record<string, any>;
+          try {
+            if (args.length === 0) {
+              throw new Error('ip address is required');
+            }
+            if (!process.env.GEOLOCATION_URL)
+              throw new Error('geolocation is not available right now');
+            const res = await fetch(`${process.env.GEOLOCATION_URL}/geoip/${args[0]}`, {
+              timeout: parseInt(process.env.GEOLOCATION_TIMEOUT_IN_MS || '1000', 10),
+            } as any);
+            if (res.status !== 200) {
+              throw new Error(
+                `request to fetch geolocation failed with status code: ${res.status}`,
+              );
+            }
+            const geoData = await res.json();
+            geoTags.isSuccess = 'true';
+            return geoData;
+          } catch (error) {
+            const err = JSON.parse(JSON.stringify(error, Object.getOwnPropertyNames(error)));
+            geoTags.isSuccess = 'false';
+            throw err;
+          } finally {
+            stats.timing('geo_call_duration', geoStartTime, geoTags);
+          }
+        },
+        isAsync: true,
+      },
+      {
+        name: 'extractStackTrace',
+        fn(trace: string, stringLiterals: string[]) {
+          return extractStackTraceUptoLastSubstringMatch(trace, stringLiterals);
+        },
+      },
+      {
+        name: 'getCredential',
+        fn: (key: string) => {
+          if (key === null || key === undefined) {
+            throw new TypeError('Key should be valid and defined');
+          }
+          return this.credentialsMap.get(key);
+        },
+      },
+      {
+        name: 'log',
+        fn: () => {},
+      },
+    ]);
+  }
+
+  private async registerDependencies() {
+    const dependencies = this?.dependencies;
+    if (dependencies?.length) {
+      await Promise.all(
+        dependencies.map((dependency) =>
+          this.engine.registerModule(dependency.importName, dependency.code),
+        ),
+      );
+    }
+  }
+
+  private async initializeEnvironment() {
+    try {
+      if (this.initialized) {
+        return;
+      }
+      await this.registerGlobalFunctions();
+      await this.registerDependencies();
+      await this.engine.registerModule('main', this.mainCode, {
+        allowImports: true,
+        evaluate: true,
+      });
+      this.initialized = true;
+    } catch (e) {
+      this.engine.resetContext();
+      throw e;
+    }
+  }
+
+  private createExecutionContext() {
+    return new ExecutionContext(this.engine, { testMode: this.testMode });
+  }
+
+  async run<RT, ARG extends unknown[] = unknown[]>(
+    fnName: string,
+    args: ARG,
+    options?: { timeout?: number; promise?: boolean; args?: { transferIn?: boolean } },
+  ): Promise<{ result: RT; logs: string[] }> {
+    if (!this.initialized) {
+      await this.initializeEnvironment();
+    }
+
+    if (this.testMode) {
+      const executionContext = this.createExecutionContext();
+      const result = await executionContext.run<RT>(fnName, args, options);
+      return result;
+    }
+
+    const result = await this.engine.runModuleFunction<RT>('main', fnName, args, options);
+    return { result, logs: [] };
+  }
+
+  async listExportedFunctions(): Promise<string[]> {
+    await this.initializeEnvironment();
+    return this.engine.listExportsFromModule('main');
+  }
+
+  async dispose() {
+    await this.engine.dispose();
+  }
+
+  /*
+   * Reset the environment by clearing the context and re-registering
+   * credentials and dependencies if provided
+   */
+  resetEnvironment(input?: { credentials?: Credential[]; dependencies?: Dependency[] }) {
+    this.initialized = false;
+    this.engine.resetContext();
+    if (input?.credentials) {
+      this.setCredentialsMap(input.credentials);
+    }
+    if (input?.dependencies) {
+      this.setDependencies(input.dependencies);
+    }
+  }
+}

--- a/src/userTransformerV1/codeRunner/transformationsJSRunner.ts
+++ b/src/userTransformerV1/codeRunner/transformationsJSRunner.ts
@@ -16,10 +16,7 @@ type TestEvent = Record<string, unknown>;
 type Metadata = Record<string, unknown>;
 export type TestEventOutputError = { error: string; metadata: Metadata };
 export type TestEventOutput = { transformedEvent: TestEvent; metadata: Metadata };
-export type TransformationOutput = {
-  transformedEvents: (TestEventOutput | TestEventOutputError)[];
-  logs: string[];
-};
+export type TransformationOutput = (TestEventOutput | TestEventOutputError)[];
 
 interface TransformationCodeRunnerMetadata {
   transformationId?: string;

--- a/src/userTransformerV1/codeRunner/transformationsJSRunner.ts
+++ b/src/userTransformerV1/codeRunner/transformationsJSRunner.ts
@@ -1,0 +1,230 @@
+import { init, parse } from 'es-module-lexer';
+import { TransformationsJSEnvironment } from './transformationsJSEnvironment';
+import { CredentialInput, LibraryCodeInput } from '../types';
+
+enum TransformationType {
+  TRANSFORM_EVENT = 'transformEvent',
+  TRANSFORM_BATCH = 'transformBatch',
+}
+
+const SUPPORTED_FUNC_NAMES = [
+  TransformationType.TRANSFORM_EVENT,
+  TransformationType.TRANSFORM_BATCH,
+];
+
+type TestEvent = Record<string, unknown>;
+type Metadata = Record<string, unknown>;
+export type TestEventOutputError = { error: string; metadata: Metadata };
+export type TestEventOutput = { transformedEvent: TestEvent; metadata: Metadata };
+export type TransformationOutput = {
+  transformedEvents: (TestEventOutput | TestEventOutputError)[];
+  logs: string[];
+};
+
+interface TransformationCodeRunnerMetadata {
+  transformationId?: string;
+  workspaceId?: string;
+}
+
+interface TransformationCodeRunnerInput {
+  code: string;
+  dependencies: {
+    libraries: LibraryCodeInput[];
+    credentials: CredentialInput[];
+  };
+  testMode: boolean;
+}
+export class TransformationJavascriptRunner {
+  private executionEnvironment?: TransformationsJSEnvironment;
+
+  constructor(
+    readonly input: TransformationCodeRunnerInput,
+    readonly metadata?: TransformationCodeRunnerMetadata,
+  ) {}
+
+  private async initializeExecutionEnvironment() {
+    const transformationType = await this.getTransformationType();
+    this.executionEnvironment = new TransformationsJSEnvironment(
+      {
+        code: this.wrapCode(this.input.code, transformationType),
+        dependencies: this.input.dependencies.libraries,
+        credentials: this.input.dependencies.credentials,
+        testMode: this.input.testMode,
+      },
+      this.metadata,
+    );
+  }
+
+  private transformationType?: TransformationType;
+
+  private async getTransformationType(): Promise<TransformationType> {
+    if (!this.transformationType) {
+      try {
+        await init;
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const [, exports] = parse(this.input.code);
+        this.transformationType = exports.find((exp) =>
+          SUPPORTED_FUNC_NAMES.includes(exp.n as TransformationType),
+        )?.n as TransformationType;
+      } catch (e) {
+        throw new Error(`Failed to parse code: ${e}`);
+      }
+    }
+    if (!this.transformationType) {
+      throw new Error(`Expected one of ${SUPPORTED_FUNC_NAMES.join(', ')}.`);
+    }
+    return this.transformationType;
+  }
+
+  async transform(events: TestEvent[]) {
+    if (!this.executionEnvironment) {
+      await this.initializeExecutionEnvironment();
+    }
+    const result = await this.executionEnvironment!.run<TransformationOutput>(
+      'transformWrapper',
+      [events],
+      {
+        timeout: 60000,
+        promise: true,
+      },
+    );
+    return result;
+  }
+
+  async dispose() {
+    if (this.executionEnvironment) {
+      await this.executionEnvironment.dispose();
+    }
+  }
+
+  private wrapCode(userCode: string, transformationType?: string): string {
+    const commonCode = `${userCode}
+    const isObject = (o) => Object.prototype.toString.call(o) === '[object Object]';
+
+    function getMetadata(eventsMetadata, event) {
+        const eventMetadata = event ? eventsMetadata[event.messageId] || {} : {};
+        return {
+          sourceId: eventMetadata.sourceId,
+          sourceName: eventMetadata.sourceName,
+          workspaceId: eventMetadata.workspaceId,
+          sourceType: eventMetadata.sourceType,
+          sourceCategory: eventMetadata.sourceCategory,
+          destinationId: eventMetadata.destinationId,
+          destinationType: eventMetadata.destinationType,
+          destinationName: eventMetadata.destinationName,
+
+          namespace: eventMetadata.namespace,
+          originalSourceId: eventMetadata.originalSourceId,
+          trackingPlanId: eventMetadata.trackingPlanId,
+          trackingPlanVersion: eventMetadata.trackingPlanVersion,
+          sourceTpConfig: eventMetadata.sourceTpConfig,
+          mergedTpConfig: eventMetadata.mergedTpConfig,
+          jobId: eventMetadata.jobId,
+          sourceJobId: eventMetadata.sourceJobId,
+          sourceJobRunId: eventMetadata.sourceJobRunId,
+          sourceTaskRunId: eventMetadata.sourceTaskRunId,
+          recordId: eventMetadata.recordId,
+          messageId: eventMetadata.messageId,
+          messageIds: eventMetadata.messageIds,
+          rudderId: eventMetadata.rudderId,
+          receivedAt: eventMetadata.receivedAt,
+          eventName: eventMetadata.eventName,
+          eventType: eventMetadata.eventType,
+          sourceDefinitionId: eventMetadata.sourceDefinitionId,
+          destinationDefinitionId: eventMetadata.destinationDefinitionId,
+          transformationId: eventMetadata.transformationId,
+          transformationVersionId: eventMetadata.transformationVersionId,
+          isTest: eventMetadata.isTest
+        };
+    }
+    `;
+
+    const batchWrapper = `
+    export async function transformWrapper(events) {
+       let outputEvents = []
+       const eventMessages = events.map(event => event.message);
+       const eventsMetadata = {};
+       events.forEach(ev => {
+         eventsMetadata[ev.message.messageId] = ev.metadata;
+       });
+       
+       const metadata = function(event) {
+          return getMetadata(eventsMetadata, event);
+       }
+       
+       let transformedEventsBatch;
+       try {
+         transformedEventsBatch = await transformBatch(eventMessages, metadata);
+       } catch (error) {
+         outputEvents.push({error: extractStackTrace(error.stack, ["transformBatch"]), metadata: {}});
+         return outputEvents;
+       }
+       if (!Array.isArray(transformedEventsBatch)) {
+         outputEvents.push({error: "returned events from transformBatch(event) is not an array", metadata: {}});
+         return outputEvents;
+       }
+       outputEvents = transformedEventsBatch.map(transformedEvent => {
+         if (!isObject(transformedEvent)) {
+           return{error: "returned event in events array from transformBatch(events) is not an object", metadata: {}};
+         }
+         return{transformedEvent, metadata: metadata(transformedEvent)};
+       })
+       return outputEvents;
+    }
+    `;
+
+    const eventWrapper = `
+    export async function transformWrapper(events) {
+       let outputEvents = []
+       const eventMessages = events.map(event => event.message);
+       const eventsMetadata = {};
+       events.forEach(ev => {
+         eventsMetadata[ev.message.messageId] = ev.metadata;
+       });
+       
+       const metadata = function(event) {
+          return getMetadata(eventsMetadata, event);
+       }
+
+       await Promise.all(eventMessages.map(async ev => {
+            const currMsgId = ev.messageId;
+            try{
+              let transformedOutput = await transformEvent(ev, metadata);
+              // if func returns null/undefined drop event
+              if (transformedOutput === null || transformedOutput === undefined){ return;}
+              if (Array.isArray(transformedOutput)) {
+                const producedEvents = [];
+                const encounteredError = !transformedOutput.every(e => {
+                  if (isObject(e)) {
+                    producedEvents.push({transformedEvent: e, metadata: eventsMetadata[currMsgId] || {}});
+                    return true;
+                  } else {
+                    outputEvents.push({error: "returned event in events array from transformEvent(event) is not an object", metadata: eventsMetadata[currMsgId] || {}});
+                    return false;
+                  }
+                })
+                if (!encounteredError) {
+                  outputEvents.push(...producedEvents);
+                }
+                return;
+              }
+              if (!isObject(transformedOutput)) {
+                return outputEvents.push({error: "returned event from transformEvent(event) is not an object", metadata: eventsMetadata[currMsgId] || {}});
+              }
+              outputEvents.push({transformedEvent: transformedOutput, metadata: eventsMetadata[currMsgId] || {}});
+              return;
+            } catch (error) {
+              // Handling the errors in versionedRouter.js
+              return outputEvents.push({error: extractStackTrace(error.stack, ["transformEvent"]), metadata: eventsMetadata[currMsgId] || {}});
+            }
+       }));
+       return outputEvents;
+    }
+    `;
+
+    return `
+    ${commonCode}
+    ${transformationType === 'transformBatch' ? batchWrapper : eventWrapper}
+    `;
+  }
+}

--- a/src/userTransformerV1/codeRunner/transformationsJSRunner.ts
+++ b/src/userTransformerV1/codeRunner/transformationsJSRunner.ts
@@ -71,7 +71,7 @@ export class TransformationJavascriptRunner {
       }
     }
     if (!this.transformationType) {
-      throw new Error(`Expected one of ${SUPPORTED_FUNC_NAMES.join(', ')}.`);
+      throw new Error(`Expected one of ${SUPPORTED_FUNC_NAMES.join(', ')}`);
     }
     return this.transformationType;
   }

--- a/src/userTransformerV1/types.ts
+++ b/src/userTransformerV1/types.ts
@@ -1,0 +1,21 @@
+export interface CredentialInput {
+  key: string;
+  value: string;
+  isSecret: boolean;
+}
+
+export type LibraryCodeInput = {
+  importName: string;
+  code: string;
+};
+
+export type LibraryVersionInput = {
+  versionId: string;
+};
+
+export type LibraryInput = LibraryCodeInput | LibraryVersionInput;
+
+export interface Dependencies {
+  libraries: LibraryInput[];
+  credentials: CredentialInput[];
+}

--- a/src/userTransformerV1/userTransformerV1.controller.ts
+++ b/src/userTransformerV1/userTransformerV1.controller.ts
@@ -1,0 +1,21 @@
+import { Context } from 'koa';
+import { ControllerUtility } from '../controllers/util';
+import logger from '../logger';
+import { TestRunRequestBody, transformerService } from './userTransformerV1.service';
+
+export class UserTransformerV1Controller {
+  public static async testRun(ctx: Context) {
+    const response = await transformerService.runTransformation(
+      ctx.request.body as TestRunRequestBody,
+      true,
+    );
+
+    ctx.body = response;
+    ControllerUtility.postProcess(ctx, 200);
+    logger.debug(
+      '(User transform - router:/transformation/testRun ):: Response from transformer',
+      ctx.response.body,
+    );
+    return ctx;
+  }
+}

--- a/src/userTransformerV1/userTransformerV1.service.ts
+++ b/src/userTransformerV1/userTransformerV1.service.ts
@@ -1,0 +1,154 @@
+import { isNil } from 'lodash';
+import { getTransformationCode } from '../util/customTransforrmationsStore';
+import { getLibraryCodeV1 } from '../util/customTransforrmationsStore-v1';
+import { TransformationJavascriptRunner } from './codeRunner/transformationsJSRunner';
+import { CredentialInput, Dependencies, LibraryCodeInput, LibraryVersionInput } from './types';
+import { runOpenFaasUserTransform } from '../util/customTransformer-faas';
+import { parserForImport } from '../util/parser';
+
+interface PythonDependencies {
+  libraries: LibraryVersionInput[];
+  credentials: CredentialInput[];
+}
+
+interface PythonTransformationRunInput {
+  workspaceId: string;
+  versionId: string;
+  code: string;
+  imports?: string[];
+  dependencies: PythonDependencies;
+}
+interface PythonTransformationTestRunInput {
+  code: string;
+  imports?: string[];
+  dependencies: PythonDependencies;
+}
+
+export interface TestRunRequestBody {
+  input: Record<string, any>[];
+  code?: string;
+  versionId?: string;
+  dependencies: Dependencies;
+  language: string;
+  metadata: {
+    transformationId: string;
+    workspaceId: string;
+  };
+}
+
+export class UserTransformerService {
+  private async resolveLibraries(libraries: Dependencies['libraries'], imports?: string[]) {
+    const librariesVersionIds = libraries
+      ?.filter((l) => !!(l as LibraryVersionInput).versionId && !(l as LibraryCodeInput).code)
+      .map((dependency) => (dependency as LibraryVersionInput).versionId);
+
+    const librariesCode = libraries
+      .filter((l) => !!(l as LibraryCodeInput).code)
+      .map((dependency) => ({
+        importName: (dependency as LibraryCodeInput).importName,
+        code: (dependency as LibraryCodeInput).code,
+      }));
+
+    const libs = (
+      await Promise.all(
+        librariesVersionIds.map(async (libraryVersionId) => getLibraryCodeV1(libraryVersionId)),
+      )
+    )
+      .filter((library) => imports?.includes(library.name))
+      .map((library) => ({
+        importName: library.name,
+        code: library.code,
+      }));
+    return [...libs, ...librariesCode];
+  }
+
+  private async runJSTransformation(
+    events: Record<string, any>[],
+    transformation: {
+      id?: string;
+      workspaceId?: string;
+      code: string;
+      imports?: string[];
+      language: string;
+      dependencies: {
+        libraries: LibraryCodeInput[];
+        credentials: CredentialInput[];
+      };
+    },
+  ) {
+    const { code, imports, id, workspaceId, dependencies } = transformation;
+
+    const importedLibrariesNames =
+      imports || Object.keys(await parserForImport(code, false, [], 'javascript'));
+
+    const libraries = await this.resolveLibraries(dependencies.libraries, importedLibrariesNames);
+
+    if (!code) {
+      throw new Error('No code provided');
+    }
+
+    const transformationRunner = new TransformationJavascriptRunner(
+      {
+        code,
+        dependencies: {
+          libraries,
+          credentials: dependencies.credentials,
+        },
+        testMode: true,
+      },
+      {
+        transformationId: id || '',
+        workspaceId: workspaceId || '',
+      },
+    );
+    try {
+      const result = await transformationRunner.transform(events);
+      return result;
+    } finally {
+      await transformationRunner.dispose();
+    }
+  }
+
+  private async runPythonTransformation(
+    events: Record<string, any>[],
+    transformation: PythonTransformationTestRunInput | PythonTransformationRunInput,
+    testMode?: boolean,
+  ): Promise<any> {
+    const { code, dependencies } = transformation;
+    const librariesVersionIds = dependencies.libraries.map((l) => l.versionId);
+
+    const updatedEvents = events.map((ev) => {
+      if (isNil(ev.credentials)) {
+        return {
+          ...ev,
+          credentials: dependencies.credentials,
+        };
+      }
+      return ev;
+    });
+    return runOpenFaasUserTransform(
+      updatedEvents,
+      {
+        code,
+      },
+      librariesVersionIds,
+      testMode,
+    );
+  }
+
+  async runTransformation(input: TestRunRequestBody, testMode: boolean = false) {
+    const { input: events, code, language = 'javascript', versionId, dependencies } = input;
+    const transformation = versionId ? await getTransformationCode(versionId) : { code, language };
+    if (language === 'javascript') {
+      return this.runJSTransformation(events, { ...transformation, dependencies });
+    }
+    const resp = await this.runPythonTransformation(
+      events,
+      { ...transformation, dependencies },
+      testMode,
+    );
+    return resp;
+  }
+}
+
+export const transformerService = new UserTransformerService();

--- a/src/userTransformerV1/userTransformerV1.service.ts
+++ b/src/userTransformerV1/userTransformerV1.service.ts
@@ -43,6 +43,9 @@ export interface TestRunRequestBody {
 
 export class UserTransformerService {
   private async resolveLibraries(libraries: Dependencies['libraries'], imports?: string[]) {
+    if (!imports?.length || !libraries?.length) {
+      return [];
+    }
     const librariesVersionIds = libraries
       ?.filter((l) => !!(l as LibraryVersionInput).versionId && !(l as LibraryCodeInput).code)
       .map((dependency) => (dependency as LibraryVersionInput).versionId);

--- a/src/userTransformerV1/userTransformerV1.service.ts
+++ b/src/userTransformerV1/userTransformerV1.service.ts
@@ -6,7 +6,7 @@ import { CredentialInput, Dependencies, LibraryCodeInput, LibraryVersionInput } 
 import { runOpenFaasUserTransform } from '../util/customTransformer-faas';
 import { parserForImport } from '../util/parser';
 
-interface PythonDependencies {
+interface PythonTransDependencies {
   libraries: LibraryVersionInput[];
   credentials: CredentialInput[];
 }
@@ -16,12 +16,12 @@ interface PythonTransformationRunInput {
   versionId: string;
   code: string;
   imports?: string[];
-  dependencies: PythonDependencies;
+  dependencies: PythonTransDependencies;
 }
 interface PythonTransformationTestRunInput {
   code: string;
   imports?: string[];
-  dependencies: PythonDependencies;
+  dependencies: PythonTransDependencies;
 }
 
 export interface TestRunRequestBody {
@@ -75,6 +75,7 @@ export class UserTransformerService {
         credentials: CredentialInput[];
       };
     },
+    testMode: boolean = false,
   ) {
     const { code, imports, id, workspaceId, dependencies } = transformation;
 
@@ -94,7 +95,7 @@ export class UserTransformerService {
           libraries,
           credentials: dependencies.credentials,
         },
-        testMode: true,
+        testMode,
       },
       {
         transformationId: id || '',
@@ -140,7 +141,7 @@ export class UserTransformerService {
     const { input: events, code, language = 'javascript', versionId, dependencies } = input;
     const transformation = versionId ? await getTransformationCode(versionId) : { code, language };
     if (language === 'javascript') {
-      return this.runJSTransformation(events, { ...transformation, dependencies });
+      return this.runJSTransformation(events, { ...transformation, dependencies }, testMode);
     }
     const resp = await this.runPythonTransformation(
       events,

--- a/src/userTransformerV1/userTransformerV1.service.ts
+++ b/src/userTransformerV1/userTransformerV1.service.ts
@@ -11,6 +11,11 @@ interface PythonTransDependencies {
   credentials: CredentialInput[];
 }
 
+interface JSTransDependencies {
+  libraries: LibraryCodeInput[];
+  credentials: CredentialInput[];
+}
+
 interface PythonTransformationRunInput {
   workspaceId: string;
   versionId: string;
@@ -70,10 +75,7 @@ export class UserTransformerService {
       code: string;
       imports?: string[];
       language: string;
-      dependencies: {
-        libraries: LibraryCodeInput[];
-        credentials: CredentialInput[];
-      };
+      dependencies: JSTransDependencies;
     },
     testMode: boolean = false,
   ) {


### PR DESCRIPTION
## What are the changes introduced in this PR?

- Refactor isolated-vm for better performance and readability 
- New `transformation/testRun` endpoint that uses the new implementation of the ivm

Request body
```javascript
{
  "input": [ ], // events input
  "language": "javascript",
  "code": "export function transformEvent(event, metadata) { }",
  "dependencies": {
    "libraries": [
      {
        "versionId": "37xcHnudX5LtsRsTi2Xkg5EfoMQ"
      }
    ],
    "credentials": []
  }
}
```
Response
```javascript
{
  "result": [
    {
      "error": "Error: dd\n    at transformEvent (main:2:106)",
      "metadata": {
        "rudderId": 1,
        "messageId": 2,
        "isTest": false
      }
    },
    {
      "transformedEvent": {
        "messageId": 1,
        "type": "track1"
      },
      "metadata": {
        "isTest": true,
        "messageId": 1,
        "rudderId": 0
      }
    }
  ],
  "logs": [ ]
}
```


run the comparison load test
```bash
cd loadtest
chmod +x benchmark.sh 
MODE=stress ./benchmark.sh # MODE=simple | stress | exhaust 
```

## Local results
### Benchmark Results (Mode = Simple) (rate: 50, 100 events per request)
> To ensure a fair comparison, during testing I modified the new endpoint (transformation/testRun) to return the same response as the old endpoint (transformation/test).


| Scenario | Average (ms) | Median (ms) | P90 (ms) | P95 (ms) | Max (ms) | RPS  | VUs (max) | Dropped |
|----------|--------------|-------------|----------|----------|----------|------|-----------|---------|
| legacy   | 7.32         | 6.27        | 7.31     | 9.26     | 195.71   | 50.00| 9.00      | 0.00    |
| new      | 5.98         | 5.62        | 6.25     | 7.05     | 110.73   | 50.00| 1.00      | 0.00    |
| **Winners** | **New (18.25%)** | **New (10.32%)** | **New (14.60%)** | **New (23.81%)** | **New (43.42%)** | **Tie** | **New (88.89%)** | **Tie** |

### Benchmark Results (Mode = stress)  (rate: 50-150, 200 events per request)
| Scenario | Average (ms) | Median (ms) | P90 (ms) | P95 (ms) | Max (ms) | RPS  | VUs (max) | Dropped |
|----------|--------------|-------------|----------|----------|----------|------|-----------|---------|
| legacy   | 16.81        | 13.72       | 22.97    | 29.13    | 327.67   | 83.74| 20.00     | 0.00    |
| new      | 13.83        | 12.47       | 19.26    | 22.77    | 114.81   | 83.74| 17.00     | 0.00    |
| **Winners** | **New (17.73%)** | **New (9.15%)** | **New (16.18%)** | **New (21.82%)** | **New (64.96%)** | **Tie** | **New (15.00%)** | **Tie** |

### Benchmark Results (Mode = Exhaust)  (rate: 50-200, 300 events per request)

| Scenario | Average (ms) | Median (ms) | P90 (ms) | P95 (ms) | Max (ms) | RPS  | VUs (max) | Dropped |
|----------|--------------|-------------|----------|----------|----------|------|-----------|---------|
| legacy   | 1393.70      | 800.47      | 1943.93  | 2149.85  | 60007.10 | 78.57| 400.00    | 3406.00 |
| new      | 1268.73      | 523.44      | 1755.35  | 1916.40  | 60004.74 | 79.49| 400.00    | 3240.00 |
| **Winners** | **New (8.97%)** | **New (34.61%)** | **New (9.70%)** | **New (10.86%)** | **New (0.00%)** | **New (1.18%)** | **Tie** | **New (4.87%)** |

### Developer checklist

- [ ] My code follows the style guidelines of this project

- [ ] **No breaking changes are being introduced.**

- [ ] All related docs linked with the PR?

- [ ] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [ ] Is the PR limited to 10 file changes?

- [ ] Is the PR limited to one linear task?

- [ ] Are relevant unit and component test-cases added in **new readability format**?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.
