### PR TITLE
chore: use actions/checkout for cross-repo checkouts in deploy workflows

### DIFF
--- a/.github/workflows/prepare-for-prod-dt-deploy.yml
+++ b/.github/workflows/prepare-for-prod-dt-deploy.yml
@@ -104,6 +104,7 @@ jobs:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
           gh repo clone rudderlabs/rudder-devops
+          git -C rudder-devops remote set-url origin https://x-access-token:${GH_TOKEN}@github.com/rudderlabs/rudder-devops.git
 
       - name: Extract branch name
         id: extract_branch_name
@@ -203,6 +204,7 @@ jobs:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
           gh repo clone rudderlabs/rudderstack-operator
+          git -C rudderstack-operator remote set-url origin https://x-access-token:${GH_TOKEN}@github.com/rudderlabs/rudderstack-operator.git
 
       - name: Update helm charts and raise pull request for dedicated transformer from operator
         env:

--- a/.github/workflows/prepare-for-prod-dt-deploy.yml
+++ b/.github/workflows/prepare-for-prod-dt-deploy.yml
@@ -99,12 +99,12 @@ jobs:
         run: |
           echo "Transformer: $TAG_NAME"
 
-      - name: Clone Devops Repo
-        env:
-          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
-        run: |
-          gh repo clone rudderlabs/rudder-devops
-          git -C rudder-devops remote set-url origin https://x-access-token:${GH_TOKEN}@github.com/rudderlabs/rudder-devops.git
+      - name: Checkout Devops Repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: rudderlabs/rudder-devops
+          token: ${{ steps.generate-token.outputs.token }}
+          path: rudder-devops
 
       - name: Extract branch name
         id: extract_branch_name
@@ -199,12 +199,12 @@ jobs:
           cd rudder-devops
           gh pr create --fill
 
-      - name: Clone Operator Repo
-        env:
-          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
-        run: |
-          gh repo clone rudderlabs/rudderstack-operator
-          git -C rudderstack-operator remote set-url origin https://x-access-token:${GH_TOKEN}@github.com/rudderlabs/rudderstack-operator.git
+      - name: Checkout Operator Repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: rudderlabs/rudderstack-operator
+          token: ${{ steps.generate-token.outputs.token }}
+          path: rudderstack-operator
 
       - name: Update helm charts and raise pull request for dedicated transformer from operator
         env:

--- a/.github/workflows/prepare-for-prod-ut-deploy.yml
+++ b/.github/workflows/prepare-for-prod-ut-deploy.yml
@@ -96,12 +96,12 @@ jobs:
         run: |
           echo "User Transformer: $UT_TAG_NAME"
 
-      - name: Clone Devops Repo
-        env:
-          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
-        run: |
-          gh repo clone rudderlabs/rudder-devops
-          git -C rudder-devops remote set-url origin https://x-access-token:${GH_TOKEN}@github.com/rudderlabs/rudder-devops.git
+      - name: Checkout Devops Repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: rudderlabs/rudder-devops
+          token: ${{ steps.generate-token.outputs.token }}
+          path: rudder-devops
 
       - name: Extract branch name
         id: extract_branch_name

--- a/.github/workflows/prepare-for-prod-ut-deploy.yml
+++ b/.github/workflows/prepare-for-prod-ut-deploy.yml
@@ -101,6 +101,7 @@ jobs:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
           gh repo clone rudderlabs/rudder-devops
+          git -C rudder-devops remote set-url origin https://x-access-token:${GH_TOKEN}@github.com/rudderlabs/rudder-devops.git
 
       - name: Extract branch name
         id: extract_branch_name

--- a/.github/workflows/prepare-for-staging-deploy.yml
+++ b/.github/workflows/prepare-for-staging-deploy.yml
@@ -123,11 +123,17 @@ jobs:
           echo "Transformer: $TAG_NAME"
           echo "User Transformer: $UT_TAG_NAME"
 
+      - name: Checkout Devops Repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: rudderlabs/rudder-devops
+          token: ${{ steps.generate-token.outputs.token }}
+          path: rudder-devops
+
       - name: Update Helm Charts and Raise Pull Request
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
-          gh repo clone rudderlabs/rudder-devops
           cd rudder-devops
           git config user.name "GitHub Actions"
           git config user.email "noreply@github.com"


### PR DESCRIPTION
## Summary
- \`git push\` in prod and staging deploy workflows was failing with \`fatal: could not read Username for 'https://github.com'\`
- Root cause: \`gh repo clone\` clones via HTTPS but doesn't configure git credentials, so subsequent \`git push\` calls fail
- Fixed by replacing \`gh repo clone\` with \`actions/checkout\` (using \`repository\`, \`token\`, and \`path\` params), which automatically configures HTTPS auth

## Affected workflows
- \`prepare-for-prod-dt-deploy.yml\` — \`rudder-devops\` and \`rudderstack-operator\`
- \`prepare-for-prod-ut-deploy.yml\` — \`rudder-devops\`
- \`prepare-for-staging-deploy.yml\` — \`rudder-devops\`

## Test plan
- [ ] Verify the next prod deploy workflow run completes the \`git push\` steps successfully
- [ ] Confirm PRs are created in \`rudder-devops\` and \`rudderstack-operator\` as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)