### PR TITLE
feat: enable SOQL lookup for salesforce oauth destination by default

### DIFF
--- a/src/v0/destinations/salesforce/config.js
+++ b/src/v0/destinations/salesforce/config.js
@@ -28,6 +28,7 @@ const SF_TOKEN_REQUEST_URL_SANDBOX = 'https://test.salesforce.com/services/oauth
 
 const DESTINATION = 'Salesforce';
 const SALESFORCE_OAUTH_SANDBOX = 'salesforce_oauth_sandbox';
+const SALESFORCE_OAUTH = 'SALESFORCE_OAUTH';
 const OAUTH = 'oauth';
 const LEGACY = 'legacy';
 
@@ -48,4 +49,5 @@ module.exports = {
   OAUTH,
   LEGACY,
   SALESFORCE_OAUTH_SANDBOX,
+  SALESFORCE_OAUTH,
 };

--- a/src/v0/destinations/salesforce/transform.js
+++ b/src/v0/destinations/salesforce/transform.js
@@ -29,7 +29,7 @@ const {
   getAuthHeader,
   getSalesforceIdForRecord,
   getSalesforceIdForLead,
-  isWorkspaceSupportedForSoql,
+  isDestTypeSupportedForSoql,
 } = require('./utils');
 const { JSON_MIME_TYPE } = require('../../util/constant');
 // Basic response builder
