### PR TITLE
chore: tiktok audience hashing pii

### DIFF
--- a/src/v0/destinations/tiktok_audience/config.ts
+++ b/src/v0/destinations/tiktok_audience/config.ts
@@ -11,8 +11,24 @@ export const ACTION_RECORD_MAP: Record<string, string> = {
   [EVENT_TYPES.DELETE]: 'delete',
 };
 
+export const DESTINATION_TYPE = 'tiktok_audience';
+
 export const SHA256_TRAITS = ['IDFA_SHA256', 'AAID_SHA256', 'EMAIL_SHA256', 'PHONE_SHA256'];
+export const MD5_TRAITS = ['IDFA_MD5', 'AAID_MD5'];
 
 export const BASE_URL = 'https://business-api.tiktok.com/open_api/v1.3';
 export const ENDPOINT_PATH = '/segment/mapping/';
 export const ENDPOINT = `${BASE_URL}${ENDPOINT_PATH}`;
+
+export const REMOVE_SPACES_REGEX = /\s/g;
+
+/**
+ * Whether to reject invalid field values (e.g., malformed emails, invalid country codes) for TikTok Audience
+ * by replacing them with empty strings. When disabled, invalid values are passed through as-is.
+ *
+ * Controlled via env var: TIKTOK_AUDIENCE_REJECT_INVALID_FIELDS=true
+ * Default: false
+ */
+export function isRejectInvalidFieldsEnabled(): boolean {
+  return process.env.TIKTOK_AUDIENCE_REJECT_INVALID_FIELDS === 'true';
+}

--- a/src/v0/destinations/tiktok_audience/config.ts
+++ b/src/v0/destinations/tiktok_audience/config.ts
@@ -15,6 +15,7 @@ export const DESTINATION_TYPE = 'tiktok_audience';
 
 export const SHA256_TRAITS = ['IDFA_SHA256', 'AAID_SHA256', 'EMAIL_SHA256', 'PHONE_SHA256'];
 export const MD5_TRAITS = ['IDFA_MD5', 'AAID_MD5'];
+export const TRAITS_SET = new Set([...SHA256_TRAITS, ...MD5_TRAITS]);
 
 export const BASE_URL = 'https://business-api.tiktok.com/open_api/v1.3';
 export const ENDPOINT_PATH = '/segment/mapping/';

