### PR TITLE
fix(facebook_lead_ads_native): add actual response to error log for debugging

### DIFF
--- a/src/sources/facebook_lead_ads_native/hydrate.test.ts
+++ b/src/sources/facebook_lead_ads_native/hydrate.test.ts
@@ -471,13 +471,14 @@ describe('Facebook Lead Ads Hydration', () => {
         '[facebook_lead_ads_native] Non-OK response from Facebook API',
         {
           status: 500,
-          response: JSON.stringify({
+          responseSchema: JSON.stringify({
             type: 'object',
             properties: {
               response: { type: 'object', properties: { some_field: { type: 'string' } } },
               status: { type: 'number' },
             },
           }),
+          response: { some_field: 'some_value' },
         },
       );
     });
@@ -500,13 +501,14 @@ describe('Facebook Lead Ads Hydration', () => {
         '[facebook_lead_ads_native] Non-OK response from Facebook API',
         {
           status: 500,
-          response: JSON.stringify({
+          responseSchema: JSON.stringify({
             type: 'object',
             properties: {
               response: { type: 'object', properties: {} },
               status: { type: 'number' },
             },
           }),
+          response: {},
         },
       );
     });
@@ -529,13 +531,14 @@ describe('Facebook Lead Ads Hydration', () => {
         '[facebook_lead_ads_native] Non-OK response from Facebook API',
         {
           status: 500,
-          response: JSON.stringify({
+          responseSchema: JSON.stringify({
             type: 'object',
             properties: {
               response: { type: 'string' },
               status: { type: 'number' },
             },
           }),
+          response: 'Internal Server Error',
         },
       );
     });
@@ -558,13 +561,14 @@ describe('Facebook Lead Ads Hydration', () => {
         '[facebook_lead_ads_native] Non-OK response from Facebook API',
         {
           status: 500,
-          response: JSON.stringify({
+          responseSchema: JSON.stringify({
             type: 'object',
             properties: {
               response: { type: 'object', properties: { error: { type: 'null' } } },
               status: { type: 'number' },
             },
           }),
+          response: { error: null },
         },
       );
     });

--- a/src/sources/facebook_lead_ads_native/hydrate.ts
+++ b/src/sources/facebook_lead_ads_native/hydrate.ts
@@ -112,7 +112,8 @@ async function fetchLeadData(
   }
   logger.error(`[facebook_lead_ads_native] Non-OK response from Facebook API`, {
     status: processedResponse.status,
-    response: JSON.stringify(JsonSchemaGenerator.generate(processedResponse)),
+    responseSchema: JSON.stringify(JsonSchemaGenerator.generate(processedResponse)),
+    response: processedResponse.response,
   });
   // This should never be reached since errorResponseHandler always throws for errors
   throw new Error('Unexpected: errorResponseHandler did not throw for non-OK response');


### PR DESCRIPTION
## Summary
- Renamed `response` field to `responseSchema` in the non-OK Facebook API error log to clarify it contains the JSON schema
- Added new `response` field with `processedResponse.response` to log the actual API response body for better debugging

## Test plan
- [ ] Verify error logs now include the actual response body when Facebook API returns a non-OK status

🤖 Generated with [Claude Code](https://claude.com/claude-code)