### PR TITLE
fix(hs): convert null trait values to empty string in rETL path

### DIFF
--- a/src/v0/destinations/hs/util.test.ts
+++ b/src/v0/destinations/hs/util.test.ts
@@ -16,6 +16,7 @@ import {
   getObjectAndIdentifierType,
   removeHubSpotSystemField,
   isLookupFieldUnique,
+  populateTraits,
 } from './util';
 import { primaryToSecondaryFields } from './config';
 import { HubspotRudderMessage } from './types';
@@ -296,6 +297,162 @@ describe('removeHubSpotSystemField utility test cases', () => {
 
     const result = removeHubSpotSystemField(properties);
     expect(result).toEqual(expectedOutput);
+  });
+});
+
+describe('populateTraits', () => {
+  const mockDestination = {
+    ID: 'dest-123',
+    Config: {
+      authorizationType: 'newPrivateAppApi' as const,
+      accessToken: 'test-token',
+    },
+  };
+  const mockMetadata = { jobId: 1 };
+
+  const propMap = {
+    status: 'string',
+    score: 'number',
+    created_date: 'date',
+    migrated_at: 'datetime',
+    is_active: 'bool',
+  };
+
+  const UTC_MIDNIGHT_2024_03_15 = new Date('2024-03-15').setUTCHours(0, 0, 0, 0);
+  const UTC_MIDNIGHT_2024_01_01 = new Date('2024-01-01').setUTCHours(0, 0, 0, 0);
+
+  describe('when propertyMap is provided', () => {
+    it.each([
+      {
+        description: 'null string field → empty string (clears HS property)',
+        traits: { status: null },
+        expected: { status: '' },
+      },
+      {
+        description: 'null number field → empty string (clears HS property)',
+        traits: { score: null },
+        expected: { score: '' },
+      },
+      {
+        description: 'null date field → empty string (null takes priority over date conversion)',
+        traits: { created_date: null },
+        expected: { created_date: '' },
+      },
+      {
+        description: 'null datetime field → empty string',
+        traits: { migrated_at: null },
+        expected: { migrated_at: '' },
+      },
+      {
+        description: 'empty string on date field → passed through as-is (not treated as null)',
+        traits: { created_date: '' },
+        expected: { created_date: '' },
+      },
+      {
+        description: 'valid date string → converted to UTC midnight timestamp',
+        traits: { created_date: '2024-03-15T12:00:00Z' },
+        expected: { created_date: UTC_MIDNIGHT_2024_03_15 },
+      },
+      {
+        description:
+          'datetime field with valid date → not converted (only "date" type is converted)',
+        traits: { migrated_at: '2024-03-15T12:00:00Z' },
+        expected: { migrated_at: '2024-03-15T12:00:00Z' },
+      },
+      {
+        description: 'false value → passed through unchanged (not treated as null)',
+        traits: { is_active: false },
+        expected: { is_active: false },
+      },
+      {
+        description: '0 value → passed through unchanged (not treated as null)',
+        traits: { score: 0 },
+        expected: { score: 0 },
+      },
+      {
+        description: 'non-null string → passed through unchanged',
+        traits: { status: 'active' },
+        expected: { status: 'active' },
+      },
+      {
+        description: 'empty traits → returns empty object',
+        traits: {},
+        expected: {},
+      },
+      {
+        description: 'mix of null, 0, false, valid date, and datetime null',
+        traits: {
+          status: null,
+          score: 0,
+          is_active: false,
+          created_date: '2024-01-01',
+          migrated_at: null,
+        },
+        expected: {
+          status: '',
+          score: 0,
+          is_active: false,
+          created_date: UTC_MIDNIGHT_2024_01_01,
+          migrated_at: '',
+        },
+      },
+    ])('$description', async ({ traits, expected }) => {
+      const result = await populateTraits(
+        propMap,
+        traits as Record<string, unknown>,
+        mockDestination as any,
+        mockMetadata as any,
+      );
+      expect(result).toEqual(expected);
+    });
+
+    it('returns a new object and does not mutate the input traits', async () => {
+      const traits = { status: null, score: 42 };
+      const result = await populateTraits(
+        propMap,
+        traits,
+        mockDestination as any,
+        mockMetadata as any,
+      );
+      expect(result).not.toBe(traits);
+      expect(traits).toEqual({ status: null, score: 42 });
+    });
+  });
+
+  describe('when propertyMap is not provided — fetches from API', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+      (httpGET as jest.Mock).mockResolvedValue({
+        success: true,
+        response: {
+          data: [{ name: 'created_date', type: 'date' }],
+          status: 200,
+          headers: {},
+        },
+      });
+    });
+
+    it.each([
+      {
+        description: 'fetches from API and converts date field to UTC midnight timestamp',
+        traits: { created_date: '2024-06-01' },
+        expected: { created_date: new Date('2024-06-01').setUTCHours(0, 0, 0, 0) },
+      },
+      {
+        description: 'fetches from API and converts null fields to empty string',
+        traits: { created_date: null, status: null },
+        expected: { created_date: '', status: '' },
+      },
+    ])('$description', async ({ traits, expected }) => {
+      const result = await populateTraits(
+        undefined,
+        traits as Record<string, unknown>,
+        mockDestination as any,
+        mockMetadata as any,
+      );
+      expect(httpGET).toHaveBeenCalled();
+      expect(result).toEqual(expected);
+    });
   });
 });
 