--- a/src/v0/destinations/tiktok_audience/recordTransform.test.ts
+++ b/src/v0/destinations/tiktok_audience/recordTransform.test.ts
@@ -1,0 +1,284 @@
+import { processTiktokAudienceRecords } from './recordTransform';
+import stats from '../../../util/stats';
+import type { TiktokAudienceRecordRequest } from './recordTypes';
+import sha256 from 'sha256';
+import md5 from 'md5';
+
+jest.mock('../../../util/stats', () => ({
+  increment: jest.fn(),
+}));
+
+const TEST_WORKSPACE_ID = 'ws-1';
+const TEST_DESTINATION_ID = 'dest-1';
+
+const buildBaseEvent = (
+  overrides: Partial<TiktokAudienceRecordRequest['message']> = {},
+  isHashRequired = true,
+): TiktokAudienceRecordRequest => {
+  const message: TiktokAudienceRecordRequest['message'] = {
+    type: 'record',
+    action: 'insert',
+    userId: 'user-1',
+    identifiers: {
+      EMAIL_SHA256: 'user@example.com',
+    },
+    fields: {},
+    ...overrides,
+  } as any;
+
+  return {
+    message,
+    destination: {
+      ID: TEST_DESTINATION_ID,
+      Config: {
+        advertiserId: 'dummyAdverTiserID',
+      },
+    } as any,
+    connection: {
+      config: {
+        destination: {
+          schemaVersion: '1.1',
+          isHashRequired,
+          audienceId: '23856594064540489',
+        },
+      },
+    } as any,
+    metadata: {
+      workspaceId: TEST_WORKSPACE_ID,
+      secret: {
+        accessToken: 'dummyAccessToken',
+      },
+    } as any,
+  } as any;
+};
+
+describe('processTiktokAudienceRecords hashing validation for tiktok_audience', () => {
+  const hashedValue = 'b94d27b9934d3e08a52e52d7da7dabfac484efe04294e576ca48e1cb0d7d6267'; // sha256 of 'test'
+  const plaintextEmail = 'user@example.com';
+  const mockStatsIncrement = stats.increment as jest.Mock;
+
+  beforeEach(() => {
+    mockStatsIncrement.mockClear();
+  });
+
+  afterEach(() => {
+    delete process.env.AUDIENCE_HASHING_VALIDATION_ENABLED;
+    delete process.env.TIKTOK_AUDIENCE_REJECT_INVALID_FIELDS;
+  });
+
+  it('Hashing ON + pre-hashed value → emits metric and returns failed response when validation enabled', () => {
+    process.env.AUDIENCE_HASHING_VALIDATION_ENABLED = 'true';
+    const event = buildBaseEvent({
+      identifiers: {
+        EMAIL_SHA256: hashedValue,
+      },
+    });
+
+    const { failedResponses, successfulResponses } = processTiktokAudienceRecords([event]);
+
+    expect(successfulResponses).toHaveLength(0);
+    expect(failedResponses).toHaveLength(1);
+    expect(failedResponses[0].error).toContain(
+      'Hashing is enabled but the value for field EMAIL_SHA256 appears to already be hashed. Either disable hashing or send unhashed data.',
+    );
+    expect(mockStatsIncrement).toHaveBeenCalledWith('audience_hashing_inconsistency', {
+      propertyName: 'EMAIL_SHA256',
+      type: 'hashed_when_hash_enabled',
+      workspaceId: TEST_WORKSPACE_ID,
+      destinationId: TEST_DESTINATION_ID,
+      destType: 'tiktok_audience',
+    });
+  });
+
+  it('Hashing ON + plaintext value → no error, no metric, one successful response', () => {
+    const event = buildBaseEvent({
+      identifiers: {
+        EMAIL_SHA256: plaintextEmail,
+      },
+    });
+
+    const { failedResponses, successfulResponses } = processTiktokAudienceRecords([event]);
+
+    expect(failedResponses).toHaveLength(0);
+    expect(successfulResponses).toHaveLength(1);
+    expect(mockStatsIncrement).not.toHaveBeenCalled();
+  });
+
+  it('Hashing OFF + plaintext value → emits metric and returns failed response when validation enabled', () => {
+    process.env.AUDIENCE_HASHING_VALIDATION_ENABLED = 'true';
+    const event = buildBaseEvent(
+      {
+        identifiers: {
+          EMAIL_SHA256: plaintextEmail,
+        },
+      },
+      false,
+    );
+
+    const { failedResponses, successfulResponses } = processTiktokAudienceRecords([event]);
+
+    expect(successfulResponses).toHaveLength(0);
+    expect(failedResponses).toHaveLength(1);
+    expect(failedResponses[0].error).toContain(
+      'Hashing is disabled but the value for field EMAIL_SHA256 appears to be unhashed. Either enable hashing or send pre-hashed data.',
+    );
+    expect(mockStatsIncrement).toHaveBeenCalledWith('audience_hashing_inconsistency', {
+      propertyName: 'EMAIL_SHA256',
+      type: 'unhashed_when_hash_disabled',
+      workspaceId: TEST_WORKSPACE_ID,
+      destinationId: TEST_DESTINATION_ID,
+      destType: 'tiktok_audience',
+    });
+  });
+
+  it('Hashing OFF + 64-char hex value → no error, one successful response', () => {
+    const event = buildBaseEvent(
+      {
+        identifiers: {
+          EMAIL_SHA256: hashedValue,
+        },
+      },
+      false,
+    );
+
+    const { failedResponses, successfulResponses } = processTiktokAudienceRecords([event]);
+
+    expect(failedResponses).toHaveLength(0);
+    expect(successfulResponses).toHaveLength(1);
+  });
+
+  it('Validation disabled (default) + hashing ON + pre-hashed value → emits metric but no failed responses', () => {
+    const event = buildBaseEvent({
+      identifiers: {
+        EMAIL_SHA256: hashedValue,
+      },
+    });
+
+    const { failedResponses, successfulResponses } = processTiktokAudienceRecords([event]);
+
+    expect(failedResponses).toHaveLength(0);
+    expect(successfulResponses).toHaveLength(1);
+    expect(mockStatsIncrement).toHaveBeenCalledWith('audience_hashing_inconsistency', {
+      propertyName: 'EMAIL_SHA256',
+      type: 'hashed_when_hash_enabled',
+      workspaceId: TEST_WORKSPACE_ID,
+      destinationId: TEST_DESTINATION_ID,
+      destType: 'tiktok_audience',
+    });
+  });
+
+  it('Validation disabled (default) + hashing OFF + plaintext value → emits metric but no failed responses', () => {
+    const event = buildBaseEvent(
+      {
+        identifiers: {
+          EMAIL_SHA256: plaintextEmail,
+        },
+      },
+      false,
+    );
+
+    const { failedResponses, successfulResponses } = processTiktokAudienceRecords([event]);
+
+    expect(failedResponses).toHaveLength(0);
+    expect(successfulResponses).toHaveLength(1);
+    expect(mockStatsIncrement).toHaveBeenCalledWith('audience_hashing_inconsistency', {
+      propertyName: 'EMAIL_SHA256',
+      type: 'unhashed_when_hash_disabled',
+      workspaceId: TEST_WORKSPACE_ID,
+      destinationId: TEST_DESTINATION_ID,
+      destType: 'tiktok_audience',
+    });
+  });
+});
+
+describe('processTiktokAudienceRecords tiktok_audience record edge cases', () => {
+  const mockStatsIncrement = stats.increment as jest.Mock;
+
+  beforeEach(() => {
+    mockStatsIncrement.mockClear();
+  });
+
+  afterEach(() => {
+    delete process.env.TIKTOK_AUDIENCE_REJECT_INVALID_FIELDS;
+    delete process.env.AUDIENCE_HASHING_VALIDATION_ENABLED;
+  });
+
+  it('Unknown identifier key → returns failed response with invalid trait error', () => {
+    const event = buildBaseEvent({
+      identifiers: {
+        PHONE_NUMBER: '1234567890',
+      },
+    });
+
+    const { failedResponses, successfulResponses } = processTiktokAudienceRecords([event]);
+    expect(successfulResponses).toHaveLength(0);
+    expect(failedResponses).toHaveLength(1);
+    expect(failedResponses[0].error).toContain(
+      'Invalid identifier key PHONE_NUMBER for TikTok Audience.',
+    );
+  });
+
+  it('All identifiers null/empty → returns failed response "No identifiers found"', () => {
+    const event = buildBaseEvent({
+      identifiers: {
+        EMAIL_SHA256: null,
+      },
+    });
+
+    const { failedResponses, successfulResponses } = processTiktokAudienceRecords([event]);
+    expect(successfulResponses).toHaveLength(0);
+    expect(failedResponses).toHaveLength(1);
+    expect(failedResponses[0].error).toContain('No identifiers found, aborting event.');
+  });
+
+  it('Invalid email + reject disabled (default) → increments metric and hashes normalized value', () => {
+    const event = buildBaseEvent({
+      identifiers: {
+        EMAIL_SHA256: ' Not-An-Email ',
+      },
+    });
+
+    const { failedResponses, successfulResponses } = processTiktokAudienceRecords([event]);
+    expect(failedResponses).toHaveLength(0);
+    expect(successfulResponses).toHaveLength(1);
+
+    expect(mockStatsIncrement).toHaveBeenCalledWith('tiktok_audience_invalid_email', {
+      workspaceId: TEST_WORKSPACE_ID,
+      destinationId: TEST_DESTINATION_ID,
+    });
+
+    const output = (successfulResponses[0] as any).batchedRequest;
+    const id = output.body.JSON.batch_data[0][0].id;
+    expect(id).toBe(sha256('not-an-email'));
+  });
+
+  it('Invalid email + reject enabled → returns failed response', () => {
+    process.env.TIKTOK_AUDIENCE_REJECT_INVALID_FIELDS = 'true';
+    const event = buildBaseEvent({
+      identifiers: {
+        EMAIL_SHA256: ' Not-An-Email ',
+      },
+    });
+
+    const { failedResponses, successfulResponses } = processTiktokAudienceRecords([event]);
+    expect(successfulResponses).toHaveLength(0);
+    expect(failedResponses).toHaveLength(1);
+    expect(failedResponses[0].error).toContain('No identifiers found');
+  });
+
+  it('MD5 traits are trimmed/lowercased before hashing when hashing enabled', () => {
+    const event = buildBaseEvent({
+      identifiers: {
+        AAID_MD5: '  ABCDEF  ',
+      },
+    });
+
+    const { failedResponses, successfulResponses } = processTiktokAudienceRecords([event]);
+    expect(failedResponses).toHaveLength(0);
+    expect(successfulResponses).toHaveLength(1);
+
+    const output = (successfulResponses[0] as any).batchedRequest;
+    const id = output.body.JSON.batch_data[0][0].id;
+    expect(id).toBe(md5('abcdef'));
+  });
+});

