### PR TITLE
feat(custom_audience): add template validator module

### DIFF
--- a/.claude/skills/code-structure/SKILL.md
+++ b/.claude/skills/code-structure/SKILL.md
@@ -49,20 +49,26 @@ When multiple functions need per-type behavior, use a single handler map rather 
 // Good — one map entry per type, both behaviors co-located
 const EVENT_HANDLERS: Record<string, { validate: ValidateFn; transform?: TransformFn }> = {
   purchase: {
-    validate: (event, ctx) => { /* ... */ },
-    transform: (event, output) => { /* ... */ },
+    validate: (event, ctx) => {
+      /* ... */
+    },
+    transform: (event, output) => {
+      /* ... */
+    },
   },
 };
 
 // Bad — parallel switches that must stay in sync
 function validateEvent(event: Event) {
   switch (event.type) {
-    case 'purchase': /* ... */ break;
+    case 'purchase':
+      /* ... */ break;
   }
 }
 function transformEvent(event: Event) {
   switch (event.type) {
-    case 'purchase': /* ... */ break;
+    case 'purchase':
+      /* ... */ break;
   }
 }
 ```
@@ -87,7 +93,10 @@ const ROUTE_HANDLERS = {
 
 function processRequest(request: Request, ctx: Context): void {
   const handler = ROUTE_HANDLERS[request.type];
-  if (!handler) { ctx.errors.push(`Unknown type: ${request.type}`); return; }
+  if (!handler) {
+    ctx.errors.push(`Unknown type: ${request.type}`);
+    return;
+  }
   handler.process(request, ctx);
 }
 
@@ -98,7 +107,10 @@ function processRequest(request: Request, ctx: Context): void {
     return;
   }
   const handler = ROUTE_HANDLERS[request.type];
-  if (!handler) { ctx.errors.push(`Unknown type: ${request.type}`); return; }
+  if (!handler) {
+    ctx.errors.push(`Unknown type: ${request.type}`);
+    return;
+  }
   handler.process(request, ctx);
 }
 ```

--- a/.claude/skills/code-structure/SKILL.md
+++ b/.claude/skills/code-structure/SKILL.md
@@ -1,0 +1,183 @@
+---
+name: code-structure
+description: Code design conventions — handler maps, dependency management, function extraction. Applied automatically — not user-invocable.
+---
+
+# Code Structure Conventions
+
+Follow these conventions when writing or restructuring modules.
+
+## Avoid eslint-disable; Restructure Instead
+
+Never suppress lint rules with `eslint-disable`. If a pattern triggers a violation (e.g. circular references between a const map and functions), restructure the code to eliminate the forward reference.
+
+```ts
+// Good — pass the recursive function as a parameter to break the cycle
+const PLUGINS: Record<string, Plugin> = {
+  markdown: {
+    render: (content, renderChild) => {
+      content.sections.forEach((s) => renderChild(s));
+    },
+  },
+};
+
+function render(content: Content): string {
+  return PLUGINS[content.type].render(content, render);
+}
+
+// Bad — suppress the lint rule
+/* eslint-disable @typescript-eslint/no-use-before-define */
+const PLUGINS: Record<string, Plugin> = {
+  markdown: {
+    render: (content) => {
+      content.sections.forEach((s) => render(s)); // forward ref
+    },
+  },
+};
+
+function render(content: Content): string {
+  return PLUGINS[content.type].render(content);
+}
+/* eslint-enable @typescript-eslint/no-use-before-define */
+```
+
+## Centralized Handler Map Over Duplicated Logic
+
+When multiple functions need per-type behavior, use a single handler map rather than parallel switch statements or if-else chains. Adding a new type should require a change in exactly one place.
+
+```ts
+// Good — one map entry per type, both behaviors co-located
+const EVENT_HANDLERS: Record<string, { validate: ValidateFn; transform?: TransformFn }> = {
+  purchase: {
+    validate: (event, ctx) => { /* ... */ },
+    transform: (event, output) => { /* ... */ },
+  },
+};
+
+// Bad — parallel switches that must stay in sync
+function validateEvent(event: Event) {
+  switch (event.type) {
+    case 'purchase': /* ... */ break;
+  }
+}
+function transformEvent(event: Event) {
+  switch (event.type) {
+    case 'purchase': /* ... */ break;
+  }
+}
+```
+
+## Type-Specific Logic Belongs in the Handler
+
+The generic dispatch function should only look up and invoke the handler. Checks specific to one type belong inside that type's handler, not in the dispatcher.
+
+```ts
+// Good — type-specific guard lives in the handler
+const ROUTE_HANDLERS = {
+  webhook: {
+    process: (request, ctx) => {
+      if (!ctx.signatureVerified) {
+        ctx.errors.push('Webhooks require a verified signature.');
+        return;
+      }
+      // ... handle webhook
+    },
+  },
+};
+
+function processRequest(request: Request, ctx: Context): void {
+  const handler = ROUTE_HANDLERS[request.type];
+  if (!handler) { ctx.errors.push(`Unknown type: ${request.type}`); return; }
+  handler.process(request, ctx);
+}
+
+// Bad — type-specific check leaks into the dispatcher
+function processRequest(request: Request, ctx: Context): void {
+  if (request.type === 'webhook' && !ctx.signatureVerified) {
+    ctx.errors.push('Webhooks require a verified signature.');
+    return;
+  }
+  const handler = ROUTE_HANDLERS[request.type];
+  if (!handler) { ctx.errors.push(`Unknown type: ${request.type}`); return; }
+  handler.process(request, ctx);
+}
+```
+
+## Named Constants for Magic Strings in Comparisons
+
+Extract string literals used in equality checks to named constants with a comment explaining what produces that value. This applies to any string coming from an external library, parser output, or engine internal.
+
+```ts
+// Good — named constants with origin documented
+// Dot notation `$.records` → prop.type = "id"
+// Bracket notation `$["records"]` → prop.type = "str"
+const SELECTOR_PROP_TYPE_ID = 'id';
+const SELECTOR_PROP_TYPE_STR = 'str';
+
+if (prop.type === SELECTOR_PROP_TYPE_STR) {
+  errors.push('Bracket notation is not supported.');
+}
+
+// Bad — magic strings with no explanation of where they come from
+if (prop.type === 'str') {
+  errors.push('Bracket notation is not supported.');
+}
+```
+
+## Comments Proportional to Complexity
+
+Comment density should match code complexity. Straightforward code needs no comments. Non-obvious code — especially code operating on parsed structures, engine internals, or implicit conventions — needs inline comments showing concrete examples of the runtime data shape.
+
+```ts
+// Good — complex code has comments showing the actual data shape
+// $ path — check if this is `$.records.(<block>)` to enter iteration context.
+// AST shape: root="___d", parts=[selector("records"), block_expr([...])]
+const isRecordsPath =
+  root === INTERNAL_ROOT &&
+  parts.length >= 2 &&
+  parts[0].type === SyntaxType.SELECTOR &&
+  parts[0].prop?.value === RECORDS_FIELD;
+
+// Good — simple code has no comments
+const fields = new Set<string>();
+collectFields(ast, false, fields);
+return [...fields];
+
+// Bad — complex code with no explanation of "___d" or what parts[0] represents
+const isRecordsPath =
+  root === '___d' &&
+  parts.length >= 2 &&
+  parts[0].type === 'selector' &&
+  parts[0].prop?.value === 'records';
+```
+
+## Inline Single-Use Wrapper Functions
+
+Don't extract a function that's called from exactly one place and adds no clarity. Inline it.
+
+```ts
+// Good — logic directly in the function that uses it
+function loadConfig(raw: string): AppConfig {
+  let parsed: RawConfig;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (e: any) {
+    throw new ConfigError(e.message);
+  }
+  return normalize(parsed);
+}
+
+// Bad — unnecessary wrapper called from one place
+function safeParse(raw: string): RawConfig {
+  try {
+    return JSON.parse(raw);
+  } catch (e: any) {
+    throw new ConfigError(e.message);
+  }
+}
+
+function loadConfig(raw: string): AppConfig {
+  const parsed = safeParse(raw);
+  return normalize(parsed);
+}
+```

