### PR TITLE
chore: add env flag to disable eventSchemaCache

### DIFF
--- a/src/util/eventValidation.js
+++ b/src/util/eventValidation.js
@@ -11,6 +11,7 @@ const logger = require('../logger');
 const trackingPlan = require('./trackingPlan');
 
 const SECONDS_IN_DAY = 60 * 60 * 24 * 1;
+const eventSchemaCacheDisabled = process.env.DISABLE_EVENT_SCHEMA_CACHE === 'true';
 const eventSchemaCache = new NodeCache();
 const ajv19Cache = new NodeCache({ useClones: false, stdTTL: SECONDS_IN_DAY });
 const ajv4Cache = new NodeCache({ useClones: false, stdTTL: SECONDS_IN_DAY });
@@ -182,10 +183,12 @@ async function validate(event) {
       }
     }
 
-    let validateEvent = eventSchemaCache.get(schemaHash);
+    let validateEvent = eventSchemaCacheDisabled ? undefined : eventSchemaCache.get(schemaHash);
     if (!validateEvent) {
       validateEvent = ajv.compile(eventSchema);
-      eventSchemaCache.set(schemaHash, validateEvent);
+      if (!eventSchemaCacheDisabled) {
+        eventSchemaCache.set(schemaHash, validateEvent);
+      }
     }
 
     const valid = validateEvent(event.message);


### PR DESCRIPTION
## What are the changes introduced in this PR?

Add an environment flag `DISABLE_EVENT_SCHEMA_CACHE` to bypass the `eventSchemaCache` (`NodeCache`) in `src/util/eventValidation.js`. When set to `true`, compiled AJV validators are no longer stored in or read from the external cache — AJV's internal schema deduplication handles caching instead.

## What is the related Linear task?

Resolves DAW-3236

## Please explain the objectives of your changes below

`eventSchemaCache` has no TTL and no `maxKeys`, so it grows unbounded over the lifetime of the process. Each entry is a compiled AJV validator function holding closures, schema references, and internal AJV metadata. The key cardinality is `tpId × version × eventType × eventName × draftVersion`, making this the highest-growth cache in the tracking plan validation path.

Additionally, `ajv.compile()` already caches compiled schemas internally, so `eventSchemaCache` is a duplicate layer that doubles memory usage for validators.

This env flag allows us to disable the cache in production to validate memory improvement before removing it entirely.

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

When `DISABLE_EVENT_SCHEMA_CACHE=true`, the `eventSchemaCache.get()` and `eventSchemaCache.set()` calls are skipped. `ajv.compile()` is called on every validation but AJV internally deduplicates compiled schemas, so there is no correctness impact and minimal performance impact.

When the env var is unset or any value other than `true`, behaviour is unchanged.

### Any new dependencies introduced with this change?

N/A

### Any new generic utility introduced or modified. Please explain the changes.

N/A

### Any technical or performance related pointers to consider with the change?

- AJV maintains its own internal compiled schema cache, so disabling `eventSchemaCache` does not mean schemas are recompiled from scratch every time.
- The `NodeCache` instance is still created but remains empty when the flag is enabled. Full removal can follow once memory improvement is validated.

@coderabbitai review

<hr>

### Developer checklist

- [x] My code follows the style guidelines of this project
- [x] **No breaking changes are being introduced.**
- [x] All related docs linked with the PR?
- [x] All changes manually tested?
- [ ] Any documentation changes needed with this change?
- [x] Is the PR limited to 10 file changes?
- [x] Is the PR limited to one linear task?
- [ ] Are relevant unit and component test-cases added in **new readability format**?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?
- [ ] Verified that there are no credentials or confidential data exposed with the changes.