--- a/src/v0/destinations/tiktok_audience/recordTransform.test.ts
+++ b/src/v0/destinations/tiktok_audience/recordTransform.test.ts
@@ -3,6 +3,7 @@ import stats from '../../../util/stats';
 import type { TiktokAudienceRecordRequest } from './recordTypes';
 import sha256 from 'sha256';
 import md5 from 'md5';
+import { RouterTransformationResponse } from '../../../types';
 
 jest.mock('../../../util/stats', () => ({
   increment: jest.fn(),
@@ -24,7 +25,7 @@ const buildBaseEvent = (
     },
     fields: {},
     ...overrides,
-  } as any;
+  };
 
   return {
     message,
@@ -33,7 +34,7 @@ const buildBaseEvent = (
       Config: {
         advertiserId: 'dummyAdverTiserID',
       },
-    } as any,
+    },
     connection: {
       config: {
         destination: {
@@ -42,14 +43,14 @@ const buildBaseEvent = (
           audienceId: '23856594064540489',
         },
       },
-    } as any,
+    },
     metadata: {
       workspaceId: TEST_WORKSPACE_ID,
       secret: {
         accessToken: 'dummyAccessToken',
       },
-    } as any,
-  } as any;
+    },
+  };
 };
 
 describe('processTiktokAudienceRecords hashing validation for tiktok_audience', () => {
@@ -109,7 +110,7 @@ describe('processTiktokAudienceRecords hashing validation for tiktok_audience', 
     const event = buildBaseEvent(
       {
         identifiers: {
-          EMAIL_SHA256: plaintextEmail,
+          EMAIL_SHA256: hashedValue,
         },
       },
       false,
@@ -117,18 +118,8 @@ describe('processTiktokAudienceRecords hashing validation for tiktok_audience', 
 
     const { failedResponses, successfulResponses } = processTiktokAudienceRecords([event]);
 
-    expect(successfulResponses).toHaveLength(0);
-    expect(failedResponses).toHaveLength(1);
-    expect(failedResponses[0].error).toContain(
-      'Hashing is disabled but the value for field EMAIL_SHA256 appears to be unhashed. Either enable hashing or send pre-hashed data.',
-    );
-    expect(mockStatsIncrement).toHaveBeenCalledWith('audience_hashing_inconsistency', {
-      propertyName: 'EMAIL_SHA256',
-      type: 'unhashed_when_hash_disabled',
-      workspaceId: TEST_WORKSPACE_ID,
-      destinationId: TEST_DESTINATION_ID,
-      destType: 'tiktok_audience',
-    });
+    expect(failedResponses).toHaveLength(0);
+    expect(successfulResponses).toHaveLength(1);
   });
 
   it('Hashing OFF + 64-char hex value → no error, one successful response', () => {
@@ -178,16 +169,9 @@ describe('processTiktokAudienceRecords hashing validation for tiktok_audience', 
     );
 
     const { failedResponses, successfulResponses } = processTiktokAudienceRecords([event]);
-
     expect(failedResponses).toHaveLength(0);
     expect(successfulResponses).toHaveLength(1);
-    expect(mockStatsIncrement).toHaveBeenCalledWith('audience_hashing_inconsistency', {
-      propertyName: 'EMAIL_SHA256',
-      type: 'unhashed_when_hash_disabled',
-      workspaceId: TEST_WORKSPACE_ID,
-      destinationId: TEST_DESTINATION_ID,
-      destType: 'tiktok_audience',
-    });
+    expect(mockStatsIncrement).not.toHaveBeenCalled();
   });
 });
 
@@ -241,13 +225,18 @@ describe('processTiktokAudienceRecords tiktok_audience record edge cases', () =>
     const { failedResponses, successfulResponses } = processTiktokAudienceRecords([event]);
     expect(failedResponses).toHaveLength(0);
     expect(successfulResponses).toHaveLength(1);
+    expect(successfulResponses[0]).toBeDefined();
 
     expect(mockStatsIncrement).toHaveBeenCalledWith('tiktok_audience_invalid_email', {
       workspaceId: TEST_WORKSPACE_ID,
       destinationId: TEST_DESTINATION_ID,
     });
 
-    const output = (successfulResponses[0] as any).batchedRequest;
+    const output = (
+      successfulResponses[0] as unknown as {
+        batchedRequest: { body: { JSON: { batch_data: { id: string }[] } } };
+      }
+    ).batchedRequest;
     const id = output.body.JSON.batch_data[0][0].id;
     expect(id).toBe(sha256('not-an-email'));
   });
@@ -277,7 +266,11 @@ describe('processTiktokAudienceRecords tiktok_audience record edge cases', () =>
     expect(failedResponses).toHaveLength(0);
     expect(successfulResponses).toHaveLength(1);
 
-    const output = (successfulResponses[0] as any).batchedRequest;
+    const output = (
+      successfulResponses[0] as unknown as {
+        batchedRequest: { body: { JSON: { batch_data: { id: string }[] } } };
+      }
+    ).batchedRequest;
     const id = output.body.JSON.batch_data[0][0].id;
     expect(id).toBe(md5('abcdef'));
   });

--- a/src/v0/destinations/tiktok_audience/recordTransform.test.ts
+++ b/src/v0/destinations/tiktok_audience/recordTransform.test.ts
@@ -158,7 +158,7 @@ describe('processTiktokAudienceRecords hashing validation for tiktok_audience', 
     });
   });
 
