### PR TITLE
fix(hs): prevent NaN when date property cannot be parsed

### DIFF
--- a/src/v0/destinations/hs/util.test.ts
+++ b/src/v0/destinations/hs/util.test.ts
@@ -16,6 +16,7 @@ import {
   getObjectAndIdentifierType,
   removeHubSpotSystemField,
   isLookupFieldUnique,
+  getUTCMidnightTimeStampValue,
 } from './util';
 import { primaryToSecondaryFields } from './config';
 import { HubspotRudderMessage } from './types';
@@ -404,5 +405,53 @@ describe('isLookupFieldUnique utility test cases', () => {
     );
 
     expect(result).toBe(false);
+  });
+});
+
+describe('getUTCMidnightTimeStampValue', () => {
+  const testCases: {
+    description: string;
+    input: string | number | Date | null;
+    expected: string | number | Date | null;
+  }[] = [
+    {
+      description: 'ISO date string with time component',
+      input: '2023-06-15T10:30:00Z',
+      expected: 1686787200000,
+    },
+    {
+      description: 'plain date string',
+      input: '2023-06-15',
+      expected: 1686787200000,
+    },
+    {
+      description: 'Date object',
+      input: new Date('2023-06-15T14:00:00Z'),
+      expected: 1686787200000,
+    },
+    {
+      description: 'numeric timestamp',
+      input: new Date('2023-06-15T14:00:00Z').getTime(),
+      expected: 1686787200000,
+    },
+    {
+      description: 'empty string (customer intentionally clears the field)',
+      input: '',
+      expected: '',
+    },
+    {
+      description: 'unparseable string',
+      input: 'not-a-date',
+      expected: 'not-a-date',
+    },
+    {
+      description: 'null (customer intentionally clears the field)',
+      input: null,
+      expected: null,
+    },
+  ];
+
+  it.each(testCases)('$description', ({ input, expected }) => {
+    expect(getUTCMidnightTimeStampValue(input)).toBe(expected);
   });
 });

--- a/src/v0/destinations/hs/util.ts
+++ b/src/v0/destinations/hs/util.ts
@@ -255,9 +255,16 @@ const validatePayloadDataTypes = (
  * @param {*} propValue
  * @returns
  */
-const getUTCMidnightTimeStampValue = (propValue: string | number | Date): number => {
-  const time = propValue;
-  const date = new Date(time);
+const getUTCMidnightTimeStampValue = (
+  propValue: string | number | Date | null,
+): number | string | Date | null => {
+  if (propValue === null) {
+    return null;
+  }
+  const date = new Date(propValue);
+  if (Number.isNaN(date.getTime())) {
+    return propValue;
+  }
   date.setUTCHours(0, 0, 0, 0);
   return date.getTime();
 };

--- a/test/integrations/destinations/hs/router/data.ts
+++ b/test/integrations/destinations/hs/router/data.ts
@@ -858,7 +858,12 @@ export const data = [
                   },
                 },
                 type: 'identify',
-                traits: { firstname: 'Test Hubspot 1', anonymousId: '123451', country: 'India 1' },
+                traits: {
+                  firstname: 'Test Hubspot 1',
+                  anonymousId: '123451',
+                  country: 'India 1',
+                  test_date: '',
+                },
                 messageId: '50360b9c-ea8d-409c-b672-c9230f91cce5',
                 originalTimestamp: '2019-10-15T09:35:31.288Z',
                 anonymousId: '00000000000000000000000000',
@@ -1119,6 +1124,7 @@ export const data = [
                           anonymousId: '123451',
                           country: 'India 1',
                           email: 'testhubspot@email.com',
+                          test_date: '',
                         },
                       },
                       {


### PR DESCRIPTION
## What are the changes introduced in this PR?

Return the original value as-is when getUTCMidnightTimeStampValue receives an unparseable string, empty string, or null — instead of silently producing NaN or epoch 0.

## What is the related Linear task?

[Resolves INT-6283](https://linear.app/rudderstack/issue/INT-6283/fix-null-value-field-handling-for-retl-connections)

## Please explain the objectives of your changes below

Put down any required details on the broader aspect of your changes. If there are any dependent changes, **mandatorily** mention them here

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

N/A

### Any new dependencies introduced with this change?

N/A

### Any new generic utility introduced or modified. Please explain the changes.

N/A

### Any technical or performance related pointers to consider with the change?

N/A

@coderabbitai review

<hr>

### Developer checklist

- [ ] My code follows the style guidelines of this project

- [ ] **No breaking changes are being introduced.**

- [ ] All related docs linked with the PR?

- [ ] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [ ] Is the PR limited to 10 file changes?

- [ ] Is the PR limited to one linear task?

- [ ] Are relevant unit and component test-cases added in **new readability format**?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.