--- a/.claude/skills/typescript-guidelines/SKILL.md
+++ b/.claude/skills/typescript-guidelines/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: typescript-guidelines
+description: TypeScript-specific conventions — type narrowing, optional chaining, type safety. Applied automatically — not user-invocable.
+---
+
+# TypeScript Guidelines
+
+Follow these conventions when writing TypeScript code.
+
+## No Optional Chaining When the Type Guarantees the Property
+
+Inside a type-specific handler or after narrowing, don't use `?.` on properties that the type guarantees exist. It adds noise and obscures which properties are genuinely optional.
+
+```ts
+// Good — inside the "order" handler, lineItems is guaranteed
+order: {
+  process: (event) => {
+    event.lineItems.forEach((item) => validateItem(item));
+  },
+},
+
+// Bad — unnecessary defensive chaining
+order: {
+  process: (event) => {
+    event.lineItems?.forEach((item) => validateItem(item));
+  },
+},
+```

--- a/.claude/skills/typescript-guidelines/SKILL.md
+++ b/.claude/skills/typescript-guidelines/SKILL.md
@@ -26,3 +26,15 @@ order: {
   },
 },
 ```
+
+## Discriminated Unions in Return Types
+
+When a function returns success/failure outcomes, use a union type discriminated on a literal field — not a single type with optional fields.
+
+```ts
+// Good
+type Result = { valid: true; recordFields: string[] } | { valid: false; errors: string[] };
+
+// Bad
+type Result = { valid: boolean; errors?: string[]; recordFields?: string[] };
+```

--- a/.claude/skills/writing-tests/SKILL.md
+++ b/.claude/skills/writing-tests/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: writing-tests
+description: Conventions to follow when writing or modifying tests in this repo. Applied automatically — not user-invocable.
+---
+
+# Test Writing Conventions
+
+Follow these conventions when writing or modifying tests in this repo.
+
+## Error Matchers
+
+Never use `/.+/` or other catch-all patterns in test assertions. Run the code to find the actual error message and match on a distinctive substring.
+
+```ts
+// Good
+errorMatch: /Unexpected token/
+
+// Bad
+errorMatch: /.+/
+```
+
+## No Redundant If-Guards After Assertions
+
+`expect(result.valid).toBe(true)` already throws on failure — don't wrap the next assertion in `if (result.valid)`. Use `'field' in result && result.field` for TypeScript narrowing without a runtime branch.
+
+```ts
+// Good
+expect(result.valid).toBe(true);
+expect('recordFields' in result && result.recordFields.sort()).toEqual(expected);
+
+// Bad
+expect(result.valid).toBe(true);
+if (result.valid) {
+  expect(result.recordFields.sort()).toEqual(expected);
+}
+```
+
+## Table-Driven Tests With `it.each()`
+
+When multiple test cases share the same assertion structure, use `it.each()` with a data table instead of individual `it()` blocks. Keep test data arrays at the top of the file or describe block for easy scanning.
+
+```ts
+// Good — data table + single runner
+const invalidTemplates = [
+  { name: 'spread operator', template: '{ ...$.records }', errorMatch: /spread_expr/ },
+  { name: 'variable declarations', template: 'let x = 1', errorMatch: /definition_expr/ },
+  { name: 'bare identifier', template: 'process', errorMatch: /Bare identifiers/ },
+];
+
+it.each(invalidTemplates)('should reject: $name', ({ template, errorMatch }) => {
+  const result = validateTemplate(template);
+  expect(result.valid).toBe(false);
+  expect(result.errors?.[0]).toMatch(errorMatch);
+});
+
+// Bad — repetitive individual blocks with identical structure
+it('should reject spread operator', () => {
+  const result = validateTemplate('{ ...$.records }');
+  expect(result.valid).toBe(false);
+  expect(result.errors?.[0]).toMatch(/spread_expr/);
+});
+
+it('should reject variable declarations', () => {
+  const result = validateTemplate('let x = 1');
+  expect(result.valid).toBe(false);
+  expect(result.errors?.[0]).toMatch(/definition_expr/);
+});
+```
+
+## Consistent Test Data Scoping
+
+All test data arrays within a `describe` block should live at the same scope — either all inside or all outside. Don't mix.
+
+## Discriminated Unions in Return Types
+
+When a function returns success/failure outcomes, use a union type discriminated on a literal field — not a single type with optional fields.
+
+```ts
+// Good
+type Result =
+  | { valid: true; recordFields: string[] }
+  | { valid: false; errors: string[] };
+
+// Bad
+type Result = { valid: boolean; errors?: string[]; recordFields?: string[] };
+```

--- a/.claude/skills/writing-tests/SKILL.md
+++ b/.claude/skills/writing-tests/SKILL.md
@@ -13,10 +13,10 @@ Never use `/.+/` or other catch-all patterns in test assertions. Run the code to
 
 ```ts
 // Good
-errorMatch: /Unexpected token/
+errorMatch: /Unexpected token/;
 
 // Bad
