### PR TITLE
feat(reddit): map product price and quantity to Reddit event payload

### DIFF
--- a/src/cdk/v2/destinations/reddit/transformV3.ts
+++ b/src/cdk/v2/destinations/reddit/transformV3.ts
@@ -102,6 +102,8 @@ const prepareProductsArrayWithItemCount = (message: RudderMessage): RedditEventM
       id: product.product_id,
       name: product.name,
       category: product.category,
+      item_price: product.price,
+      quantity: product.quantity,
     }));
 
     return {
@@ -117,6 +119,8 @@ const prepareProductsArrayWithItemCount = (message: RudderMessage): RedditEventM
         id: eventProperties?.product_id,
         name: eventProperties?.name,
         category: eventProperties?.category,
+        item_price: eventProperties?.price,
+        quantity: eventProperties?.quantity,
       },
     ],
   };

--- a/src/cdk/v2/destinations/reddit/types.ts
+++ b/src/cdk/v2/destinations/reddit/types.ts
@@ -63,6 +63,8 @@ export const RedditProductSchema = z.object({
   category: z.string().optional(),
   id: z.string().optional(),
   name: z.string().optional(),
+  quantity: z.number().int().nonnegative().optional(),
+  item_price: z.number().nonnegative().optional(),
 });
 
 export const RedditEventMetadataSchema = z.object({
@@ -144,6 +146,8 @@ export interface ProductProperties {
   product_id?: string;
   name?: string;
   category?: string;
+  price?: number;
+  quantity?: number;
 }
 
 export interface EventProperties {
@@ -151,4 +155,6 @@ export interface EventProperties {
   product_id?: string;
   name?: string;
   category?: string;
+  price?: number;
+  quantity?: number;
 }

--- a/test/integrations/destinations/reddit/router/data.ts
+++ b/test/integrations/destinations/reddit/router/data.ts
@@ -73,10 +73,10 @@ const HASHED_USER_DATA = {
 
 // Common product objects
 const PRODUCTS = {
-  monopoly: { id: '123', name: 'Monopoly' },
-  uno: { id: '345', name: 'UNO' },
-  monopolyLarge: { id: '123456', name: 'Monopoly' },
-  unoLarge: { id: '345678', name: 'UNO' },
+  monopoly: { id: '123', name: 'Monopoly', item_price: 14, quantity: 1 },
+  uno: { id: '345', name: 'UNO', item_price: 3.45, quantity: 2 },
+  monopolyLarge: { id: '123456', name: 'Monopoly', item_price: 140, quantity: 1 },
+  unoLarge: { id: '345678', name: 'UNO', item_price: 345, quantity: 2 },
 };
 
 const v3Data: RouterTestData[] = [


### PR DESCRIPTION
## What are the changes introduced in this PR?

Adds `item_price` and `quantity` to each entry of the `event_metadata.products` array sent to Reddit's V3 Conversions API. Values are sourced from the standard RudderStack ecommerce product properties (`properties.products[].price` / `quantity`, or top-level `properties.price` / `quantity` for single-product events). The Zod schema, TypeScript interfaces, and router fixtures are updated accordingly.

Resolves INT-6345

## What is the related Linear task?

No linear task, request from customer

## Please explain the objectives of your changes below

Reddit's V3 Conversions API accepts per-product `item_price` and `quantity` inside `event_metadata.products[]`, but the current transformer only forwards `id`, `name`, and `category`. This drops information that advertisers rely on for value-based optimization and ROAS reporting on product-scoped events (Purchase, AddToCart, etc.). This PR forwards the price and quantity already present on RudderStack ecommerce events into the corresponding Reddit fields.

Reddit documentation:
- Reddit Ads API V3 — Post Conversion Events: https://ads-api.reddit.com/docs/v3/operations/Post%20Conversion%20Events
- Reddit Event Metadata reference: https://business.reddithelp.com/s/article/about-event-metadata
- Reddit CAPI Best Practices: https://ads-api.reddit.com/docs/v3/capi-best-practices

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

Existing product payloads will now additionally include `item_price` and `quantity` when those properties are present on the inbound event. Both fields are optional in the schema, so events that don't carry price/quantity continue to transform exactly as before — no breaking change to existing payloads.

### Any new dependencies introduced with this change?

N/A

### Any new generic utility introduced or modified. Please explain the changes.

N/A — change is localized to `prepareProductsArrayWithItemCount` in `src/cdk/v2/destinations/reddit/transformV3.ts` and the corresponding type/schema definitions in `src/cdk/v2/destinations/reddit/types.ts`.

### Any technical or performance related pointers to consider with the change?

- Schema validates `quantity` as a non-negative integer and `item_price` as a non-negative number, matching Reddit's expectations for these fields.
- No additional network calls, lookups, or per-event work beyond two extra field assignments inside the existing products map.

@coderabbitai review

<hr>

### Developer checklist

- [x] My code follows the style guidelines of this project

- [x] **No breaking changes are being introduced.**

- [x] All related docs linked with the PR?

- [ ] All changes manually tested?

- [x] Any documentation changes needed with this change?

- [x] Is the PR limited to 10 file changes?

- [x] Is the PR limited to one linear task?

- [x] Are relevant unit and component test-cases added in **new readability format**?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?