### PR TITLE
fix: add validation to posthog to fail events more than 1mb

### DIFF
--- a/src/v0/destinations/posthog/config.ts
+++ b/src/v0/destinations/posthog/config.ts
@@ -42,4 +42,8 @@ const PROPERTY = {
 
 const MAPPING_CONFIG = getMappingConfig({ ...CONFIG_CATEGORIES, PROPERTY }, __dirname);
 
-export { DEFAULT_BASE_ENDPOINT, CONFIG_CATEGORIES, MAPPING_CONFIG, PROPERTY };
+// PostHog's Kafka producer defaults to message.max.bytes = 1,000,000. To keep headroom of 100kb we kept the limit to 900_000
+// https://posthog.com/docs/data/ingestion-warnings
+const MAX_EVENT_SIZE_BYTES = 900_000;
+
+export { DEFAULT_BASE_ENDPOINT, CONFIG_CATEGORIES, MAPPING_CONFIG, PROPERTY, MAX_EVENT_SIZE_BYTES };

--- a/src/v0/destinations/posthog/config.ts
+++ b/src/v0/destinations/posthog/config.ts
@@ -43,9 +43,8 @@ const PROPERTY = {
 const MAPPING_CONFIG = getMappingConfig({ ...CONFIG_CATEGORIES, PROPERTY }, __dirname);
 
 // PostHog documents a 1 MB event size limit, but through trial and error we found
-// that events under 1 MB are also rejected. PostHog's Kafka producer defaults to
-// message.max.bytes = 1,000,000 and Kafka adds framing overhead on top of the payload.
-// To keep headroom we set the limit to 900,000 bytes (~100 KB buffer).
+// that events under 1 MB are also rejected. To keep headroom we set the limit to
+// 900,000 bytes (~100 KB buffer).
 // https://posthog.com/docs/data/ingestion-warnings
 const MAX_EVENT_SIZE_BYTES = 900_000;
 

--- a/src/v0/destinations/posthog/config.ts
+++ b/src/v0/destinations/posthog/config.ts
@@ -42,7 +42,10 @@ const PROPERTY = {
 
 const MAPPING_CONFIG = getMappingConfig({ ...CONFIG_CATEGORIES, PROPERTY }, __dirname);
 
-// PostHog's Kafka producer defaults to message.max.bytes = 1,000,000. To keep headroom of 100kb we kept the limit to 900_000
+// PostHog documents a 1 MB event size limit, but through trial and error we found
+// that events under 1 MB are also rejected. PostHog's Kafka producer defaults to
+// message.max.bytes = 1,000,000 and Kafka adds framing overhead on top of the payload.
+// To keep headroom we set the limit to 900,000 bytes (~100 KB buffer).
 // https://posthog.com/docs/data/ingestion-warnings
 const MAX_EVENT_SIZE_BYTES = 900_000;
 

--- a/src/v0/destinations/posthog/routerTransform.test.ts
+++ b/src/v0/destinations/posthog/routerTransform.test.ts
@@ -3,6 +3,7 @@ import { ChunkBatchStrategy } from '../../../services/destination/nativeBatching
 import type { Metadata, RudderMessage } from '../../../types/rudderEvents';
 import type { RouterTransformationRequestData } from '../../../types/destinationTransformation';
 import type { PostHogMessage, PostHogDestination } from './types';
+import { MAX_EVENT_SIZE_BYTES } from './config';
 
 // ---------------------------------------------------------------------------
 // Test helpers
@@ -83,6 +84,24 @@ describe('Integration', () => {
       const input = makeInput(1, 'track');
       delete (input.message as Record<string, unknown>).type;
       expect(() => integration.transformEvent(input)).toThrow('Event type is required');
+    });
+
+    it('throws when event size exceeds PostHog 1 MB limit', () => {
+      // Generate a large string that pushes the event body over 1 MB
+      const largeValue = 'x'.repeat(MAX_EVENT_SIZE_BYTES + 1);
+      const input = makeInput(1, 'track', {
+        properties: { hugeField: largeValue },
+      });
+      expect(() => integration.transformEvent(input)).toThrow(/exceeds PostHog's 1 MB limit/);
+    });
+
+    it('accepts events just under the 1 MB limit', () => {
+      // A moderately large payload that stays under 1 MB
+      const value = 'x'.repeat(500_000);
+      const input = makeInput(1, 'track', {
+        properties: { largeField: value },
+      });
+      expect(() => integration.transformEvent(input)).not.toThrow();
     });
   });
 

--- a/src/v0/destinations/posthog/routerTransform.ts
+++ b/src/v0/destinations/posthog/routerTransform.ts
@@ -1,4 +1,5 @@
 import { z, ZodType } from 'zod';
+import { InstrumentationError } from '@rudderstack/integrations-lib';
 import {
   BatchDestination,
   TransformedEvent,
@@ -7,6 +8,7 @@ import {
 import type { BatchStrategy } from '../../../services/destination/nativeBatching/types';
 import { processEvent } from './transform';
 import type { PostHogPayload, PostHogRouterRequest } from './types';
+import { MAX_EVENT_SIZE_BYTES } from './config';
 
 class PostHogIntegration extends BatchDestination<PostHogPayload> {
   transformEvent(input: PostHogRouterRequest): TransformedEvent<PostHogPayload> {
@@ -14,6 +16,14 @@ class PostHogIntegration extends BatchDestination<PostHogPayload> {
     // Strip api_key from the body — it belongs in the wrapBody wrapper
     // eslint-disable-next-line @typescript-eslint/naming-convention
     const { api_key, ...eventBody } = result.body.JSON!;
+
+    const eventSize = Buffer.byteLength(JSON.stringify(eventBody), 'utf8');
+    if (eventSize > MAX_EVENT_SIZE_BYTES) {
+      throw new InstrumentationError(
+        `Event size (${eventSize} bytes) exceeds PostHog's 1 MB limit. PostHog will reject this event with "maximum event size exceeded". Reduce the properties payload.`,
+      );
+    }
+
     return {
       body: eventBody,
       endpoint: result.endpoint,

--- a/src/v0/destinations/posthog/routerTransform.ts
+++ b/src/v0/destinations/posthog/routerTransform.ts
@@ -20,7 +20,7 @@ class PostHogIntegration extends BatchDestination<PostHogPayload> {
     const eventSize = Buffer.byteLength(JSON.stringify(eventBody), 'utf8');
     if (eventSize > MAX_EVENT_SIZE_BYTES) {
       throw new InstrumentationError(
-        `Event size (${eventSize} bytes) exceeds PostHog's 1 MB limit. PostHog will reject this event with "maximum event size exceeded". Reduce the properties payload.`,
+        `Event size (${eventSize} bytes) exceeds PostHog's 1 MB limit. PostHog will reject this event with "maximum event size exceeded". Please reduce the size of the event properties to stay within the limit.`,
       );
     }
 


### PR DESCRIPTION
## What are the changes introduced in this PR?

Add validation to discard events with a size of more than 1mb. Though in the doc it is mentioned 1MB, but they are also failing with the events with ~1MB, so we kept the limit to 900000 bytes to have some headroom.

## What is the related Linear task?

Resolves INT-6222

## Please explain the objectives of your changes below

Put down any required details on the broader aspect of your changes. If there are any dependent changes, **mandatorily** mention them here

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

N/A

### Any new dependencies introduced with this change?

N/A

### Any new generic utility introduced or modified. Please explain the changes.

N/A

### Any technical or performance related pointers to consider with the change?

N/A

@coderabbitai review

<hr>

### Developer checklist

- [ ] My code follows the style guidelines of this project

- [ ] **No breaking changes are being introduced.**

- [ ] All related docs linked with the PR?

- [ ] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [ ] Is the PR limited to 10 file changes?

- [ ] Is the PR limited to one linear task?

- [ ] Are relevant unit and component test-cases added in **new readability format**?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.