--- a/src/v0/destinations/hs/util.ts
+++ b/src/v0/destinations/hs/util.ts
@@ -297,9 +297,9 @@ const getTransformedJSON = async (
       const hsSupportedKey = formatKey(traitsKey);
       if (!rawPayload[traitsKey] && propMap && propMap[hsSupportedKey]) {
         // HS accepts empty string to remove the property from contact
-        // https://community.hubspot.com/t5/APIs-Integrations/Clearing-values-of-custom-properties-in-Hubspot-contact-using/m-p/409156
+        // https://developers.hubspot.com/docs/api-reference/legacy/crm/properties/guide#clear-a-property-value
         let propValue: unknown = isNull(traits[traitsKey]) ? '' : traits[traitsKey];
-        if (propMap[hsSupportedKey] === 'date' && isDateLike(propValue)) {
+        if (propMap[hsSupportedKey] === 'date' && propValue !== '' && isDateLike(propValue)) {
           propValue = getUTCMidnightTimeStampValue(propValue);
         }
 
@@ -943,15 +943,24 @@ const populateTraits = async (
     propertyToTypeMap = await getProperties(destination, metadata);
   }
 
-  const keys = Object.keys(populatedTraits);
-  keys.forEach((key) => {
-    const value = populatedTraits[key];
-    if (propertyToTypeMap && propertyToTypeMap[key] === 'date' && isDateLike(value)) {
-      populatedTraits[key] = getUTCMidnightTimeStampValue(value);
-    }
-  });
-
-  return populatedTraits;
+  return Object.fromEntries(
+    Object.keys(populatedTraits).map((key) => {
+      if (isNull(populatedTraits[key])) {
+        // HS accepts empty string to remove the property from contact
+        // https://developers.hubspot.com/docs/api-reference/legacy/crm/properties/guide#clear-a-property-value
+        return [key, ''];
+      }
+      if (
+        propertyToTypeMap &&
+        propertyToTypeMap[key] === 'date' &&
+        populatedTraits[key] !== '' &&
+        isDateLike(populatedTraits[key])
+      ) {
+        return [key, getUTCMidnightTimeStampValue(populatedTraits[key])];
+      }
+      return [key, populatedTraits[key]];
+    }),
+  );
 };
 
 const addExternalIdToHSTraits = (message: HubspotRudderMessage): void => {

--- a/test/integrations/destinations/hs/router/data.ts
+++ b/test/integrations/destinations/hs/router/data.ts
@@ -1005,6 +1005,97 @@ export const data = [
               },
               metadata: { jobId: 4, userId: 'u1' },
             },
+            {
+              message: {
+                channel: 'web',
+                context: {
+                  mappedToDestination: true,
+                  externalId: [
+                    {
+                      identifierType: 'email',
+                      id: 'testhubspotnull@email.com',
+                      type: 'HS-lead',
+                    },
+                  ],
+                  sources: {
+                    job_id: '24c5HJxHomh6YCngEOCgjS5r1KX/Syncher',
+                    task_id: 'vw_rs_mailchimp_mocked_hg_data',
+                    version: 'v1.8.1',
+                    batch_id: 'f252c69d-c40d-450e-bcd2-2cf26cb62762',
+                    job_run_id: 'c8el40l6e87v0c4hkbl0',
+                    task_run_id: 'c8el40l6e87v0c4hkblg',
+                  },
+                },
+                type: 'identify',
+                traits: {
+                  firstname: 'Test Null Fields',
+                  country: 'India',
+                  // null on a regular field → should become ""
+                  degree: null,
+                  // null on a date field → should become "" (not NaN)
+                  date_submitted: null,
+                  // empty string on a date field → should stay "" (not NaN)
+                  date_created: '',
+                  hs_email_recipient_fatigue_recovery_time: null,
+                },
+                messageId: '60360b9c-ea8d-409c-b672-c9230f91cce6',
+                originalTimestamp: '2019-10-15T09:35:31.288Z',
+                anonymousId: '00000000000000000000000000',
+                userId: '12346',
+                integrations: { All: true },
+                sentAt: '2019-10-14T09:03:22.563Z',
+              },
+              destination: {
+                Config: {
+                  authorizationType: 'newPrivateAppApi',
+                  accessToken: secret1,
+                  hubID: 'dummy-hubId',
+                  apiKey: 'dummy-apikey',
+                  apiVersion: 'newApi',
+                  lookupField: 'lookupField',
+                  hubspotEvents: [
+                    {
+                      rsEventName: 'Purchase',
+                      hubspotEventName: 'pedummy-hubId_rs_hub_test',
+                      eventProperties: [
+                        { from: 'Revenue', to: 'value' },
+                        { from: 'Price', to: 'cost' },
+                      ],
+                    },
+                    {
+                      rsEventName: 'Order Complete',
+                      hubspotEventName: 'pedummy-hubId_rs_hub_chair',
+                      eventProperties: [
+                        { from: 'firstName', to: 'first_name' },
+                        { from: 'lastName', to: 'last_name' },
+                      ],
+                    },
+                  ],
+                  eventFilteringOption: 'disable',
+                  blacklistedEvents: [{ eventName: '' }],
+                  whitelistedEvents: [{ eventName: '' }],
+                },
+                secretConfig: {},
+                ID: '1mMy5cqbtfuaKZv1IhVQKnBdVwe',
+                name: 'Hubspot',
+                enabled: true,
+                workspaceId: '1TSN08muJTZwH8iCDmnnRt1pmLd',
+                deleted: false,
+                createdAt: '2020-12-30T08:39:32.005Z',
+                updatedAt: '2021-02-03T16:22:31.374Z',
+                destinationDefinition: {
+                  id: '1aIXqM806xAVm92nx07YwKbRrO9',
+                  name: 'HS',
+                  displayName: 'Hubspot',
+                  createdAt: '2020-04-09T09:24:31.794Z',
+                  updatedAt: '2021-01-11T11:03:28.103Z',
+                },
+                transformations: [],
+                isConnectionEnabled: true,
+                isProcessorEnabled: true,
+              },
+              metadata: { jobId: 5, userId: 'u1' },
+            },
           ],
           destType: 'hs',
         },
