### PR TITLE
chore(vuln): suppress dangerous-triggers false positive (SEC-162)

### DIFF
--- a/.github/workflows/update-ingestion-service.yml
+++ b/.github/workflows/update-ingestion-service.yml
@@ -1,6 +1,7 @@
 name: Update Ingestion Service with Latest Transformer Version
 
 on:
+  # This workflow_run triggers on release completion — no untrusted code checkout.
   workflow_run: # zizmor: ignore[dangerous-triggers]
     workflows: ['Publish New GitHub Release']
     types:

--- a/.github/workflows/update-ingestion-service.yml
+++ b/.github/workflows/update-ingestion-service.yml
@@ -1,7 +1,7 @@
 name: Update Ingestion Service with Latest Transformer Version
 
 on:
-  workflow_run:
+  workflow_run: # zizmor: ignore[dangerous-triggers]
     workflows: ['Publish New GitHub Release']
     types:
       - completed


### PR DESCRIPTION
Suppresses zizmor dangerous-triggers false positive. This workflow_run triggers on release completion — no untrusted code checkout.