### PR TITLE
fix: linkedin audince id as string or number

### DIFF
--- a/src/v0/destinations/linkedin_audience/config.ts
+++ b/src/v0/destinations/linkedin_audience/config.ts
@@ -16,8 +16,9 @@ export const FIELD_MAP = {
 } as const;
 
 const BASE_URL = 'https://api.linkedin.com/rest';
-export const USER_ENDPOINT = (audienceId: string) => `${BASE_URL}/dmpSegments/${audienceId}/users`;
+export const USER_ENDPOINT = (audienceId: string | number) =>
+  `${BASE_URL}/dmpSegments/${audienceId}/users`;
 export const USER_ENDPOINT_PATH = '/dmpSegments/<audienceId>/users';
-export const COMPANY_ENDPOINT = (audienceId: string) =>
+export const COMPANY_ENDPOINT = (audienceId: string | number) =>
   `${BASE_URL}/dmpSegments/${audienceId}/companies`;
 export const COMPANY_ENDPOINT_PATH = '/dmpSegments/<audienceId>/companies';

--- a/src/v0/destinations/linkedin_audience/types.ts
+++ b/src/v0/destinations/linkedin_audience/types.ts
@@ -7,7 +7,7 @@ const LinkedinAudienceConnectionSchema = z
       .object({
         destination: z
           .object({
-            audienceId: z.string({
+            audienceId: z.union([z.string(), z.number()], {
               required_error: 'audienceId is not present. Aborting',
             }),
             audienceType: z.enum(['user', 'company'], {
@@ -77,7 +77,7 @@ export type LinkedinAudiencePayload = {
 
 export type LinkedinAudienceConfigParams = {
   audienceType: string;
-  audienceId: string;
+  audienceId: string | number;
   accessToken: string;
   isHashRequired: boolean;
 };

--- a/src/v0/destinations/linkedin_audience/utils.ts
+++ b/src/v0/destinations/linkedin_audience/utils.ts
@@ -40,7 +40,7 @@ export function prepareUserIds(
   return userIds;
 }
 
-export function generateEndpoint(audienceType: string, audienceId: string) {
+export function generateEndpoint(audienceType: string, audienceId: string | number) {
   if (audienceType === 'user') {
     return { endpoint: USER_ENDPOINT(audienceId), endpointPath: USER_ENDPOINT_PATH };
   }

--- a/test/integrations/destinations/linkedin_audience/router/data-native.ts
+++ b/test/integrations/destinations/linkedin_audience/router/data-native.ts
@@ -1583,6 +1583,209 @@ export const nativeData = [
     },
   },
   {
+    id: 'linkedin_audience-validation-test-3',
+    name: 'linkedin_audience',
+    description: 'Record call : audienceId can be a number (coerced to string)',
+    scenario: 'Validation',
+    successCriteria: 'should pass with 200 status code and transformed message',
+    feature: 'router',
+    module: 'destination',
+    version: 'v0',
+    input: {
+      request: {
+        method: 'POST',
+        body: {
+          input: [
+            {
+              message: {
+                type: 'record',
+                action: 'insert',
+                fields: {
+                  firstName: 'Test',
+                  lastName: 'User',
+                  country: 'Dhaka',
+                  company: 'Rudderlabs',
+                },
+                channel: 'sources',
+                context: {
+                  sources: {
+                    job_id: 'randomJobId',
+                    version: 'local',
+                    job_run_id: 'jobRunId',
+                    task_run_id: 'taskRunId',
+                  },
+                },
+                recordId: '3',
+                rudderId: 'randomRudderId',
+                messageId: 'randomMessageId',
+                receivedAt: '2024-11-08T10:30:41.618+05:30',
+                request_ip: '[::1]',
+                identifiers: {
+                  sha256Email: 'random@rudderstack.com',
+                  sha512Email: 'random@rudderstack.com',
+                },
+              },
+              metadata: {
+                jobId: 1,
+                attemptNum: 1,
+                userId: 'default-userId',
+                sourceId: 'default-sourceId',
+                destinationId: 'default-destinationId',
+                workspaceId: 'workspace-disable-cdkv2',
+                secret: {
+                  accessToken: 'commonAccessToken',
+                },
+                dontBatch: false,
+              },
+              destination: {
+                ID: '123',
+                Name: 'Linkedin Audience',
+                DestinationDefinition: {
+                  ID: '2njmJIfG6JH3guvFHSjLQNiIYh5',
+                  Name: 'LINKEDIN_AUDIENCE',
+                  DisplayName: 'Linkedin Audience',
+                  Config: {},
+                },
+                Config: {
+                  connectionMode: 'cloud',
+                  rudderAccountId: '2nmIV6FMXvyyqRM9Ifj8V92yElu',
+                },
+                Enabled: true,
+                WorkspaceID: 'workspace-disable-cdkv2',
+                Transformations: [],
+              },
+              connection: {
+                sourceId: 'randomSourceId',
+                destinationId: 'randomDestinationId',
+                enabled: true,
+                config: {
+                  destination: {
+                    accountId: 512315509,
+                    audienceId: 32589526,
+                    audienceType: 'user',
+                    createAudience: 'no',
+                    eventType: 'record',
+                    fieldMappings: [
+                      {
+                        from: 'name',
+                        to: 'firstName',
+                      },
+                      {
+                        from: 'name',
+                        to: 'lastName',
+                      },
+                    ],
+                    identifierMappings: [
+                      {
+                        from: 'email',
+                        to: 'sha256Email',
+                      },
+                      {
+                        from: 'email',
+                        to: 'sha512Email',
+                      },
+                    ],
+                    isHashRequired: true,
+                  },
+                  source: {},
+                },
+              },
+            },
+          ],
+          destType: 'linkedin_audience',
+        },
+      },
+    },
+    output: {
+      response: {
+        status: 200,
+        body: {
+          output: [
+            {
+              batched: true,
+              batchedRequest: {
+                body: {
+                  FORM: {},
+                  JSON: {
+                    elements: [
+                      {
+                        action: 'ADD',
+                        company: 'Rudderlabs',
+                        country: 'Dhaka',
+                        firstName: 'Test',
+                        lastName: 'User',
+                        userIds: [
+                          {
+                            idType: 'SHA256_EMAIL',
+                            idValue:
+                              '52ac4b9ef8f745e007c19fac81ddb0a3f50b20029f6699ca1406225fc217f392',
+                          },
+                          {
+                            idType: 'SHA512_EMAIL',
+                            idValue:
+                              '631372c5eafe80f3fe1b5d067f6a1870f1f04a0f0c0d9298eeaa20b9e54224da9588e3164d2ec6e2a5545a5299ed7df563e4a60315e6782dfa7db4de6b1c5326',
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                  JSON_ARRAY: {},
+                  XML: {},
+                },
+                endpoint: 'https://api.linkedin.com/rest/dmpSegments/32589526/users',
+                endpointPath: '/dmpSegments/<audienceId>/users',
+                files: {},
+                headers: {
+                  Authorization: 'Bearer commonAccessToken',
+                  'Content-Type': 'application/json',
+                  'LinkedIn-Version': '202509',
+                  'X-RestLi-Method': 'BATCH_CREATE',
+                  'X-Restli-Protocol-Version': '2.0.0',
+                },
+                method: 'POST',
+                params: {},
+                type: 'REST',
+                version: '1',
+              },
+              destination: {
+                ID: '123',
+                Name: 'Linkedin Audience',
+                DestinationDefinition: {
+                  ID: '2njmJIfG6JH3guvFHSjLQNiIYh5',
+                  Name: 'LINKEDIN_AUDIENCE',
+                  DisplayName: 'Linkedin Audience',
+                  Config: {},
+                },
+                Config: {
+                  connectionMode: 'cloud',
+                  rudderAccountId: '2nmIV6FMXvyyqRM9Ifj8V92yElu',
+                },
+                Enabled: true,
+                WorkspaceID: 'workspace-disable-cdkv2',
+                Transformations: [],
+              },
+              metadata: [
+                {
+                  jobId: 1,
+                  attemptNum: 1,
+                  userId: 'default-userId',
+                  sourceId: 'default-sourceId',
+                  destinationId: 'default-destinationId',
+                  workspaceId: 'workspace-disable-cdkv2',
+                  secret: {
+                    accessToken: 'commonAccessToken',
+                  },
+                  dontBatch: false,
+                },
+              ],
+              statusCode: 200,
+            },
+          ],
+        },
+      },
+    },
+  },
+  {
     id: 'linkedin_audience-validation-test-4',
     name: 'linkedin_audience',
     description: 'Record call : Access Token is missing in metadata secret',


### PR DESCRIPTION
🔒 Scanned for secrets using gitleaks 8.29.1

## What are the changes introduced in this PR?

## Summary
Allows **LinkedIn Audience** `audienceId` to be provided as either a **string or number**, updates endpoint builders/util types accordingly, and adds a router fixture to validate numeric `audienceId` works end-to-end.

- In case of creating Audience flow, we are getting audienceID as a number.
- In case of existing Audience flow, we are getting audienceID as a string.

Since the existing CDK flow is working, keep it as it is. We can fix the UI as well later to send it as a string only if needed.

## What is the related Linear task?

- Resolves INT-6199
