### PR TITLE
feat(snapchat): add brand field to contents array in CAPI v3 payload

### DIFF
--- a/src/v0/destinations/snapchat_conversion/transformV3.js
+++ b/src/v0/destinations/snapchat_conversion/transformV3.js
@@ -167,6 +167,9 @@ const buildBasePayload = (message, event) => {
 
   const contents = productsToContentsMapping(message);
   if (contents.length > 0) {
+    if (!payload.data[0].custom_data) {
+      payload.data[0].custom_data = {};
+    }
     payload.data[0].custom_data.contents = contents;
   }
   return payload;

--- a/src/v0/destinations/snapchat_conversion/utilsV3.js
+++ b/src/v0/destinations/snapchat_conversion/utilsV3.js
@@ -145,7 +145,6 @@ const productsToContentsMapping = (message) => {
       item_price: product?.price,
       quantity: product?.quantity,
       delivery_category: product?.delivery_category,
-      brand: product?.brand,
     });
 
   // Handle case where products array is empty or doesn't exist
@@ -160,6 +159,9 @@ const productsToContentsMapping = (message) => {
   products.forEach((product) => {
     if (isObject(product)) {
       const content = mapProductToContent(product);
+      if (product?.brand) {
+        content.brand = product.brand;
+      }
       if (!isEmptyObject(content)) {
         result.push(content);
       }

--- a/src/v0/destinations/snapchat_conversion/utilsV3.js
+++ b/src/v0/destinations/snapchat_conversion/utilsV3.js
@@ -145,6 +145,7 @@ const productsToContentsMapping = (message) => {
       item_price: product?.price,
       quantity: product?.quantity,
       delivery_category: product?.delivery_category,
+      brand: product?.brand,
     });
 
   // Handle case where products array is empty or doesn't exist


### PR DESCRIPTION
## What are the changes introduced in this PR?
Adds `brand` field mapping to Snapchat CAPI `contents` array for product events (PURCHASE, VIEW_CONTENT). Maps `properties.products[].brand` to `custom_data.contents[].brand`.

## What is the related Linear task?
Resolves INT-XXX

## Please explain the objectives of your changes below
**Customer request**: Snapchat rep directly requested this field be included in product events for improved targeting and campaign optimization.

Snapchat's official CAPI documentation includes `brand` within contents objects in their example code ([see docs](https://developers.snap.com/api/marketing-api/Conversions-API/UsingTheAPI#structure-of-json-body)), and this field is used by major integration partners (Segment, GTM server-side). Note: There's a discrepancy in Snapchat's docs - their Parameters page only lists 4 `contents` fields, but their example code and integrations use `brand`.

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?
No breaking changes. This adds an optional field to the contents array. Events without brand data will continue to work as before.

### Any new dependencies introduced with this change?
N/A

### Any new generic utility introduced or modified. Please explain the changes.
N/A

### Any technical or performance related pointers to consider with the change?
N/A

@coderabbitai review

<hr>

### Developer checklist
- [ ] My code follows the style guidelines of this project
- [ ] **No breaking changes are being introduced.**
- [ ] All related docs linked with the PR?
- [ ] All changes manually tested?
- [ ] Any documentation changes needed with this change?
- [ ] Is the PR limited to 10 file changes?
- [ ] Is the PR limited to one linear task?
- [ ] Are relevant unit and component test-cases added in **new readability format**?

### Reviewer checklist
- [ ] Is the type of change in the PR title appropriate as per the changes?
- [ ] Verified that there are no credentials or confidential data exposed with the changes.