### PR TITLE
feat(moengage): add support for Datacenter 04 (api-04.moengage.com) (#4970)

### DIFF
--- a/src/v0/destinations/moengage/README.md
+++ b/src/v0/destinations/moengage/README.md
@@ -22,6 +22,7 @@ Implementation in **Javascript**
     - `US`: United States data center (api-01.moengage.com)
     - `EU`: European data center (api-02.moengage.com)
     - `IND`: India data center (api-03.moengage.com)
+    - `DC_04`: Datacenter 04 (api-04.moengage.com)
   - Default: `US`
 
 ### Optional Settings
@@ -260,7 +261,7 @@ The destination implements comprehensive error handling for various scenarios:
 
 1. **ConfigurationError**: Thrown when required configuration is missing or invalid
 
-   - Invalid region values (must be 'US', 'EU', or 'IND')
+   - Invalid region values (must be 'US', 'EU', 'IND', or 'DC_04')
    - Missing API ID or API Key
 
 2. **TransformationError**: Thrown when payload construction fails
@@ -323,7 +324,7 @@ The destination performs automatic data type conversions:
 
 - **Authentication Failed**: Check API ID and API Key configuration
   - **Solution**: Verify credentials from MoEngage Dashboard > Settings > Account > APIs
-- **Invalid Region**: Ensure region is set to 'US', 'EU', or 'IND'
+- **Invalid Region**: Ensure region is set to 'US', 'EU', 'IND', or 'DC_04'
   - **Solution**: Update destination configuration with correct region
 - **Rate Limit Exceeded**: 429 error due to too many requests
   - **Solution**: Implement retry logic with exponential backoff

--- a/src/v0/destinations/moengage/config.js
+++ b/src/v0/destinations/moengage/config.js
@@ -28,6 +28,12 @@ const endpoints = {
     device: `https://api-03.moengage.com/v1/${endpointPaths.device}/`,
     alias: `https://api-03.moengage.com/v1/${endpointPaths.alias}?app_id=`,
   },
+  DC_04: {
+    identify: `https://api-04.moengage.com/v1/${endpointPaths.identify}/`,
+    track: `https://api-04.moengage.com/v1/${endpointPaths.track}/`,
+    device: `https://api-04.moengage.com/v1/${endpointPaths.device}/`,
+    alias: `https://api-04.moengage.com/v1/${endpointPaths.alias}?app_id=`,
+  },
 };
 
 // moengage supports object types, we added a new mapping for identify, track and device to support object data type

--- a/src/v0/destinations/moengage/docs/businesslogic.md
+++ b/src/v0/destinations/moengage/docs/businesslogic.md
@@ -240,6 +240,7 @@ Based on the `region` configuration:
 | US     | `https://api-01.moengage.com` |
 | EU     | `https://api-02.moengage.com` |
 | IND    | `https://api-03.moengage.com` |
+| DC_04  | `https://api-04.moengage.com` |
 
 ## Use Cases
 

--- a/src/v0/destinations/moengage/transform.test.js
+++ b/src/v0/destinations/moengage/transform.test.js
@@ -108,6 +108,30 @@ describe('getCommonDestinationEndpoint', () => {
       expectedEndpoint: endpoints.IND.alias + 'testApiId',
       expectedPath: endpointPaths.alias,
     },
+    {
+      description: 'should return DC_04 endpoint for identify',
+      input: { apiId: 'testApiId', region: 'DC_04', category: { type: 'identify' } },
+      expectedEndpoint: endpoints.DC_04.identify + 'testApiId',
+      expectedPath: endpointPaths.identify,
+    },
+    {
+      description: 'should return DC_04 endpoint for track',
+      input: { apiId: 'testApiId', region: 'DC_04', category: { type: 'track' } },
+      expectedEndpoint: endpoints.DC_04.track + 'testApiId',
+      expectedPath: endpointPaths.track,
+    },
+    {
+      description: 'should return DC_04 endpoint for device',
+      input: { apiId: 'testApiId', region: 'DC_04', category: { type: 'device' } },
+      expectedEndpoint: endpoints.DC_04.device + 'testApiId',
+      expectedPath: endpointPaths.device,
+    },
+    {
+      description: 'should return DC_04 endpoint for alias',
+      input: { apiId: 'testApiId', region: 'DC_04', category: { type: 'alias' } },
+      expectedEndpoint: endpoints.DC_04.alias + 'testApiId',
+      expectedPath: endpointPaths.alias,
+    },
   ])('$description', ({ input, expectedEndpoint, expectedPath }) => {
     const result = getCommonDestinationEndpoint(input);
     expect(result.endpoint).toBe(expectedEndpoint);


### PR DESCRIPTION
Closes #4970

## Changes
- Added DC_04 region endpoints (api-04.moengage.com) to config.js
- Added unit tests for all DC_04 event types (identify, track, device, alias) in transform.test.js
- Updated README.md and docs/businesslogic.md to document the new datacenter

## Testing
- Unit tests added for all 4 event types with DC_04 region
- Existing tests for US, EU, IND regions remain unchanged