### PR TITLE
chore(bugsnag): add cluster name to alerts

### DIFF
--- a/src/util/errorNotifier/bugsnag.js
+++ b/src/util/errorNotifier/bugsnag.js
@@ -26,6 +26,7 @@ const {
   BUGSNAG_API_KEY: apiKey,
   transformer_build_version: imageVersion,
   git_commit_sha: gitCommitSHA,
+  // Reused from Pyroscope config — already reflects the deployment cluster name
   PYROSCOPE_CLUSTER_NAME: clusterName,
 } = process.env;
 
@@ -66,7 +67,7 @@ function init() {
         source: {
           gitCommitSHA,
         },
-        cluster: clusterName,
+        cluster: { name: clusterName },
       },
       onError(event) {
         event.severity = 'error';

--- a/src/util/errorNotifier/bugsnag.js
+++ b/src/util/errorNotifier/bugsnag.js
@@ -26,6 +26,7 @@ const {
   BUGSNAG_API_KEY: apiKey,
   transformer_build_version: imageVersion,
   git_commit_sha: gitCommitSHA,
+  PYROSCOPE_CLUSTER_NAME: clusterName,
 } = process.env;
 
 const errorTypesDenyList = [
@@ -65,6 +66,7 @@ function init() {
         source: {
           gitCommitSHA,
         },
+        cluster: clusterName,
       },
       onError(event) {
         event.severity = 'error';


### PR DESCRIPTION
## Summary
- Adds `PYROSCOPE_CLUSTER_NAME` as `cluster` metadata to Bugsnag error events
- Allows distinguishing staging vs production alerts in Bugsnag dashboard

## Test plan
- [ ] Deploy to staging, trigger an error, verify `cluster` metadata appears in Bugsnag
- [ ] Confirm production alerts show the correct cluster name

🤖 Generated with [Claude Code](https://claude.com/claude-code)