@@ -259,7 +259,8 @@ async function process(event) {
   const authInfo = await collectAuthorizationInfo(event);
 
   let salesforceSdk;
-  if (isWorkspaceSupportedForSoql(event?.metadata?.workspaceId ?? '')) {
+  const destinationDefinitionName = event?.destination?.DestinationDefinition?.Name ?? '';
+  if (isDestTypeSupportedForSoql(destinationDefinitionName)) {
     const { token, instanceUrl } = authInfo.authorizationData;
     salesforceSdk = new SalesforceSDK.Salesforce({
       accessToken: token,
@@ -291,8 +292,8 @@ const processRouterDest = async (inputs, reqMetadata) => {
   }
 
   try {
-    const metadata = inputs?.[0]?.metadata;
-    if (isWorkspaceSupportedForSoql(metadata?.workspaceId ?? '')) {
+    const destinationDefinitionName = inputs?.[0]?.destination?.DestinationDefinition?.Name ?? '';
+    if (isDestTypeSupportedForSoql(destinationDefinitionName)) {
       const { token, instanceUrl } = authInfo.authorizationData;
 
       salesforceSdk = new SalesforceSDK.Salesforce({

--- a/src/v0/destinations/salesforce/utils.js
+++ b/src/v0/destinations/salesforce/utils.js
@@ -25,6 +25,7 @@ const {
   OAUTH,
   SALESFORCE_OAUTH_SANDBOX,
   SF_API_VERSION,
+  SALESFORCE_OAUTH,
 } = require('./config');
 const { REFRESH_TOKEN } = require('../../../adapters/networkhandler/authConstants');
 
@@ -248,7 +249,7 @@ const getAuthHeader = (authInfo) => {
 
 const isDestTypeSupportedForSoql = (destinationDefinitionName = '') => {
   const upperCaseName = destinationDefinitionName?.toUpperCase?.() ?? '';
-  return upperCaseName === 'SALESFORCE_OAUTH';
+  return upperCaseName === SALESFORCE_OAUTH;
 };
 
 /**

--- a/test/integrations/mocks/salesforceSDK.mock.ts
+++ b/test/integrations/mocks/salesforceSDK.mock.ts
@@ -110,11 +110,18 @@ export const createMockQuery = () => {
  * This should be called in afterEach hooks to restore the mock after jest.resetAllMocks()
  */
 export const restoreSalesforceSDKMock = () => {
-  const mockedLib = jest.requireMock('@rudderstack/integrations-lib');
-  if (mockedLib.SalesforceSDK?.Salesforce) {
-    // Reapply the mock implementation if it was reset
-    mockedLib.SalesforceSDK.Salesforce.mockImplementation(({ accessToken, instanceUrl }) => {
-      return { query: createMockQuery() };
-    });
+  // Patch the runtime integrations-lib module directly so the mock
+  // survives Jest's resetAllMocks/clearAllMocks calls.
+  // eslint-disable-next-line global-require
+  const lib = require('@rudderstack/integrations-lib');
+
+  if (!lib.SalesforceSDK) {
+    // eslint-disable-next-line no-param-reassign
+    lib.SalesforceSDK = {};
   }
+
+  // eslint-disable-next-line no-param-reassign
+  lib.SalesforceSDK.Salesforce = function SalesforceMock() {
+    return { query: createMockQuery() };
+  };
 };

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -4,13 +4,5 @@ process.env.DEST_ZOHO_DELETION_BATCHING_SUPPORTED_WORKSPACE_IDS = 'workspaceId2'
 process.env.DEST_BRAZE_MAU_WORKSPACE_IDS_SKIP_LIST = 'workspace-non-mau';
 process.env.DISABLE_TIKTOK_AUDIENCE_CDK_V2 = 'workspace-disable-cdkv2';
 
-// Load Salesforce SDK mock before app loads when running Salesforce component tests
-// so SOQL lookups use the mock and router tests pass (pattern: mock must be in place before first require of integrations-lib)
-const isSalesforceDestinationTest = process.argv.some(
-  (arg) => arg === '--destination=salesforce' || arg.includes('destination=salesforce'),
-);
-if (isSalesforceDestinationTest) {
-  // eslint-disable-next-line global-require
-  const { restoreSalesforceSDKMock } = require('./integrations/mocks/salesforceSDK.mock');
-  restoreSalesforceSDKMock();
-}
+const { restoreSalesforceSDKMock } = require('./integrations/mocks/salesforceSDK.mock');
+restoreSalesforceSDKMock();

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -3,3 +3,14 @@ process.env.GOOGLE_ADS_DEVELOPER_TOKEN = 'test-developer-token-12345';
 process.env.DEST_ZOHO_DELETION_BATCHING_SUPPORTED_WORKSPACE_IDS = 'workspaceId2';
 process.env.DEST_BRAZE_MAU_WORKSPACE_IDS_SKIP_LIST = 'workspace-non-mau';
 process.env.DISABLE_TIKTOK_AUDIENCE_CDK_V2 = 'workspace-disable-cdkv2';
+
+// Load Salesforce SDK mock before app loads when running Salesforce component tests
+// so SOQL lookups use the mock and router tests pass (pattern: mock must be in place before first require of integrations-lib)
+const isSalesforceDestinationTest = process.argv.some(
+  (arg) => arg === '--destination=salesforce' || arg.includes('destination=salesforce'),
+);
+if (isSalesforceDestinationTest) {
+  // eslint-disable-next-line global-require
+  const { restoreSalesforceSDKMock } = require('./integrations/mocks/salesforceSDK.mock');
+  restoreSalesforceSDKMock();
+}


### PR DESCRIPTION
## What are the changes introduced in this PR?

We are updating the utility function to enable SOQL lookup by default for Salseforce oauth destinaiton only.

## What is the related Linear task?

Resolves INT-5643

## Please explain the objectives of your changes below

Put down any required details on the broader aspect of your changes. If there are any dependent changes, **mandatorily** mention them here

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

N/A

### Any new dependencies introduced with this change?

N/A

### Any new generic utility introduced or modified. Please explain the changes.

N/A

### Any technical or performance related pointers to consider with the change?

N/A

@coderabbitai review

<hr>

### Developer checklist

- [ ] My code follows the style guidelines of this project

- [ ] **No breaking changes are being introduced.**

- [ ] All related docs linked with the PR?

- [ ] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [ ] Is the PR limited to 10 file changes?

- [ ] Is the PR limited to one linear task?

- [ ] Are relevant unit and component test-cases added in **new readability format**?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.
