### PR TITLE
chore: remove compiled schema from AJV instance after compile

### DIFF
--- a/src/util/eventValidation.js
+++ b/src/util/eventValidation.js
@@ -11,7 +11,7 @@ const logger = require('../logger');
 const trackingPlan = require('./trackingPlan');
 
 const SECONDS_IN_DAY = 60 * 60 * 24 * 1;
-const eventSchemaCache = new NodeCache();
+const eventSchemaCache = new NodeCache({ stdTTL: 2 * SECONDS_IN_DAY });
 const ajv19Cache = new NodeCache({ useClones: false, stdTTL: SECONDS_IN_DAY });
 const ajv4Cache = new NodeCache({ useClones: false, stdTTL: SECONDS_IN_DAY });
 const { isEmptyObject } = require('../v0/util');
@@ -186,6 +186,7 @@ async function validate(event) {
     if (!validateEvent) {
       validateEvent = ajv.compile(eventSchema);
       eventSchemaCache.set(schemaHash, validateEvent);
+      ajv.removeSchema(eventSchema);
     }
 
     const valid = validateEvent(event.message);

--- a/src/util/eventValidation.js
+++ b/src/util/eventValidation.js
@@ -11,7 +11,9 @@ const logger = require('../logger');
 const trackingPlan = require('./trackingPlan');
 
 const SECONDS_IN_DAY = 60 * 60 * 24 * 1;
-const eventSchemaCache = new NodeCache({ stdTTL: 2 * SECONDS_IN_DAY });
+const eventSchemaCacheTTL =
+  parseInt(process.env.EVENT_SCHEMA_CACHE_TTL_SECS, 10) || 2 * SECONDS_IN_DAY;
+const eventSchemaCache = new NodeCache({ stdTTL: eventSchemaCacheTTL });
 const ajv19Cache = new NodeCache({ useClones: false, stdTTL: SECONDS_IN_DAY });
 const ajv4Cache = new NodeCache({ useClones: false, stdTTL: SECONDS_IN_DAY });
 const { isEmptyObject } = require('../v0/util');
@@ -186,6 +188,9 @@ async function validate(event) {
     if (!validateEvent) {
       validateEvent = ajv.compile(eventSchema);
       eventSchemaCache.set(schemaHash, validateEvent);
+      // ajv.compile() stores the schema in ajv's internal _cache (Map) and refs (Object) on every call.
+      // Since eventSchemaCache already holds the compiled validator, ajv doesn't need to retain the schema.
+      // Without this cleanup, the ajv instance accumulates unbounded memory
       ajv.removeSchema(eventSchema);
     }
 


### PR DESCRIPTION
## What are the changes introduced in this PR?

After `ajv.compile(eventSchema)`, call `ajv.removeSchema(eventSchema)` to clean up AJV's internal `_cache` immediately. Also add a 2-day TTL to `eventSchemaCache` so it no longer grows unbounded.

## What is the related Linear task?

Resolves DAW-3248

## Please explain the objectives of your changes below

Every `ajv.compile()` call permanently adds the compiled schema to the AJV instance's internal `_cache` (ES6 Map) and `refs` (Object). Over the 1-day TTL of `ajvCache`, a single AJV instance accumulates every schema it has ever compiled — with no eviction. Meanwhile, `eventSchemaCache` (NodeCache) stores the same compiled validators with no TTL, meaning memory grows monotonically in two places.

Since event schemas are immutable for a given `(trackingPlanId, trackingPlanVersion)`, the compiled validator stored in `eventSchemaCache` is valid forever. AJV's internal `_cache` is only needed for the initial compile — never for re-lookup. By calling `removeSchema()` immediately after compile, the AJV instance stays lean while `eventSchemaCache` serves as the single source of truth.

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

- `ajv.removeSchema(eventSchema)` is called after every compile. The compiled validator function is self-contained and continues to work without AJV remembering the schema.
- `eventSchemaCache` now has a 2-day TTL (`stdTTL: 2 * SECONDS_IN_DAY`). Previously it had no TTL and entries lived forever. The 2-day TTL outlives the `ajvCache` 1-day TTL, so validators survive AJV instance rotation without recompilation. After 2 days, entries expire and are lazily recompiled on demand.

### Any new dependencies introduced with this change?

N/A

### Any new generic utility introduced or modified. Please explain the changes.

N/A

### Any technical or performance related pointers to consider with the change?

- **Memory**: AJV `_cache` no longer accumulates schemas. `eventSchemaCache` is now bounded by TTL. Duplicate storage (same validator in both AJV `_cache` and `eventSchemaCache`) is eliminated.
- **CPU**: No change for the common path (`eventSchemaCache` hit). On cache miss after TTL expiry, `ajv.compile()` runs as before. This is lazy and amortised.
- **`refs` leak**: `removeSchema(schemaObject)` cleans `_cache` but `refs` may retain an entry per compile. This is a minor residual — significantly less memory than the full `SchemaEnv` + validator closure that was previously retained in `_cache`.

@coderabbitai review

<hr>

### Developer checklist

- [x] My code follows the style guidelines of this project
- [x] **No breaking changes are being introduced.**
- [x] All related docs linked with the PR?
- [x] All changes manually tested?
- [ ] Any documentation changes needed with this change?
- [x] Is the PR limited to 10 file changes?
- [x] Is the PR limited to one linear task?
- [ ] Are relevant unit and component test-cases added in **new readability format**?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?
- [ ] Verified that there are no credentials or confidential data exposed with the changes.