### PR TITLE
fix(fb_custom_audience): add accessToken config validation

### DIFF
--- a/src/v0/destinations/fb_custom_audience/recordTransform.ts
+++ b/src/v0/destinations/fb_custom_audience/recordTransform.ts
@@ -209,6 +209,9 @@ async function preparePayload(
 
   const cleanUserSchema = userSchema.map((field) => field.trim());
 
+  if (!isDefinedAndNotNullAndNotEmpty(accessToken)) {
+    throw new ConfigurationError('Missing required configuration field: accessToken');
+  }
   if (!isDefinedAndNotNullAndNotEmpty(audienceId)) {
     throw new ConfigurationError('Audience ID is a mandatory field');
   }

--- a/src/v0/destinations/fb_custom_audience/recordTransform.ts
+++ b/src/v0/destinations/fb_custom_audience/recordTransform.ts
@@ -209,9 +209,6 @@ async function preparePayload(
 
   const cleanUserSchema = userSchema.map((field) => field.trim());
 
-  if (!isDefinedAndNotNullAndNotEmpty(accessToken)) {
-    throw new ConfigurationError('Missing required configuration field: accessToken');
-  }
   if (!isDefinedAndNotNullAndNotEmpty(audienceId)) {
     throw new ConfigurationError('Audience ID is a mandatory field');
   }

--- a/src/v0/destinations/fb_custom_audience/transform.ts
+++ b/src/v0/destinations/fb_custom_audience/transform.ts
@@ -251,6 +251,11 @@ const process = (event: {
 }) => processEvent(event.message, event.destination, event.metadata?.workspaceId as string);
 
 const processRouterDest = async (inputs: FbRecordEvent[], reqMetadata: unknown) => {
+  const { accessToken } = inputs[0].destination.Config;
+  if (!isDefinedAndNotNullAndNotEmpty(accessToken)) {
+    throw new ConfigurationError('Missing required configuration field: accessToken');
+  }
+
   const respList: unknown[] = [];
   const groupedInputs = await groupByInBatches(inputs, (input) =>
     (input.message.type ?? '').toLowerCase(),

--- a/src/v0/destinations/fb_custom_audience/transform.ts
+++ b/src/v0/destinations/fb_custom_audience/transform.ts
@@ -173,13 +173,17 @@ const processEvent = (
   const respList: unknown[] = [];
   let toSendEvents: WrappedResponse[] = [];
   let { userSchema } = destination.Config;
-  const { isHashRequired, audienceId } = destination.Config;
+  const { isHashRequired, audienceId, accessToken } = destination.Config;
   if (!message.type) {
     throw new InstrumentationError('Message Type is not present. Aborting message.');
   }
 
   if (message.type.toLowerCase() !== 'audiencelist') {
     throw new InstrumentationError(` ${message.type} call is not supported `);
+  }
+
+  if (!isDefinedAndNotNullAndNotEmpty(accessToken)) {
+    throw new ConfigurationError('Missing required configuration field: accessToken');
   }
 
   if (!isDefinedAndNotNullAndNotEmpty(audienceId)) {

--- a/src/v0/destinations/fb_custom_audience/transform.ts
+++ b/src/v0/destinations/fb_custom_audience/transform.ts
@@ -183,7 +183,7 @@ const processEvent = (
   }
 
   if (!isDefinedAndNotNullAndNotEmpty(accessToken)) {
-    throw new ConfigurationError('Missing required configuration field: accessToken');
+    throw new ConfigurationError('Access Token is a mandatory field');
   }
 
   if (!isDefinedAndNotNullAndNotEmpty(audienceId)) {
@@ -253,7 +253,7 @@ const process = (event: {
 const processRouterDest = async (inputs: FbRecordEvent[], reqMetadata: unknown) => {
   const { accessToken } = inputs[0].destination.Config;
   if (!isDefinedAndNotNullAndNotEmpty(accessToken)) {
-    throw new ConfigurationError('Missing required configuration field: accessToken');
+    throw new ConfigurationError('Access Token is a mandatory field');
   }
 
   const respList: unknown[] = [];

--- a/test/integrations/destinations/fb_custom_audience/processor/data.ts
+++ b/test/integrations/destinations/fb_custom_audience/processor/data.ts
@@ -306,7 +306,7 @@ export const data = [
         status: 200,
         body: [
           {
-            error: 'Missing required configuration field: accessToken',
+            error: 'Access Token is a mandatory field',
             statTags: {
               destType: 'FB_CUSTOM_AUDIENCE',
               errorCategory: 'dataValidation',

--- a/test/integrations/destinations/fb_custom_audience/processor/data.ts
+++ b/test/integrations/destinations/fb_custom_audience/processor/data.ts
@@ -226,6 +226,103 @@ export const data = [
   },
   {
     name: 'fb_custom_audience',
+    description: 'Missing accessToken in config',
+    feature: 'processor',
+    module: 'destination',
+    version: 'v0',
+    input: {
+      request: {
+        body: [
+          {
+            message: {
+              userId: 'user 1',
+              anonymousId: 'anon-id-new',
+              type: 'audiencelist',
+              event: 'event1',
+              properties: {
+                listData: {
+                  add: [
+                    {
+                      EMAIL: 'shrouti@abc.com',
+                      DOBM: '2',
+                      DOBD: '13',
+                      DOBY: '2013',
+                      PHONE: '@09432457768',
+                      GEN: 'f',
+                      FI: 'Ms.',
+                      MADID: 'ABC',
+                      ZIP: 'ZIP ',
+                      ST: '123abc ',
+                      COUNTRY: 'IN',
+                    },
+                  ],
+                },
+              },
+              context: {
+                ip: '14.5.67.21',
+                library: {
+                  name: 'http',
+                },
+              },
+              timestamp: '2020-02-02T00:23:09.544Z',
+            },
+            destination: {
+              Config: {
+                accessToken: '',
+                userSchema: [
+                  'EMAIL',
+                  'DOBM',
+                  'DOBD',
+                  'DOBY',
+                  'PHONE',
+                  'GEN',
+                  'FI',
+                  'MADID',
+                  'ZIP',
+                  'ST',
+                  'COUNTRY',
+                ],
+                isHashRequired: false,
+                disableFormat: false,
+                audienceId: 'aud1',
+                isRaw: true,
+                type: 'UNKNOWN',
+                subType: 'ANYTHING',
+              },
+              Enabled: true,
+              Transformations: [],
+              IsProcessorEnabled: true,
+            },
+            libraries: [],
+            request: {
+              query: {},
+            },
+          },
+        ],
+      },
+    },
+    output: {
+      response: {
+        status: 200,
+        body: [
+          {
+            error: 'Missing required configuration field: accessToken',
+            statTags: {
+              destType: 'FB_CUSTOM_AUDIENCE',
+              errorCategory: 'dataValidation',
+              errorType: 'configuration',
+              feature: 'processor',
+              implementation: 'native',
+              module: 'destination',
+            },
+            statusCode: 400,
+          },
+        ],
+      },
+    },
+  },
+  {
+    name: 'fb_custom_audience',
     description: 'Audience ID Empty Event',
     feature: 'processor',
     module: 'destination',

--- a/test/integrations/destinations/fb_custom_audience/router/data.ts
+++ b/test/integrations/destinations/fb_custom_audience/router/data.ts
@@ -6,6 +6,7 @@ import {
   rETLRecordV2RouterRequestWithValueBasedAudience,
   rETLRecordV2RouterInvalidRequestWithValueBasedAudience,
   rETLRecordV2RouterInvalidRequestWithLookalikeValue,
+  rETLRecordV2RouterMissingAccessTokenRequest,
 } from './rETL';
 import { mockFns } from '../mocks';
 import { defaultAccessToken } from '../../../common/secrets';
@@ -1608,5 +1609,44 @@ export const data = [
       },
     },
     envOverrides: { FB_CUSTOM_AUDIENCE_PAYLOAD_IN_BODY: 'ALL' },
+  },
+  {
+    name: 'fb_custom_audience',
+    description: 'rETL record V2 missing accessToken tests',
+    scenario: 'Framework',
+    successCriteria: 'All the record V2 events should fail with missing accessToken error',
+    feature: 'router',
+    module: 'destination',
+    version: 'v0',
+    input: {
+      request: {
+        body: rETLRecordV2RouterMissingAccessTokenRequest,
+      },
+    },
+    output: {
+      response: {
+        status: 200,
+        body: {
+          output: [
+            {
+              metadata: [generateMetadata(1)],
+              batched: false,
+              statusCode: 400,
+              error: 'Missing required configuration field: accessToken',
+              statTags: {
+                errorCategory: 'dataValidation',
+                errorType: 'configuration',
+                destType: 'FB_CUSTOM_AUDIENCE',
+                module: 'destination',
+                implementation: 'native',
+                feature: 'router',
+                destinationId: 'default-destinationId',
+                workspaceId: 'default-workspaceId',
+              },
+            },
+          ],
+        },
+      },
+    },
   },
 ].map((d) => ({ ...d, mockFns }));

--- a/test/integrations/destinations/fb_custom_audience/router/data.ts
+++ b/test/integrations/destinations/fb_custom_audience/router/data.ts
@@ -1632,7 +1632,7 @@ export const data = [
               metadata: [generateMetadata(1)],
               batched: false,
               statusCode: 400,
-              error: 'Missing required configuration field: accessToken',
+              error: 'Access Token is a mandatory field',
               statTags: {
                 errorCategory: 'dataValidation',
                 errorType: 'configuration',

--- a/test/integrations/destinations/fb_custom_audience/router/rETL.ts
+++ b/test/integrations/destinations/fb_custom_audience/router/rETL.ts
@@ -55,6 +55,14 @@ const connectionWithValueBasedAudience: Connection = {
   },
 };
 
+const destinationV2MissingAccessToken: Destination = {
+  ...destinationV2,
+  Config: {
+    ...destinationV2.Config,
+    accessToken: '',
+  },
+};
+
 const missingAudienceIDConnection: Connection = {
   sourceId: '2MUWghI7u85n91dd1qzGyswpZan',
   destinationId: '1mMy5cqbtfuaKZv1IhVQKnBdVwe',
@@ -716,6 +724,35 @@ export const rETLRecordV1RouterRequest: RouterTransformationRequest = {
         type: 'record',
       },
       metadata: generateMetadata(7),
+    },
+  ],
+  destType: 'fb_custom_audience',
+};
+
+export const rETLRecordV2RouterMissingAccessTokenRequest: RouterTransformationRequest = {
+  input: [
+    {
+      destination: destinationV2MissingAccessToken,
+      connection: connection,
+      message: {
+        action: 'insert',
+        context: {
+          sources: {
+            job_run_id: 'cgiiurt8um7k7n5dq480',
+            task_run_id: 'cgiiurt8um7k7n5dq48g',
+            job_id: '2MUWghI7u85n91dd1qzGyswpZan',
+            version: '895/merge',
+          },
+        },
+        recordId: '2',
+        rudderId: '2',
+        identifiers: {
+          EMAIL: 'subscribed@eewrfrd.com',
+          FI: 'ghui',
+        },
+        type: 'record',
+      },
+      metadata: generateMetadata(1),
     },
   ],
   destType: 'fb_custom_audience',


### PR DESCRIPTION
## Summary
- Adds `accessToken` config validation for `fb_custom_audience` at the two entry points: `processRouterDest` (router) and `processEvent` (processor)
- Throws `ConfigurationError` with a clear message when `accessToken` is empty, instead of failing with a vague API error downstream
- Adds test cases for both processor and router paths covering the missing accessToken scenario

## Test plan
- [ ] Existing `fb_custom_audience` tests pass
- [ ] New processor test: empty `accessToken` returns 400 with `ConfigurationError`
- [ ] New router test: rETL record V2 with empty `accessToken` returns 400 with `ConfigurationError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)