### PR TITLE
fix(errorNotifier): remove secret metadata from bugsnag reports

### DIFF
--- a/src/services/errorReporting.ts
+++ b/src/services/errorReporting.ts
@@ -5,8 +5,8 @@ export class ErrorReportingService {
     const metadata = {
       ...errorResp,
       // metadata contains secret which should not be sent to error notifier
-      metadata: undefined
-    }
+      metadata: undefined,
+    };
     client.notify(error, context, metadata);
   }
 }

--- a/src/services/errorReporting.ts
+++ b/src/services/errorReporting.ts
@@ -2,8 +2,11 @@ import { client } from '../util/errorNotifier';
 
 export class ErrorReportingService {
   public static reportError(error: NonNullable<unknown>, context: string, errorResp: object) {
-    client.notify(error, context, {
+    const metadata = {
       ...errorResp,
-    });
+      // metadata contains secret which should not be sent to error notifier
+      metadata: undefined
+    }
+    client.notify(error, context, metadata);
   }
 }

--- a/src/v0/util/index.js
+++ b/src/v0/util/index.js
@@ -1795,11 +1795,15 @@ const handleRtTfSingleEventError = (input, error, reqMetadata) => {
     resp.authErrorCategory = error.authErrorCategory;
   }
 
-  errNotificationClient.notify(error, 'Router Transformation (event level)', {
+  const notifyMetadata = {
     ...resp,
     ...reqMetadata,
     ...getEventReqMetadata(input),
-  });
+    // metadata contains secret which should not be sent to error notifier
+    metadata: undefined,
+  }
+
+  errNotificationClient.notify(error, 'Router Transformation (event level)', notifyMetadata);
 
   return { ...resp, destination: input?.destination };
 };

--- a/src/v0/util/index.js
+++ b/src/v0/util/index.js
@@ -1801,7 +1801,7 @@ const handleRtTfSingleEventError = (input, error, reqMetadata) => {
     ...getEventReqMetadata(input),
     // metadata contains secret which should not be sent to error notifier
     metadata: undefined,
-  }
+  };
 
   errNotificationClient.notify(error, 'Router Transformation (event level)', notifyMetadata);
 


### PR DESCRIPTION
## Summary
- Strip `metadata` field (which contains `secret` with access tokens) from error notification payloads before sending to Bugsnag
- Applied in both `ErrorReportingService.reportError` and `handleRtTfSingleEventError` call sites
- Adds comments explaining why metadata is set to undefined

Closes INT-6226

## Test plan
- [ ] Verify lint passes: `npm run lint`
- [ ] Confirm no regressions in error reporting flow
- [ ] Verify Bugsnag errors no longer contain secret metadata after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)