### PR TITLE
chore: bump build-scan-push-action from v2.1.0 to v2.2.0

### DIFF
--- a/.github/workflows/build-push-docker-image.yml
+++ b/.github/workflows/build-push-docker-image.yml
@@ -192,7 +192,7 @@ jobs:
         uses: aws-actions/amazon-ecr-login@f2e9fc6c2b355c1890b65e6f6f0e2ac3e6e22f78 # 2.1.2
 
       - name: Build and Push Multi-platform Images to ECR
-        uses: rudderlabs/build-scan-push-action@96d7bfca912dd2e8805dbb322dc2540504ecac1e # v2.1.0
+        uses: rudderlabs/build-scan-push-action@865b4253caa57f8f20cd109e0efc1affe3a64939 # v2.2.0
         if: ${{ needs.check_actor.outputs.is_dependabot == 'false' }}
         with:
           context: .
@@ -212,7 +212,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and Push Multi-platform Images to DockerHub
-        uses: rudderlabs/build-scan-push-action@96d7bfca912dd2e8805dbb322dc2540504ecac1e # v2.1.0
+        uses: rudderlabs/build-scan-push-action@865b4253caa57f8f20cd109e0efc1affe3a64939 # v2.2.0
         if: ${{ needs.check_actor.outputs.is_dependabot == 'false' }}
         with:
           context: .


### PR DESCRIPTION
## Summary
- Update `rudderlabs/build-scan-push-action` from `v2.1.0` to `v2.2.0`
- SHA: `96d7bfca912dd2e8805dbb322dc2540504ecac1e` → `865b4253caa57f8f20cd109e0efc1affe3a64939`

## Files changed
- `.github/workflows/build-push-docker-image.yml` (2 references)

🤖 Generated with [Claude Code](https://claude.com/claude-code)