### PR TITLE
fix(mp): engage/groups API errors silently treated as success

### DIFF
--- a/src/v0/destinations/mp/transform.js
+++ b/src/v0/destinations/mp/transform.js
@@ -110,6 +110,7 @@ const responseBuilderSimple = (payload, message, eventType, destConfig) => {
       response.headers = {
         'Content-Type': 'application/json',
       };
+      response.params = { verbose: 2 };
   }
   return response;
 };

--- a/test/integrations/destinations/mp/processor/data.ts
+++ b/test/integrations/destinations/mp/processor/data.ts
@@ -690,7 +690,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {},
+              params: { verbose: 2 },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -826,7 +826,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {},
+              params: { verbose: 2 },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -858,7 +858,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {},
+              params: { verbose: 2 },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -1167,7 +1167,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {},
+              params: { verbose: 2 },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -1393,7 +1393,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {},
+              params: { verbose: 2 },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -2057,7 +2057,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {},
+              params: { verbose: 2 },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -2163,7 +2163,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {},
+              params: { verbose: 2 },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -2194,7 +2194,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {},
+              params: { verbose: 2 },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -2290,7 +2290,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {},
+              params: { verbose: 2 },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -2321,7 +2321,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {},
+              params: { verbose: 2 },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -2352,7 +2352,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {},
+              params: { verbose: 2 },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -2449,7 +2449,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {},
+              params: { verbose: 2 },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -2480,7 +2480,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {},
+              params: { verbose: 2 },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -2617,7 +2617,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {},
+              params: { verbose: 2 },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -2798,7 +2798,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {},
+              params: { verbose: 2 },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -2910,7 +2910,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {},
+              params: { verbose: 2 },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -3293,7 +3293,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {},
+              params: { verbose: 2 },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -3442,7 +3442,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {},
+              params: { verbose: 2 },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -3555,7 +3555,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {},
+              params: { verbose: 2 },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -3667,7 +3667,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {},
+              params: { verbose: 2 },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -3787,7 +3787,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {},
+              params: { verbose: 2 },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -3904,7 +3904,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {},
+              params: { verbose: 2 },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -4020,7 +4020,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {},
+              params: { verbose: 2 },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -4135,7 +4135,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {},
+              params: { verbose: 2 },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -4249,7 +4249,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {},
+              params: { verbose: 2 },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -4372,7 +4372,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {},
+              params: { verbose: 2 },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -5045,7 +5045,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {},
+              params: { verbose: 2 },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -5174,7 +5174,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {},
+              params: { verbose: 2 },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -5399,7 +5399,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {},
+              params: { verbose: 2 },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -5787,7 +5787,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {},
+              params: { verbose: 2 },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -5818,7 +5818,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {},
+              params: { verbose: 2 },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -6060,7 +6060,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {},
+              params: { verbose: 2 },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -6190,7 +6190,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {},
+              params: { verbose: 2 },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -6399,7 +6399,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {},
+              params: { verbose: 2 },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -6688,7 +6688,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {},
+              params: { verbose: 2 },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -6719,7 +6719,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {},
+              params: { verbose: 2 },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -6899,7 +6899,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {},
+              params: { verbose: 2 },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -7056,7 +7056,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {},
+              params: { verbose: 2 },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -7214,7 +7214,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {},
+              params: { verbose: 2 },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -7468,7 +7468,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {},
+              params: { verbose: 2 },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -7502,7 +7502,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {},
+              params: { verbose: 2 },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -7634,7 +7634,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {},
+              params: { verbose: 2 },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -7668,7 +7668,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {},
+              params: { verbose: 2 },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -8022,7 +8022,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {},
+              params: { verbose: 2 },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -8056,7 +8056,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {},
+              params: { verbose: 2 },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -8096,7 +8096,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {},
+              params: { verbose: 2 },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -8135,7 +8135,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {},
+              params: { verbose: 2 },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -8274,7 +8274,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {},
+              params: { verbose: 2 },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -8502,7 +8502,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {},
+              params: { verbose: 2 },
               body: {
                 JSON: {},
                 JSON_ARRAY: {
@@ -8535,7 +8535,7 @@ export const data = [
               headers: {
                 'Content-Type': 'application/json',
               },
-              params: {},
+              params: { verbose: 2 },
               body: {
                 JSON: {},
                 JSON_ARRAY: {

--- a/test/integrations/destinations/mp/router/data.ts
+++ b/test/integrations/destinations/mp/router/data.ts
@@ -520,7 +520,7 @@ export const data = [
                   headers: {
                     'Content-Type': 'application/json',
                   },
-                  params: {},
+                  params: { verbose: 2 },
                   body: {
                     JSON: {},
                     JSON_ARRAY: {
@@ -631,7 +631,7 @@ export const data = [
                   headers: {
                     'Content-Type': 'application/json',
                   },
-                  params: {},
+                  params: { verbose: 2 },
                   body: {
                     JSON: {},
                     JSON_ARRAY: {
@@ -772,7 +772,7 @@ export const data = [
                   headers: {
                     'Content-Type': 'application/json',
                   },
-                  params: {},
+                  params: { verbose: 2 },
                   body: {
                     JSON: {},
                     JSON_ARRAY: {
@@ -799,7 +799,7 @@ export const data = [
                   headers: {
                     'Content-Type': 'application/json',
                   },
-                  params: {},
+                  params: { verbose: 2 },
                   body: {
                     JSON: {},
                     JSON_ARRAY: {
@@ -1402,7 +1402,7 @@ export const data = [
                   headers: {
                     'Content-Type': 'application/json',
                   },
-                  params: {},
+                  params: { verbose: 2 },
                   body: {
                     JSON: {},
                     JSON_ARRAY: {
@@ -1512,7 +1512,7 @@ export const data = [
                   headers: {
                     'Content-Type': 'application/json',
                   },
-                  params: {},
+                  params: { verbose: 2 },
                   body: {
                     JSON: {},
                     JSON_ARRAY: {
@@ -1652,7 +1652,7 @@ export const data = [
                   headers: {
                     'Content-Type': 'application/json',
                   },
-                  params: {},
+                  params: { verbose: 2 },
                   body: {
                     JSON: {},
                     JSON_ARRAY: {
@@ -1679,7 +1679,7 @@ export const data = [
                   headers: {
                     'Content-Type': 'application/json',
                   },
-                  params: {},
+                  params: { verbose: 2 },
                   body: {
                     JSON: {},
                     JSON_ARRAY: {


### PR DESCRIPTION
## Summary
- Without `verbose=2` query param, MixPanel's `/engage` and `groups` endpoint return a non-standard response format that the transformer incorrectly parses as success (HTTP 200)
- Errors like missing `$distinct_id` were silently swallowed instead of propagating the actual 400 error from MixPanel
- Adding `verbose=2` makes MixPanel return the proper error response, e.g. `{"error": "Engage API error: $distinct_id, missing or empty", "status": 0}`

## Before / After
**Before** (error silently treated as success):
```json
{ "statusCode": 200, "error": "success" }
```
**After** (error correctly propagated):
```json
{ "statusCode": 400, "error": "Engage API error: $distinct_id, missing or empty" }
```

## Test plan
- [ ] Updated processor test expectations to include `params: { verbose: 2 }` (50 cases)
- [ ] Updated router test expectations to include `params: { verbose: 2 }` (8 cases)
- [ ] Run `jest mp` integration tests locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)