### PR TITLE
fix: check endpoint before updating 409 to 500 for intercom

### DIFF
--- a/src/v0/destinations/intercom/networkHandler.js
+++ b/src/v0/destinations/intercom/networkHandler.js
@@ -2,9 +2,14 @@ const { RetryableError } = require('@rudderstack/integrations-lib');
 const { prepareProxyRequest, httpSend } = require('../../../adapters/network');
 const { processAxiosResponse } = require('../../../adapters/utils/networkUtils');
 
-const errorResponseHandler = (destinationResponse, dest) => {
+const errorResponseHandler = (destinationResponse, dest, destinationRequest) => {
   const { status, response } = destinationResponse;
-  if (status === 409) {
+  const endpoint = destinationRequest?.endpoint || '';
+  // Intercom's search index is eventually consistent. A contact created may not
+  // appear in searchContact() results immediately, causing the transformer to attempt POST /contacts
+  // which returns 409 (contact already exists). Retrying allows the search index to catch up so the
+  // contact is found and updated via PUT on the next attempt.
+  if (status === 409 && endpoint.endsWith('/contacts')) {
     throw new RetryableError(
       `[Intercom Response Handler] Request failed for destination ${dest} with status: ${status}. ${JSON.stringify(response)}`,
       500,
@@ -21,8 +26,8 @@ const errorResponseHandler = (destinationResponse, dest) => {
 };
 
 const destResponseHandler = (responseParams) => {
-  const { destinationResponse, destType } = responseParams;
-  errorResponseHandler(destinationResponse, destType);
+  const { destinationResponse, destType, destinationRequest } = responseParams;
+  errorResponseHandler(destinationResponse, destType, destinationRequest);
   return {
     destinationResponse: destinationResponse.response,
     message: 'Request Processed Successfully',


### PR DESCRIPTION
## What are the changes introduced in this PR?

We are adding the endpoint in the networkHandler so that we can decide that the updation of 409 to 500 will happen only when the `/contacts` endpoint is being used.

## What is the related Linear task?

Resolves INT-6196

## Please explain the objectives of your changes below

Put down any required details on the broader aspect of your changes. If there are any dependent changes, **mandatorily** mention them here

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

N/A

### Any new dependencies introduced with this change?

N/A

### Any new generic utility introduced or modified. Please explain the changes.

N/A

### Any technical or performance related pointers to consider with the change?

N/A

@coderabbitai review

<hr>

### Developer checklist

- [ ] My code follows the style guidelines of this project

- [ ] **No breaking changes are being introduced.**

- [ ] All related docs linked with the PR?

- [ ] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [ ] Is the PR limited to 10 file changes?

- [ ] Is the PR limited to one linear task?

- [ ] Are relevant unit and component test-cases added in **new readability format**?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.