@@ -1132,6 +1223,17 @@ export const data = [
                           date_submitted: 1695600000000,
                         },
                       },
+                      {
+                        properties: {
+                          firstname: 'Test Null Fields',
+                          country: 'India',
+                          email: 'testhubspotnull@email.com',
+                          degree: '',
+                          date_submitted: '',
+                          date_created: '',
+                          hs_email_recipient_fatigue_recovery_time: '',
+                        },
+                      },
                     ],
                   },
                   JSON_ARRAY: {},
@@ -1143,6 +1245,7 @@ export const data = [
               metadata: [
                 { jobId: 3, userId: 'u1' },
                 { jobId: 4, userId: 'u1' },
+                { jobId: 5, userId: 'u1' },
               ],
               batched: true,
               statusCode: 200,


### PR DESCRIPTION
## What are the changes introduced in this PR?

For rETL identify events, trait fields with null values were being forwarded as null in the HubSpot API payload. HubSpot requires an empty string to clear a property value — null is not accepted.

Root cause: the rETL path goes through populateTraits instead of getTransformedJSON, and populateTraits had no null handling. removeUndefinedAndNullValues is shallow so nulls inside the nested properties object survived into the final payload.

Also fixed a secondary bug in both populateTraits and getTransformedJSON: an empty string on a date-typed property was passed into getUTCMidnightTimeStampValue (via isDateLike returning true for ''), which produced NaN. Added a propValue !== '' guard before the date conversion in both functions.

Ref: INT-6283

## What is the related Linear task?

[Resolves INT-6283](https://linear.app/rudderstack/issue/INT-6283/fix-null-value-field-handling-for-retl-connections)

## Please explain the objectives of your changes below

Put down any required details on the broader aspect of your changes. If there are any dependent changes, **mandatorily** mention them here

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

N/A

### Any new dependencies introduced with this change?

N/A

### Any new generic utility introduced or modified. Please explain the changes.

N/A

### Any technical or performance related pointers to consider with the change?

N/A

@coderabbitai review

<hr>

### Developer checklist

- [ ] My code follows the style guidelines of this project

- [ ] **No breaking changes are being introduced.**

- [ ] All related docs linked with the PR?

- [ ] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [ ] Is the PR limited to 10 file changes?

- [ ] Is the PR limited to one linear task?

- [ ] Are relevant unit and component test-cases added in **new readability format**?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.
