### PR TITLE
fix: handle 409 conflict as retryable error in intercom network handler

### DIFF
--- a/src/v0/destinations/intercom/networkHandler.js
+++ b/src/v0/destinations/intercom/networkHandler.js
@@ -3,7 +3,14 @@ const { prepareProxyRequest, httpSend } = require('../../../adapters/network');
 const { processAxiosResponse } = require('../../../adapters/utils/networkUtils');
 
 const errorResponseHandler = (destinationResponse, dest) => {
-  const { status } = destinationResponse;
+  const { status, response } = destinationResponse;
+  if (status === 409) {
+    throw new RetryableError(
+      `[Intercom Response Handler] Request failed for destination ${dest} with status: ${status}. ${JSON.stringify(response)}`,
+      500,
+      destinationResponse,
+    );
+  }
   if (status === 408) {
     throw new RetryableError(
       `[Intercom Response Handler] Request failed for destination ${dest} with status: ${status}`,

--- a/test/integrations/destinations/intercom/dataDelivery/business.ts
+++ b/test/integrations/destinations/intercom/dataDelivery/business.ts
@@ -271,7 +271,7 @@ export const testScenariosForV0API = [
     id: 'intercom_v0_other_scenario_5',
     name: 'intercom',
     description: '[Proxy v0 API] :: Scenario to test Conflict User Handling from Destination',
-    successCriteria: 'Should return 409 status code with error message',
+    successCriteria: 'Should return 500 status code with retryable error for 409 conflict',
     scenario: 'Business',
     feature: 'dataDelivery',
     module: 'destination',
@@ -291,21 +291,35 @@ export const testScenariosForV0API = [
     },
     output: {
       response: {
-        status: 409,
+        status: 500,
         body: {
           output: {
+            status: 500,
+            message:
+              '[Intercom Response Handler] Request failed for destination intercom with status: 409. {"type":"error.list","request_id":"request126","errors":[{"code":"conflict","message":"A contact matching those details already exists with id=test1"}]}',
             destinationResponse: {
-              errors: [
-                {
-                  code: 'conflict',
-                  message: 'A contact matching those details already exists with id=test1',
-                },
-              ],
-              request_id: 'request126',
-              type: 'error.list',
+              response: {
+                type: 'error.list',
+                request_id: 'request126',
+                errors: [
+                  {
+                    code: 'conflict',
+                    message: 'A contact matching those details already exists with id=test1',
+                  },
+                ],
+              },
+              status: 409,
             },
-            message: 'Request Processed Successfully',
-            status: 409,
+            statTags: {
+              destType: 'INTERCOM',
+              destinationId: 'default-destinationId',
+              errorCategory: 'network',
+              errorType: 'retryable',
+              feature: 'dataDelivery',
+              implementation: 'native',
+              module: 'destination',
+              workspaceId: 'default-workspaceId',
+            },
           },
         },
       },
@@ -543,7 +557,7 @@ export const testScenariosForV1API = [
     id: 'intercom_v1_other_scenario_5',
     name: 'intercom',
     description: '[Proxy v1 API] :: Scenario to test Conflict User Handling from Destination',
-    successCriteria: 'Should return 409 status code with error message',
+    successCriteria: 'Should return 500 status code with retryable error for 409 conflict',
     scenario: 'Business',
     feature: 'dataDelivery',
     module: 'destination',
@@ -569,7 +583,8 @@ export const testScenariosForV1API = [
         status: 200,
         body: {
           output: {
-            message: 'Request Processed Successfully',
+            message:
+              '[Intercom Response Handler] Request failed for destination intercom with status: 409. {"type":"error.list","request_id":"request126","errors":[{"code":"conflict","message":"A contact matching those details already exists with id=test1"}]}',
             response: [
               {
                 error: JSON.stringify({
@@ -583,10 +598,20 @@ export const testScenariosForV1API = [
                   ],
                 }),
                 metadata: generateMetadata(1),
-                statusCode: 409,
+                statusCode: 500,
               },
             ],
-            status: 409,
+            statTags: {
+              destType: 'INTERCOM',
+              destinationId: 'default-destinationId',
+              errorCategory: 'network',
+              errorType: 'retryable',
+              feature: 'dataDelivery',
+              implementation: 'native',
+              module: 'destination',
+              workspaceId: 'default-workspaceId',
+            },
+            status: 500,
           },
         },
       },


### PR DESCRIPTION
🔒 Scanned for secrets using gitleaks 8.28.0

## What are the changes introduced in this PR?

When Intercom returns a **409 Conflict** during `POST /contacts` (contact already exists due to eventual consistency in Intercom's search index), the network handler now treats it as a **retryable error (500)** instead of letting it fall through as a non-retried failure.

## What is the related Linear task?

Resolves INT-6196

## Please explain the objectives of your changes below

**Problem:** Intercom's contact search index has propagation delays (eventual consistency). When a contact is created via the Intercom JS SDK and an `identify` event is sent shortly after via RudderStack, `searchContact()` finds no results, the transformer constructs `POST /contacts`, and Intercom returns 409 Conflict. Currently `errorResponseHandler()` has no 409 case — it falls through and the event is permanently dropped (~1% of identify events affected).

**Fix:** Added a `status === 409` case in `errorResponseHandler()` that throws `RetryableError` with status `500`. On retry, the transformer re-runs `searchContact()` — once Intercom's index has caught up, the contact is found and updated via `PUT /contacts/{id}` instead.

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes?

409 responses from Intercom were previously treated as terminal failures. They are now retried, matching the existing 408 (Request Timeout) retry pattern.

### Any new dependencies introduced with this change?

N/A

### Any new generic utility introduced or modified. Please explain the changes.

N/A

### Any technical or performance related pointers to consider with the change?

Retries add a small amount of additional load, but only for the ~1% of events that hit the 409 race condition. The retry succeeds once Intercom's search index catches up.

@coderabbitai review

<hr>

### Developer checklist

- [x] My code follows the style guidelines of this project

- [x] **No breaking changes are being introduced.**

- [ ] All related docs linked with the PR?

- [x] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [x] Is the PR limited to 10 file changes?

- [x] Is the PR limited to one linear task?

- [x] Are relevant unit and component test-cases added in **new readability format**?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.