### PR TITLE
feat(google_adwords_remarketing_lists): add hashing validation for audience data

### DIFF
--- a/src/v0/destinations/google_adwords_remarketing_lists/recordTransform.ts
+++ b/src/v0/destinations/google_adwords_remarketing_lists/recordTransform.ts
@@ -25,6 +25,7 @@ const processRecordEventArray = async (
   records: RecordInput[],
   context: RecordEventContext,
   operationType: string,
+  workspaceId: string,
 ) => {
   const {
     message,
@@ -46,6 +47,8 @@ const processRecordEventArray = async (
     typeOfList,
     userSchema,
     isHashRequired,
+    workspaceId,
+    destination.ID,
   );
 
   const outputPayload = constructPayload(message, offlineDataJobsMapping)!;
@@ -108,6 +111,8 @@ async function preparePayload(
   const { destination, message, metadata } = validEvents[0];
   const accessToken = getAccessToken(metadata, 'access_token');
 
+  const workspaceId = metadata.workspaceId;
+
   const context: RecordEventContext = {
     message,
     destination,
@@ -131,6 +136,7 @@ async function preparePayload(
             groupedRecordsByAction[action],
             context,
             operationType,
+            workspaceId,
           ),
         };
       }

--- a/src/v0/destinations/google_adwords_remarketing_lists/transform.ts
+++ b/src/v0/destinations/google_adwords_remarketing_lists/transform.ts
@@ -37,7 +37,7 @@ function extraKeysPresent(dictionary: Record<string, unknown>, keyList: string[]
  * @param {rudder event destination} destination
  * @returns
  */
-const createPayload = (message: Message, destination: GARLDestination) => {
+const createPayload = (message: Message, destination: GARLDestination, workspaceId: string) => {
   const { listData } = message.properties;
   const properties = ['add', 'remove'];
   const { typeOfList, userSchema, isHashRequired } = destination.Config;
@@ -51,6 +51,8 @@ const createPayload = (message: Message, destination: GARLDestination) => {
         typeOfList,
         userSchema,
         isHashRequired,
+        workspaceId,
+        destination.ID,
       );
       if (userIdentifiersList.length === 0) {
         logger.info(
@@ -102,7 +104,7 @@ const createPayload = (message: Message, destination: GARLDestination) => {
 };
 
 const processEvent = async (
-  metadata: Record<string, unknown>,
+  metadata: { workspaceId: string },
   message: Message,
   destination: GARLDestination,
 ) => {
@@ -117,7 +119,7 @@ const processEvent = async (
     throw new InstrumentationError('listData is not present inside properties. Aborting message.');
   }
   if (message.type.toLowerCase() === 'audiencelist') {
-    const createdPayload = createPayload(message, destination);
+    const createdPayload = createPayload(message, destination, metadata.workspaceId);
 
     if (Object.keys(createdPayload).length === 0) {
       throw new InstrumentationError(
@@ -147,7 +149,7 @@ const processEvent = async (
 };
 
 const process = async (event: {
-  metadata: Record<string, unknown>;
+  metadata: { workspaceId: string; [key: string]: unknown };
   message: Message;
   destination: GARLDestination;
 }) => processEvent(event.metadata, event.message, event.destination);

--- a/src/v0/destinations/google_adwords_remarketing_lists/types.ts
+++ b/src/v0/destinations/google_adwords_remarketing_lists/types.ts
@@ -14,7 +14,7 @@ export interface GARLDestinationConfig {
 
 export interface RecordEventContext {
   message: unknown;
-  destination: { Config: GARLDestinationConfig };
+  destination: { Config: GARLDestinationConfig; ID: string };
   accessToken: string;
   audienceId: string;
   typeOfList: string;
@@ -37,9 +37,12 @@ export interface RecordInput {
     fields: Record<string, unknown>;
     identifiers?: Record<string, string | number>;
   };
-  metadata: Record<string, unknown>;
+  metadata: {
+    workspaceId: string;
+  };
   destination: {
     Config: GARLDestinationConfig;
+    ID: string;
   };
   connection: {
     config: {

--- a/src/v0/destinations/google_adwords_remarketing_lists/util.ts
+++ b/src/v0/destinations/google_adwords_remarketing_lists/util.ts
@@ -9,6 +9,7 @@ import {
   removeUndefinedAndNullValues,
   getDestinationExternalIDInfoForRetl,
 } from '../../util';
+import { validateHashingConsistency } from '../../util/audienceUtils';
 import logger from '../../../logger';
 import { MappedToDestinationKey } from '../../../constants';
 import { JSON_MIME_TYPE } from '../../util/constant';
@@ -20,6 +21,7 @@ import {
   BASE_ENDPOINT,
   hashAttributes,
   ADDRESS_INFO_ATTRIBUTES,
+  destType,
 } from './config';
 import type { GARLDestinationConfig } from './types';
 
@@ -80,6 +82,8 @@ const populateIdentifiers = (
   typeOfList: string,
   userSchema: string[],
   isHashRequired: boolean,
+  workspaceId: string,
+  destinationId: string,
 ) => {
   const userIdentifier: Record<string, unknown>[] = [];
   let attribute: string | string[];
@@ -89,8 +93,19 @@ const populateIdentifiers = (
     attribute = userSchema;
   }
   if (isDefinedAndNotNullAndNotEmpty(attributeArray)) {
+    const audienceDest = {
+      workspaceId,
+      id: destinationId,
+      type: destType,
+      config: { isHashRequired },
+    };
     // traversing through every element in the add array
     attributeArray.forEach((element, index) => {
+      hashAttributes.forEach((field) => {
+        if (element[field]) {
+          validateHashingConsistency(field, String(element[field]), audienceDest);
+        }
+      });
       if (isHashRequired) {
         hashEncrypt(element);
       }
@@ -126,12 +141,25 @@ const populateIdentifiersForRecordEvent = (
   typeOfList: string,
   userSchema: string[] | undefined,
   isHashRequired: boolean,
+  workspaceId: string,
+  destinationId: string,
 ) => {
   const userIdentifiers: Record<string, unknown>[] = [];
 
   if (isDefinedAndNotNullAndNotEmpty(identifiersArray)) {
+    const audienceDest = {
+      workspaceId,
+      id: destinationId,
+      type: destType,
+      config: { isHashRequired },
+    };
     // traversing through every element in the add array
     identifiersArray.forEach((identifiers) => {
+      hashAttributes.forEach((field) => {
+        if (identifiers[field]) {
+          validateHashingConsistency(field, String(identifiers[field]), audienceDest);
+        }
+      });
       if (isHashRequired) {
         hashEncrypt(identifiers);
       }

--- a/test/integrations/destinations/google_adwords_remarketing_lists/router/data.ts
+++ b/test/integrations/destinations/google_adwords_remarketing_lists/router/data.ts
@@ -5,6 +5,8 @@ import {
   rETLRecordRouterRequestVDMv2General,
   rETLRecordRouterRequestVDMv2UserId,
   eventStreamRecordRouterRequest,
+  eventStreamRecordPreHashedRequest,
+  eventStreamRecordHashOffRequest,
   rETLRecordRouterRequestVDMv1,
   rETLRecordRouterRequestForVDMV2Flow,
 } from './record';
@@ -1610,5 +1612,109 @@ export const data = [
         },
       },
     },
+  },
+  {
+    name: 'google_adwords_remarketing_lists record event tests EventStream pre-hashed input',
+    description:
+      'pre-hashed data with isHashRequired true should fail when hashing validation is enabled',
+    feature: 'router',
+    module: 'destination',
+    version: 'v0',
+    input: {
+      request: {
+        body: eventStreamRecordPreHashedRequest,
+        method: 'POST',
+      },
+    },
+    output: {
+      response: {
+        status: 200,
+        body: {
+          output: [
+            {
+              metadata: [
+                {
+                  attemptNum: 1,
+                  destinationId: 'default-destinationId',
+                  dontBatch: false,
+                  secret: { access_token: secret3 },
+                  sourceId: 'default-sourceId',
+                  userId: 'default-userId',
+                  workspaceId: 'default-workspaceId',
+                  jobId: 2,
+                },
+              ],
+              batched: false,
+              statusCode: 400,
+              error:
+                'Hashing is enabled but the value for field email appears to already be hashed. Either disable hashing or send unhashed data.',
+              statTags: {
+                errorCategory: 'dataValidation',
+                errorType: 'instrumentation',
+                destType: 'GOOGLE_ADWORDS_REMARKETING_LISTS',
+                module: 'destination',
+                implementation: 'native',
+                feature: 'router',
+                destinationId: 'default-destinationId',
+                workspaceId: 'default-workspaceId',
+              },
+            },
+          ],
+        },
+      },
+    },
+    envOverrides: { AUDIENCE_HASHING_VALIDATION_ENABLED: 'true' },
+  },
+  {
+    name: 'google_adwords_remarketing_lists record event tests EventStream hash-off plaintext input',
+    description:
+      'plaintext data with isHashRequired false should fail when hashing validation is enabled',
+    feature: 'router',
+    module: 'destination',
+    version: 'v0',
+    input: {
+      request: {
+        body: eventStreamRecordHashOffRequest,
+        method: 'POST',
+      },
+    },
+    output: {
+      response: {
+        status: 200,
+        body: {
+          output: [
+            {
+              metadata: [
+                {
+                  attemptNum: 1,
+                  destinationId: 'default-destinationId',
+                  dontBatch: false,
+                  secret: { access_token: secret3 },
+                  sourceId: 'default-sourceId',
+                  userId: 'default-userId',
+                  workspaceId: 'default-workspaceId',
+                  jobId: 2,
+                },
+              ],
+              batched: false,
+              statusCode: 400,
+              error:
+                'Hashing is disabled but the value for field email appears to be unhashed. Either enable hashing or send pre-hashed data.',
+              statTags: {
+                errorCategory: 'dataValidation',
+                errorType: 'instrumentation',
+                destType: 'GOOGLE_ADWORDS_REMARKETING_LISTS',
+                module: 'destination',
+                implementation: 'native',
+                feature: 'router',
+                destinationId: 'default-destinationId',
+                workspaceId: 'default-workspaceId',
+              },
+            },
+          ],
+        },
+      },
+    },
+    envOverrides: { AUDIENCE_HASHING_VALIDATION_ENABLED: 'true' },
   },
 ];

--- a/test/integrations/destinations/google_adwords_remarketing_lists/router/record.ts
+++ b/test/integrations/destinations/google_adwords_remarketing_lists/router/record.ts
@@ -271,6 +271,62 @@ export const rETLRecordRouterRequestVDMv2UserId: RouterTransformationRequest = {
   destType: 'google_adwords_remarketing_lists',
 };
 
+export const eventStreamRecordPreHashedRequest: RouterTransformationRequest = {
+  input: [
+    {
+      destination: destination,
+      message: {
+        action: 'insert',
+        context: { ip: '14.5.67.21', library: { name: 'http' } },
+        recordId: '2',
+        rudderId: '2',
+        fields: {
+          // pre-hashed values: sha256('test@abc.com') and sha256('@09876543210')
+          email: 'd3142c8f9c9129484daf28df80cc5c955791efed5e69afabb603bc8cb9ffd419',
+          phone: '8846dcb6ab2d73a0e67dbd569fa17cec2d9d391e5b05d1dd42919bc21ae82c45',
+          country: 'US',
+          postalCode: '1245',
+        },
+        type: 'record',
+      },
+      metadata: generateGoogleOAuthMetadata(2),
+    },
+  ],
+  destType: 'google_adwords_remarketing_lists',
+};
+
+const destinationHashOff: Destination = {
+  ...destination,
+  Config: {
+    ...destination.Config,
+    isHashRequired: false,
+  },
+};
+
+// Plaintext email/phone with isHashRequired: false → triggers hashing validation
+export const eventStreamRecordHashOffRequest: RouterTransformationRequest = {
+  input: [
+    {
+      destination: destinationHashOff,
+      message: {
+        action: 'insert',
+        context: { ip: '14.5.67.21', library: { name: 'http' } },
+        recordId: '2',
+        rudderId: '2',
+        fields: {
+          email: 'test@abc.com',
+          phone: '@09876543210',
+          country: 'US',
+          postalCode: '1245',
+        },
+        type: 'record',
+      },
+      metadata: generateGoogleOAuthMetadata(2),
+    },
+  ],
+  destType: 'google_adwords_remarketing_lists',
+};
+
 export const eventStreamRecordRouterRequest: RouterTransformationRequest = {
   input: [
     {


### PR DESCRIPTION
## Summary
- Add `validateHashingConsistency` checks for hashable fields (email, phone, etc.) in both EventStream and rETL record flows for the Google Ads Remarketing Lists destination
- Pass `workspaceId` and `destinationId` through the call chain to enable hashing validation (detects pre-hashed data sent with hashing enabled, and plaintext data sent with hashing disabled)
- Add integration tests covering pre-hashed input with `isHashRequired: true` and plaintext input with `isHashRequired: false` scenarios

## Test plan
- [ ] Existing router tests pass
- [ ] New test: pre-hashed email/phone with `isHashRequired: true` returns 400 with appropriate error when `AUDIENCE_HASHING_VALIDATION_ENABLED=true`
- [ ] New test: plaintext email/phone with `isHashRequired: false` returns 400 with appropriate error when `AUDIENCE_HASHING_VALIDATION_ENABLED=true`
- [ ] TypeScript types updated to include `ID` on destination and `workspaceId` on metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)