### PR TITLE
fix: validate hashing consistency for hashing types

### DIFF
--- a/src/v0/destinations/fb_custom_audience/util.ts
+++ b/src/v0/destinations/fb_custom_audience/util.ts
@@ -25,6 +25,7 @@ import {
   processAudienceRecord,
   isValidPhoneNumber,
   type AudienceField,
+  HashingType,
 } from '../../util/audienceUtils';
 
 // ISO 3166-1 alpha-2: exactly two lowercase letters
@@ -113,46 +114,49 @@ const FB_FIELD_CONFIG: Record<string, AudienceField> = {
   EMAIL: {
     normalize: (v) => v.trim().toLowerCase(),
     validate: (v) => validator.isEmail(v),
-    hashable: true,
+    hashingType: HashingType.SHA256,
   },
   PHONE: {
     // Remove all non-numerical characters, then remove all leading zeros.
     // Note: libphonenumber-js is not used here as it requires a country code to validate.
     normalize: (v) => v.trim().replace(/\D/g, '').replace(/^0+/g, ''),
     validate: isValidPhoneNumber,
-    hashable: true,
+    hashingType: HashingType.SHA256,
   },
   GEN: {
     normalize: (v) => {
       const lower = v.trim().toLowerCase();
       return lower === 'f' || lower === 'female' ? 'f' : 'm';
     },
-    hashable: true,
+    hashingType: HashingType.SHA256,
   },
-  DOBY: { normalize: (v) => v.trim().replace(/\./g, ''), hashable: true },
-  DOBM: { normalize: normalizeDobPart, hashable: true },
-  DOBD: { normalize: normalizeDobPart, hashable: true },
-  LN: { normalize: normalizeNameField, hashable: true },
-  FN: { normalize: normalizeNameField, hashable: true },
+  DOBY: { normalize: (v) => v.trim().replace(/\./g, ''), hashingType: HashingType.SHA256 },
+  DOBM: { normalize: normalizeDobPart, hashingType: HashingType.SHA256 },
+  DOBD: { normalize: normalizeDobPart, hashingType: HashingType.SHA256 },
+  LN: { normalize: normalizeNameField, hashingType: HashingType.SHA256 },
+  FN: { normalize: normalizeNameField, hashingType: HashingType.SHA256 },
   FI: {
     normalize: (v) =>
       v
         .trim()
         .toLowerCase()
         .replace(/[^!"#$%&'()*+,-./a-z]/g, ''),
-    hashable: true,
+    hashingType: HashingType.SHA256,
   },
-  MADID: { normalize: (v) => v.trim().toLowerCase(), hashable: false },
+  MADID: { normalize: (v) => v.trim().toLowerCase(), hashingType: HashingType.NONE },
   COUNTRY: {
     normalize: (v) => v.trim().toLowerCase(),
     validate: (v) => COUNTRY_CODE_REGEX.test(v),
-    hashable: true,
+    hashingType: HashingType.SHA256,
   },
-  ZIP: { normalize: (v) => v.trim().replace(/[\s-]/g, '').toLowerCase(), hashable: true },
-  ST: { normalize: normalizeLocationTextField, hashable: true },
-  CT: { normalize: normalizeLocationTextField, hashable: true },
-  EXTERN_ID: { normalize: (v) => v, hashable: false },
-  LOOKALIKE_VALUE: { normalize: (v) => v, hashable: false },
+  ZIP: {
+    normalize: (v) => v.trim().replace(/[\s-]/g, '').toLowerCase(),
+    hashingType: HashingType.SHA256,
+  },
+  ST: { normalize: normalizeLocationTextField, hashingType: HashingType.SHA256 },
+  CT: { normalize: normalizeLocationTextField, hashingType: HashingType.SHA256 },
+  EXTERN_ID: { normalize: (v) => v, hashingType: HashingType.NONE },
+  LOOKALIKE_VALUE: { normalize: (v) => v, hashingType: HashingType.NONE },
 };
 
 /**

--- a/src/v0/destinations/google_adwords_remarketing_lists/util.ts
+++ b/src/v0/destinations/google_adwords_remarketing_lists/util.ts
@@ -27,6 +27,7 @@ import {
   destType,
 } from './config';
 import type { GARLDestinationConfig } from './types';
+import { HashingType } from '../../util/audienceUtils';
 
 const COUNTRY_CODE_REGEX = /^[A-Za-z]{2,3}$/;
 const GMAIL_DOMAINS = new Set(['gmail.com', 'googlemail.com']);
@@ -57,24 +58,36 @@ const normalizePhone = (v: string): string => {
  * https://developers.google.com/google-ads/api/docs/remarketing/audience-segments/customer-match/get-started
  */
 const GARL_FIELD_CONFIG: Record<string, AudienceField> = {
-  email: { normalize: normalizeEmail, validate: validator.isEmail, hashable: true },
-  phone: { normalize: normalizePhone, validate: isValidPhoneNumber, hashable: true },
+  email: {
+    normalize: normalizeEmail,
+    validate: validator.isEmail,
+    hashingType: HashingType.SHA256,
+  },
+  phone: {
+    normalize: normalizePhone,
+    validate: isValidPhoneNumber,
+    hashingType: HashingType.SHA256,
+  },
   firstName: {
     normalize: (v) => v.trim().toLowerCase(),
     validate: (v) => v.length > 0,
-    hashable: true,
+    hashingType: HashingType.SHA256,
   },
   lastName: {
     normalize: (v) => v.trim().toLowerCase(),
     validate: (v) => v.length > 0,
-    hashable: true,
+    hashingType: HashingType.SHA256,
   },
   country: {
     normalize: (v) => v.trim(),
     validate: (v) => COUNTRY_CODE_REGEX.test(v),
-    hashable: false,
+    hashingType: HashingType.NONE,
   },
-  postalCode: { normalize: (v) => v.trim(), validate: (v) => v.length > 0, hashable: false },
+  postalCode: {
+    normalize: (v) => v.trim(),
+    validate: (v) => v.length > 0,
+    hashingType: HashingType.NONE,
+  },
 };
 
 const responseBuilder = (

--- a/src/v0/destinations/tiktok_audience/recordTransform.test.ts
+++ b/src/v0/destinations/tiktok_audience/recordTransform.test.ts
@@ -54,7 +54,8 @@ const buildBaseEvent = (
 };
 
 describe('processTiktokAudienceRecords hashing validation for tiktok_audience', () => {
-  const hashedValue = 'b94d27b9934d3e08a52e52d7da7dabfac484efe04294e576ca48e1cb0d7d6267'; // sha256 of 'test'
+  const sha256HashedValue = 'b94d27b9934d3e08a52e52d7da7dabfac484efe04294e576ca48e1cb0d7d6267'; // sha256 of 'test'
+  const md5HashedValue = '098f6bcd4621d373cade4e832627b4f6'; // md5 of 'test'
   const plaintextEmail = 'user@example.com';
   const mockStatsIncrement = stats.increment as jest.Mock;
 
@@ -71,7 +72,7 @@ describe('processTiktokAudienceRecords hashing validation for tiktok_audience', 
     process.env.AUDIENCE_HASHING_VALIDATION_ENABLED = 'true';
     const event = buildBaseEvent({
       identifiers: {
-        EMAIL_SHA256: hashedValue,
+        EMAIL_SHA256: sha256HashedValue,
       },
     });
 
@@ -110,7 +111,7 @@ describe('processTiktokAudienceRecords hashing validation for tiktok_audience', 
     const event = buildBaseEvent(
       {
         identifiers: {
-          EMAIL_SHA256: hashedValue,
+          EMAIL_SHA256: sha256HashedValue,
         },
       },
       false,
@@ -126,7 +127,7 @@ describe('processTiktokAudienceRecords hashing validation for tiktok_audience', 
     const event = buildBaseEvent(
       {
         identifiers: {
-          EMAIL_SHA256: hashedValue,
+          EMAIL_SHA256: sha256HashedValue,
         },
       },
       false,
@@ -141,7 +142,7 @@ describe('processTiktokAudienceRecords hashing validation for tiktok_audience', 
   it('Validation disabled (default) + hashing ON + pre-hashed value → emits metric but no failed responses', () => {
     const event = buildBaseEvent({
       identifiers: {
-        EMAIL_SHA256: hashedValue,
+        EMAIL_SHA256: sha256HashedValue,
       },
     });
 
@@ -178,6 +179,26 @@ describe('processTiktokAudienceRecords hashing validation for tiktok_audience', 
       destinationId: TEST_DESTINATION_ID,
       destType: 'tiktok_audience',
     });
+  });
+
+  it('Validation enabled + hashing OFF + pre-hashed value → no error, one successful response', () => {
+    process.env.AUDIENCE_HASHING_VALIDATION_ENABLED = 'true';
+    const event = buildBaseEvent(
+      {
+        identifiers: {
+          IDFA_SHA256: sha256HashedValue,
+          AAID_SHA256: sha256HashedValue,
+          IDFA_MD5: md5HashedValue,
+          AAID_MD5: md5HashedValue,
+          EMAIL_SHA256: sha256HashedValue,
+        },
+      },
+      false,
+    );
+
+    const { failedResponses, successfulResponses } = processTiktokAudienceRecords([event]);
+    expect(failedResponses).toHaveLength(0);
+    expect(successfulResponses).toHaveLength(1);
   });
 });
 

--- a/src/v0/destinations/tiktok_audience/recordTransform.ts
+++ b/src/v0/destinations/tiktok_audience/recordTransform.ts
@@ -26,7 +26,7 @@ import {
   handleRtTfSingleEventError,
   isDefinedAndNotNullAndNotEmpty,
 } from '../../util';
-import { validateHashingConsistency } from '../../util/audienceUtils';
+import { HashingType, validateHashingConsistency } from '../../util/audienceUtils';
 import stats from '../../../util/stats';
 
 function prepareIdentifiersPayload(event: TiktokAudienceRecordRequest): IdentifiersPayload {
@@ -80,12 +80,24 @@ function prepareIdentifiersPayload(event: TiktokAudienceRecordRequest): Identifi
       throw new Error(`Invalid identifier key ${fieldName} for TikTok Audience.`);
     }
     if (value) {
-      validateHashingConsistency(fieldName, value, {
-        workspaceId: metadata.workspaceId,
-        id: destination.ID,
-        type: DESTINATION_TYPE,
-        config: { isHashRequired },
-      });
+      let hashingType: HashingType = HashingType.NONE;
+      if (SHA256_TRAITS.includes(fieldName)) {
+        hashingType = HashingType.SHA256;
+      } else if (MD5_TRAITS.includes(fieldName)) {
+        hashingType = HashingType.MD5;
+      }
+
+      validateHashingConsistency(
+        fieldName,
+        value,
+        {
+          workspaceId: metadata.workspaceId,
+          id: destination.ID,
+          type: DESTINATION_TYPE,
+          config: { isHashRequired },
+        },
+        hashingType,
+      );
 
       if (isHashRequired) {
         const normalizedFieldValue = normalizedValue(fieldName, value);

--- a/src/v0/util/audienceUtils.test.ts
+++ b/src/v0/util/audienceUtils.test.ts
@@ -1,6 +1,6 @@
 import sha256 from 'sha256';
 import { InstrumentationError, hashToSha256 } from '@rudderstack/integrations-lib';
-import { processAudienceRecord, AudienceField } from './audienceUtils';
+import { processAudienceRecord, AudienceField, HashingType } from './audienceUtils';
 
 jest.mock('../../util/stats', () => ({
   increment: jest.fn(),
@@ -31,18 +31,18 @@ const makeDestination = (
 const emailField: AudienceField = {
   normalize: (v) => v.toLowerCase().trim(),
   validate: (v) => v.includes('@'),
-  hashable: true,
+  hashingType: HashingType.SHA256,
 };
 
 const phoneField: AudienceField = {
   normalize: (v) => v.replace(/\D/g, ''),
   validate: (v) => v.length >= 7,
-  hashable: true,
+  hashingType: HashingType.SHA256,
 };
 
 const idField: AudienceField = {
   normalize: (v) => v,
-  hashable: false,
+  hashingType: HashingType.NONE,
 };
 
 beforeEach(() => {
@@ -80,7 +80,7 @@ describe('processAudienceRecord', () => {
     it('drops fields that normalize to an empty string', () => {
       const emptyNormalize: AudienceField = {
         normalize: () => '',
-        hashable: false,
+        hashingType: HashingType.NONE,
       };
       const result = processAudienceRecord(
         { email: 'user@example.com' },
@@ -93,7 +93,7 @@ describe('processAudienceRecord', () => {
       const result = processAudienceRecord(
         { age: 42 },
         {
-          fieldConfigs: { age: { normalize: (v) => v, hashable: false } },
+          fieldConfigs: { age: { normalize: (v) => v, hashingType: HashingType.NONE } },
           destination: makeDestination(),
         },
       );
@@ -182,7 +182,7 @@ describe('processAudienceRecord', () => {
     });
 
     it('uses a permissive default validator for fields without validate function', () => {
-      const noValidate: AudienceField = { normalize: (v) => v, hashable: false };
+      const noValidate: AudienceField = { normalize: (v) => v, hashingType: HashingType.NONE };
       const result = processAudienceRecord(
         { custom: 'anything' },
         { fieldConfigs: { custom: noValidate }, destination: makeDestination() },
@@ -196,12 +196,14 @@ describe('processAudienceRecord', () => {
   });
 
   describe('hashing consistency validation', () => {
-    const hashedValue = 'b94d27b9934d3e08a52e52d7da7dabfac484efe04294e576ca48e1cb0d7d6267'; // 64 hex chars
     const plaintextEmail = 'user@example.com';
+    const sha256HashedEmail = hashToSha256(plaintextEmail);
+    const sha512HashedEmail = createHash('sha512').update(plaintextEmail).digest('hex');
+    const md5HashedEmail = md5(plaintextEmail);
 
     it('emits audience_hashing_inconsistency metric when hashing ON but value already hashed', () => {
       processAudienceRecord(
-        { email: hashedValue },
+        { email: sha256HashedEmail },
         {
           fieldConfigs: { email: emailField },
           destination: makeDestination({ isHashRequired: true }),
@@ -237,7 +239,7 @@ describe('processAudienceRecord', () => {
       process.env.AUDIENCE_HASHING_VALIDATION_ENABLED = 'true';
       expect(() =>
         processAudienceRecord(
-          { email: hashedValue },
+          { email: sha256HashedEmail },
           {
             fieldConfigs: { email: emailField },
             destination: makeDestination({ isHashRequired: true }),
@@ -246,7 +248,7 @@ describe('processAudienceRecord', () => {
       ).toThrow(InstrumentationError);
       expect(() =>
         processAudienceRecord(
-          { email: hashedValue },
+          { email: sha256HashedEmail },
           {
             fieldConfigs: { email: emailField },
             destination: makeDestination({ isHashRequired: true }),
@@ -270,7 +272,7 @@ describe('processAudienceRecord', () => {
 
     it('does not emit hashing inconsistency metric for non-hashable fields', () => {
       processAudienceRecord(
-        { extern_id: hashedValue },
+        { extern_id: sha256HashedEmail },
         {
           fieldConfigs: { extern_id: idField },
           destination: makeDestination({ isHashRequired: true }),
@@ -298,7 +300,7 @@ describe('processAudienceRecord', () => {
 
     it('does not emit metric when hashing OFF and value is pre-hashed (consistent)', () => {
       processAudienceRecord(
-        { email: hashedValue },
+        { email: sha256HashedEmail },
         {
           fieldConfigs: { email: emailField },
           destination: makeDestination({ isHashRequired: false }),
@@ -308,6 +310,57 @@ describe('processAudienceRecord', () => {
         'audience_hashing_inconsistency',
         expect.anything(),
       );
+    });
+
+    it('dont throw error when hashing type is sha256 and value is already hashed', () => {
+      process.env.AUDIENCE_HASHING_VALIDATION_ENABLED = 'true';
+
+      const emailField: AudienceField = {
+        normalize: (v) => v,
+        hashingType: HashingType.SHA256,
+      };
+      const result = processAudienceRecord(
+        { email: sha256HashedEmail },
+        {
+          fieldConfigs: { email: emailField },
+          destination: makeDestination({ isHashRequired: false }),
+        },
+      );
+      expect(result.email).toBe(sha256HashedEmail);
+    });
+
+    it('dont throw error when hashing type is sha512 and value is already hashed', () => {
+      process.env.AUDIENCE_HASHING_VALIDATION_ENABLED = 'true';
+
+      const emailField: AudienceField = {
+        normalize: (v) => v,
+        hashingType: HashingType.SHA512,
+      };
+      const result = processAudienceRecord(
+        { email: sha512HashedEmail },
+        {
+          fieldConfigs: { email: emailField },
+          destination: makeDestination({ isHashRequired: false }),
+        },
+      );
+      expect(result.email).toBe(sha512HashedEmail);
+    });
+
+    it('dont throw error when hashing type is md5 and value is already hashed', () => {
+      process.env.AUDIENCE_HASHING_VALIDATION_ENABLED = 'true';
+
+      const emailField: AudienceField = {
+        normalize: (v) => v,
+        hashingType: HashingType.MD5,
+      };
+      const result = processAudienceRecord(
+        { email: md5HashedEmail },
+        {
+          fieldConfigs: { email: emailField },
+          destination: makeDestination({ isHashRequired: false }),
+        },
+      );
+      expect(result.email).toBe(md5HashedEmail);
     });
   });
 
@@ -351,64 +404,5 @@ describe('processAudienceRecord', () => {
     });
   });
 
-  describe('hashing type', () => {
-    const plaintextEmail = 'user@example.com';
-    const sha256HashedEmail = hashToSha256(plaintextEmail);
-    const sha512HashedEmail = createHash('sha512').update(plaintextEmail).digest('hex');
-    const md5HashedEmail = md5(plaintextEmail);
-
-    it('hashes the value using sha256 when hashing type is sha256', () => {
-      process.env.AUDIENCE_HASHING_VALIDATION_ENABLED = 'true';
-
-      const emailField: AudienceField = {
-        normalize: (v) => v,
-        hashable: true,
-        hashingType: 'sha256',
-      };
-      const result = processAudienceRecord(
-        { email: sha256HashedEmail },
-        {
-          fieldConfigs: { email: emailField },
-          destination: makeDestination({ isHashRequired: false }),
-        },
-      );
-      expect(result.email).toBe(sha256HashedEmail);
-    });
-
-    it('hashes the value using sha512 when hashing type is sha512', () => {
-      process.env.AUDIENCE_HASHING_VALIDATION_ENABLED = 'true';
-
-      const emailField: AudienceField = {
-        normalize: (v) => v,
-        hashable: true,
-        hashingType: 'sha512',
-      };
-      const result = processAudienceRecord(
-        { email: sha512HashedEmail },
-        {
-          fieldConfigs: { email: emailField },
-          destination: makeDestination({ isHashRequired: false }),
-        },
-      );
-      expect(result.email).toBe(sha512HashedEmail);
-    });
-
-    it('hashes the value using md5 when hashing type is md5', () => {
-      process.env.AUDIENCE_HASHING_VALIDATION_ENABLED = 'true';
-
-      const emailField: AudienceField = {
-        normalize: (v) => v,
-        hashable: true,
-        hashingType: 'md5',
-      };
-      const result = processAudienceRecord(
-        { email: md5HashedEmail },
-        {
-          fieldConfigs: { email: emailField },
-          destination: makeDestination({ isHashRequired: false }),
-        },
-      );
-      expect(result.email).toBe(md5HashedEmail);
-    });
-  });
+  describe('hashing type', () => {});
 });

--- a/src/v0/util/audienceUtils.test.ts
+++ b/src/v0/util/audienceUtils.test.ts
@@ -403,6 +403,4 @@ describe('processAudienceRecord', () => {
       expect(result.custom).toBe('value');
     });
   });
-
-  describe('hashing type', () => {});
 });

--- a/src/v0/util/audienceUtils.test.ts
+++ b/src/v0/util/audienceUtils.test.ts
@@ -1,5 +1,5 @@
 import sha256 from 'sha256';
-import { InstrumentationError } from '@rudderstack/integrations-lib';
+import { InstrumentationError, hashToSha256 } from '@rudderstack/integrations-lib';
 import { processAudienceRecord, AudienceField } from './audienceUtils';
 
 jest.mock('../../util/stats', () => ({
@@ -7,6 +7,8 @@ jest.mock('../../util/stats', () => ({
 }));
 
 import stats from '../../util/stats';
+import { createHash } from 'crypto';
+import md5 from 'md5';
 
 const mockStatsIncrement = stats.increment as jest.Mock;
 
@@ -346,6 +348,67 @@ describe('processAudienceRecord', () => {
       );
       expect(result.email).toBe(sha256('user@example.com'));
       expect(result.custom).toBe('value');
+    });
+  });
+
+  describe('hashing type', () => {
+    const plaintextEmail = 'user@example.com';
+    const sha256HashedEmail = hashToSha256(plaintextEmail);
+    const sha512HashedEmail = createHash('sha512').update(plaintextEmail).digest('hex');
+    const md5HashedEmail = md5(plaintextEmail);
+
+    it('hashes the value using sha256 when hashing type is sha256', () => {
+      process.env.AUDIENCE_HASHING_VALIDATION_ENABLED = 'true';
+
+      const emailField: AudienceField = {
+        normalize: (v) => v,
+        hashable: true,
+        hashingType: 'sha256',
+      };
+      const result = processAudienceRecord(
+        { email: sha256HashedEmail },
+        {
+          fieldConfigs: { email: emailField },
+          destination: makeDestination({ isHashRequired: false }),
+        },
+      );
+      expect(result.email).toBe(sha256HashedEmail);
+    });
+
+    it('hashes the value using sha512 when hashing type is sha512', () => {
+      process.env.AUDIENCE_HASHING_VALIDATION_ENABLED = 'true';
+
+      const emailField: AudienceField = {
+        normalize: (v) => v,
+        hashable: true,
+        hashingType: 'sha512',
+      };
+      const result = processAudienceRecord(
+        { email: sha512HashedEmail },
+        {
+          fieldConfigs: { email: emailField },
+          destination: makeDestination({ isHashRequired: false }),
+        },
+      );
+      expect(result.email).toBe(sha512HashedEmail);
+    });
+
+    it('hashes the value using md5 when hashing type is md5', () => {
+      process.env.AUDIENCE_HASHING_VALIDATION_ENABLED = 'true';
+
+      const emailField: AudienceField = {
+        normalize: (v) => v,
+        hashable: true,
+        hashingType: 'md5',
+      };
+      const result = processAudienceRecord(
+        { email: md5HashedEmail },
+        {
+          fieldConfigs: { email: emailField },
+          destination: makeDestination({ isHashRequired: false }),
+        },
+      );
+      expect(result.email).toBe(md5HashedEmail);
     });
   });
 });

--- a/src/v0/util/audienceUtils.ts
+++ b/src/v0/util/audienceUtils.ts
@@ -10,7 +10,7 @@ export enum HashingType {
   NONE = 'NONE',
 }
 
-export const HashingTypeToRegex = {
+const HashingTypeToRegex = {
   [HashingType.SHA256]: /^[\dA-Fa-f]{64}$/,
   [HashingType.SHA512]: /^[\dA-Fa-f]{128}$/,
   [HashingType.MD5]: /^[\dA-Fa-f]{32}$/,
@@ -43,16 +43,7 @@ function isHashingValidationEnabled(): boolean {
 }
 
 function isAlreadyHashedValidation(sourceValue: string, hashingType: HashingType): boolean {
-  switch (hashingType) {
-    case HashingType.SHA256:
-      return HashingTypeToRegex[HashingType.SHA256].test(sourceValue);
-    case HashingType.SHA512:
-      return HashingTypeToRegex[HashingType.SHA512].test(sourceValue);
-    case HashingType.MD5:
-      return HashingTypeToRegex[HashingType.MD5].test(sourceValue);
-    default:
-      return false;
-  }
+  return HashingTypeToRegex[hashingType]?.test(sourceValue) ?? false;
 }
 
 /**

--- a/src/v0/util/audienceUtils.ts
+++ b/src/v0/util/audienceUtils.ts
@@ -3,14 +3,25 @@ import { InstrumentationError } from '@rudderstack/integrations-lib';
 import stats from '../../util/stats';
 import { isDefinedAndNotNull } from '.';
 
-export interface AudienceField {
-  normalize: ((v: string) => string) | undefined;
-  validate?: (normalized: string) => boolean;
-  /** Whether this field should be hashed when hashing is enabled */
-  hashable: boolean;
+export enum HashingType {
+  SHA256 = 'SHA256',
+  SHA512 = 'SHA512',
+  MD5 = 'MD5',
+  NONE = 'NONE',
 }
 
-export const HASHED_VALUE_REGEX = /^[\dA-Fa-f]{64}$/;
+export const HashingTypeToRegex = {
+  [HashingType.SHA256]: /^[\dA-Fa-f]{64}$/,
+  [HashingType.SHA512]: /^[\dA-Fa-f]{128}$/,
+  [HashingType.MD5]: /^[\dA-Fa-f]{32}$/,
+};
+
+export interface AudienceField {
+  hashingType: HashingType;
+  normalize: ((v: string) => string) | undefined;
+  validate?: (normalized: string) => boolean;
+}
+
 const PHONE_NUMBER_REGEX = /^\+?\d+$/;
 
 /**
@@ -31,6 +42,19 @@ function isHashingValidationEnabled(): boolean {
   return process.env.AUDIENCE_HASHING_VALIDATION_ENABLED === 'true';
 }
 
+function isAlreadyHashedValidation(sourceValue: string, hashingType: HashingType): boolean {
+  switch (hashingType) {
+    case HashingType.SHA256:
+      return HashingTypeToRegex[HashingType.SHA256].test(sourceValue);
+    case HashingType.SHA512:
+      return HashingTypeToRegex[HashingType.SHA512].test(sourceValue);
+    case HashingType.MD5:
+      return HashingTypeToRegex[HashingType.MD5].test(sourceValue);
+    default:
+      return false;
+  }
+}
+
 /**
  * Validates that the hashing configuration is consistent with the actual data.
  * Emits a metric when inconsistency is detected.
@@ -40,10 +64,11 @@ export const validateHashingConsistency = (
   propertyName: string,
   sourceValue: string,
   destination: AudienceDestination,
+  hashingType: HashingType,
 ): void => {
   const { workspaceId, id: destinationId, type: destType, config } = destination;
   const { isHashRequired } = config;
-  const isAlreadyHashed = HASHED_VALUE_REGEX.test(sourceValue);
+  const isAlreadyHashed = isAlreadyHashedValidation(sourceValue, hashingType);
   if (isHashRequired && isAlreadyHashed) {
     stats.increment('audience_hashing_inconsistency', {
       propertyName,
@@ -105,12 +130,12 @@ export const processAudienceRecord = (
 
     const fieldConfig = fieldConfigs[fieldName];
 
-    const isHashable = fieldConfig?.hashable;
+    const isHashable = fieldConfig?.hashingType && fieldConfig?.hashingType !== HashingType.NONE;
     const sourceValue = String(rawValue);
 
     // Hashing consistency check runs on the source value before normalization
     if (isHashable) {
-      validateHashingConsistency(fieldName, sourceValue, destination);
+      validateHashingConsistency(fieldName, sourceValue, destination, fieldConfig?.hashingType);
     }
 
     // Pre-hashed values are passed through as-is: skip normalization and validation

--- a/src/v0/util/audienceUtils.ts
+++ b/src/v0/util/audienceUtils.ts
@@ -42,10 +42,6 @@ function isHashingValidationEnabled(): boolean {
   return process.env.AUDIENCE_HASHING_VALIDATION_ENABLED === 'true';
 }
 
-function isAlreadyHashedValidation(sourceValue: string, hashingType: HashingType): boolean {
-  return HashingTypeToRegex[hashingType]?.test(sourceValue) ?? false;
-}
-
 /**
  * Validates that the hashing configuration is consistent with the actual data.
  * Emits a metric when inconsistency is detected.
@@ -59,7 +55,7 @@ export const validateHashingConsistency = (
 ): void => {
   const { workspaceId, id: destinationId, type: destType, config } = destination;
   const { isHashRequired } = config;
-  const isAlreadyHashed = isAlreadyHashedValidation(sourceValue, hashingType);
+  const isAlreadyHashed = HashingTypeToRegex[hashingType]?.test(sourceValue) ?? false;
   if (isHashRequired && isAlreadyHashed) {
     stats.increment('audience_hashing_inconsistency', {
       propertyName,


### PR DESCRIPTION
🔒 Scanned for secrets using gitleaks 8.29.1

## What are the changes introduced in this PR?

Fix hashing-consistency validation to be **hash-type aware** (sha256/sha512/md5), so we don’t incorrectly flag or mishandle pre-hashed identifiers that aren’t SHA-256.
## Changes
- **`src/v0/util/audienceUtils.ts`**
  - Introduced `HashingType = 'sha256' | 'sha512' | 'md5'` and optional `hashingType` on `AudienceField`.
  - Replaced the single `HASHED_VALUE_REGEX` with type-specific regexes:
    - `SHA256_HASHED_VALUE_REGEX` (64 hex)
    - `SHA512_HASHED_VALUE_REGEX` (128 hex)
    - `MD5_HASHED_VALUE_REGEX` (32 hex)
  - Updated `validateHashingConsistency(propertyName, sourceValue, destination, hashingType?)` to detect “already hashed” correctly per hashing type (defaulting to sha256 when not specified).
  - Updated `processAudienceRecord` to pass `fieldConfig.hashingType` into `validateHashingConsistency`.


## What is the related Linear task?

Resolves INT-6139