-errorMatch: /.+/
+errorMatch: /.+/;
 ```
 
 ## No Redundant If-Guards After Assertions
@@ -70,17 +70,3 @@ it('should reject variable declarations', () => {
 ## Consistent Test Data Scoping
 
 All test data arrays within a `describe` block should live at the same scope — either all inside or all outside. Don't mix.
-
-## Discriminated Unions in Return Types
-
-When a function returns success/failure outcomes, use a union type discriminated on a literal field — not a single type with optional fields.
-
-```ts
-// Good
-type Result =
-  | { valid: true; recordFields: string[] }
-  | { valid: false; errors: string[] };
-
-// Bad
-type Result = { valid: boolean; errors?: string[]; recordFields?: string[] };
-```

--- a/src/v0/destinations/custom_audience/templateValidator.test.ts
+++ b/src/v0/destinations/custom_audience/templateValidator.test.ts
@@ -1,0 +1,211 @@
+import { validateTemplate, extractInputFields } from './templateValidator';
+
+const validTemplates = [
+  {
+    name: 'iteration producing objects with nested arrays',
+    template: `{
+      "elements": $.records.({
+        "action": "ADD",
+        "firstName": .first_name,
+        "lastName": .last_name,
+        "company": .company,
+        "country": .country,
+        "userIds": [
+          { "idType": "SHA256_EMAIL", "idValue": .email_sha256 }
+        ]
+      })
+    }`,
+  },
+  {
+    name: 'Number() casting and connection paths',
+    template: `{
+      "id_schema": ["EMAIL_SHA256"],
+      "advertiser_ids": ["my_advertiser_id"],
+      "action": "add",
+      "batch_data": $.records.({
+        "id": .email_sha256,
+        "audience_ids": [Number($.connection.audience_id)]
+      })
+    }`,
+  },
+  {
+    name: 'deeply nested objects inside iteration',
+    template: `{
+      "enablePartialFailure": true,
+      "operations": $.records.({
+        "create": {
+          "userIdentifiers": [
+            { "hashedEmail": .email_sha256 },
+            { "hashedPhoneNumber": .phone_sha256 }
+          ]
+        }
+      })
+    }`,
+  },
+  {
+    name: 'iteration producing arrays',
+    template: `{
+      "is_raw": true,
+      "data_source": { "sub_type": "ANYTHING" },
+      "schema": ["EMAIL", "PHONE", "GEN", "COUNTRY"],
+      "data": $.records.([.email, .phone, .gender, .country])
+    }`,
+  },
+];
+
+const invalidTemplates = [
+  { name: 'spread operator', template: '{ ...$.records }', errorMatch: /spread_expr/ },
+  {
+    name: 'variable declarations',
+    template: 'let x = 1; { "a": x }',
+    errorMatch: /definition_expr/,
+  },
+  {
+    name: 'generic function calls',
+    template: '$.records.map(.email)',
+    errorMatch: /Only Number\(\) casting/,
+  },
+  {
+    name: 'function definitions',
+    template: 'function() { $.records }',
+    errorMatch: /function_expr/,
+  },
+  {
+    name: 'loops',
+    template: 'for(let i = 0; i < 10; i = i + 1) { i }',
+    errorMatch: /not supported/,
+  },
+  { name: 'bare identifier (process)', template: 'process', errorMatch: /Bare identifiers/ },
+  { name: 'bare identifier (Object)', template: 'Object', errorMatch: /Bare identifiers/ },
+  { name: 'bracket notation', template: '$["records"]', errorMatch: /Bracket notation/ },
+  { name: 'standalone block expressions', template: '($.a; $.b)', errorMatch: /Standalone block/ },
+  { name: 'assignment expressions', template: 'let x = 1; x = 2', errorMatch: /not supported/ },
+  { name: 'return expressions (parser level)', template: 'return $.records', errorMatch: /.+/ },
+  { name: 'throw expressions (parser level)', template: 'throw "error"', errorMatch: /.+/ },
+  { name: 'unparseable syntax', template: '{ invalid :: syntax }', errorMatch: /.+/ },
+  {
+    name: 'relative path outside iteration',
+    template: '{ "a": .field }',
+    errorMatch: /Relative field/,
+  },
+  {
+    name: 'non-Number function call (String)',
+    template: '{ "a": String($.records) }',
+    errorMatch: /Only Number\(\) casting/,
+  },
+];
+
+describe('validateTemplate', () => {
+  it.each(validTemplates)('should accept: $name', ({ template }) => {
+    expect(validateTemplate(template)).toEqual({ valid: true });
+  });
+
+  it.each(invalidTemplates)('should reject: $name', ({ template, errorMatch }) => {
+    const result = validateTemplate(template);
+    expect(result.valid).toBe(false);
+    expect(result.errors?.[0]).toMatch(errorMatch);
+  });
+});
+
+const fieldExtractionErrorCases = [
+  {
+    name: 'unsupported function call',
+    template: '$.records.map(.email)',
+    errorMatch: /Only Number\(\) casting/,
+  },
+  { name: 'unparseable syntax', template: '{ invalid :: syntax }', errorMatch: /.+/ },
+  {
+    name: 'relative path outside iteration',
+    template: '{ "a": .field }',
+    errorMatch: /Relative field references/,
+  },
+  { name: 'bare identifier', template: 'process', errorMatch: /Bare identifiers/ },
+  { name: 'bracket notation', template: '$["records"]', errorMatch: /Bracket notation/ },
+  { name: 'standalone block expression', template: '($.a; $.b)', errorMatch: /Standalone block/ },
+  {
+    name: 'spread operator',
+    template: '{ ...$.records }',
+    errorMatch: /spread_expr.*not supported/,
+  },
+];
+
+const fieldExtractionCases = [
+  {
+    name: 'iteration producing objects with nested arrays',
+    template: `{
+      "elements": $.records.({
+        "action": "ADD",
+        "firstName": .first_name,
+        "lastName": .last_name,
+        "company": .company,
+        "country": .country,
+        "userIds": [
+          { "idType": "SHA256_EMAIL", "idValue": .email_sha256 }
+        ]
+      })
+    }`,
+    expected: ['company', 'country', 'email_sha256', 'first_name', 'last_name'],
+  },
+  {
+    name: 'connection fields excluded',
+    template: `{
+      "id_schema": ["EMAIL_SHA256"],
+      "advertiser_ids": ["my_advertiser_id"],
+      "action": "add",
+      "batch_data": $.records.({
+        "id": .email_sha256,
+        "audience_ids": [Number($.connection.audience_id)]
+      })
+    }`,
+    expected: ['email_sha256'],
+  },
+  {
+    name: 'deeply nested iteration objects',
+    template: `{
+      "enablePartialFailure": true,
+      "operations": $.records.({
+        "create": {
+          "userIdentifiers": [
+            { "hashedEmail": .email_sha256 },
+            { "hashedPhoneNumber": .phone_sha256 }
+          ]
+        }
+      })
+    }`,
+    expected: ['email_sha256', 'phone_sha256'],
+  },
+  {
+    name: 'iteration producing arrays',
+    template: `{
+      "is_raw": true,
+      "data_source": { "sub_type": "ANYTHING" },
+      "schema": ["EMAIL", "PHONE", "GEN", "COUNTRY"],
+      "data": $.records.([Number(.email), .phone, .gender, .country])
+    }`,
+    expected: ['country', 'email', 'gender', 'phone'],
+  },
+  {
+    name: 'deduplicated fields',
+    template: `{
+      "data": $.records.({
+        "email1": .email,
+        "email2": .email
+      })
+    }`,
+    expected: ['email'],
+  },
+];
+
+describe('extractInputFields', () => {
+  it.each(fieldExtractionCases)('$name', ({ template, expected }) => {
+    const result = extractInputFields(template);
+    expect(result.fields.sort()).toEqual(expected);
+    expect(result.errors).toBeUndefined();
+  });
+
+  it.each(fieldExtractionErrorCases)('should return error: $name', ({ template, errorMatch }) => {
+    const result = extractInputFields(template);
+    expect(result.fields).toEqual([]);
+    expect(result.errors?.[0]).toMatch(errorMatch);
+  });
+});

--- a/src/v0/destinations/custom_audience/templateValidator.test.ts
+++ b/src/v0/destinations/custom_audience/templateValidator.test.ts
@@ -66,6 +66,11 @@ describe('parseTemplate', () => {
       }`,
       expectedFields: ['email'],
     },
