### PR TITLE
feat(custom_audience): add parse-template endpoint

### DIFF
--- a/.claude/skills/code-structure/SKILL.md
+++ b/.claude/skills/code-structure/SKILL.md
@@ -163,6 +163,29 @@ const isRecordsPath =
   parts[0].prop?.value === 'records';
 ```
 
+## Use `formatZodError` for Zod Validation Errors
+
+When returning Zod validation errors in controllers or utilities, use `formatZodError` from `@rudderstack/integrations-lib` instead of manually formatting `error.issues`.
+
+```ts
+// Good
+import { formatZodError } from '@rudderstack/integrations-lib';
+
+const parsed = schema.safeParse(ctx.request.body);
+if (!parsed.success) {
+  ctx.body = { error: formatZodError(parsed.error) };
+  ctx.status = 400;
+  return;
+}
+
+// Bad — manual formatting duplicates what the util already does
+if (!parsed.success) {
+  ctx.body = { error: parsed.error.issues.map((i) => i.message).join('; ') };
+  ctx.status = 400;
+  return;
+}
+```
+
 ## Inline Single-Use Wrapper Functions
 
 Don't extract a function that's called from exactly one place and adds no clarity. Inline it.

--- a/.claude/skills/writing-tests/SKILL.md
+++ b/.claude/skills/writing-tests/SKILL.md
@@ -37,23 +37,24 @@ if (result.valid) {
 
 ## Table-Driven Tests With `it.each()`
 
-When multiple test cases share the same assertion structure, use `it.each()` with a data table instead of individual `it()` blocks. Keep test data arrays at the top of the file or describe block for easy scanning.
+When two or more test cases share the same assertion structure, group them into an `it.each()` data table. When a describe block has cases with different assertion shapes, use one `it.each()` per shape. Keep test data arrays at the top of the describe block for easy scanning.
 
 ```ts
