### PR TITLE
chore(vuln): replace secrets inherit with explicit forwarding (SEC-162)

### DIFF
--- a/.github/workflows/dt-test-and-report-code-coverage.yml
+++ b/.github/workflows/dt-test-and-report-code-coverage.yml
@@ -107,4 +107,6 @@ jobs:
     with:
       workflow_url: ${{ needs.get_workflow_url.outputs.url }}
       should_notify: ${{startsWith(github.event.pull_request.head.ref, 'hotfix-release/')}}
-    secrets: inherit
+    secrets:
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      SLACK_INTEGRATION_DEV_CHANNEL_ID: ${{ secrets.SLACK_INTEGRATION_DEV_CHANNEL_ID }}

--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -9,6 +9,11 @@ on:
       workflow_url:
         type: string
         required: true
+    secrets:
+      SLACK_BOT_TOKEN:
+        required: true
+      SLACK_INTEGRATION_DEV_CHANNEL_ID:
+        required: true
 
 jobs:
   notify:


### PR DESCRIPTION
## Summary
- Replace `secrets: inherit` with explicit secret forwarding when calling `slack-notify.yml`
- Add `workflow_call.secrets` declarations to `slack-notify.yml`
- Enforces Principle of Least Authority — slack notification workflow only receives the 2 secrets it needs

## zizmor rule
`secrets-inherit` — 1 finding resolved

## Test plan
- [ ] Slack notifications still fire on workflow failure
- [ ] No other callers of slack-notify.yml are broken