-  it('Validation disabled (default) + hashing OFF + plaintext value → emits metric but no failed responses', () => {
+  it('Validation disabled (default) + hashing ON + plaintext value → emits metric but no failed responses', () => {
     const event = buildBaseEvent(
       {
         identifiers: {
@@ -171,7 +171,13 @@ describe('processTiktokAudienceRecords hashing validation for tiktok_audience', 
     const { failedResponses, successfulResponses } = processTiktokAudienceRecords([event]);
     expect(failedResponses).toHaveLength(0);
     expect(successfulResponses).toHaveLength(1);
-    expect(mockStatsIncrement).not.toHaveBeenCalled();
+    expect(mockStatsIncrement).toHaveBeenCalledWith('audience_hashing_inconsistency', {
+      propertyName: 'EMAIL_SHA256',
+      type: 'unhashed_when_hash_disabled',
+      workspaceId: TEST_WORKSPACE_ID,
+      destinationId: TEST_DESTINATION_ID,
+      destType: 'tiktok_audience',
+    });
   });
 });
 

--- a/src/v0/destinations/tiktok_audience/recordTransform.ts
+++ b/src/v0/destinations/tiktok_audience/recordTransform.ts
@@ -18,6 +18,7 @@ import {
   DESTINATION_TYPE,
   isRejectInvalidFieldsEnabled,
   REMOVE_SPACES_REGEX,
+  TRAITS_SET,
 } from './config';
 import {
   defaultRequestConfig,
@@ -33,12 +34,11 @@ function prepareIdentifiersPayload(event: TiktokAudienceRecordRequest): Identifi
   const { isHashRequired, audienceId } = connection.config.destination;
   const { advertiserId } = destination.Config;
   const { action, identifiers } = message;
-  const traitsSet = new Set([...SHA256_TRAITS, ...MD5_TRAITS]);
 
   const normalizedValue = (fieldName: string, fieldvalue: string): string => {
     switch (fieldName) {
       case 'EMAIL_SHA256': {
-        // 1. Remove spaces at the beginning and end
+        // 1. Remove spaces
         // 2. Convert all characters to lowercase
         const removeSpacesValue = fieldvalue.replace(REMOVE_SPACES_REGEX, '');
         const emailValue = removeSpacesValue.toLowerCase();
@@ -72,30 +72,32 @@ function prepareIdentifiersPayload(event: TiktokAudienceRecordRequest): Identifi
       config: { isHashRequired },
     });
 
-    if (isHashRequired) {
-      if (SHA256_TRAITS.includes(fieldName)) {
-        return hashToSha256(value);
-      }
-      if (MD5_TRAITS.includes(fieldName)) {
-        return md5(value);
-      }
-      throw new InstrumentationError(
-        `Invalid hashing method for identifier key ${fieldName} for TikTok Audience.`,
-      );
+    if (SHA256_TRAITS.includes(fieldName)) {
+      return hashToSha256(value);
     }
-    return value;
+    if (MD5_TRAITS.includes(fieldName)) {
+      return md5(value);
+    }
+    throw new Error(`Invalid hashing method for identifier key ${fieldName} for TikTok Audience.`);
   };
 
   const identifiersList: Identifier[] = [];
   for (const [fieldName, value] of Object.entries(identifiers)) {
-    if (!traitsSet.has(fieldName)) {
-      throw new InstrumentationError(`Invalid identifier key ${fieldName} for TikTok Audience.`);
+    if (!TRAITS_SET.has(fieldName)) {
+      throw new Error(`Invalid identifier key ${fieldName} for TikTok Audience.`);
     }
     if (value) {
-      const normalizedFieldValue = normalizedValue(fieldName, value);
-      if (isDefinedAndNotNullAndNotEmpty(normalizedFieldValue)) {
+      if (isHashRequired) {
+        const normalizedFieldValue = normalizedValue(fieldName, value);
+        if (isDefinedAndNotNullAndNotEmpty(normalizedFieldValue)) {
+          identifiersList.push({
+            id: hashIdentifier(fieldName, normalizedFieldValue),
+            audience_ids: [audienceId],
+          });
+        }
+      } else {
         identifiersList.push({
-          id: hashIdentifier(fieldName, normalizedFieldValue),
+          id: value,
           audience_ids: [audienceId],
         });
       }

--- a/src/v0/destinations/tiktok_audience/recordTransform.ts
+++ b/src/v0/destinations/tiktok_audience/recordTransform.ts
@@ -1,5 +1,6 @@
 import md5 from 'md5';
 import { hashToSha256, InstrumentationError, formatZodError } from '@rudderstack/integrations-lib';
+import validator from 'validator';
 import type {
   TiktokAudienceRecordRequest,
   IdentifiersPayload,
@@ -8,33 +9,100 @@ import type {
   ProcessTiktokAudienceRecordsResponse,
 } from './recordTypes';
 import { TiktokAudienceRecordRouterRequestSchema } from './recordTypes';
-import { SHA256_TRAITS, ENDPOINT, ENDPOINT_PATH, ACTION_RECORD_MAP } from './config';
-import { defaultRequestConfig, getSuccessRespEvents, handleRtTfSingleEventError } from '../../util';
+import {
+  SHA256_TRAITS,
+  MD5_TRAITS,
+  ENDPOINT,
+  ENDPOINT_PATH,
+  ACTION_RECORD_MAP,
+  DESTINATION_TYPE,
+  isRejectInvalidFieldsEnabled,
+  REMOVE_SPACES_REGEX,
+} from './config';
+import {
+  defaultRequestConfig,
+  getSuccessRespEvents,
+  handleRtTfSingleEventError,
+  isDefinedAndNotNullAndNotEmpty,
+} from '../../util';
+import { validateHashingConsistency } from '../../util/audienceUtils';
+import stats from '../../../util/stats';
 
 function prepareIdentifiersPayload(event: TiktokAudienceRecordRequest): IdentifiersPayload {
-  const { message, connection, destination } = event;
+  const { message, connection, destination, metadata } = event;
   const { isHashRequired, audienceId } = connection.config.destination;
   const { advertiserId } = destination.Config;
   const { action, identifiers } = message;
+  const traitsSet = new Set([...SHA256_TRAITS, ...MD5_TRAITS]);
+
+  const normalizedValue = (fieldName: string, fieldvalue: string): string => {
+    switch (fieldName) {
+      case 'EMAIL_SHA256': {
+        // 1. Remove spaces at the beginning and end
+        // 2. Convert all characters to lowercase
+        const removeSpacesValue = fieldvalue.replace(REMOVE_SPACES_REGEX, '');
+        const emailValue = removeSpacesValue.toLowerCase();
+        if (validator.isEmail(emailValue)) {
+          return emailValue;
+        }
+        stats.increment('tiktok_audience_invalid_email', {
+          workspaceId: metadata.workspaceId,
+          destinationId: destination.ID,
+        });
+        return isRejectInvalidFieldsEnabled() ? '' : emailValue;
+      }
+      case 'IDFA_SHA256':
+      case 'AAID_SHA256':
+      case 'IDFA_MD5':
+      case 'AAID_MD5': {
+        // 1. Convert all characters to lowercase
+        // 2. Remove any spaces at the beginning or end
+        return fieldvalue.trim().toLowerCase();
+      }
+      default:
+        return fieldvalue;
+    }
+  };
 
   const hashIdentifier = (fieldName: string, value: string) => {
+    validateHashingConsistency(fieldName, value, {
+      workspaceId: metadata.workspaceId,
+      id: destination.ID,
+      type: DESTINATION_TYPE,
+      config: { isHashRequired },
+    });
+
     if (isHashRequired) {
       if (SHA256_TRAITS.includes(fieldName)) {
         return hashToSha256(value);
       }
-      return md5(value);
+      if (MD5_TRAITS.includes(fieldName)) {
+        return md5(value);
+      }
+      throw new InstrumentationError(
+        `Invalid hashing method for identifier key ${fieldName} for TikTok Audience.`,
+      );
     }
     return value;
   };
 
   const identifiersList: Identifier[] = [];
   for (const [fieldName, value] of Object.entries(identifiers)) {
-    if (value) {
-      identifiersList.push({
-        id: hashIdentifier(fieldName, value),
-        audience_ids: [audienceId],
-      });
+    if (!traitsSet.has(fieldName)) {
+      throw new InstrumentationError(`Invalid identifier key ${fieldName} for TikTok Audience.`);
     }
+    if (value) {
+      const normalizedFieldValue = normalizedValue(fieldName, value);
+      if (isDefinedAndNotNullAndNotEmpty(normalizedFieldValue)) {
+        identifiersList.push({
+          id: hashIdentifier(fieldName, normalizedFieldValue),
+          audience_ids: [audienceId],
+        });
+      }
+    }
+  }
+  if (identifiersList.length === 0) {
+    throw new InstrumentationError('No identifiers found, aborting event.');
   }
 
   const payload: IdentifiersPayload = {

--- a/src/v0/destinations/tiktok_audience/recordTransform.ts
+++ b/src/v0/destinations/tiktok_audience/recordTransform.ts
@@ -65,13 +65,6 @@ function prepareIdentifiersPayload(event: TiktokAudienceRecordRequest): Identifi
   };
 
   const hashIdentifier = (fieldName: string, value: string) => {
-    validateHashingConsistency(fieldName, value, {
-      workspaceId: metadata.workspaceId,
-      id: destination.ID,
-      type: DESTINATION_TYPE,
-      config: { isHashRequired },
-    });
-
     if (SHA256_TRAITS.includes(fieldName)) {
       return hashToSha256(value);
     }
@@ -87,6 +80,13 @@ function prepareIdentifiersPayload(event: TiktokAudienceRecordRequest): Identifi
       throw new Error(`Invalid identifier key ${fieldName} for TikTok Audience.`);
     }
     if (value) {
+      validateHashingConsistency(fieldName, value, {
+        workspaceId: metadata.workspaceId,
+        id: destination.ID,
+        type: DESTINATION_TYPE,
+        config: { isHashRequired },
+      });
+
       if (isHashRequired) {
         const normalizedFieldValue = normalizedValue(fieldName, value);
         if (isDefinedAndNotNullAndNotEmpty(normalizedFieldValue)) {

--- a/src/v0/destinations/tiktok_audience/recordTypes.ts
+++ b/src/v0/destinations/tiktok_audience/recordTypes.ts
@@ -3,6 +3,7 @@ import { RouterTransformationResponse } from '../../../types';
 
 const TiktokAudienceDestinationSchema = z
   .object({
+    ID: z.string(),
     Config: z
       .object({
         advertiserId: z.string(),
@@ -42,6 +43,7 @@ const TiktokAudienceMessageSchema = z
 
 const TiktokAudienceMetadataSchema = z
   .object({
+    workspaceId: z.string(),
     secret: z
       .object({
         accessToken: z.string(),

--- a/test/integrations/destinations/tiktok_audience/router/data-native.ts
+++ b/test/integrations/destinations/tiktok_audience/router/data-native.ts
@@ -44,6 +44,7 @@ export const nativeData = [
                 userId: 'u1',
               },
               destination: {
+                ID: 'dummyDestinationId',
                 DestinationDefinition: { Name: 'TIKTOK_AUDIENCE', Config: {} },
                 Config: {
                   isHashRequired: true,
@@ -156,6 +157,7 @@ export const nativeData = [
               ],
               batched: true,
               destination: {
+                ID: 'dummyDestinationId',
                 DestinationDefinition: { Name: 'TIKTOK_AUDIENCE', Config: {} },
                 Config: {
                   isHashRequired: true,
@@ -225,6 +227,7 @@ export const nativeData = [
                 userId: 'u1',
               },
               destination: {
+                ID: 'dummyDestinationId',
                 DestinationDefinition: { Name: 'TIKTOK_AUDIENCE', Config: {} },
                 Config: {
                   isHashRequired: true,
@@ -361,6 +364,7 @@ export const nativeData = [
               ],
               batched: true,
               destination: {
+                ID: 'dummyDestinationId',
                 DestinationDefinition: { Name: 'TIKTOK_AUDIENCE', Config: {} },
                 Config: {
                   isHashRequired: true,
@@ -439,6 +443,7 @@ export const nativeData = [
                 userId: 'u1',
               },
               destination: {
+                ID: 'dummyDestinationId',
                 DestinationDefinition: { Name: 'TIKTOK_AUDIENCE', Config: {} },
                 Config: {
                   isHashRequired: true,
@@ -538,6 +543,7 @@ export const nativeData = [
               },
               batched: true,
               destination: {
+                ID: 'dummyDestinationId',
                 DestinationDefinition: { Name: 'TIKTOK_AUDIENCE', Config: {} },
                 Config: {
                   isHashRequired: true,
@@ -612,6 +618,7 @@ export const nativeData = [
                 userId: 'u1',
               },
               destination: {
+                ID: 'dummyDestinationId',
                 DestinationDefinition: { Name: 'TIKTOK_AUDIENCE', Config: {} },
                 Config: {
                   isHashRequired: true,
@@ -699,6 +706,7 @@ export const nativeData = [
               },
               batched: true,
               destination: {
+                ID: 'dummyDestinationId',
                 DestinationDefinition: { Name: 'TIKTOK_AUDIENCE', Config: {} },
                 Config: {
                   isHashRequired: true,
@@ -756,6 +764,7 @@ export const nativeData = [
                 dontBatch: false,
               },
               destination: {
+                ID: 'dummyDestinationId',
                 DestinationDefinition: { Name: 'TIKTOK_AUDIENCE', Config: {} },
                 Config: { isHashRequired: true },
               },
@@ -775,6 +784,7 @@ export const nativeData = [
               error: 'unsupported event found undefined',
               batched: false,
               destination: {
+                ID: 'dummyDestinationId',
                 DestinationDefinition: { Name: 'TIKTOK_AUDIENCE', Config: {} },
                 Config: { isHashRequired: true },
               },
@@ -841,6 +851,7 @@ export const nativeData = [
                 dontBatch: false,
               },
               destination: {
+                ID: 'dummyDestinationId',
                 DestinationDefinition: { Name: 'TIKTOK_AUDIENCE', Config: {} },
                 Config: { isHashRequired: true },
               },
@@ -860,6 +871,7 @@ export const nativeData = [
               error: 'unsupported event found identify',
               batched: false,
               destination: {
+                ID: 'dummyDestinationId',
                 DestinationDefinition: { Name: 'TIKTOK_AUDIENCE', Config: {} },
                 Config: { isHashRequired: true },
               },
@@ -925,6 +937,7 @@ export const nativeData = [
                 dontBatch: false,
               },
               destination: {
+                ID: 'dummyDestinationId',
                 DestinationDefinition: { Name: 'TIKTOK_AUDIENCE', Config: {} },
                 Config: { isHashRequired: true },
               },
@@ -944,6 +957,7 @@ export const nativeData = [
               error: 'message.properties: Message properties is not present. Aborting message.',
               batched: false,
               destination: {
+                ID: 'dummyDestinationId',
                 DestinationDefinition: { Name: 'TIKTOK_AUDIENCE', Config: {} },
                 Config: { isHashRequired: true },
               },
@@ -1010,6 +1024,7 @@ export const nativeData = [
                 dontBatch: false,
               },
               destination: {
+                ID: 'dummyDestinationId',
                 DestinationDefinition: { Name: 'TIKTOK_AUDIENCE', Config: {} },
                 Config: { isHashRequired: true },
               },
@@ -1030,6 +1045,7 @@ export const nativeData = [
                 'message.properties.listData: listData is not present inside properties. Aborting message.',
               batched: false,
               destination: {
+                ID: 'dummyDestinationId',
                 DestinationDefinition: { Name: 'TIKTOK_AUDIENCE', Config: {} },
                 Config: { isHashRequired: true },
               },
@@ -1096,6 +1112,7 @@ export const nativeData = [
                 dontBatch: false,
               },
               destination: {
+                ID: 'dummyDestinationId',
                 DestinationDefinition: { Name: 'TIKTOK_AUDIENCE', Config: {} },
                 Config: { isHashRequired: true },
               },
@@ -1116,6 +1133,7 @@ export const nativeData = [
                 'message.properties.listData: unsupported action type update. Aborting message.',
               batched: false,
               destination: {
+                ID: 'dummyDestinationId',
                 DestinationDefinition: { Name: 'TIKTOK_AUDIENCE', Config: {} },
                 Config: { isHashRequired: true },
               },
@@ -1172,6 +1190,7 @@ export const nativeData = [
                 secret: { accessToken: 'dummyAccessToken' },
               },
               destination: {
+                ID: 'dummyDestinationId',
                 DestinationDefinition: { Name: 'TIKTOK_AUDIENCE', Config: {} },
                 Config: { advertiserId: 'dummyAdverTiserID' },
               },
@@ -1231,6 +1250,7 @@ export const nativeData = [
               },
               batched: true,
               destination: {
+                ID: 'dummyDestinationId',
                 DestinationDefinition: { Name: 'TIKTOK_AUDIENCE', Config: {} },
                 Config: { advertiserId: 'dummyAdverTiserID' },
               },
@@ -1272,6 +1292,7 @@ export const nativeData = [
                 secret: { accessToken: 'dummyAccessToken' },
               },
               destination: {
+                ID: 'dummyDestinationId',
                 DestinationDefinition: { Name: 'TIKTOK_AUDIENCE', Config: {} },
                 Config: { advertiserId: 'dummyAdverTiserID' },
               },
@@ -1331,6 +1352,7 @@ export const nativeData = [
               },
               batched: true,
               destination: {
+                ID: 'dummyDestinationId',
                 DestinationDefinition: { Name: 'TIKTOK_AUDIENCE', Config: {} },
                 Config: { advertiserId: 'dummyAdverTiserID' },
               },
@@ -1372,6 +1394,7 @@ export const nativeData = [
                 secret: { accessToken: 'dummyAccessToken' },
               },
               destination: {
+                ID: 'dummyDestinationId',
                 DestinationDefinition: { Name: 'TIKTOK_AUDIENCE', Config: {} },
                 Config: { advertiserId: 'dummyAdverTiserID' },
               },
@@ -1431,6 +1454,7 @@ export const nativeData = [
               },
               batched: true,
               destination: {
+                ID: 'dummyDestinationId',
                 DestinationDefinition: { Name: 'TIKTOK_AUDIENCE', Config: {} },
                 Config: { advertiserId: 'dummyAdverTiserID' },
               },
@@ -1493,6 +1517,7 @@ export const nativeData = [
                 userId: 'u1',
               },
               destination: {
+                ID: 'dummyDestinationId',
                 DestinationDefinition: { Name: 'TIKTOK_AUDIENCE', Config: {} },
                 Config: {
                   isHashRequired: true,
@@ -1538,6 +1563,7 @@ export const nativeData = [
                 userId: 'u1',
               },
               destination: {
+                ID: 'dummyDestinationId',
                 DestinationDefinition: { Name: 'TIKTOK_AUDIENCE', Config: {} },
                 Config: {
                   isHashRequired: true,
@@ -1592,6 +1618,7 @@ export const nativeData = [
                 userId: 'u1',
               },
               destination: {
+                ID: 'dummyDestinationId',
                 DestinationDefinition: { Name: 'TIKTOK_AUDIENCE', Config: {} },
                 Config: {
                   isHashRequired: true,
@@ -1642,6 +1669,7 @@ export const nativeData = [
                 userId: 'u1',
               },
               destination: {
+                ID: 'dummyDestinationId',
                 DestinationDefinition: { Name: 'TIKTOK_AUDIENCE', Config: {} },
                 Config: {
                   isHashRequired: true,
@@ -1691,6 +1719,7 @@ export const nativeData = [
                 userId: 'u1',
               },
               destination: {
+                ID: 'dummyDestinationId',
                 DestinationDefinition: { Name: 'TIKTOK_AUDIENCE', Config: {} },
                 Config: {
                   isHashRequired: true,
@@ -1716,6 +1745,7 @@ export const nativeData = [
               error: 'unsupported event found undefined',
               batched: false,
               destination: {
+                ID: 'dummyDestinationId',
                 DestinationDefinition: { Name: 'TIKTOK_AUDIENCE', Config: {} },
                 Config: {
                   isHashRequired: true,
@@ -1835,6 +1865,7 @@ export const nativeData = [
               ],
               batched: true,
               destination: {
+                ID: 'dummyDestinationId',
                 DestinationDefinition: { Name: 'TIKTOK_AUDIENCE', Config: {} },
                 Config: {
                   isHashRequired: true,
@@ -1969,6 +2000,7 @@ export const nativeData = [
               ],
               batched: true,
               destination: {
+                ID: 'dummyDestinationId',
                 DestinationDefinition: { Name: 'TIKTOK_AUDIENCE', Config: {} },
                 Config: {
                   isHashRequired: true,
@@ -2063,6 +2095,7 @@ export const nativeData = [
               },
               batched: true,
               destination: {
+                ID: 'dummyDestinationId',
                 DestinationDefinition: { Name: 'TIKTOK_AUDIENCE', Config: {} },
                 Config: {
                   isHashRequired: true,
@@ -2148,6 +2181,7 @@ export const nativeData = [
               },
               batched: true,
               destination: {
+                ID: 'dummyDestinationId',
                 DestinationDefinition: { Name: 'TIKTOK_AUDIENCE', Config: {} },
                 Config: {
                   isHashRequired: true,
@@ -2207,6 +2241,7 @@ export const nativeData = [
                 userId: 'u1',
               },
               destination: {
+                ID: 'dummyDestinationId',
                 DestinationDefinition: { Name: 'TIKTOK_AUDIENCE', Config: {} },
                 Config: {
                   advertiserId: 'dummyAdverTiserID',
@@ -2247,6 +2282,7 @@ export const nativeData = [
                 userId: 'u1',
               },
               destination: {
+                ID: 'dummyDestinationId',
                 DestinationDefinition: { Name: 'TIKTOK_AUDIENCE', Config: {} },
                 Config: {
                   advertiserId: 'dummyAdverTiserID',
@@ -2287,6 +2323,7 @@ export const nativeData = [
                 userId: 'u1',
               },
               destination: {
+                ID: 'dummyDestinationId',
                 DestinationDefinition: { Name: 'TIKTOK_AUDIENCE', Config: {} },
                 Config: {
                   advertiserId: 'dummyAdverTiserID',
@@ -2354,6 +2391,7 @@ export const nativeData = [
               },
               batched: true,
               destination: {
+                ID: 'dummyDestinationId',
                 DestinationDefinition: { Name: 'TIKTOK_AUDIENCE', Config: {} },
                 Config: {
                   advertiserId: 'dummyAdverTiserID',
@@ -2410,6 +2448,7 @@ export const nativeData = [
               },
               batched: true,
               destination: {
+                ID: 'dummyDestinationId',
                 DestinationDefinition: { Name: 'TIKTOK_AUDIENCE', Config: {} },
                 Config: {
                   advertiserId: 'dummyAdverTiserID',
@@ -2455,6 +2494,7 @@ export const nativeData = [
                 secret: { accessToken: 'dummyAccessToken' },
               },
               destination: {
+                ID: 'dummyDestinationId',
                 DestinationDefinition: { Name: 'TIKTOK_AUDIENCE', Config: {} },
                 Config: {
                   advertiserId: 'dummyAdverTiserID',
@@ -2485,6 +2525,7 @@ export const nativeData = [
               error: 'message.action: action is not present. Aborting message.',
               batched: false,
               destination: {
+                ID: 'dummyDestinationId',
                 DestinationDefinition: { Name: 'TIKTOK_AUDIENCE', Config: {} },
                 Config: {
                   advertiserId: 'dummyAdverTiserID',
@@ -2507,6 +2548,202 @@ export const nativeData = [
                 workspaceId: 'workspace-disable-cdkv2',
               },
               statusCode: 400,
+            },
+          ],
+        },
+      },
+    },
+  },
+  {
+    name: 'tiktok_audience',
+    description: 'Native Test 18: record events: invalid identifiers',
+    feature: 'router',
+    module: 'destination',
+    version: 'v0',
+    input: {
+      request: {
+        body: {
+          input: [
+            {
+              message: {
+                type: 'record',
+                action: 'insert',
+                userId: 'user 1',
+                identifiers: {
+                  EMAIL_SHA256: 'alex@email.com',
+                  PHONE_SHA256: '1234567890',
+                  IDFA_SHA256: null,
+                  AAID_SHA256: null,
+                },
+                fields: {},
+                context: {
+                  sources: {
+                    job_id: '38FFCLxl3eMTUFU3XY9o7dhlT0v',
+                    job_run_id: 'd5jn6pn3a8bc73cdd0v0',
+                    task_run_id: 'd5jn6pn3a8bc73cdd0vg',
+                    version: 'v1.79.0',
+                  },
+                },
+              },
+              metadata: {
+                jobId: 1,
+                workspaceId: 'workspace-disable-cdkv2',
+                secret: { accessToken: 'dummyAccessToken' },
+                userId: 'u1',
+              },
+              destination: {
+                ID: 'dummyDestinationId',
+                DestinationDefinition: { Name: 'TIKTOK_AUDIENCE', Config: {} },
+                Config: {
+                  advertiserId: 'dummyAdverTiserID',
+                },
+              },
+              connection: {
+                config: {
+                  destination: {
+                    schemaVersion: '1.1',
+                    isHashRequired: true,
+                    audienceId: '23856594064540489',
+                  },
+                },
+              },
+            },
+            {
+              message: {
+                type: 'record',
+                action: 'update',
+                userId: 'user 1',
+                identifiers: {
+                  EMAIL_SHA256: null,
+                  PHONE_SHA256: null,
+                  IDFA_SHA256: null,
+                  AAID_SHA256: null,
+                },
+                fields: {},
+                context: {
+                  sources: {
+                    job_id: '38FFCLxl3eMTUFU3XY9o7dhlT0v',
+                    job_run_id: 'd5jn6pn3a8bc73cdd0v0',
+                    task_run_id: 'd5jn6pn3a8bc73cdd0vg',
+                    version: 'v1.79.0',
+                  },
+                },
+              },
+              metadata: {
+                jobId: 2,
+                workspaceId: 'workspace-disable-cdkv2',
+                secret: { accessToken: 'dummyAccessToken' },
+                userId: 'u1',
+              },
+              destination: {
+                ID: 'dummyDestinationId',
+                DestinationDefinition: { Name: 'TIKTOK_AUDIENCE', Config: {} },
+                Config: {
+                  advertiserId: 'dummyAdverTiserID',
+                },
+              },
+              connection: {
+                config: {
+                  destination: {
+                    schemaVersion: '1.1',
+                    isHashRequired: true,
+                    audienceId: '23856594064540489',
+                  },
+                },
+              },
+            },
+          ],
+          destType: 'tiktok_audience',
+        },
+        method: 'POST',
+      },
+    },
+    output: {
+      response: {
+        status: 200,
+        body: {
+          output: [
+            {
+              error: 'No identifiers found, aborting event.',
+              batched: false,
+              destination: {
+                ID: 'dummyDestinationId',
+                DestinationDefinition: { Name: 'TIKTOK_AUDIENCE', Config: {} },
+                Config: { advertiserId: 'dummyAdverTiserID' },
+              },
+              metadata: [
+                {
+                  jobId: 2,
+                  userId: 'u1',
+                  workspaceId: 'workspace-disable-cdkv2',
+                  secret: { accessToken: 'dummyAccessToken' },
+                },
+              ],
+              statTags: {
+                destType: 'TIKTOK_AUDIENCE',
+                errorCategory: 'dataValidation',
+                errorType: 'instrumentation',
+                feature: 'router',
+                implementation: 'native',
+                module: 'destination',
+                workspaceId: 'workspace-disable-cdkv2',
+              },
+              statusCode: 400,
+            },
+            {
+              batchedRequest: {
+                version: '1',
+                type: 'REST',
+                method: 'POST',
+                endpoint: 'https://business-api.tiktok.com/open_api/v1.3/segment/mapping/',
+                endpointPath: '/segment/mapping/',
+                headers: {
+                  'Access-Token': 'dummyAccessToken',
+                  'Content-Type': 'application/json',
+                },
+                params: {},
+                body: {
+                  JSON: {
+                    batch_data: [
+                      [
+                        {
+                          id: 'ac0f1baec38a9ef3cfcb56db981df7d9bab2568c7f53ef3776d1c059ec58e72b',
+                          audience_ids: ['23856594064540489'],
+                        },
+                        {
+                          id: 'c775e7b757ede630cd0aa1113bd102661ab38829ca52a6422ab782862f268646',
+                          audience_ids: ['23856594064540489'],
+                        },
+                      ],
+                    ],
+                    id_schema: ['AAID_SHA256', 'EMAIL_SHA256', 'IDFA_SHA256', 'PHONE_SHA256'],
+                    advertiser_ids: ['dummyAdverTiserID'],
+                    action: 'add',
+                  },
+                  JSON_ARRAY: {},
+                  XML: {},
+                  FORM: {},
+                },
+                files: {},
+                userId: 'user 1',
+              },
+              batched: true,
+              destination: {
+                ID: 'dummyDestinationId',
+                DestinationDefinition: { Name: 'TIKTOK_AUDIENCE', Config: {} },
+                Config: {
+                  advertiserId: 'dummyAdverTiserID',
+                },
+              },
+              metadata: [
+                {
+                  jobId: 1,
+                  workspaceId: 'workspace-disable-cdkv2',
+                  secret: { accessToken: 'dummyAccessToken' },
+                  userId: 'u1',
+                },
+              ],
+              statusCode: 200,
             },
           ],
         },


### PR DESCRIPTION
🔒 Scanned for secrets using gitleaks 8.29.1

## What are the changes introduced in this PR?

This change hardens **TikTok Audience `record` event** processing around **PII normalization + hashing consistency**.
- Adds **hashing-consistency validation + metrics** via shared `validateHashingConsistency`, so we can detect cases like “hashing enabled but value already hashed” (and optionally fail fast via `AUDIENCE_HASHING_VALIDATION_ENABLED=true`).
- Introduces **identifier normalization** for supported traits:
  - `EMAIL_SHA256`: remove spaces + lowercase + validate email (emits `tiktok_audience_invalid_email`)
  - `IDFA_*` / `AAID_*`: trim + lowercase
- Restricts identifiers to **allowed TikTok traits** only (SHA256 + MD5 lists). Unknown traits now error.
- Adds **config knobs**:
  - `DESTINATION_TYPE = 'tiktok_audience'`
  - `TIKTOK_AUDIENCE_REJECT_INVALID_FIELDS=true` to replace invalid values with empty strings (default: pass-through).


## What is the related Linear task?

- Resolves INT-5830