-// Good — data table + single runner
-const invalidTemplates = [
+// Good — cases grouped by assertion shape, each group gets its own it.each()
+const validCases = [
+  { name: 'objects', template: '$.records.({ "e": .email })', expectedFields: ['email'] },
+  { name: 'arrays', template: '$.records.([.email, .phone])', expectedFields: ['email', 'phone'] },
+];
+
+const invalidCases = [
   { name: 'spread operator', template: '{ ...$.records }', errorMatch: /spread_expr/ },
-  { name: 'variable declarations', template: 'let x = 1', errorMatch: /definition_expr/ },
   { name: 'bare identifier', template: 'process', errorMatch: /Bare identifiers/ },
 ];
 
-it.each(invalidTemplates)('should reject: $name', ({ template, errorMatch }) => {
-  const result = validateTemplate(template);
-  expect(result.valid).toBe(false);
-  expect(result.errors?.[0]).toMatch(errorMatch);
-});
+it.each(validCases)('should accept: $name', ({ template, expectedFields }) => { ... });
+it.each(invalidCases)('should reject: $name', ({ template, errorMatch }) => { ... });
 
-// Bad — repetitive individual blocks with identical structure
+// Bad — individual blocks with identical assertion structure
 it('should reject spread operator', () => {
   const result = validateTemplate('{ ...$.records }');
   expect(result.valid).toBe(false);
@@ -65,6 +66,43 @@ it('should reject variable declarations', () => {
   expect(result.valid).toBe(false);
   expect(result.errors?.[0]).toMatch(/definition_expr/);
 });
+```
+
+## Test Depth Should Match Logic Ownership
+
+Thoroughly test the logic a layer owns (e.g., input validation in a controller — cover all invalid shapes). For success/failure paths delegated to another module that has its own tests, one representative case each is enough.
+
+```ts
+// Good — controller owns Zod validation, so test all 400 shapes;
+// one valid + one invalid template case since templateValidator.test.ts covers the rest
+const badRequestCases = [
+  { name: 'missing field', body: {}, expectedError: 'requestBody: Required' },
+  { name: 'empty string', body: { requestBody: '' }, expectedError: '...' },
+  { name: 'wrong type', body: { requestBody: 123 }, expectedError: '...' },
+];
+
+it.each(badRequestCases)('should return 400: $name', async ({ body, expectedError }) => { ... });
+
+it('should return valid=true for a valid template', async () => { ... });
+it('should return valid=false for an invalid template', async () => { ... });
+
+// Bad — controller test re-tests every template validation scenario
+// that templateValidator.test.ts already covers
+it('should reject spread operator', ...);
+it('should reject bare identifiers', ...);
+it('should reject bracket notation', ...);
+```
+
+## Test File Location and Naming
+
+Test files use 1:1 name mapping to the source file. If a `__tests__/` directory already exists at that level, place the test there. Otherwise, co-locate it alongside the source file.
+
+```
+# If __tests__/ exists
+src/controllers/__tests__/eventTest.test.ts
+
+# If no __tests__/ directory
+src/v0/destinations/custom_audience/templateValidator.test.ts
 ```
 
 ## Consistent Test Data Scoping

--- a/src/controllers/__tests__/eventTest.test.ts
+++ b/src/controllers/__tests__/eventTest.test.ts
@@ -1,0 +1,77 @@
+import http from 'http';
+import Koa from 'koa';
+import bodyParser from 'koa-bodyparser';
+import request from 'supertest';
+import { createHttpTerminator } from 'http-terminator';
+import { applicationRoutes } from '../../routes';
+
+let server: http.Server;
+
+beforeAll(() => {
+  const app = new Koa();
+  app.use(bodyParser({ jsonLimit: '200mb' }));
+  applicationRoutes(app);
+  server = app.listen();
+});
+
+afterAll(async () => {
+  const httpTerminator = createHttpTerminator({ server });
+  await httpTerminator.terminate();
+});
+
+const ENDPOINT = '/test-router/custom_audience/parse-template';
+
+describe('POST /test-router/custom_audience/parse-template', () => {
+  it('should return valid=true with recordFields for a valid template', async () => {
+    const response = await request(server)
+      .post(ENDPOINT)
+      .send({
+        requestBody: `{
+          "data": $.records.({
+            "email": .email,
+            "phone": .phone_sha256
+          })
+        }`,
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body.valid).toBe(true);
+    expect('recordFields' in response.body && response.body.recordFields.sort()).toEqual([
+      'email',
+      'phone_sha256',
+    ]);
+  });
+
+  it('should return valid=false with errors for an invalid template', async () => {
+    const response = await request(server).post(ENDPOINT).send({ requestBody: '{ ...$.records }' });
+
+    expect(response.status).toBe(200);
+    expect(response.body.valid).toBe(false);
+    expect('errors' in response.body && response.body.errors[0]).toMatch(/spread_expr/);
+  });
+
+  const badRequestCases = [
+    {
+      name: 'missing requestBody',
+      body: {},
+      expectedError: 'requestBody: Required',
+    },
+    {
+      name: 'empty string requestBody',
+      body: { requestBody: '' },
+      expectedError: 'requestBody: requestBody must be a non-empty string',
+    },
+    {
+      name: 'non-string requestBody',
+      body: { requestBody: 123 },
+      expectedError: 'requestBody: Expected string, received number',
+    },
+  ];
+
+  it.each(badRequestCases)('should return 400: $name', async ({ body, expectedError }) => {
+    const response = await request(server).post(ENDPOINT).send(body);
+
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe(expectedError);
+  });
+});

--- a/src/controllers/eventTest.ts
+++ b/src/controllers/eventTest.ts
@@ -1,7 +1,14 @@
 import { Context } from 'koa';
+import { formatZodError } from '@rudderstack/integrations-lib';
+import { z } from 'zod';
 import { EventTesterService } from '../services/eventTest/eventTester';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { CatchErr, FixMe } from '../types';
+import { parseTemplate } from '../v0/destinations/custom_audience/templateValidator';
+
+const parseTemplateBodySchema = z.object({
+  requestBody: z.string().min(1, 'requestBody must be a non-empty string'),
+});
 
 export class EventTestController {
   private static API_VERSION = '1';
@@ -25,5 +32,15 @@ export class EventTestController {
   public static status(ctx: Context) {
     ctx.status = 200;
     ctx.body = 'OK';
+  }
+
+  public static parseCustomAudienceTemplate(ctx: Context) {
+    const parsed = parseTemplateBodySchema.safeParse(ctx.request.body);
+    if (!parsed.success) {
+      ctx.status = 400;
+      ctx.body = { error: formatZodError(parsed.error) };
+      return;
+    }
+    ctx.body = parseTemplate(parsed.data.requestBody);
   }
 }

--- a/src/routes/testEvents.ts
+++ b/src/routes/testEvents.ts
@@ -3,6 +3,7 @@ import { EventTestController } from '../controllers/eventTest';
 
 const router = new Router({ prefix: '/test-router' });
 
+router.post('/custom_audience/parse-template', EventTestController.parseCustomAudienceTemplate);
 router.post('/:version/:destination', EventTestController.testEvent);
 router.get('/:version/health', EventTestController.status);
 

--- a/src/v0/destinations/custom_audience/templateValidator.test.ts
+++ b/src/v0/destinations/custom_audience/templateValidator.test.ts
@@ -115,6 +115,11 @@ describe('parseTemplate', () => {
       errorMatch: /return, throw, continue and break/,
     },
     {
+      name: 'recursive descent (..field)',
+      template: `{ "data": $.records.({ "email": ..email, "phone": .phone_sha256 }) }`,
+      errorMatch: /Recursive descent/,
+    },
+    {
       name: 'unparseable syntax',
       template: '{ invalid :: syntax }',
       errorMatch: /Unexpected token/,

--- a/src/v0/destinations/custom_audience/templateValidator.ts
+++ b/src/v0/destinations/custom_audience/templateValidator.ts
@@ -199,8 +199,12 @@ const NODE_HANDLERS: Record<string, NodeHandler> = {
   // Note: prop is genuinely optional on SelectorExpression.
   [SyntaxType.SELECTOR]: {
     validate: (node, ctx) => {
-      const { prop } = node;
-      if (prop?.type === SELECTOR_PROP_TYPE_STR) {
+      const { prop, selector } = node;
+      if (selector === '..') {
+        ctx.errors.push(
+          'Recursive descent (..) is not supported. Use single dot notation (.key) instead.',
+        );
+      } else if (prop?.type === SELECTOR_PROP_TYPE_STR) {
         ctx.errors.push(
           'Bracket notation (["key"]) is not supported. Use dot notation (.key) instead.',
         );


### PR DESCRIPTION
## Summary

- Wire `POST /test-router/custom_audience/parse-template` endpoint with Zod input validation and `parseTemplate` controller
- Add controller-level tests (valid template, invalid template, 400 bad-request cases)
- Reject recursive descent (`..field`) syntax in template validator
- Update skill files with new conventions (formatZodError, test depth, test file location)

## Test plan

- [ ] `npm test -- --testPathPattern="eventTest" --no-coverage` — controller tests pass
- [ ] `npm test -- --testPathPattern="templateValidator" --no-coverage` — validator tests pass (including new recursive descent case)
- [ ] `npm run lint` — no lint errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)