### PR TITLE
chore: fix ut dedicate deployment action

### DIFF
--- a/.github/workflows/prepare-for-prod-ut-deploy.yml
+++ b/.github/workflows/prepare-for-prod-ut-deploy.yml
@@ -161,8 +161,8 @@ jobs:
           for directory in "${sub_directories[@]}"; do
             for f in "./$directory"/*; do
               [[ -f $f ]] || continue
-              yq eval -i ".spec.user-transformer.image.version=\"$UT_TAG_NAME\"" $customer
-              git add $customer
+              yq eval -i ".spec.user-transformer.image.version=\"$UT_TAG_NAME\"" $f
+              git add $f
             done
           done
 

--- a/.github/workflows/prepare-for-prod-ut-deploy.yml
+++ b/.github/workflows/prepare-for-prod-ut-deploy.yml
@@ -155,25 +155,15 @@ jobs:
 
           cd customer-objects
 
-          declare -a enabled_ut_customers=()
           declare -a sub_directories=('enterprise-us' 'enterprise-eu')
 
           # identify the customers enabled in sub-directories
           for directory in "${sub_directories[@]}"; do
             for f in "./$directory"/*; do
               [[ -f $f ]] || continue
-
-              enabled="$(yq e '.spec.user-transformer.enabled' $f)"
-              if [ $enabled == "true" ]; then
-                  enabled_ut_customers+=( $f )
-              fi
+              yq eval -i ".spec.user-transformer.image.version=\"$UT_TAG_NAME\"" $customer
+              git add $customer
             done
-          done
-
-          # bump up the customers version and repository information
-          for customer in "${enabled_ut_customers[@]}"; do
-            yq eval -i ".spec.user-transformer.image.version=\"$UT_TAG_NAME\"" $customer
-            git add $customer
           done
 
           git commit -m "chore: upgrade dedicated user transformers to $TAG_NAME"


### PR DESCRIPTION
## What are the changes introduced in this PR?

### Context
UT action is failing because we were not able to find deployment where [spec.user-transformer.enabled](https://github.com/rudderlabs/rudder-transformer/pull/4974/changes#diff-362ff0e4790b0d51fae48b71344a0aed3321a6b56afd8c541e8481a92bfd94dbL166) 
is true, due to this we can not able update the version of user-transformer.

### Solution
In this pr we removed the check `spec.user-transformer.enabled = true` we will only update those deployment for which we will find spec.user-transformer.image  

https://github.com/rudderlabs/rudder-transformer/actions/runs/21899965065/job/63226299532?pr=4972

## What is the related Linear task?

Resolves INT-XXX

## Please explain the objectives of your changes below

Put down any required details on the broader aspect of your changes. If there are any dependent changes, **mandatorily** mention them here

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

N/A

### Any new dependencies introduced with this change?

N/A

### Any new generic utility introduced or modified. Please explain the changes.

N/A

### Any technical or performance related pointers to consider with the change?

N/A

@coderabbitai review

<hr>

### Developer checklist

- [ ] My code follows the style guidelines of this project

- [ ] **No breaking changes are being introduced.**

- [ ] All related docs linked with the PR?

- [ ] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [ ] Is the PR limited to 10 file changes?

- [ ] Is the PR limited to one linear task?

- [ ] Are relevant unit and component test-cases added in **new readability format**?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.
