### PR TITLE
fix(vuln): remediate GHA script injection

### DIFF
--- a/.github/workflows/build-pr-artifacts.yml
+++ b/.github/workflows/build-pr-artifacts.yml
@@ -36,8 +36,10 @@ jobs:
       # Replace problematic characters in branch name (like '/') with safe characters (like '.')
       - name: Generate Tag Names
         id: gen_tag_names
+        env:
+          HEAD_REF: ${{ github.head_ref }}
         run: |
-          tag_name=$(echo ${{ github.head_ref }} | tr "/" .)
+          tag_name=$(echo "$HEAD_REF" | tr "/" .)
           echo "Tag Name: branch-$tag_name"
           echo "tag_name=branch-$tag_name" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/build-push-docker-image.yml
+++ b/.github/workflows/build-push-docker-image.yml
@@ -53,13 +53,15 @@ jobs:
 
       - name: Check actor
         id: check
+        env:
+          GITHUB_ACTOR_NAME: ${{ github.actor }}
         run: |
-          if [[ "${{ github.actor }}" == "dependabot[bot]" ]]; then
+          if [[ "$GITHUB_ACTOR_NAME" == "dependabot[bot]" ]]; then
             echo "is_dependabot=true" >> $GITHUB_OUTPUT
             echo "Actor is dependabot[bot] - skipping certain steps"
           else
             echo "is_dependabot=false" >> $GITHUB_OUTPUT
-            echo "Actor is ${{ github.actor }} - proceeding normally"
+            echo "Actor is $GITHUB_ACTOR_NAME - proceeding normally"
           fi
 
   get_sha:

--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -37,8 +37,10 @@ jobs:
 
       - name: Extract Version
         id: extract-version
+        env:
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
-          branch_name="${{ github.event.pull_request.head.ref }}"
+          branch_name="$PR_HEAD_REF"
           version=${branch_name#hotfix-}
           version=${version#release/v}
 


### PR DESCRIPTION
Replaces direct ${{ github.* }} interpolation in run: blocks with env: indirection. Prevents script injection RCE via crafted branch names or other user-controlled inputs. Ref: SEC-93.