+    {
+      name: 'iteration on non-records path (no record fields extracted)',
+      template: '{ "data": $.connection.({ "id": .email }) }',
+      expectedFields: [],
+    },
   ];
 
   const invalidTemplates = [
@@ -93,11 +98,27 @@ describe('parseTemplate', () => {
     { name: 'bare identifier (process)', template: 'process', errorMatch: /Bare identifiers/ },
     { name: 'bare identifier (Object)', template: 'Object', errorMatch: /Bare identifiers/ },
     { name: 'bracket notation', template: '$["records"]', errorMatch: /Bracket notation/ },
-    { name: 'standalone block expressions', template: '($.a; $.b)', errorMatch: /Standalone block/ },
+    {
+      name: 'standalone block expressions',
+      template: '($.a; $.b)',
+      errorMatch: /Standalone block/,
+    },
     { name: 'assignment expressions', template: 'let x = 1; x = 2', errorMatch: /not supported/ },
-    { name: 'return expressions (parser level)', template: 'return $.records', errorMatch: /return, throw, continue and break/ },
-    { name: 'throw expressions (parser level)', template: 'throw "error"', errorMatch: /return, throw, continue and break/ },
-    { name: 'unparseable syntax', template: '{ invalid :: syntax }', errorMatch: /Unexpected token/ },
+    {
+      name: 'return expressions (parser level)',
+      template: 'return $.records',
+      errorMatch: /return, throw, continue and break/,
+    },
+    {
+      name: 'throw expressions (parser level)',
+      template: 'throw "error"',
+      errorMatch: /return, throw, continue and break/,
+    },
+    {
+      name: 'unparseable syntax',
+      template: '{ invalid :: syntax }',
+      errorMatch: /Unexpected token/,
+    },
     {
       name: 'relative path outside iteration',
       template: '{ "a": .field }',
@@ -108,13 +129,21 @@ describe('parseTemplate', () => {
       template: '{ "a": String($.records) }',
       errorMatch: /Only Number\(\) casting/,
     },
+    {
+      name: 'nested iteration under $.records',
+      template: '{ "data": $.records.foo.({ "id": .email }) }',
+      errorMatch: /Nested iteration under \$\.records/,
+    },
   ];
 
-  it.each(validTemplates)('should accept and extract fields: $name', ({ template, expectedFields }) => {
-    const result = parseTemplate(template);
-    expect(result.valid).toBe(true);
-    expect('recordFields' in result && result.recordFields.sort()).toEqual(expectedFields);
-  });
+  it.each(validTemplates)(
+    'should accept and extract fields: $name',
+    ({ template, expectedFields }) => {
+      const result = parseTemplate(template);
+      expect(result.valid).toBe(true);
+      expect('recordFields' in result && result.recordFields.sort()).toEqual(expectedFields);
+    },
+  );
 
   it.each(invalidTemplates)('should reject: $name', ({ template, errorMatch }) => {
     const result = parseTemplate(template);

--- a/src/v0/destinations/custom_audience/templateValidator.test.ts
+++ b/src/v0/destinations/custom_audience/templateValidator.test.ts
@@ -1,211 +1,124 @@
-import { validateTemplate, extractInputFields } from './templateValidator';
+import { parseTemplate } from './templateValidator';
 
-const validTemplates = [
-  {
-    name: 'iteration producing objects with nested arrays',
-    template: `{
-      "elements": $.records.({
-        "action": "ADD",
-        "firstName": .first_name,
-        "lastName": .last_name,
-        "company": .company,
-        "country": .country,
-        "userIds": [
-          { "idType": "SHA256_EMAIL", "idValue": .email_sha256 }
-        ]
-      })
-    }`,
-  },
-  {
-    name: 'Number() casting and connection paths',
-    template: `{
-      "id_schema": ["EMAIL_SHA256"],
-      "advertiser_ids": ["my_advertiser_id"],
-      "action": "add",
-      "batch_data": $.records.({
-        "id": .email_sha256,
-        "audience_ids": [Number($.connection.audience_id)]
-      })
-    }`,
-  },
-  {
-    name: 'deeply nested objects inside iteration',
-    template: `{
-      "enablePartialFailure": true,
-      "operations": $.records.({
-        "create": {
-          "userIdentifiers": [
-            { "hashedEmail": .email_sha256 },
-            { "hashedPhoneNumber": .phone_sha256 }
+describe('parseTemplate', () => {
+  const validTemplates = [
+    {
+      name: 'iteration producing objects with nested arrays',
+      template: `{
+        "elements": $.records.({
+          "action": "ADD",
+          "firstName": .first_name,
+          "lastName": .last_name,
+          "company": .company,
+          "country": .country,
+          "userIds": [
+            { "idType": "SHA256_EMAIL", "idValue": .email_sha256 }
           ]
-        }
-      })
-    }`,
-  },
-  {
-    name: 'iteration producing arrays',
-    template: `{
-      "is_raw": true,
-      "data_source": { "sub_type": "ANYTHING" },
-      "schema": ["EMAIL", "PHONE", "GEN", "COUNTRY"],
-      "data": $.records.([.email, .phone, .gender, .country])
-    }`,
-  },
-];
+        })
+      }`,
+      expectedFields: ['company', 'country', 'email_sha256', 'first_name', 'last_name'],
+    },
+    {
+      name: 'Number() casting and connection fields excluded',
+      template: `{
+        "id_schema": ["EMAIL_SHA256"],
+        "advertiser_ids": ["my_advertiser_id"],
+        "action": "add",
+        "batch_data": $.records.({
+          "id": .email_sha256,
+          "audience_ids": [Number($.connection.audience_id)]
+        })
+      }`,
+      expectedFields: ['email_sha256'],
+    },
+    {
+      name: 'deeply nested objects inside iteration',
+      template: `{
+        "enablePartialFailure": true,
+        "operations": $.records.({
+          "create": {
+            "userIdentifiers": [
+              { "hashedEmail": .email_sha256 },
+              { "hashedPhoneNumber": .phone_sha256 }
+            ]
+          }
+        })
+      }`,
+      expectedFields: ['email_sha256', 'phone_sha256'],
+    },
+    {
+      name: 'iteration producing arrays',
+      template: `{
+        "is_raw": true,
+        "data_source": { "sub_type": "ANYTHING" },
+        "schema": ["EMAIL", "PHONE", "GEN", "COUNTRY"],
+        "data": $.records.([Number(.email), .phone, .gender, .country])
+      }`,
+      expectedFields: ['country', 'email', 'gender', 'phone'],
+    },
+    {
+      name: 'deduplicated fields',
+      template: `{
+        "data": $.records.({
+          "email1": .email,
+          "email2": .email
+        })
+      }`,
+      expectedFields: ['email'],
+    },
+  ];
 
-const invalidTemplates = [
-  { name: 'spread operator', template: '{ ...$.records }', errorMatch: /spread_expr/ },
-  {
-    name: 'variable declarations',
-    template: 'let x = 1; { "a": x }',
-    errorMatch: /definition_expr/,
-  },
-  {
-    name: 'generic function calls',
-    template: '$.records.map(.email)',
-    errorMatch: /Only Number\(\) casting/,
-  },
-  {
-    name: 'function definitions',
-    template: 'function() { $.records }',
-    errorMatch: /function_expr/,
-  },
-  {
-    name: 'loops',
-    template: 'for(let i = 0; i < 10; i = i + 1) { i }',
-    errorMatch: /not supported/,
-  },
-  { name: 'bare identifier (process)', template: 'process', errorMatch: /Bare identifiers/ },
-  { name: 'bare identifier (Object)', template: 'Object', errorMatch: /Bare identifiers/ },
-  { name: 'bracket notation', template: '$["records"]', errorMatch: /Bracket notation/ },
-  { name: 'standalone block expressions', template: '($.a; $.b)', errorMatch: /Standalone block/ },
-  { name: 'assignment expressions', template: 'let x = 1; x = 2', errorMatch: /not supported/ },
-  { name: 'return expressions (parser level)', template: 'return $.records', errorMatch: /.+/ },
-  { name: 'throw expressions (parser level)', template: 'throw "error"', errorMatch: /.+/ },
-  { name: 'unparseable syntax', template: '{ invalid :: syntax }', errorMatch: /.+/ },
-  {
-    name: 'relative path outside iteration',
-    template: '{ "a": .field }',
-    errorMatch: /Relative field/,
-  },
-  {
-    name: 'non-Number function call (String)',
-    template: '{ "a": String($.records) }',
-    errorMatch: /Only Number\(\) casting/,
-  },
-];
+  const invalidTemplates = [
+    { name: 'spread operator', template: '{ ...$.records }', errorMatch: /spread_expr/ },
+    {
+      name: 'variable declarations',
+      template: 'let x = 1; { "a": x }',
+      errorMatch: /definition_expr/,
+    },
+    {
+      name: 'generic function calls',
+      template: '$.records.map(.email)',
+      errorMatch: /Only Number\(\) casting/,
+    },
+    {
+      name: 'function definitions',
+      template: 'function() { $.records }',
+      errorMatch: /function_expr/,
+    },
+    {
+      name: 'loops',
+      template: 'for(let i = 0; i < 10; i = i + 1) { i }',
+      errorMatch: /not supported/,
+    },
+    { name: 'bare identifier (process)', template: 'process', errorMatch: /Bare identifiers/ },
+    { name: 'bare identifier (Object)', template: 'Object', errorMatch: /Bare identifiers/ },
+    { name: 'bracket notation', template: '$["records"]', errorMatch: /Bracket notation/ },
+    { name: 'standalone block expressions', template: '($.a; $.b)', errorMatch: /Standalone block/ },
+    { name: 'assignment expressions', template: 'let x = 1; x = 2', errorMatch: /not supported/ },
+    { name: 'return expressions (parser level)', template: 'return $.records', errorMatch: /return, throw, continue and break/ },
+    { name: 'throw expressions (parser level)', template: 'throw "error"', errorMatch: /return, throw, continue and break/ },
+    { name: 'unparseable syntax', template: '{ invalid :: syntax }', errorMatch: /Unexpected token/ },
+    {
+      name: 'relative path outside iteration',
+      template: '{ "a": .field }',
+      errorMatch: /Relative field/,
+    },
+    {
+      name: 'non-Number function call (String)',
+      template: '{ "a": String($.records) }',
+      errorMatch: /Only Number\(\) casting/,
+    },
+  ];
 
-describe('validateTemplate', () => {
-  it.each(validTemplates)('should accept: $name', ({ template }) => {
-    expect(validateTemplate(template)).toEqual({ valid: true });
+  it.each(validTemplates)('should accept and extract fields: $name', ({ template, expectedFields }) => {
+    const result = parseTemplate(template);
+    expect(result.valid).toBe(true);
+    expect('recordFields' in result && result.recordFields.sort()).toEqual(expectedFields);
   });
 
   it.each(invalidTemplates)('should reject: $name', ({ template, errorMatch }) => {
-    const result = validateTemplate(template);
+    const result = parseTemplate(template);
     expect(result.valid).toBe(false);
-    expect(result.errors?.[0]).toMatch(errorMatch);
-  });
-});
-
-const fieldExtractionErrorCases = [
-  {
-    name: 'unsupported function call',
-    template: '$.records.map(.email)',
-    errorMatch: /Only Number\(\) casting/,
-  },
-  { name: 'unparseable syntax', template: '{ invalid :: syntax }', errorMatch: /.+/ },
-  {
-    name: 'relative path outside iteration',
-    template: '{ "a": .field }',
-    errorMatch: /Relative field references/,
-  },
-  { name: 'bare identifier', template: 'process', errorMatch: /Bare identifiers/ },
-  { name: 'bracket notation', template: '$["records"]', errorMatch: /Bracket notation/ },
-  { name: 'standalone block expression', template: '($.a; $.b)', errorMatch: /Standalone block/ },
-  {
-    name: 'spread operator',
-    template: '{ ...$.records }',
-    errorMatch: /spread_expr.*not supported/,
-  },
-];
-
-const fieldExtractionCases = [
-  {
-    name: 'iteration producing objects with nested arrays',
-    template: `{
-      "elements": $.records.({
-        "action": "ADD",
-        "firstName": .first_name,
-        "lastName": .last_name,
-        "company": .company,
-        "country": .country,
-        "userIds": [
-          { "idType": "SHA256_EMAIL", "idValue": .email_sha256 }
-        ]
-      })
-    }`,
-    expected: ['company', 'country', 'email_sha256', 'first_name', 'last_name'],
-  },
-  {
-    name: 'connection fields excluded',
-    template: `{
-      "id_schema": ["EMAIL_SHA256"],
-      "advertiser_ids": ["my_advertiser_id"],
-      "action": "add",
-      "batch_data": $.records.({
-        "id": .email_sha256,
-        "audience_ids": [Number($.connection.audience_id)]
-      })
-    }`,
-    expected: ['email_sha256'],
-  },
-  {
-    name: 'deeply nested iteration objects',
-    template: `{
-      "enablePartialFailure": true,
-      "operations": $.records.({
-        "create": {
-          "userIdentifiers": [
-            { "hashedEmail": .email_sha256 },
-            { "hashedPhoneNumber": .phone_sha256 }
-          ]
-        }
-      })
-    }`,
-    expected: ['email_sha256', 'phone_sha256'],
-  },
-  {
-    name: 'iteration producing arrays',
-    template: `{
-      "is_raw": true,
-      "data_source": { "sub_type": "ANYTHING" },
-      "schema": ["EMAIL", "PHONE", "GEN", "COUNTRY"],
-      "data": $.records.([Number(.email), .phone, .gender, .country])
-    }`,
-    expected: ['country', 'email', 'gender', 'phone'],
-  },
-  {
-    name: 'deduplicated fields',
-    template: `{
-      "data": $.records.({
-        "email1": .email,
-        "email2": .email
-      })
-    }`,
-    expected: ['email'],
-  },
-];
-
-describe('extractInputFields', () => {
-  it.each(fieldExtractionCases)('$name', ({ template, expected }) => {
-    const result = extractInputFields(template);
-    expect(result.fields.sort()).toEqual(expected);
-    expect(result.errors).toBeUndefined();
-  });
-
-  it.each(fieldExtractionErrorCases)('should return error: $name', ({ template, errorMatch }) => {
-    const result = extractInputFields(template);
-    expect(result.fields).toEqual([]);
-    expect(result.errors?.[0]).toMatch(errorMatch);
+    expect('errors' in result && result.errors[0]).toMatch(errorMatch);
   });
 });

--- a/src/v0/destinations/custom_audience/templateValidator.ts
+++ b/src/v0/destinations/custom_audience/templateValidator.ts
@@ -131,6 +131,23 @@ const NODE_HANDLERS: Record<string, NodeHandler> = {
         return;
       }
 
+      // Reject nested iteration under $.records (e.g. `$.records.foo.({...})`).
+      // Only `$.records.({...})` is allowed — deeper paths would produce
+      // incorrect recordFields since the relative fields refer to nested data.
+      const hasBlockExpr = parts.some((part: Expression) => part.type === SyntaxType.BLOCK_EXPR);
+      if (
+        hasBlockExpr &&
+        root === INTERNAL_ROOT &&
+        parts[0]?.type === SyntaxType.SELECTOR &&
+        parts[0].prop?.value === RECORDS_FIELD &&
+        !(parts.length === 2 && parts[1].type === SyntaxType.BLOCK_EXPR)
+      ) {
+        ctx.errors.push(
+          'Nested iteration under $.records is not supported. Use $.records.({...}) directly.',
+        );
+        return;
+      }
+
       // Validate each part (selector, block_expr) with insidePathParts=true
       // so block_expr is treated as iteration, not standalone.
       parts.forEach((part: Expression) => walk(part, { ...ctx, insidePathParts: true }));

--- a/src/v0/destinations/custom_audience/templateValidator.ts
+++ b/src/v0/destinations/custom_audience/templateValidator.ts
@@ -341,36 +341,28 @@ function parseAndValidate(template: string): { ast: Expression } | { errors: str
   return { ast };
 }
 
+type ParseTemplateResult =
+  | { valid: true; recordFields: string[] }
+  | { valid: false; errors: string[] };
+
 /**
- * Validate a user-provided template string.
+ * Parse, validate, and extract record fields from a user-provided template.
  *
- * Parses the template into an AST and walks every node against a whitelist.
- * Returns all validation errors (not fail-fast) so users can fix everything
- * in one pass.
+ * Parses the template into an AST, walks every node against a whitelist
+ * (returning all errors so users can fix everything in one pass), then
+ * extracts deduplicated record field names from `$.records.()` iteration
+ * blocks.
+ *
+ * Example: `{ "data": $.records.([.email, .phone]) }`
+ *   → { valid: true, fields: ["email", "phone"] }
  */
-export function validateTemplate(template: string): { valid: boolean; errors?: string[] } {
+export function parseTemplate(template: string): ParseTemplateResult {
   const result = parseAndValidate(template);
   if ('errors' in result) {
     return { valid: false, errors: result.errors };
   }
-  return { valid: true };
-}
-
-/**
- * Extract record field names referenced in a template.
- *
- * Returns deduplicated field names accessed inside `$.records.()` iteration
- * blocks.  Unsupported syntax returns errors instead of fields.
- *
- * Example: `{ "data": $.records.([.email, .phone]) }` → { fields: ["email", "phone"] }
- */
-export function extractInputFields(template: string): { fields: string[]; errors?: string[] } {
-  const result = parseAndValidate(template);
-  if ('errors' in result) {
-    return { fields: [], errors: result.errors };
-  }
 
   const fields = new Set<string>();
   collectFields(result.ast, false, fields);
-  return { fields: [...fields] };
+  return { valid: true, recordFields: [...fields] };
 }

--- a/src/v0/destinations/custom_audience/templateValidator.ts
+++ b/src/v0/destinations/custom_audience/templateValidator.ts
@@ -1,0 +1,376 @@
+/**
+ * Template Validator for Custom Audience destinations.
+ *
+ * User-provided request body templates are parsed into an AST by the
+ * json-template-engine and then walked against a whitelist of allowed node
+ * types.  Any node type not in the whitelist is rejected, which blocks
+ * function calls, loops, assignments, spread, and all other dynamic
+ * constructs.  The only function call allowed is `Number()` casting.
+ *
+ * Example of a valid template:
+ *
+ *   {
+ *     "action": "add",
+ *     "batch_data": $.records.({
+ *       "id": .email_sha256,
+ *       "audience_ids": [Number($.connection.audience_id)]
+ *     })
+ *   }
+ *
+ * The engine parses this into an AST where:
+ *   - `$` paths get root = "___d" (engine-internal alias for the root data)
+ *   - relative paths like `.email_sha256` have no root (undefined)
+ *   - `$.records.({...})` produces a path with a block_expr part (iteration)
+ *   - `Number(...)` produces a function_call_expr with parent = "Number"
+ */
+import {
+  JsonTemplateEngine,
+  PathType,
+  Expression,
+  SyntaxType,
+} from '@rudderstack/json-template-engine';
+
+// The engine internally rewrites `$` (JSONPath root) to this identifier.
+// e.g. `$.records` → path { root: "___d", parts: [selector "records"] }
+const INTERNAL_ROOT = '___d';
+
+// Selector prop types produced by the engine's parser.
+// Dot notation `$.records` → prop.type = "id"
+// Bracket notation `$["records"]` → prop.type = "str"
+const SELECTOR_PROP_TYPE_ID = 'id';
+const SELECTOR_PROP_TYPE_STR = 'str';
+
+// The field name used in `$.records.()` iteration paths.
+const RECORDS_FIELD = 'records';
+
+// The only function call allowed in templates — `Number(value)` for type
+// casting.  e.g. `Number($.connection.audience_id)` parses as:
+//   { type: "function_call_expr", parent: "Number", args: [<path-expr>] }
+const ALLOWED_FUNCTION_PARENT = 'Number';
+
+interface ValidationContext {
+  /** True when inside a $.records.() iteration block, where relative paths are valid. */
+  insideIterationBlock: boolean;
+  /** True when walking parts of a path expression (selectors, block_expr). */
+  insidePathParts: boolean;
+  errors: string[];
+}
+
+// Walk function signatures passed to handlers so they can recurse
+// without directly referencing validateNode/collectFields.
+type ValidateWalker = (node: Expression, ctx: ValidationContext) => void;
+type FieldWalker = (node: Expression, insideRecordsIteration: boolean, fields: Set<string>) => void;
+
+interface NodeHandler {
+  /**
+   * Validate this node type's children. Called during validateTemplate().
+   * Presence of a handler entry in NODE_HANDLERS IS the whitelist — if the
+   * node type isn't here, it's rejected.
+   */
+  validate: (node: Expression, ctx: ValidationContext, walk: ValidateWalker) => void;
+
+  /**
+   * Extract record field names from this node type's children.
+   * Called during extractInputFields(). Optional — omit for leaf nodes
+   * or nodes whose children are traversed by their parent's handler
+   * (e.g. SELECTOR is a leaf, BLOCK_EXPR is entered via PATH's handler).
+   */
+  collectFields?: (
+    node: Expression,
+    insideRecordsIteration: boolean,
+    fields: Set<string>,
+    walk: FieldWalker,
+  ) => void;
+}
+
+/**
+ * Unified handler map for all allowed AST node types.
+ *
+ * Each entry defines how to validate and extract fields for one node type.
+ * A node type being present here IS the whitelist — anything not in this
+ * map is rejected during validation.
+ *
+ * To add a new allowed node type: add one entry here with both handlers.
+ */
+const NODE_HANDLERS: Record<string, NodeHandler> = {
+  // Top-level wrapper — every parsed template starts with this.
+  // e.g. `{ "a": 1 }` → { type: "statements_expr", statements: [<object_expr>] }
+  [SyntaxType.STATEMENTS_EXPR]: {
+    validate: (node, ctx, walk) => {
+      node.statements.forEach((stmt: Expression) => walk(stmt, ctx));
+    },
+    collectFields: (node, insideRecordsIteration, fields, walk) => {
+      node.statements.forEach((stmt: Expression) => walk(stmt, insideRecordsIteration, fields));
+    },
+  },
+
+  // Path expression — `$.records`, `$.connection.id`, or relative `.email`.
+  // Three cases for `root`:
+  //   1. root === "___d"    → `$` path (e.g. `$.records`) — allowed
+  //   2. root === undefined → relative path (e.g. `.email`) — only inside iteration
+  //   3. root === "process" → bare identifier — rejected
+  [SyntaxType.PATH]: {
+    validate: (node, ctx, walk) => {
+      const { root } = node;
+      const parts: Expression[] = node.parts ?? [];
+
+      if (root === undefined || root === null) {
+        // Relative path like `.email_sha256` — only valid inside $.records.()
+        if (!ctx.insideIterationBlock) {
+          ctx.errors.push(
+            'Relative field references (.field) can only be used inside a $.records.() iteration block.',
+          );
+          return;
+        }
+      } else if (typeof root === 'string' && root !== INTERNAL_ROOT) {
+        // Bare identifier like `process` or `Object` — root is the identifier name.
+        // Only `$` (internally "___d") is allowed as a path root.
+        ctx.errors.push(
+          `Bare identifiers (e.g., "${root}") are not allowed. Use $.field to access data.`,
+        );
+        return;
+      }
+
+      // Validate each part (selector, block_expr) with insidePathParts=true
+      // so block_expr is treated as iteration, not standalone.
+      parts.forEach((part: Expression) => walk(part, { ...ctx, insidePathParts: true }));
+    },
+
+    // Field extraction for paths:
+    //   - Relative path (no root) inside iteration → first selector = record field name
+    //     e.g. `.email_sha256` → "email_sha256"
+    //   - `$.records.(<block>)` → enter the block with insideRecordsIteration=true
+    //   - `$.connection.*` and other `$` paths → ignored (no record fields)
+    collectFields: (node, insideRecordsIteration, fields, walk) => {
+      const { root } = node;
+      const parts: Expression[] = node.parts ?? [];
+
+      if (root === undefined || root === null) {
+        // Relative path inside iteration — first selector is the record field name.
+        // e.g. `.email_sha256` → parts[0] is selector with prop.value = "email_sha256"
+        if (insideRecordsIteration && parts.length > 0) {
+          const [firstPart] = parts;
+          if (
+            firstPart.type === SyntaxType.SELECTOR &&
+            firstPart.prop?.type === SELECTOR_PROP_TYPE_ID
+          ) {
+            fields.add(firstPart.prop.value);
+          }
+        }
+      } else {
+        // $ path — check if this is `$.records.(<block>)` to enter iteration context.
+        // AST shape: root="___d", parts=[selector("records"), block_expr([...])]
+        const isRecordsPath =
+          root === INTERNAL_ROOT &&
+          parts.length >= 2 &&
+          parts[0].type === SyntaxType.SELECTOR &&
+          parts[0].prop?.value === RECORDS_FIELD;
+
+        parts.forEach((part: Expression) => {
+          if (part.type === SyntaxType.BLOCK_EXPR && isRecordsPath) {
+            part.statements.forEach((stmt: Expression) => walk(stmt, true, fields));
+          }
+        });
+      }
+    },
+  },
+
+  // Selector — the ".field" part of a path.
+  // Dot notation (`$.records`) produces prop.type = "id" — allowed.
+  // Bracket notation (`$["records"]`) produces prop.type = "str" — rejected.
+  // No collectFields needed — selectors are leaf nodes with no children to extract from.
+  // Note: prop is genuinely optional on SelectorExpression.
+  [SyntaxType.SELECTOR]: {
+    validate: (node, ctx) => {
+      const { prop } = node;
+      if (prop?.type === SELECTOR_PROP_TYPE_STR) {
+        ctx.errors.push(
+          'Bracket notation (["key"]) is not supported. Use dot notation (.key) instead.',
+        );
+      }
+    },
+  },
+
+  // Object literal — `{ "key": value }`
+  [SyntaxType.OBJECT_EXPR]: {
+    validate: (node, ctx, walk) => {
+      node.props.forEach((prop: Expression) => walk(prop, ctx));
+    },
+    collectFields: (node, insideRecordsIteration, fields, walk) => {
+      node.props.forEach((prop: Expression) => walk(prop, insideRecordsIteration, fields));
+    },
+  },
+
+  // Single property in an object — `"key": value`
+  [SyntaxType.OBJECT_PROP_EXPR]: {
+    validate: (node, ctx, walk) => {
+      walk(node.value, ctx);
+    },
+    collectFields: (node, insideRecordsIteration, fields, walk) => {
+      walk(node.value, insideRecordsIteration, fields);
+    },
+  },
+
+  // Array literal — `[item1, item2]`
+  [SyntaxType.ARRAY_EXPR]: {
+    validate: (node, ctx, walk) => {
+      node.elements.forEach((elem: Expression) => walk(elem, ctx));
+    },
+    collectFields: (node, insideRecordsIteration, fields, walk) => {
+      node.elements.forEach((elem: Expression) => walk(elem, insideRecordsIteration, fields));
+    },
+  },
+
+  // Block expression — appears in two contexts:
+  //   1. As a path part (iteration): `$.records.({...})` — insidePathParts=true
+  //   2. As a standalone statement: `($.a; $.b)` — insidePathParts=false, rejected
+  //
+  // When valid (iteration), must contain exactly one expression: object or array.
+  // e.g. `$.records.({ "id": .email })` → block with one object_expr
+  //      `$.records.([.email, .phone])` → block with one array_expr
+  //
+  // No collectFields needed — PATH's collectFields handler enters block_expr
+  // directly when it detects a `$.records.(<block>)` pattern.
+  [SyntaxType.BLOCK_EXPR]: {
+    validate: (node, ctx, walk) => {
+      if (!ctx.insidePathParts) {
+        ctx.errors.push('Standalone block expressions are not supported.');
+        return;
+      }
+      if (node.statements.length !== 1) {
+        ctx.errors.push(
+          'Iteration blocks must contain exactly one expression (an object or array).',
+        );
+        return;
+      }
+      const [inner] = node.statements;
+      if (inner.type !== SyntaxType.OBJECT_EXPR && inner.type !== SyntaxType.ARRAY_EXPR) {
+        ctx.errors.push(
+          'Iteration blocks must contain exactly one expression (an object or array).',
+        );
+        return;
+      }
+      // Inside the iteration body, relative paths (.field) become valid
+      walk(inner, { ...ctx, insideIterationBlock: true, insidePathParts: false });
+    },
+  },
+
+  // Function call expressions — only Number() type casting is allowed.
+  // e.g. `Number($.connection.audience_id)` → walk into the argument
+  // Other function calls (`.map()`, `String()`, etc.) are rejected.
+  [SyntaxType.FUNCTION_CALL_EXPR]: {
+    validate: (node, ctx, walk) => {
+      if (node.parent !== ALLOWED_FUNCTION_PARENT || node.args.length !== 1) {
+        ctx.errors.push('Function calls are not supported. Only Number() casting is allowed.');
+        return;
+      }
+      walk(node.args[0], ctx);
+    },
+    collectFields: (node, insideRecordsIteration, fields, walk) => {
+      // After validation, only Number(expr) with a single arg reaches here
+      walk(node.args[0], insideRecordsIteration, fields);
+    },
+  },
+
+  // Literal values — "string", 123, true, false, null.  Always valid, no children.
+  [SyntaxType.LITERAL]: {
+    validate: () => {},
+  },
+};
+
+/**
+ * Recursively validate an AST node against the whitelist.
+ *
+ * Walks the tree depth-first.  For each node:
+ *   1. Look up the node type in NODE_HANDLERS — if missing, reject
+ *   2. Call the validate handler to recurse into children
+ */
+function validateNode(node: Expression, ctx: ValidationContext): void {
+  if (!node || !node.type) return;
+
+  const handler = NODE_HANDLERS[node.type];
+  if (!handler) {
+    ctx.errors.push(`Expression type "${node.type}" is not supported.`);
+    return;
+  }
+
+  handler.validate(node, ctx, validateNode);
+}
+
+/**
+ * Recursively collect record field names from the AST.
+ *
+ * Only extracts fields accessed via relative paths inside `$.records.()`
+ * iteration blocks.  Connection fields (e.g. `$.connection.audience_id`)
+ * and static literals are ignored.
+ *
+ * Example: for the template
+ *   { "data": $.records.({ "id": .email, "x": [Number($.connection.id)] }) }
+ * this returns ["email"] — `.email` is a record field, `$.connection.id` is not.
+ */
+function collectFields(
+  node: Expression,
+  insideRecordsIteration: boolean,
+  fields: Set<string>,
+): void {
+  if (!node || !node.type) return;
+  NODE_HANDLERS[node.type].collectFields?.(node, insideRecordsIteration, fields, collectFields);
+}
+
+/**
+ * Parse and validate a template string, returning the validated AST or errors.
+ */
+function parseAndValidate(template: string): { ast: Expression } | { errors: string[] } {
+  let ast: Expression;
+  try {
+    ast = JsonTemplateEngine.parse(template, { defaultPathType: PathType.JSON });
+  } catch (e: any) {
+    return { errors: [e.message || 'Failed to parse template.'] };
+  }
+
+  const ctx: ValidationContext = {
+    insideIterationBlock: false,
+    insidePathParts: false,
+    errors: [],
+  };
+  validateNode(ast, ctx);
+
+  if (ctx.errors.length > 0) {
+    return { errors: ctx.errors };
+  }
+  return { ast };
+}
+
+/**
+ * Validate a user-provided template string.
+ *
+ * Parses the template into an AST and walks every node against a whitelist.
+ * Returns all validation errors (not fail-fast) so users can fix everything
+ * in one pass.
+ */
+export function validateTemplate(template: string): { valid: boolean; errors?: string[] } {
+  const result = parseAndValidate(template);
+  if ('errors' in result) {
+    return { valid: false, errors: result.errors };
+  }
+  return { valid: true };
+}
+
+/**
+ * Extract record field names referenced in a template.
+ *
+ * Returns deduplicated field names accessed inside `$.records.()` iteration
+ * blocks.  Unsupported syntax returns errors instead of fields.
+ *
+ * Example: `{ "data": $.records.([.email, .phone]) }` → { fields: ["email", "phone"] }
+ */
+export function extractInputFields(template: string): { fields: string[]; errors?: string[] } {
+  const result = parseAndValidate(template);
+  if ('errors' in result) {
+    return { fields: [], errors: result.errors };
+  }
+
+  const fields = new Set<string>();
+  collectFields(result.ast, false, fields);
+  return { fields: [...fields] };
+}


### PR DESCRIPTION
## Summary
- Add whitelist-based AST validator and field extractor for user-provided request body templates (`parseTemplate`)
- Walks the json-template-engine AST against a minimal whitelist of allowed node types (objects, arrays, paths, selectors, literals, iteration blocks, Number() casting)
- Returns a discriminated union: `{ valid: true, recordFields: string[] }` or `{ valid: false, errors: string[] }`
- Rejects function calls, loops, assignments, spread, bare identifiers, bracket notation, and standalone blocks

## Test plan
- [x] 5 valid template cases (nested objects, Number() casting, deeply nested, array iteration, deduplication)
- [x] 15 invalid template cases (spread, variable decls, function calls/defs, loops, bare identifiers, bracket notation, standalone blocks, assignments, return/throw, parse errors, relative paths outside iteration, non-Number function calls)
- [x] `npm run lint` passes
- [x] `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)