### PR TITLE
chore: version upgrade google ad destinations from 19 to 22

### DIFF
--- a/.github/scripts/versions.json
+++ b/.github/scripts/versions.json
@@ -112,7 +112,7 @@
     "Sunset Date Current Version used in backend": "Not Available"
   },
   {
-    "Destination": "GAEC",
+    "Destination": "GOOGLE_ADWORDS_ENHANCED_CONVERSIONS",
     "Version currently referred in CloudMode Services": "/v22/customers/:customerId/uploadClickConversions, /v22/customers/:customerId/uploadCallConversions, /v22/customers/:customerId/googleAds:searchStream, /v22/customers/:customerId/offlineUserDataJobs (currently used: v22)",
     "Link to check Versions documentation": "https://developers.google.com/google-ads/api/docs/sunset-dates https://developers.google.com/google-ads/api/docs/release-notes",
     "Latest Version rolled out": "v23 (released Jan 28, 2026)",

--- a/.github/scripts/versions.json
+++ b/.github/scripts/versions.json
@@ -113,17 +113,17 @@
   },
   {
     "Destination": "GAEC",
-    "Version currently referred in CloudMode Services": "/v19/customers/:customerId/uploadClickConversions, /v19/customers/:customerId/uploadCallConversions, /v19/customers/:customerId/googleAds:searchStream, /v19/customers/:customerId/offlineUserDataJobs",
-    "Link to check Versions documentation": "https://developers.google.com/google-ads/api/docs/release-notes",
-    "Latest Version rolled out": "v20",
-    "Sunset Date Current Version used in backend": "v19 will be deprecated in February 2026"
+    "Version currently referred in CloudMode Services": "/v22/customers/:customerId/uploadClickConversions, /v22/customers/:customerId/uploadCallConversions, /v22/customers/:customerId/googleAds:searchStream, /v22/customers/:customerId/offlineUserDataJobs (currently used: v22)",
+    "Link to check Versions documentation": "https://developers.google.com/google-ads/api/docs/sunset-dates https://developers.google.com/google-ads/api/docs/release-notes",
+    "Latest Version rolled out": "v23 (released Jan 28, 2026)",
+    "Sunset Date Current Version used in backend": "v22 sunset: October 2026 (tentative). Latest available: v23 (released Jan 28, 2026) with sunset February 2027."
   },
   {
     "Destination": "GOOGLE_ADWORDS_OFFLINE_CONVERSIONS",
-    "Version currently referred in CloudMode Services": "/v19/customers/:customerId/uploadClickConversions, /v19/customers/:customerId/uploadCallConversions, /v19/customers/:customerId/googleAds:searchStream, /v19/customers/:customerId/offlineUserDataJobs",
-    "Link to check Versions documentation": "https://developers.google.com/google-ads/api/docs/sunset-dates",
-    "Latest Version rolled out": "v20",
-    "Sunset Date Current Version used in backend": "v19 will be deprecated in February 2026"
+    "Version currently referred in CloudMode Services": "/v22/customers/:customerId/uploadClickConversions, /v22/customers/:customerId/uploadCallConversions, /v22/customers/:customerId/googleAds:searchStream, /v22/customers/:customerId/offlineUserDataJobs (currently used: v22)",
+    "Link to check Versions documentation": "https://developers.google.com/google-ads/api/docs/sunset-dates https://developers.google.com/google-ads/api/docs/release-notes",
+    "Latest Version rolled out": "v23 (released Jan 28, 2026)",
+    "Sunset Date Current Version used in backend": "v22 sunset: October 2026 (tentative). Latest available: v23 (released Jan 28, 2026) with sunset February 2027."
   },
   {
     "Destination": "GOOGLE_ADWORDS_REMARKETING_LISTS",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@koa/router": "^12.0.0",
         "@ndhoule/extend": "^2.0.0",
         "@pyroscope/nodejs": "^0.4.5",
-        "@rudderstack/integrations-lib": "^0.2.59",
+        "@rudderstack/integrations-lib": "^0.2.61",
         "@rudderstack/json-template-engine": "^0.19.5",
         "@rudderstack/workflow-engine": "^0.9.0",
         "@shopify/jest-koa-mocks": "^5.1.1",
@@ -3449,9 +3449,9 @@
       }
     },
     "node_modules/@rudderstack/integrations-lib": {
-      "version": "0.2.59",
-      "resolved": "https://registry.npmjs.org/@rudderstack/integrations-lib/-/integrations-lib-0.2.59.tgz",
-      "integrity": "sha512-D8n5oQmTcf7chq+d/D6COar8uTlCOiVMdkuvQ2yeiCmjVzvrge+Zh809yDM+aRqh/S1V6VFuY/LBaqWIoLkqbw==",
+      "version": "0.2.61",
+      "resolved": "https://registry.npmjs.org/@rudderstack/integrations-lib/-/integrations-lib-0.2.61.tgz",
+      "integrity": "sha512-0cCGr94/+Nr75uf5L8j6UsUSGjLRgc6zuOjuUUt36uEnUQTZ9GL+r3dkRxmhp1xvFPix79KG9PQrxU+40aQTXA==",
       "license": "MIT",
       "dependencies": {
         "@rudderstack/featureflag-sdk-node": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@koa/router": "^12.0.0",
     "@ndhoule/extend": "^2.0.0",
     "@pyroscope/nodejs": "^0.4.5",
-    "@rudderstack/integrations-lib": "^0.2.59",
+    "@rudderstack/integrations-lib": "^0.2.61",
     "@rudderstack/json-template-engine": "^0.19.5",
     "@rudderstack/workflow-engine": "^0.9.0",
     "@shopify/jest-koa-mocks": "^5.1.1",

--- a/src/v0/destinations/google_adwords_offline_conversions/config.js
+++ b/src/v0/destinations/google_adwords_offline_conversions/config.js
@@ -1,20 +1,20 @@
 const { getMappingConfig } = require('../../util');
 
-const API_VERSION = 'v19';
+const API_VERSION = 'v22';
 
 const CUSTOMER_ID_PARAM = ':customerId';
 
 const BASE_ENDPOINT = `https://googleads.googleapis.com/${API_VERSION}/customers/${CUSTOMER_ID_PARAM}`;
 
-// Ref - https://developers.google.com/google-ads/api/rest/reference/rest/v19/customers/uploadClickConversions
+// Ref - https://developers.google.com/google-ads/api/rest/reference/rest/v22/customers/uploadClickConversions
 const CLICK_CONVERSION_ENDPOINT_PATH = 'uploadClickConversions';
 const CLICK_CONVERSION = `${BASE_ENDPOINT}:${CLICK_CONVERSION_ENDPOINT_PATH}`;
 
-// Ref - https://developers.google.com/google-ads/api/rest/reference/rest/v19/customers/uploadCallConversions
+// Ref - https://developers.google.com/google-ads/api/rest/reference/rest/v22/customers/uploadCallConversions
 const CALL_CONVERSION_ENDPOINT_PATH = 'uploadCallConversions';
 const CALL_CONVERSION = `${BASE_ENDPOINT}:${CALL_CONVERSION_ENDPOINT_PATH}`;
 
-// Ref - https://developers.google.com/google-ads/api/rest/reference/rest/v19/customers.googleAds/searchStream
+// Ref - https://developers.google.com/google-ads/api/rest/reference/rest/v22/customers.googleAds/searchStream
 const SEARCH_STREAM_ENDPOINT_PATH = 'searchStream';
 const SEARCH_STREAM = `${BASE_ENDPOINT}/googleAds:${SEARCH_STREAM_ENDPOINT_PATH}`;
 

--- a/src/v0/destinations/google_adwords_offline_conversions/utils.test.js
+++ b/src/v0/destinations/google_adwords_offline_conversions/utils.test.js
@@ -7,7 +7,11 @@ const {
   getCallConversionPayload,
   getAddConversionPayload,
 } = require('./utils');
-const { CLICK_CONVERSION_ENDPOINT_PATH, CALL_CONVERSION_ENDPOINT_PATH, API_VERSION } = require('./config');
+const {
+  CLICK_CONVERSION_ENDPOINT_PATH,
+  CALL_CONVERSION_ENDPOINT_PATH,
+  API_VERSION,
+} = require('./config');
 
 const getTestMessage = () => {
   let message = {

--- a/src/v0/destinations/google_adwords_offline_conversions/utils.test.js
+++ b/src/v0/destinations/google_adwords_offline_conversions/utils.test.js
@@ -9,7 +9,7 @@ const {
 } = require('./utils');
 const { CLICK_CONVERSION_ENDPOINT_PATH, CALL_CONVERSION_ENDPOINT_PATH } = require('./config');
 
-const API_VERSION = 'v19';
+const API_VERSION = 'v22';
 
 const getTestMessage = () => {
   let message = {
@@ -327,7 +327,7 @@ describe('getCallConversionPayload', () => {
     });
     expect(result).toEqual({
       endpointDetails: {
-        endpoint: 'https://googleads.googleapis.com/v19/customers/9625812972:uploadCallConversions',
+        endpoint: 'https://googleads.googleapis.com/v22/customers/9625812972:uploadCallConversions',
         path: CALL_CONVERSION_ENDPOINT_PATH,
       },
       payload: {
@@ -359,7 +359,7 @@ describe('getCallConversionPayload', () => {
     });
     expect(result).toEqual({
       endpointDetails: {
-        endpoint: 'https://googleads.googleapis.com/v19/customers/9625812972:uploadCallConversions',
+        endpoint: 'https://googleads.googleapis.com/v22/customers/9625812972:uploadCallConversions',
         path: CALL_CONVERSION_ENDPOINT_PATH,
       },
       payload: {
@@ -388,7 +388,7 @@ describe('getCallConversionPayload', () => {
     const result = getCallConversionPayload(message, '9625812972', {});
     expect(result).toEqual({
       endpointDetails: {
-        endpoint: 'https://googleads.googleapis.com/v19/customers/9625812972:uploadCallConversions',
+        endpoint: 'https://googleads.googleapis.com/v22/customers/9625812972:uploadCallConversions',
         path: CALL_CONVERSION_ENDPOINT_PATH,
       },
       payload: {

--- a/src/v0/destinations/google_adwords_offline_conversions/utils.test.js
+++ b/src/v0/destinations/google_adwords_offline_conversions/utils.test.js
@@ -7,9 +7,7 @@ const {
   getCallConversionPayload,
   getAddConversionPayload,
 } = require('./utils');
-const { CLICK_CONVERSION_ENDPOINT_PATH, CALL_CONVERSION_ENDPOINT_PATH } = require('./config');
-
-const API_VERSION = 'v22';
+const { CLICK_CONVERSION_ENDPOINT_PATH, CALL_CONVERSION_ENDPOINT_PATH, API_VERSION } = require('./config');
 
 const getTestMessage = () => {
   let message = {

--- a/src/v0/destinations/hs/transform.ts
+++ b/src/v0/destinations/hs/transform.ts
@@ -1,6 +1,6 @@
 import get from 'get-value';
 import { InstrumentationError } from '@rudderstack/integrations-lib';
-import { EventType } from '../../../constants';
+import { EventType , MappedToDestinationKey, GENERIC_TRUE_VALUES } from '../../../constants';
 import {
   handleRtTfSingleEventError,
   getDestinationExternalIDInfoForRetl,
@@ -8,7 +8,6 @@ import {
 } from '../../util';
 import { API_VERSION } from './config';
 import { processLegacyIdentify, processLegacyTrack, legacyBatchEvents } from './HSTransform-v1';
-import { MappedToDestinationKey, GENERIC_TRUE_VALUES } from '../../../constants';
 import { processIdentify, processTrack, batchEvents } from './HSTransform-v2';
 import {
   splitEventsForCreateUpdate,

--- a/test/integrations/destinations/google_adwords_enhanced_conversions/network.ts
+++ b/test/integrations/destinations/google_adwords_enhanced_conversions/network.ts
@@ -159,7 +159,7 @@ const v18NetworkCallsData = [
 const v19NetworkCallsData = [
   {
     httpReq: {
-      url: `https://googleads.googleapis.com/v19/customers/1234567890/googleAds:searchStream`,
+      url: `https://googleads.googleapis.com/v22/customers/1234567890/googleAds:searchStream`,
       data: {
         query: `SELECT conversion_action.id FROM conversion_action WHERE conversion_action.name = 'Product Added'`,
       },
@@ -187,7 +187,7 @@ const v19NetworkCallsData = [
   },
   {
     httpReq: {
-      url: `https://googleads.googleapis.com/v19/customers/1234567899/googleAds:searchStream`,
+      url: `https://googleads.googleapis.com/v22/customers/1234567899/googleAds:searchStream`,
       data: {
         query: `SELECT conversion_action.id FROM conversion_action WHERE conversion_action.name = 'Product Added'`,
       },
@@ -218,7 +218,7 @@ const v19NetworkCallsData = [
   },
   {
     httpReq: {
-      url: `https://googleads.googleapis.com/v19/customers/1234567899:uploadConversionAdjustments`,
+      url: `https://googleads.googleapis.com/v22/customers/1234567899:uploadConversionAdjustments`,
       data: {
         conversionAdjustments: [
           {
@@ -282,7 +282,7 @@ const v19NetworkCallsData = [
   },
   {
     httpReq: {
-      url: `https://googleads.googleapis.com/v19/customers/1234567888/googleAds:searchStream`,
+      url: `https://googleads.googleapis.com/v22/customers/1234567888/googleAds:searchStream`,
       data: {
         query: `SELECT conversion_action.id FROM conversion_action WHERE conversion_action.name = 'Product Added'`,
       },
@@ -312,7 +312,7 @@ const v19NetworkCallsData = [
   },
   {
     httpReq: {
-      url: `https://googleads.googleapis.com/v19/customers/1234567888:uploadConversionAdjustments`,
+      url: `https://googleads.googleapis.com/v22/customers/1234567888:uploadConversionAdjustments`,
       data: {
         conversionAdjustments: [
           {
@@ -388,7 +388,7 @@ const v19NetworkCallsData = [
   },
   {
     httpReq: {
-      url: `https://googleads.googleapis.com/v19/customers/1234567910/googleAds:searchStream`,
+      url: `https://googleads.googleapis.com/v22/customers/1234567910/googleAds:searchStream`,
       data: {
         query: `SELECT conversion_action.id FROM conversion_action WHERE conversion_action.name = 'Product Added'`,
       },
@@ -423,7 +423,7 @@ const v19NetworkCallsData = [
   },
   {
     httpReq: {
-      url: `https://googleads.googleapis.com/v19/customers/validCustomerId/googleAds:searchStream`,
+      url: `https://googleads.googleapis.com/v22/customers/validCustomerId/googleAds:searchStream`,
       data: {
         query: `SELECT conversion_action.id FROM conversion_action WHERE conversion_action.name = 'Invalid Conversion'`,
       },
@@ -442,7 +442,7 @@ const v19NetworkCallsData = [
   },
   {
     httpReq: {
-      url: `https://googleads.googleapis.com/v19/customers/1234567888/googleAds:searchStream`,
+      url: `https://googleads.googleapis.com/v22/customers/1234567888/googleAds:searchStream`,
       data: {
         query: `SELECT conversion_action.id FROM conversion_action WHERE conversion_action.name = 'Wrong Conversion'`,
       },
@@ -472,7 +472,7 @@ const v19NetworkCallsData = [
   },
   {
     httpReq: {
-      url: `https://googleads.googleapis.com/v19/customers/1234567888:uploadConversionAdjustments`,
+      url: `https://googleads.googleapis.com/v22/customers/1234567888:uploadConversionAdjustments`,
       data: {
         conversionAdjustments: [
           {

--- a/test/integrations/destinations/google_adwords_offline_conversions/dataDelivery/batchFetching/business.ts
+++ b/test/integrations/destinations/google_adwords_offline_conversions/dataDelivery/batchFetching/business.ts
@@ -21,7 +21,7 @@ import {
   generateProxyV1Payload,
 } from '../../../../testUtils';
 
-const API_VERSION = 'v19';
+const API_VERSION = 'v22';
 
 const transactionAttribute = {
   CUSTOM_KEY: 'CUSTOM_VALUE',

--- a/test/integrations/destinations/google_adwords_offline_conversions/dataDelivery/batchFetching/oauth.ts
+++ b/test/integrations/destinations/google_adwords_offline_conversions/dataDelivery/batchFetching/oauth.ts
@@ -22,7 +22,7 @@ import {
 } from '../../../../testUtils';
 import { defaultAccessToken } from '../../../../common/secrets';
 
-const API_VERSION = 'v19';
+const API_VERSION = 'v22';
 
 const commonHeaders = {
   Authorization: authHeader1,

--- a/test/integrations/destinations/google_adwords_offline_conversions/dataDelivery/business.ts
+++ b/test/integrations/destinations/google_adwords_offline_conversions/dataDelivery/business.ts
@@ -5,7 +5,7 @@ import {
   generateProxyV1Payload,
 } from '../../../testUtils';
 
-const API_VERSION = 'v19';
+const API_VERSION = 'v22';
 
 const transactionAttribute = {
   CUSTOM_KEY: 'CUSTOM_VALUE',

--- a/test/integrations/destinations/google_adwords_offline_conversions/dataDelivery/oauth.ts
+++ b/test/integrations/destinations/google_adwords_offline_conversions/dataDelivery/oauth.ts
@@ -6,7 +6,7 @@ import {
 } from '../../../testUtils';
 import { defaultAccessToken } from '../../../common/secrets';
 
-const API_VERSION = 'v19';
+const API_VERSION = 'v22';
 
 const commonHeaders = {
   Authorization: authHeader1,

--- a/test/integrations/destinations/google_adwords_offline_conversions/network.ts
+++ b/test/integrations/destinations/google_adwords_offline_conversions/network.ts
@@ -1,5 +1,5 @@
 import { authHeader1, authHeader2, authHeader401Test, secret3 } from './maskedSecrets';
-const API_VERSION = 'v19';
+const API_VERSION = 'v22';
 
 const commonResponse = {
   status: 401,

--- a/test/integrations/destinations/google_adwords_offline_conversions/processor/batch-fetching-data.ts
+++ b/test/integrations/destinations/google_adwords_offline_conversions/processor/batch-fetching-data.ts
@@ -23,7 +23,7 @@
 import { authHeader1, secret1, secret401Test } from '../maskedSecrets';
 import { timestampMock } from '../mocks';
 
-const API_VERSION = 'v19';
+const API_VERSION = 'v22';
 
 export const newData = [
   {

--- a/test/integrations/destinations/google_adwords_offline_conversions/processor/data.ts
+++ b/test/integrations/destinations/google_adwords_offline_conversions/processor/data.ts
@@ -10,7 +10,7 @@ import { authHeader1, secret1 } from '../maskedSecrets';
 import { timestampMock } from '../mocks';
 import { newData as batchFetchingData } from './batch-fetching-data';
 
-const API_VERSION = 'v19';
+const API_VERSION = 'v22';
 
 export const data = [
   ...batchFetchingData,

--- a/test/integrations/destinations/google_adwords_offline_conversions/router/batch-fetching-data.ts
+++ b/test/integrations/destinations/google_adwords_offline_conversions/router/batch-fetching-data.ts
@@ -23,7 +23,7 @@
 import { authHeader1, secret1, secret3, secret401Test } from '../maskedSecrets';
 import { timestampMock } from '../mocks';
 
-const API_VERSION = 'v19';
+const API_VERSION = 'v22';
 
 export const newData = [
   {
@@ -1039,7 +1039,7 @@ export const newData = [
                   type: 'REST',
                   method: 'POST',
                   endpoint:
-                    'https://googleads.googleapis.com/v19/customers/7693729833/offlineUserDataJobs',
+                    'https://googleads.googleapis.com/v22/customers/7693729833/offlineUserDataJobs',
                   headers: {
                     Authorization: 'Bearer google_adwords_offline_conversions1',
                     'Content-Type': 'application/json',
@@ -1155,7 +1155,7 @@ export const newData = [
                   type: 'REST',
                   method: 'POST',
                   endpoint:
-                    'https://googleads.googleapis.com/v19/customers/7693729833:uploadCallConversions',
+                    'https://googleads.googleapis.com/v22/customers/7693729833:uploadCallConversions',
                   headers: {
                     Authorization: 'Bearer google_adwords_offline_conversions1',
                     'Content-Type': 'application/json',

--- a/test/integrations/destinations/google_adwords_offline_conversions/router/data.ts
+++ b/test/integrations/destinations/google_adwords_offline_conversions/router/data.ts
@@ -10,7 +10,7 @@ import { authHeader1, secret1, secret3 } from '../maskedSecrets';
 import { timestampMock } from '../mocks';
 import { newData as batchFetchingData } from './batch-fetching-data';
 
-const API_VERSION = 'v19';
+const API_VERSION = 'v22';
 
 export const data = [
   ...batchFetchingData,


### PR DESCRIPTION
🔒 Scanned for secrets using gitleaks 8.29.1

## What are the changes introduced in this PR?

- Upgrade Google Ads integrations to use API v22 while documenting v23 as the latest available version, and align Google Ads version audit metadata accordingly.

## What is the related Linear task?

- Resolves INT-5594