### PR TITLE
fix(facebook-lead-ads): unexpected error during FBLA hydration when field_data entry has no values

### DIFF
--- a/src/sources/facebook_lead_ads_native/hydrate.test.ts
+++ b/src/sources/facebook_lead_ads_native/hydrate.test.ts
@@ -320,8 +320,7 @@ describe('Facebook Lead Ads Hydration', () => {
       expect(logger.warn).toHaveBeenCalledWith(
         '[facebook_lead_ads_native] field values is not an array',
         {
-          fieldName: 'missing_values_field',
-          field: {
+          fieldSchema: {
             type: 'object',
             properties: {
               name: { type: 'string' },

--- a/src/sources/facebook_lead_ads_native/hydrate.test.ts
+++ b/src/sources/facebook_lead_ads_native/hydrate.test.ts
@@ -82,6 +82,29 @@ describe('Facebook Lead Ads Hydration', () => {
         verifyHttpCall: true,
       },
       {
+        name: 'should skip field and log warning when field_data entry is missing values',
+        mockResponse: {
+          success: true,
+          response: {
+            data: {
+              id: '123456',
+              field_data: [
+                { name: 'full_name', values: ['John Doe'] },
+                { name: 'missing_values_field' },
+                { name: 'phone', values: ['+1234567890'] },
+              ],
+            },
+            status: 200,
+          },
+        },
+        input: createValidInput(['123456']),
+        expectedTraits: {
+          full_name: 'John Doe',
+          phone: '+1234567890',
+        },
+        expectedStatusCode: 200,
+      },
+      {
         name: 'should handle field_data with empty values array',
         mockResponse: {
           success: true,
@@ -274,6 +297,39 @@ describe('Facebook Lead Ads Hydration', () => {
         });
       },
     );
+
+    it('should log a warning when a field_data entry has no values property', async () => {
+      mockHttpGET.mockResolvedValue({
+        success: true,
+        response: {
+          data: {
+            id: '123456',
+            field_data: [
+              { name: 'full_name', values: ['John Doe'] },
+              { name: 'missing_values_field' },
+            ],
+          },
+          status: 200,
+        },
+      });
+
+      const input = createValidInput(['123456']);
+      const result = (await hydrate(input)) as SuccessResponse;
+
+      expect(result.batch[0].event?.context?.traits).toEqual({ full_name: 'John Doe' });
+      expect(logger.warn).toHaveBeenCalledWith(
+        '[facebook_lead_ads_native] field values is not an array',
+        {
+          fieldName: 'missing_values_field',
+          field: {
+            type: 'object',
+            properties: {
+              name: { type: 'string' },
+            },
+          },
+        },
+      );
+    });
 
     it('should handle empty batch array', async () => {
       const input = {

--- a/src/sources/facebook_lead_ads_native/hydrate.ts
+++ b/src/sources/facebook_lead_ads_native/hydrate.ts
@@ -160,7 +160,12 @@ export async function hydrate(input: SourceHydrationRequest): Promise<SourceHydr
 
       // Convert field_data array to traits object
       result.data.field_data?.forEach((field) => {
-        if (field.values.length > 0) {
+        if (!Array.isArray(field.values)) {
+          logger.warn('[facebook_lead_ads_native] field values is not an array', {
+            fieldName: field.name,
+            field: JsonSchemaGenerator.generate(field),
+          });
+        } else if (field.values.length > 0) {
           const [firstValue] = field.values;
           traits[field.name] = firstValue;
         }

--- a/src/sources/facebook_lead_ads_native/hydrate.ts
+++ b/src/sources/facebook_lead_ads_native/hydrate.ts
@@ -162,8 +162,7 @@ export async function hydrate(input: SourceHydrationRequest): Promise<SourceHydr
       result.data.field_data?.forEach((field) => {
         if (!Array.isArray(field.values)) {
           logger.warn('[facebook_lead_ads_native] field values is not an array', {
-            fieldName: field.name,
-            field: JsonSchemaGenerator.generate(field),
+            fieldSchema: JsonSchemaGenerator.generate(field),
           });
         } else if (field.values.length > 0) {
           const [firstValue] = field.values;


### PR DESCRIPTION
## Summary
- FBLA hydration was crashing with an unexpected error when a `field_data` entry had no `values` property
- Now guards against missing/non-array `values`, skips the field, and logs a warning with the field's schema
- Added tests covering both the skipping behavior and the warning payload

## Test plan
- [ ] New test: `should skip field and log warning when field_data entry is missing values`
- [ ] New test: `should log a warning when a field_data entry has no values property`
- [ ] All existing hydration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)