### PR TITLE
feat(custom_audience): router transform pipeline

### DIFF
--- a/.claude/skills/code-structure/SKILL.md
+++ b/.claude/skills/code-structure/SKILL.md
@@ -230,3 +230,72 @@ function loadConfig(raw: string): AppConfig {
   return normalize(parsed);
 }
 ```
+
+## Reuse Existing Repo-Wide Utilities Instead of Redeclaring
+
+Before defining a new constant, enum, or shared type for a record-spec destination, audience destination, or other common concept, search for an existing one. Common locations:
+
+- `src/v0/util/recordUtils.js` — `EVENT_TYPES` (`{ INSERT, UPDATE, DELETE }`) for record-action keys
+- `src/v0/util/audienceUtils.ts` — `HashingType` enum, `processAudienceRecord` for empty-stripping + hashing
+- `src/types/rudderEvents.ts` — `RecordAction` enum, `RudderRecordV2` Zod schema and inferred type, `RudderMessage`
+- `src/v0/util/index.js` — `getSuccessRespEvents`, `getErrorRespEvents`, `defaultRequestConfig`, `removeUndefinedAndNullAndEmptyValues`, `applyCustomMappings`, `applyJSONStringTemplate`
+
+```ts
+// Good — use the canonical record-action source
+import { EVENT_TYPES } from '../../util/recordUtils';
+import type { RecordAction } from '../../../types/rudderEvents';
+
+const schema = z.object({
+  action: z.enum([EVENT_TYPES.INSERT, EVENT_TYPES.UPDATE, EVENT_TYPES.DELETE]),
+});
+
+// Bad — re-declares constants and types that already exist
+const ACTIONS = { INSERT: 'insert', UPDATE: 'update', DELETE: 'delete' } as const;
+type Action = (typeof ACTIONS)[keyof typeof ACTIONS];
+```
+
+## Don't Re-Validate Inputs That Zod Has Already Validated
+
+If a function is reachable only through a Zod-guarded entry point (`getInputSchema()` in a `BatchDestination`, a controller's `safeParse()`, etc.), helpers downstream should treat the validated fields as guaranteed. Don't re-check enum membership, presence, or shape — let the type system carry that contract.
+
+```ts
+// Good — Zod validated `action`; the helper only handles its real job (lookup)
+const lookupActionConfig = (action: Action, destConfig: DestConfig): ActionConfig => {
+  const actionConfig = destConfig.actions[action];
+  if (!actionConfig) {
+    throw new InstrumentationError(`No action configuration for: ${action}`);
+  }
+  return actionConfig;
+};
+
+// Bad — duplicates the enum check Zod already enforced upstream
+const lookupActionConfig = (action: string, destConfig: DestConfig) => {
+  if (action !== 'insert' && action !== 'update' && action !== 'delete') {
+    throw new InstrumentationError(`Unsupported action: ${action}`);
+  }
+  // ... lookup
+};
+```
+
+## Don't Wrap a Callee's Existing Try-Catch
+
+If the function you call already converts errors to a project-standard error type (`InstrumentationError`, `ConfigurationError`, etc.), don't wrap the call site in another try-catch that re-throws the same kind of error. The added layer obscures the stack and only changes the message prefix.
+
+```ts
+// Good — evaluateTemplate already throws InstrumentationError on failure
+const resolveEndpoint = (template: string, baseUrl: string, conn: ConnConfig): string => {
+  const path = String(evaluateTemplate(`\`${template}\``, { connection: conn }) ?? '');
+  return `${baseUrl.replace(/\/$/, '')}${path.startsWith('/') ? path : `/${path}`}`;
+};
+
+// Bad — redundant outer try-catch that just re-wraps the same error class
+const resolveEndpoint = (template, baseUrl, conn) => {
+  let path: unknown;
+  try {
+    path = evaluateTemplate(`\`${template}\``, { connection: conn });
+  } catch (err) {
+    throw new InstrumentationError(`Failed to resolve endpoint: ${(err as Error).message}`);
+  }
+  // ...
+};
+```

--- a/.claude/skills/writing-tests/SKILL.md
+++ b/.claude/skills/writing-tests/SKILL.md
@@ -109,6 +109,76 @@ src/v0/destinations/custom_audience/templateValidator.test.ts
 
 All test data arrays within a `describe` block should live at the same scope — either all inside or all outside. Don't mix.
 
+## Component Test Fixtures Live in `common.ts`
+
+Reusable destination, connection, and override fixtures for component tests under `test/integrations/destinations/<destination>/` go in `common.ts` and are imported by `router/data.ts`, `processor/data.ts`, etc. Don't define them inline at the top of `data.ts`. This includes per-scenario variants (e.g., a destination override that changes a single action's `requestBody`, or a connection variant with `isHashRequired: true`).
+
+```ts
+// Good — variants exported from common.ts alongside the base fixtures
+// common.ts
+export const destination = { /* ... */ };
+export const connection = { /* ... */ };
+export const hashRequiredConnection = {
+  ...connection,
+  config: { destination: { ...connection.config.destination, isHashRequired: true } },
+};
+
+// router/data.ts
+import { destination, connection, hashRequiredConnection } from '../common';
+export const data = [
+  { /* ... */, connection: hashRequiredConnection },
+];
+
+// Bad — variants declared at the top of router/data.ts
+const hashRequiredConnection = { /* ... */ };  // belongs in common.ts
+```
+
+## Component Test Entries Are Plain Object Literals
+
+Each entry in the exported `data` array of `test/integrations/destinations/<destination>/{router,processor}/data.ts` is a plain object literal. Don't wrap an entry in an IIFE just to lift local consts — hoist those to top-level constants in `common.ts` (or near the top of the file if truly local) instead.
+
+```ts
+// Good — plain object entries; overrides hoisted to common.ts or top of file
+import { customMappingsDestination, customMappingsConnection } from '../common';
+
+export const data = [
+  {
+    id: 'test-4',
+    /* ... */,
+    input: { /* uses customMappingsDestination, customMappingsConnection */ },
+  },
+];
+
+// Bad — IIFE inside the array breaks the file's pattern
+export const data = [
+  (() => {
+    const customMappingsDestination = { /* ... */ };
+    const customMappingsConnection = { /* ... */ };
+    return { id: 'test-4', /* ... */ };
+  })(),
+];
+```
+
+## Compute Hashed Expected Values via the Hash Function
+
+When asserting on hashed identifiers in audience-destination tests, invoke the hash function in the test data (`sha256('a@b.com')`) instead of pasting a copied hex string. Generated values stay in sync with input edits and reviewers can scan inputs without decoding hex.
+
+```ts
+// Good
+import sha256 from 'sha256';
+
+users: [
+  { email: sha256('a@b.com') },
+  { email: sha256('c@d.com') },
+],
+
+// Bad — copied hex; rotting risk if the input email is ever changed
+users: [
+  { email: 'fb98d44ad7501a959f3f4f4a3f004fe2d9e581ea6207e218c4b02c08a4d75adf' },
+  { email: '6a4d2afe9d4d6f5cb73d8e3e3a8fa8e5dc1d2a1f64d1b9e0c5b9b1c2d6e3f5a4' },
+],
+```
+
 ## Mock Leaf Dependencies, Not Intermediate Modules
 
 Prefer using the real module and mocking only its leaf dependencies (logger, stats) rather than replacing the whole module with a stub. Only mock the module itself if using it makes the test significantly more complex.

--- a/src/constants/batchedDestinationsMap.ts
+++ b/src/constants/batchedDestinationsMap.ts
@@ -2,6 +2,7 @@
 // Once a destination is added here, it always uses the new path regardless of env var.
 export const batchedDestinationsMap: Record<string, true> = {
   POSTHOG: true,
+  CUSTOM_AUDIENCE: true,
 };
 
 // Per-destination env var: {DEST}_BATCHING_FRAMEWORK_ENABLED_WORKSPACE_IDS

--- a/src/features.ts
+++ b/src/features.ts
@@ -100,6 +100,7 @@ const defaultFeaturesConfig: FeaturesConfig = {
     ACCOIL_ANALYTICS: true,
     POSTSCRIPT: true,
     POSTHOG: true,
+    CUSTOM_AUDIENCE: true,
   },
   regulations: [
     'BRAZE',

--- a/src/services/destination/nativeBatching/batchDestination.ts
+++ b/src/services/destination/nativeBatching/batchDestination.ts
@@ -1,5 +1,5 @@
 import { ZodType } from 'zod';
-import type { Destination } from '../../../types/controlPlaneConfig';
+import type { Connection, Destination } from '../../../types/controlPlaneConfig';
 import type { RouterTransformationRequestData } from '../../../types/destinationTransformation';
 import { generateErrorObject } from '../../../v0/util';
 import type { BatchStrategy, TransformedEvent, TransformResult } from './types';
@@ -16,21 +16,34 @@ export { ChunkBatchStrategy } from './chunkBatchStrategy';
 export { CustomBatchStrategy } from './customBatchStrategy';
 
 // ---------------------------------------------------------------------------
-// Abstract class: BatchDestination<TBody>
+// Abstract class: BatchDestination<TBody, TConfig, TConnectionConfig>
 // ---------------------------------------------------------------------------
 
 // Constructor type for BatchDestination subclasses — used by the framework to instantiate per request
 export type BatchDestinationConstructor<
   TBody extends Record<string, unknown> = Record<string, unknown>,
-> = new (destination: Destination) => BatchDestination<TBody>;
+  TConfig = Record<string, unknown>,
+  TConnectionConfig = Record<string, unknown>,
+> = new (
+  destination: Destination<TConfig>,
+  connection?: Connection<TConnectionConfig>,
+) => BatchDestination<TBody, TConfig, TConnectionConfig>;
 
 export abstract class BatchDestination<
   TBody extends Record<string, unknown> = Record<string, unknown>,
+  TConfig = Record<string, unknown>,
+  TConnectionConfig = Record<string, unknown>,
 > {
-  protected destination: Destination;
+  protected destination: Destination<TConfig>;
 
-  constructor(destination: Destination) {
+  // All inputs in a single router-transform call share the same (source, destination)
+  // connection because rudder-server groups events that way before dispatching, so
+  // it's safe for the framework to inject the connection at construction time.
+  protected connection?: Connection<TConnectionConfig>;
+
+  constructor(destination: Destination<TConfig>, connection?: Connection<TConnectionConfig>) {
     this.destination = destination;
+    this.connection = connection;
   }
 
   // --- MUST implement ---

--- a/src/services/destination/nativeBatching/processBatchedDestination.ts
+++ b/src/services/destination/nativeBatching/processBatchedDestination.ts
@@ -1,5 +1,5 @@
 import stableStringify from 'fast-json-stable-stringify';
-import type { Destination } from '../../../types/controlPlaneConfig';
+import type { Connection, Destination } from '../../../types/controlPlaneConfig';
 import type { Metadata } from '../../../types/rudderEvents';
 import type {
   RouterTransformationRequestData,
@@ -20,9 +20,13 @@ import { combineBatchRequestsWithSameJobIds } from '../../../v0/util';
 // Validation
 // ---------------------------------------------------------------------------
 
-export function validateInputs<TBody extends Record<string, unknown>>(
+export function validateInputs<
+  TBody extends Record<string, unknown>,
+  TConfig = Record<string, unknown>,
+  TConnectionConfig = Record<string, unknown>,
+>(
   inputs: RouterTransformationRequestData[],
-  integration: BatchDestination<TBody>,
+  integration: BatchDestination<TBody, TConfig, TConnectionConfig>,
 ): { valid: RouterTransformationRequestData[]; errors: (TransformError & { jobId: number })[] } {
   const schema = integration.getInputSchema();
 
@@ -109,6 +113,7 @@ export function groupPayloadsByCompositeKey<
       method: payload.method,
       headers: payload.headers ?? {},
       params: payload.params ?? {},
+      internalGroupKey: payload.internalGroupKey ?? '',
     });
 
     let group = map.get(key);
@@ -190,16 +195,21 @@ function mapErrorPayloadToServerFormat(
 
 export async function processBatchedDestination<
   TBody extends Record<string, unknown> = Record<string, unknown>,
+  TConfig = Record<string, unknown>,
+  TConnectionConfig = Record<string, unknown>,
 >(
   events: RouterTransformationRequestData[],
-  IntegrationClass: BatchDestinationConstructor<TBody>,
+  IntegrationClass: BatchDestinationConstructor<TBody, TConfig, TConnectionConfig>,
   reqMetadata: NonNullable<unknown>,
 ): Promise<RouterTransformationResponse[]> {
   if (events.length === 0) {
     return [];
   }
   const { destination } = events[0];
-  const integration = new IntegrationClass(destination);
+  const connection = events.find((event) => event.connection)?.connection as
+    | Connection<TConnectionConfig>
+    | undefined;
+  const integration = new IntegrationClass(destination as Destination<TConfig>, connection);
   const destType = destination.DestinationDefinition?.Name?.toUpperCase() ?? 'unknown';
   const { workspaceId } = events[0].metadata;
   const metricTags = { destType, workspaceId, destinationId: destination.ID };

--- a/src/services/destination/nativeBatching/types.ts
+++ b/src/services/destination/nativeBatching/types.ts
@@ -8,6 +8,11 @@ export type TransformedEvent<TBody extends Record<string, unknown> = Record<stri
   method: string;
   headers?: Record<string, unknown>;
   params?: Record<string, unknown>;
+  // Optional discriminator that adds to the composite grouping key (alongside
+  // endpoint/method/headers/params) so destinations with extra dimensions
+  // (e.g. action type when multiple actions share a URL) can keep groups separate
+  // without polluting the user-visible request fields.
+  internalGroupKey?: string;
 };
 
 export type TransformError = {

--- a/src/v0/destinations/custom_audience/constants.ts
+++ b/src/v0/destinations/custom_audience/constants.ts
@@ -1,0 +1,15 @@
+export const SUPPORTED_HTTP_METHODS = ['POST', 'PUT', 'PATCH', 'GET', 'DELETE'] as const;
+
+export const AUTHENTICATION_TYPES = {
+  NO_AUTH: 'noAuth',
+  BASIC_AUTH: 'basicAuth',
+  BEARER_TOKEN: 'bearerToken',
+  API_KEY: 'apiKey',
+} as const;
+
+export const ERROR_MESSAGES = {
+  NO_ACTION_CONFIG: (action: string) => `No action configuration found for action: ${action}`,
+  ALL_FIELDS_STRIPPED: 'All fields were stripped after processing; nothing to send',
+  TEMPLATE_EVALUATION_FAILED: (reason: string) =>
+    `Failed to evaluate requestBody template: ${reason}`,
+};

--- a/src/v0/destinations/custom_audience/routerTransform.test.ts
+++ b/src/v0/destinations/custom_audience/routerTransform.test.ts
@@ -1,0 +1,243 @@
+import sha256 from 'sha256';
+import { HashingType } from '../../util/audienceUtils';
+import { Integration } from './routerTransform';
+import { processBatchedDestination } from '../../../services/destination/nativeBatching/processBatchedDestination';
+import type { Metadata } from '../../../types/rudderEvents';
+import type { RouterTransformationRequestData } from '../../../types/destinationTransformation';
+import { AUTHENTICATION_TYPES } from './constants';
+import type {
+  Action,
+  ActionConfig,
+  CustomAudienceConnection,
+  CustomAudienceConnectionConfig,
+  CustomAudienceDestConfig,
+  CustomAudienceDestination,
+} from './types';
+
+const baseInsertAction: ActionConfig = {
+  endpoint: '/audiences/${$.connection.audienceId}/members',
+  method: 'POST',
+  requestBody:
+    '{ "audienceId": $.connection.audienceId, "users": $.records.({ "email": .email }) }',
+  batchSize: 2,
+  fields: [{ name: 'email', hashType: HashingType.SHA256, isRequired: true, isCustom: false }],
+};
+
+const baseDeleteAction: ActionConfig = {
+  endpoint: '/audiences/${$.connection.audienceId}/members',
+  method: 'DELETE',
+  requestBody: '{ "audienceId": $.connection.audienceId, "users": $.records }',
+  batchSize: 2,
+  fields: [{ name: 'email', hashType: HashingType.SHA256, isRequired: true, isCustom: false }],
+};
+
+const buildDestination = (
+  configOverrides: Partial<CustomAudienceDestConfig> = {},
+): CustomAudienceDestination => ({
+  ID: 'dest-1',
+  Name: 'custom_audience',
+  DestinationDefinition: {
+    ID: 'destDef-1',
+    Name: 'CUSTOM_AUDIENCE',
+    DisplayName: 'Custom Audience',
+    Config: {},
+  },
+  Config: {
+    baseUrl: 'https://api.example.com',
+    authenticationType: AUTHENTICATION_TYPES.NO_AUTH,
+    actions: { insert: baseInsertAction, delete: baseDeleteAction },
+    ...configOverrides,
+  },
+  Enabled: true,
+  WorkspaceID: 'ws-1',
+  Transformations: [],
+});
+
+const buildConnection = (
+  destinationOverrides: Partial<CustomAudienceConnectionConfig> = {},
+): CustomAudienceConnection => ({
+  sourceId: 'src-1',
+  destinationId: 'dest-1',
+  enabled: true,
+  config: {
+    destination: {
+      audienceId: 'aud-42',
+      isHashRequired: false,
+      ...destinationOverrides,
+    },
+  },
+});
+
+const buildMetadata = (jobId: number): Metadata =>
+  ({
+    jobId,
+    workspaceId: 'ws-1',
+    destinationId: 'dest-1',
+    sourceId: 'src-1',
+    sourceType: 'warehouse',
+    sourceCategory: 'warehouse',
+    destinationType: 'CUSTOM_AUDIENCE',
+    messageId: `msg-${jobId}`,
+  }) as Metadata;
+
+const buildInput = (
+  jobId: number,
+  action: Action,
+  fields: Record<string, unknown>,
+  destination: CustomAudienceDestination = buildDestination(),
+  connection: CustomAudienceConnection = buildConnection(),
+): RouterTransformationRequestData =>
+  ({
+    message: {
+      type: 'record',
+      action,
+      fields,
+      channel: 'sources',
+      context: {},
+      recordId: String(jobId),
+    },
+    metadata: buildMetadata(jobId),
+    destination,
+    connection,
+  }) as unknown as RouterTransformationRequestData;
+
+describe('CustomAudienceIntegration via processBatchedDestination', () => {
+  it('groups events by action and chunks by batchSize', async () => {
+    const inputs = [
+      buildInput(1, 'insert', { email: 'a@b.com' }),
+      buildInput(2, 'insert', { email: 'c@d.com' }),
+      buildInput(3, 'insert', { email: 'e@f.com' }),
+      buildInput(4, 'delete', { email: 'g@h.com' }),
+    ];
+
+    const results = await processBatchedDestination(inputs, Integration, {});
+
+    const successResults = results.filter((r) => r.statusCode === 200);
+    // 3 inserts → 2 chunks of batchSize=2; 1 delete → 1 chunk. Total 3 success batches.
+    expect(successResults).toHaveLength(3);
+    expect(results.filter((r) => r.statusCode !== 200)).toHaveLength(0);
+
+    const insertBatches = successResults.filter(
+      (r) => !Array.isArray(r.batchedRequest) && r.batchedRequest?.method === 'POST',
+    );
+    const deleteBatches = successResults.filter(
+      (r) => !Array.isArray(r.batchedRequest) && r.batchedRequest?.method === 'DELETE',
+    );
+    expect(insertBatches).toHaveLength(2);
+    expect(deleteBatches).toHaveLength(1);
+
+    const insertJobIds = insertBatches.flatMap((r) => r.metadata.map((m) => m.jobId)).sort();
+    const deleteJobIds = deleteBatches.flatMap((r) => r.metadata.map((m) => m.jobId));
+    expect(insertJobIds).toEqual([1, 2, 3]);
+    expect(deleteJobIds).toEqual([4]);
+  });
+
+  const errorCases = [
+    {
+      name: 'event with action that has no matching config',
+      buildInputs: () => {
+        const destination = buildDestination();
+        delete destination.Config.actions.delete;
+        return [
+          buildInput(1, 'insert', { email: 'a@b.com' }, destination),
+          buildInput(2, 'delete', { email: 'g@h.com' }, destination),
+        ];
+      },
+      failingJobId: 2,
+      errorMatch: /No action configuration/,
+    },
+    {
+      name: 'event with all fields stripped',
+      buildInputs: () => [
+        buildInput(1, 'insert', { email: 'a@b.com' }),
+        buildInput(2, 'insert', { email: '', other: null }),
+      ],
+      failingJobId: 2,
+      errorMatch: /All fields were stripped/,
+    },
+    {
+      name: 'event failing schema validation (wrong type)',
+      buildInputs: () => [
+        buildInput(1, 'insert', { email: 'a@b.com' }),
+        {
+          ...buildInput(2, 'insert', { email: 'b@c.com' }),
+          message: { type: 'identify' },
+        } as unknown as RouterTransformationRequestData,
+      ],
+      failingJobId: 2,
+      errorMatch: /Invalid/,
+    },
+  ];
+
+  it.each(errorCases)(
+    'returns 400 for: $name',
+    async ({ buildInputs, failingJobId, errorMatch }) => {
+      const results = await processBatchedDestination(buildInputs(), Integration, {});
+      const errors = results.filter((r) => r.statusCode === 400);
+      expect(errors).toHaveLength(1);
+      expect(errors[0].metadata[0].jobId).toBe(failingJobId);
+      expect(errors[0].error).toMatch(errorMatch);
+    },
+  );
+
+  it('hashes fields when isHashRequired is true', async () => {
+    const connection = buildConnection({ isHashRequired: true });
+    const inputs = [
+      buildInput(1, 'insert', { email: 'a@b.com' }, buildDestination(), connection),
+      buildInput(2, 'insert', { email: 'c@d.com' }, buildDestination(), connection),
+    ];
+
+    const results = await processBatchedDestination(inputs, Integration, {});
+
+    const success = results.find((r) => r.statusCode === 200);
+    const batched = success?.batchedRequest;
+    if (!batched || Array.isArray(batched)) throw new Error('expected single batchedRequest');
+    const body = batched.body?.JSON as { users: { email: string }[] };
+    const emails = body.users.map((u) => u.email).sort();
+    expect(emails).toEqual([sha256('a@b.com'), sha256('c@d.com')].sort());
+  });
+
+  const authCases = [
+    {
+      name: 'Bearer',
+      overrides: { authenticationType: AUTHENTICATION_TYPES.BEARER_TOKEN, bearerToken: 'sek-ret' },
+      expectedHeader: 'Authorization',
+      expectedValue: 'Bearer sek-ret',
+    },
+    {
+      name: 'API key',
+      overrides: {
+        authenticationType: AUTHENTICATION_TYPES.API_KEY,
+        apiKeyName: 'X-Custom-Key',
+        apiKeyValue: 'secret',
+      },
+      expectedHeader: 'X-Custom-Key',
+      expectedValue: 'secret',
+    },
+  ];
+
+  it.each(authCases)(
+    'builds $name auth header when configured',
+    async ({ overrides, expectedHeader, expectedValue }) => {
+      const destination = buildDestination(overrides);
+      const inputs = [buildInput(1, 'insert', { email: 'a@b.com' }, destination)];
+
+      const results = await processBatchedDestination(inputs, Integration, {});
+
+      const success = results.find((r) => r.statusCode === 200);
+      const batched = success?.batchedRequest;
+      if (!batched || Array.isArray(batched)) throw new Error('expected single batchedRequest');
+      const headers = batched.headers as Record<string, string>;
+      expect(headers[expectedHeader]).toBe(expectedValue);
+    },
+  );
+
+  it('throws when requestBody template fails at runtime', async () => {
+    const destination = buildDestination();
+    destination.Config.actions.insert!.requestBody = '$.records[0].notARealMethod()';
+
+    const inputs = [buildInput(1, 'insert', { email: 'a@b.com' }, destination)];
+
+    await expect(processBatchedDestination(inputs, Integration, {})).rejects.toThrow();
+  });
+});

--- a/src/v0/destinations/custom_audience/routerTransform.test.ts
+++ b/src/v0/destinations/custom_audience/routerTransform.test.ts
@@ -9,7 +9,7 @@ import type {
   Action,
   ActionConfig,
   CustomAudienceConnection,
-  CustomAudienceConnectionConfig,
+  CustomAudienceConnectionDestConfig,
   CustomAudienceDestConfig,
   CustomAudienceDestination,
 } from './types';
@@ -54,7 +54,7 @@ const buildDestination = (
 });
 
 const buildConnection = (
-  destinationOverrides: Partial<CustomAudienceConnectionConfig> = {},
+  destinationOverrides: Partial<CustomAudienceConnectionDestConfig> = {},
 ): CustomAudienceConnection => ({
   sourceId: 'src-1',
   destinationId: 'dest-1',

--- a/src/v0/destinations/custom_audience/routerTransform.ts
+++ b/src/v0/destinations/custom_audience/routerTransform.ts
@@ -1,0 +1,118 @@
+import { z, ZodType } from 'zod';
+import {
+  BatchDestination,
+  ChunkBatchStrategy,
+  CustomBatchStrategy,
+  TransformedEvent,
+} from '../../../services/destination/nativeBatching/batchDestination';
+import type { BatchStrategy } from '../../../services/destination/nativeBatching/types';
+import type { Connection, Destination } from '../../../types/controlPlaneConfig';
+import { EVENT_TYPES } from '../../util/recordUtils';
+import {
+  buildRequestHeaders,
+  evaluateTemplate,
+  injectCustomMappings,
+  lookupActionConfig,
+  processFields,
+  resolveEndpoint,
+} from './utils';
+import type {
+  Action,
+  CustomAudienceConnectionConfig,
+  CustomAudienceDestConfig,
+  CustomAudienceRouterRequest,
+} from './types';
+
+class CustomAudienceIntegration extends BatchDestination<
+  Record<string, string>,
+  CustomAudienceDestConfig,
+  { destination: CustomAudienceConnectionConfig }
+> {
+  // Endpoint depends only on action.endpoint + connection (constant per request),
+  // so resolve once per configured action — not once per event.
+  private readonly endpointByAction: Partial<Record<Action, string>>;
+
+  private readonly headers: Record<string, string>;
+
+  constructor(
+    destination: Destination<CustomAudienceDestConfig>,
+    connection?: Connection<{ destination: CustomAudienceConnectionConfig }>,
+  ) {
+    super(destination, connection);
+    this.headers = buildRequestHeaders(destination.Config);
+    this.endpointByAction = Object.fromEntries(
+      Object.entries(destination.Config.actions).map(([action, actionConfig]) => [
+        action,
+        resolveEndpoint(actionConfig!.endpoint, destination.Config.baseUrl, this.connectionConfig),
+      ]),
+    ) as Partial<Record<Action, string>>;
+  }
+
+  private get connectionConfig(): CustomAudienceConnectionConfig {
+    return this.connection!.config.destination;
+  }
+
+  transformEvent(input: CustomAudienceRouterRequest): TransformedEvent<Record<string, string>> {
+    const { message } = input;
+    const actionConfig = lookupActionConfig(message.action, this.destination.Config);
+    const fieldsWithCustomMappings = injectCustomMappings(
+      message.fields!,
+      this.connectionConfig.customMappings,
+    );
+    const record = processFields(
+      fieldsWithCustomMappings,
+      actionConfig,
+      {
+        id: this.destination.ID,
+        type: this.destination.DestinationDefinition.Name,
+        workspaceId: this.destination.WorkspaceID,
+      },
+      this.connectionConfig.isHashRequired,
+    );
+
+    return {
+      body: record,
+      endpoint: this.endpointByAction[message.action]!,
+      method: actionConfig.method,
+      headers: this.headers,
+      // Force the framework's composite-key grouping to keep different actions
+      // in separate groups, even when their (endpoint, method, headers) match.
+      // Each action carries its own requestBody template.
+      internalGroupKey: message.action,
+    };
+  }
+
+  getBatchStrategy(): BatchStrategy<Record<string, string>> {
+    const { actions } = this.destination.Config;
+    const { connectionConfig } = this;
+
+    return new CustomBatchStrategy<Record<string, string>>((payloads) => {
+      const action = payloads[0].internalGroupKey as Action;
+      const actionConfig = actions[action]!;
+      return new ChunkBatchStrategy<Record<string, string>>({
+        maxItems: actionConfig.batchSize,
+        wrapBody: (records) =>
+          evaluateTemplate(actionConfig.requestBody, {
+            records,
+            connection: connectionConfig,
+          }) as Record<string, unknown>,
+      }).batch(payloads);
+    });
+  }
+
+  getInputSchema(): ZodType {
+    return z
+      .object({
+        message: z
+          .object({
+            type: z.literal('record'),
+            action: z.enum([EVENT_TYPES.INSERT, EVENT_TYPES.UPDATE, EVENT_TYPES.DELETE]),
+            fields: z.record(z.unknown()),
+          })
+          .passthrough(),
+      })
+      .passthrough();
+  }
+}
+
+export const Integration = CustomAudienceIntegration;

--- a/src/v0/destinations/custom_audience/routerTransform.ts
+++ b/src/v0/destinations/custom_audience/routerTransform.ts
@@ -1,4 +1,5 @@
 import { z, ZodType } from 'zod';
+import { InstrumentationError } from '@rudderstack/integrations-lib';
 import {
   BatchDestination,
   ChunkBatchStrategy,
@@ -18,7 +19,7 @@ import {
 } from './utils';
 import type {
   Action,
-  CustomAudienceConnectionConfig,
+  CustomAudienceConnectionDestConfig,
   CustomAudienceDestConfig,
   CustomAudienceRouterRequest,
 } from './types';
@@ -26,7 +27,7 @@ import type {
 class CustomAudienceIntegration extends BatchDestination<
   Record<string, string>,
   CustomAudienceDestConfig,
-  { destination: CustomAudienceConnectionConfig }
+  { destination: CustomAudienceConnectionDestConfig }
 > {
   // Endpoint depends only on action.endpoint + connection (constant per request),
   // so resolve once per configured action — not once per event.
@@ -36,20 +37,31 @@ class CustomAudienceIntegration extends BatchDestination<
 
   constructor(
     destination: Destination<CustomAudienceDestConfig>,
-    connection?: Connection<{ destination: CustomAudienceConnectionConfig }>,
+    connection?: Connection<{ destination: CustomAudienceConnectionDestConfig }>,
   ) {
     super(destination, connection);
+    if (!this.connection) {
+      throw new InstrumentationError('Connection config is required for custom_audience');
+    }
     this.headers = buildRequestHeaders(destination.Config);
-    this.endpointByAction = Object.fromEntries(
-      Object.entries(destination.Config.actions).map(([action, actionConfig]) => [
-        action,
-        resolveEndpoint(actionConfig!.endpoint, destination.Config.baseUrl, this.connectionConfig),
-      ]),
-    ) as Partial<Record<Action, string>>;
+    this.endpointByAction = this.buildEndpointsByAction();
   }
 
-  private get connectionConfig(): CustomAudienceConnectionConfig {
+  private get connectionConfig(): CustomAudienceConnectionDestConfig {
     return this.connection!.config.destination;
+  }
+
+  private buildEndpointsByAction(): Partial<Record<Action, string>> {
+    return Object.fromEntries(
+      Object.entries(this.destination.Config.actions).map(([action, actionConfig]) => [
+        action,
+        resolveEndpoint(
+          actionConfig!.endpoint,
+          this.destination.Config.baseUrl,
+          this.connectionConfig,
+        ),
+      ]),
+    ) as Partial<Record<Action, string>>;
   }
 
   transformEvent(input: CustomAudienceRouterRequest): TransformedEvent<Record<string, string>> {

--- a/src/v0/destinations/custom_audience/types.ts
+++ b/src/v0/destinations/custom_audience/types.ts
@@ -49,7 +49,7 @@ export type CustomMapping = {
   to: string;
 };
 
-export type CustomAudienceConnectionConfig = {
+export type CustomAudienceConnectionDestConfig = {
   audienceId: string;
   isHashRequired: boolean;
   customMappings?: CustomMapping[];
@@ -61,7 +61,9 @@ export type CustomAudienceItemBody = {
 
 export type CustomAudienceDestination = Destination<CustomAudienceDestConfig>;
 
-export type CustomAudienceConnection = Connection<{ destination: CustomAudienceConnectionConfig }>;
+export type CustomAudienceConnection = Connection<{
+  destination: CustomAudienceConnectionDestConfig;
+}>;
 
 export type CustomAudienceRouterRequest = RouterTransformationRequestData<
   RudderRecordV2,

--- a/src/v0/destinations/custom_audience/types.ts
+++ b/src/v0/destinations/custom_audience/types.ts
@@ -1,0 +1,71 @@
+import { HashingType } from '../../util/audienceUtils';
+import type { Connection, Destination } from '../../../types/controlPlaneConfig';
+import type { Metadata, RecordAction, RudderRecordV2 } from '../../../types/rudderEvents';
+import type { RouterTransformationRequestData } from '../../../types/destinationTransformation';
+import type { AUTHENTICATION_TYPES } from './constants';
+
+export type Action = `${RecordAction}`;
+
+export type AuthenticationType = (typeof AUTHENTICATION_TYPES)[keyof typeof AUTHENTICATION_TYPES];
+
+export type HttpMethod = 'POST' | 'PUT' | 'PATCH' | 'GET' | 'DELETE';
+
+export type ActionFieldConfig = {
+  name: string;
+  isRequired: boolean;
+  hashType: HashingType;
+  isCustom: boolean;
+};
+
+export type ActionConfig = {
+  endpoint: string;
+  method: HttpMethod;
+  requestBody: string;
+  batchSize: number;
+  fields: ActionFieldConfig[];
+};
+
+export type CustomAudienceHeader = {
+  key: string;
+  value: string;
+};
+
+export type CustomAudienceDestConfig = {
+  baseUrl: string;
+  authenticationType: AuthenticationType;
+  headers?: CustomAudienceHeader[];
+  actions: Partial<Record<Action, ActionConfig>>;
+  basicAuthUserName?: string;
+  basicAuthPassword?: string;
+  bearerToken?: string;
+  apiKeyName?: string;
+  apiKeyValue?: string;
+};
+
+export type CustomMapping = {
+  /** The literal value to inject (not a field reference) */
+  from: string;
+  /** The target field name on the record */
+  to: string;
+};
+
+export type CustomAudienceConnectionConfig = {
+  audienceId: string;
+  isHashRequired: boolean;
+  customMappings?: CustomMapping[];
+};
+
+export type CustomAudienceItemBody = {
+  record: Record<string, string>;
+};
+
+export type CustomAudienceDestination = Destination<CustomAudienceDestConfig>;
+
+export type CustomAudienceConnection = Connection<{ destination: CustomAudienceConnectionConfig }>;
+
+export type CustomAudienceRouterRequest = RouterTransformationRequestData<
+  RudderRecordV2,
+  CustomAudienceDestination,
+  CustomAudienceConnection,
+  Metadata
+>;

--- a/src/v0/destinations/custom_audience/utils.test.ts
+++ b/src/v0/destinations/custom_audience/utils.test.ts
@@ -12,11 +12,11 @@ import {
 import { AUTHENTICATION_TYPES } from './constants';
 import type {
   ActionConfig,
-  CustomAudienceConnectionConfig,
+  CustomAudienceConnectionDestConfig,
   CustomAudienceDestConfig,
 } from './types';
 
-const baseConnection: CustomAudienceConnectionConfig = {
+const baseConnection: CustomAudienceConnectionDestConfig = {
   audienceId: 'aud-42',
   isHashRequired: false,
 };

--- a/src/v0/destinations/custom_audience/utils.test.ts
+++ b/src/v0/destinations/custom_audience/utils.test.ts
@@ -1,0 +1,233 @@
+import sha256 from 'sha256';
+import { InstrumentationError } from '@rudderstack/integrations-lib';
+import { HashingType } from '../../util/audienceUtils';
+import {
+  buildRequestHeaders,
+  evaluateTemplate,
+  injectCustomMappings,
+  lookupActionConfig,
+  processFields,
+  resolveEndpoint,
+} from './utils';
+import { AUTHENTICATION_TYPES } from './constants';
+import type {
+  ActionConfig,
+  CustomAudienceConnectionConfig,
+  CustomAudienceDestConfig,
+} from './types';
+
+const baseConnection: CustomAudienceConnectionConfig = {
+  audienceId: 'aud-42',
+  isHashRequired: false,
+};
+
+const baseDestConfig: CustomAudienceDestConfig = {
+  baseUrl: 'https://api.example.com',
+  authenticationType: AUTHENTICATION_TYPES.NO_AUTH,
+  actions: {
+    insert: {
+      endpoint: '/audiences/${$.connection.audienceId}/members',
+      method: 'POST',
+      requestBody: '{ "users": $.records }',
+      batchSize: 100,
+      fields: [],
+    },
+  },
+};
+
+const destinationMeta = { id: 'dest-1', type: 'CUSTOM_AUDIENCE', workspaceId: 'ws-1' };
+
+describe('lookupActionConfig', () => {
+  it('returns the action config when present', () => {
+    const result = lookupActionConfig('insert', baseDestConfig);
+    expect(result.endpoint).toBe('/audiences/${$.connection.audienceId}/members');
+  });
+
+  it('throws InstrumentationError when action key is missing', () => {
+    expect(() => lookupActionConfig('delete', baseDestConfig)).toThrow(InstrumentationError);
+  });
+});
+
+describe('evaluateTemplate', () => {
+  const cases = [
+    {
+      name: 'object template with path resolution',
+      template: '{ "name": $.connection.audienceName }',
+      input: { connection: { audienceName: 'My Audience' } },
+      expected: { name: 'My Audience' },
+    },
+    {
+      name: 'iteration over records into objects',
+      template: '$.records.({ "email": .email })',
+      input: { records: [{ email: 'a@b.com' }, { email: 'c@d.com' }] },
+      expected: [{ email: 'a@b.com' }, { email: 'c@d.com' }],
+    },
+    {
+      name: 'single-element iteration returns object, not array (JSONata semantics)',
+      template: '$.records.({ "email": .email })',
+      input: { records: [{ email: 'a@b.com' }] },
+      expected: { email: 'a@b.com' },
+    },
+  ];
+
+  it.each(cases)('evaluates: $name', ({ template, input, expected }) => {
+    expect(evaluateTemplate(template, input)).toEqual(expected);
+  });
+
+  it('throws InstrumentationError on syntax error', () => {
+    expect(() => evaluateTemplate('let x =', {})).toThrow(InstrumentationError);
+  });
+});
+
+describe('resolveEndpoint', () => {
+  const cases = [
+    {
+      name: 'interpolates connection fields and prepends baseUrl',
+      endpoint: '/audiences/${$.connection.audienceId}/members',
+      baseUrl: 'https://api.example.com',
+      expected: 'https://api.example.com/audiences/aud-42/members',
+    },
+    {
+      name: 'strips trailing slash from baseUrl before joining',
+      endpoint: '/v1/users',
+      baseUrl: 'https://api.example.com/',
+      expected: 'https://api.example.com/v1/users',
+    },
+    {
+      name: 'adds leading slash if path lacks one',
+      endpoint: 'v1/users',
+      baseUrl: 'https://api.example.com',
+      expected: 'https://api.example.com/v1/users',
+    },
+  ];
+
+  it.each(cases)('$name', ({ endpoint, baseUrl, expected }) => {
+    expect(resolveEndpoint(endpoint, baseUrl, baseConnection)).toBe(expected);
+  });
+
+  it('throws InstrumentationError when template fails', () => {
+    expect(() => resolveEndpoint('${ ', 'https://api.example.com', baseConnection)).toThrow(
+      InstrumentationError,
+    );
+  });
+});
+
+describe('injectCustomMappings', () => {
+  const cases = [
+    {
+      name: 'returns fields untouched when no mappings',
+      fields: { email: 'a@b.com' },
+      mappings: undefined,
+      expected: { email: 'a@b.com' },
+    },
+    {
+      name: 'injects literal values onto target field names',
+      fields: { email: 'a@b.com' },
+      mappings: [{ from: 'fixed-list-id', to: 'listId' }],
+      expected: { email: 'a@b.com', listId: 'fixed-list-id' },
+    },
+    {
+      name: 'overwrites existing keys when target collides',
+      fields: { listId: 'from-warehouse' },
+      mappings: [{ from: 'fixed', to: 'listId' }],
+      expected: { listId: 'fixed' },
+    },
+  ];
+
+  it.each(cases)('$name', ({ fields, mappings, expected }) => {
+    expect(injectCustomMappings(fields, mappings)).toEqual(expected);
+  });
+});
+
+describe('processFields', () => {
+  const insertAction: ActionConfig = {
+    endpoint: '/x',
+    method: 'POST',
+    requestBody: '$.records',
+    batchSize: 100,
+    fields: [
+      { name: 'email', hashType: HashingType.SHA256, isRequired: true, isCustom: false },
+      { name: 'phone', hashType: HashingType.NONE, isRequired: false, isCustom: false },
+    ],
+  };
+
+  const cases = [
+    {
+      name: 'strips empty values, no hashing when isHashRequired=false',
+      fields: { email: 'a@b.com', phone: '', missing: null },
+      isHashRequired: false,
+      expected: { email: 'a@b.com' },
+    },
+    {
+      name: 'hashes hashable fields when isHashRequired=true',
+      fields: { email: 'a@b.com', phone: '+1' },
+      isHashRequired: true,
+      expected: { email: sha256('a@b.com'), phone: '+1' },
+    },
+  ];
+
+  it.each(cases)('$name', ({ fields, isHashRequired, expected }) => {
+    expect(processFields(fields, insertAction, destinationMeta, isHashRequired)).toEqual(expected);
+  });
+
+  it('throws InstrumentationError when all fields are stripped', () => {
+    expect(() =>
+      processFields({ email: null, phone: '' }, insertAction, destinationMeta, false),
+    ).toThrow(InstrumentationError);
+  });
+});
+
+describe('buildRequestHeaders', () => {
+  const cases: {
+    name: string;
+    overrides: Partial<CustomAudienceDestConfig>;
+    expectedHeaders: Record<string, string>;
+  }[] = [
+    {
+      name: 'returns Content-Type only for noAuth + no headers',
+      overrides: {},
+      expectedHeaders: { 'Content-Type': 'application/json' },
+    },
+    {
+      name: 'merges destination headers',
+      overrides: { headers: [{ key: 'X-App', value: 'rudder' }] },
+      expectedHeaders: { 'Content-Type': 'application/json', 'X-App': 'rudder' },
+    },
+    {
+      name: 'builds Basic auth header with base64-encoded credentials',
+      overrides: {
+        authenticationType: AUTHENTICATION_TYPES.BASIC_AUTH,
+        basicAuthUserName: 'user',
+        basicAuthPassword: 'pass',
+      },
+      expectedHeaders: {
+        'Content-Type': 'application/json',
+        Authorization: `Basic ${Buffer.from('user:pass').toString('base64')}`,
+      },
+    },
+    {
+      name: 'builds Bearer token header',
+      overrides: { authenticationType: AUTHENTICATION_TYPES.BEARER_TOKEN, bearerToken: 'abc' },
+      expectedHeaders: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer abc',
+      },
+    },
+    {
+      name: 'builds API key header with custom name',
+      overrides: {
+        authenticationType: AUTHENTICATION_TYPES.API_KEY,
+        apiKeyName: 'X-API-Key',
+        apiKeyValue: 'secret',
+      },
+      expectedHeaders: {
+        'Content-Type': 'application/json',
+        'X-API-Key': 'secret',
+      },
+    },
+  ];
+
+  it.each(cases)('$name', ({ overrides, expectedHeaders }) => {
+    expect(buildRequestHeaders({ ...baseDestConfig, ...overrides })).toEqual(expectedHeaders);
+  });
+});

--- a/src/v0/destinations/custom_audience/utils.ts
+++ b/src/v0/destinations/custom_audience/utils.ts
@@ -1,0 +1,153 @@
+import { InstrumentationError } from '@rudderstack/integrations-lib';
+import { JsonTemplateEngine, PathType } from '@rudderstack/json-template-engine';
+
+import { HashingType, processAudienceRecord, type AudienceField } from '../../util/audienceUtils';
+
+import { AUTHENTICATION_TYPES, ERROR_MESSAGES } from './constants';
+import type {
+  Action,
+  ActionConfig,
+  ActionFieldConfig,
+  AuthenticationType,
+  CustomAudienceConnectionConfig,
+  CustomAudienceDestConfig,
+  CustomAudienceHeader,
+  CustomMapping,
+} from './types';
+
+export const lookupActionConfig = (
+  action: Action,
+  destConfig: CustomAudienceDestConfig,
+): ActionConfig => {
+  const actionConfig = destConfig.actions[action];
+  if (!actionConfig) {
+    throw new InstrumentationError(ERROR_MESSAGES.NO_ACTION_CONFIG(action));
+  }
+  return actionConfig;
+};
+
+export const evaluateTemplate = (template: string, input: Record<string, unknown>): unknown => {
+  // TODO: sandbox template evaluation (see INT-6295). Today the template runs
+  // through the json-template-engine in-process, which is unsafe for untrusted
+  // templates. The engine's parse step is already isolated by INT-6296, but
+  // execution is not.
+  try {
+    return JsonTemplateEngine.createAsSync(template, {
+      defaultPathType: PathType.JSON,
+    }).evaluate(input);
+  } catch (err: unknown) {
+    const reason = err instanceof Error ? err.message : String(err);
+    throw new InstrumentationError(ERROR_MESSAGES.TEMPLATE_EVALUATION_FAILED(reason));
+  }
+};
+
+export const resolveEndpoint = (
+  endpointTemplate: string,
+  baseUrl: string,
+  connection: CustomAudienceConnectionConfig,
+): string => {
+  // Endpoint is a plain string with `${...}` placeholders (regex-validated upstream
+  // to allow only simple connection-field interpolation). Wrap in backticks so the
+  // template engine treats it as a string-interpolation expression.
+  const wrapped = `\`${endpointTemplate}\``;
+  const resolved = String(evaluateTemplate(wrapped, { connection }) ?? '');
+  const trimmedBase = baseUrl.endsWith('/') ? baseUrl.slice(0, -1) : baseUrl;
+  const joinedPath = resolved.startsWith('/') || resolved === '' ? resolved : `/${resolved}`;
+  return `${trimmedBase}${joinedPath}`;
+};
+
+export const injectCustomMappings = (
+  fields: Record<string, unknown>,
+  customMappings: CustomMapping[] | undefined,
+): Record<string, unknown> => {
+  if (!customMappings || customMappings.length === 0) {
+    return fields;
+  }
+  const merged: Record<string, unknown> = { ...fields };
+  // `from` holds the literal value (user-supplied constant), `to` is the destination field.
+  customMappings
+    .filter((mapping) => mapping?.to)
+    .forEach((mapping) => {
+      merged[mapping.to] = mapping.from;
+    });
+  return merged;
+};
+
+const buildFieldConfigs = (actionFields: ActionFieldConfig[]): Record<string, AudienceField> => {
+  const result: Record<string, AudienceField> = {};
+  actionFields
+    .filter((field) => field?.name)
+    .forEach((field) => {
+      result[field.name] = {
+        hashingType: field.hashType ?? HashingType.NONE,
+        normalize: undefined,
+      };
+    });
+  return result;
+};
+
+export const processFields = (
+  fields: Record<string, unknown>,
+  actionConfig: ActionConfig,
+  destinationMeta: { id: string; type: string; workspaceId: string },
+  isHashRequired: boolean,
+): Record<string, string> => {
+  const fieldConfigs = buildFieldConfigs(actionConfig.fields);
+  const processed = processAudienceRecord(fields, {
+    fieldConfigs,
+    destination: {
+      workspaceId: destinationMeta.workspaceId,
+      id: destinationMeta.id,
+      type: destinationMeta.type,
+      config: { isHashRequired },
+    },
+  });
+  if (Object.keys(processed).length === 0) {
+    throw new InstrumentationError(ERROR_MESSAGES.ALL_FIELDS_STRIPPED);
+  }
+  return processed;
+};
+
+const buildAuthHeaders = (
+  authenticationType: AuthenticationType,
+  destConfig: CustomAudienceDestConfig,
+): Record<string, string> => {
+  switch (authenticationType) {
+    case AUTHENTICATION_TYPES.NO_AUTH:
+      return {};
+    case AUTHENTICATION_TYPES.BASIC_AUTH: {
+      // Schema guarantees these fields are present when authenticationType === basicAuth.
+      const encoded = Buffer.from(
+        `${destConfig.basicAuthUserName!}:${destConfig.basicAuthPassword!}`,
+      ).toString('base64');
+      return { Authorization: `Basic ${encoded}` };
+    }
+    case AUTHENTICATION_TYPES.BEARER_TOKEN:
+      return { Authorization: `Bearer ${destConfig.bearerToken!}` };
+    case AUTHENTICATION_TYPES.API_KEY:
+      return { [destConfig.apiKeyName!]: destConfig.apiKeyValue! };
+    default:
+      return {};
+  }
+};
+
+const flattenConfigHeaders = (
+  headers: CustomAudienceHeader[] | undefined,
+): Record<string, string> => {
+  if (!headers) return {};
+  const result: Record<string, string> = {};
+  headers
+    .filter((header) => header?.key)
+    .forEach((header) => {
+      result[header.key] = header.value;
+    });
+  return result;
+};
+
+export const buildRequestHeaders = (
+  destConfig: CustomAudienceDestConfig,
+): Record<string, string> => ({
+  'Content-Type': 'application/json',
+  ...flattenConfigHeaders(destConfig.headers),
+  ...buildAuthHeaders(destConfig.authenticationType, destConfig),
+});

--- a/src/v0/destinations/custom_audience/utils.ts
+++ b/src/v0/destinations/custom_audience/utils.ts
@@ -9,7 +9,7 @@ import type {
   ActionConfig,
   ActionFieldConfig,
   AuthenticationType,
-  CustomAudienceConnectionConfig,
+  CustomAudienceConnectionDestConfig,
   CustomAudienceDestConfig,
   CustomAudienceHeader,
   CustomMapping,
@@ -44,7 +44,7 @@ export const evaluateTemplate = (template: string, input: Record<string, unknown
 export const resolveEndpoint = (
   endpointTemplate: string,
   baseUrl: string,
-  connection: CustomAudienceConnectionConfig,
+  connection: CustomAudienceConnectionDestConfig,
 ): string => {
   // Endpoint is a plain string with `${...}` placeholders (regex-validated upstream
   // to allow only simple connection-field interpolation). Wrap in backticks so the

--- a/test/integrations/destinations/custom_audience/common.ts
+++ b/test/integrations/destinations/custom_audience/common.ts
@@ -1,0 +1,111 @@
+import { HashingType } from '../../../../src/v0/util/audienceUtils';
+import { AUTHENTICATION_TYPES } from '../../../../src/v0/destinations/custom_audience/constants';
+import type {
+  ActionConfig,
+  CustomAudienceConnection,
+  CustomAudienceDestination,
+} from '../../../../src/v0/destinations/custom_audience/types';
+import { bearerToken } from './maskedSecrets';
+
+export const destType = 'custom_audience';
+const destTypeInUpperCase = 'CUSTOM_AUDIENCE';
+const displayName = 'Custom Audience';
+
+const insertActionConfig: ActionConfig = {
+  endpoint: '/audiences/${$.connection.audienceId}/members',
+  method: 'POST',
+  requestBody:
+    '{ "audienceId": $.connection.audienceId, "users": $.records.({ "email": .email }) }',
+  batchSize: 2,
+  fields: [{ name: 'email', hashType: HashingType.SHA256, isRequired: true, isCustom: false }],
+};
+
+const deleteActionConfig: ActionConfig = {
+  endpoint: '/audiences/${$.connection.audienceId}/members',
+  method: 'DELETE',
+  requestBody:
+    '{ "audienceId": $.connection.audienceId, "users": $.records.({ "email": .email }) }',
+  batchSize: 5,
+  fields: [{ name: 'email', hashType: HashingType.SHA256, isRequired: true, isCustom: false }],
+};
+
+export const destination: CustomAudienceDestination = {
+  Config: {
+    baseUrl: 'https://api.example.com',
+    authenticationType: AUTHENTICATION_TYPES.BEARER_TOKEN,
+    bearerToken,
+    headers: [{ key: 'X-App', value: 'rudderstack' }],
+    actions: {
+      insert: insertActionConfig,
+      update: insertActionConfig,
+      delete: deleteActionConfig,
+    },
+  },
+  DestinationDefinition: {
+    DisplayName: displayName,
+    ID: 'destDef-1',
+    Name: destTypeInUpperCase,
+    Config: {},
+  },
+  Enabled: true,
+  ID: 'dest-1',
+  Name: destTypeInUpperCase,
+  Transformations: [],
+  WorkspaceID: 'ws-1',
+};
+
+export const connection: CustomAudienceConnection = {
+  sourceId: 'src-1',
+  destinationId: 'dest-1',
+  enabled: true,
+  config: {
+    destination: {
+      audienceId: 'aud-42',
+      isHashRequired: false,
+      customMappings: [],
+    },
+  },
+};
+
+export const headers = {
+  'Content-Type': 'application/json',
+  'X-App': 'rudderstack',
+  Authorization: `Bearer ${bearerToken}`,
+};
+
+export const insertEndpoint = 'https://api.example.com/audiences/aud-42/members';
+export const deleteEndpoint = 'https://api.example.com/audiences/aud-42/members';
+
+// Variants used by router tests that exercise customMappings injection
+// and isHashRequired hashing.
+export const customMappingsConnection: CustomAudienceConnection = {
+  ...connection,
+  config: {
+    destination: {
+      ...connection.config.destination,
+      customMappings: [{ from: 'subscribers', to: 'listType' }],
+    },
+  },
+};
+
+export const customMappingsDestination: CustomAudienceDestination = {
+  ...destination,
+  Config: {
+    ...destination.Config,
+    actions: {
+      ...destination.Config.actions,
+      insert: {
+        ...insertActionConfig,
+        requestBody:
+          '{ "audienceId": $.connection.audienceId, "users": $.records.({ "email": .email, "listType": .listType }) }',
+      },
+    },
+  },
+};
+
+export const hashRequiredConnection: CustomAudienceConnection = {
+  ...connection,
+  config: {
+    destination: { ...connection.config.destination, isHashRequired: true },
+  },
+};

--- a/test/integrations/destinations/custom_audience/maskedSecrets.ts
+++ b/test/integrations/destinations/custom_audience/maskedSecrets.ts
@@ -1,0 +1,3 @@
+export const bearerToken = 'masked-bearer-token';
+export const basicAuthPassword = 'masked-basic-pass';
+export const apiKeyValue = 'masked-api-key-value';

--- a/test/integrations/destinations/custom_audience/router/data.ts
+++ b/test/integrations/destinations/custom_audience/router/data.ts
@@ -1,0 +1,459 @@
+import sha256 from 'sha256';
+import { generateMetadata, generateRecordPayload } from '../../../testUtils';
+import { RouterTestData } from '../../../testTypes';
+import {
+  destType,
+  destination,
+  connection,
+  headers,
+  insertEndpoint,
+  deleteEndpoint,
+  customMappingsDestination,
+  customMappingsConnection,
+  hashRequiredConnection,
+} from '../common';
+
+const errorStatTags = {
+  destType: 'CUSTOM_AUDIENCE',
+  destinationId: 'default-destinationId',
+  errorCategory: 'dataValidation',
+  errorType: 'instrumentation',
+  feature: 'router',
+  implementation: 'native',
+  module: 'destination',
+  workspaceId: 'default-workspaceId',
+};
+
+export const data: RouterTestData[] = [
+  {
+    id: 'custom-audience-router-test-1',
+    name: destType,
+    description:
+      'Splits events by action — insert/update share endpoint+method (batched together by batchSize), delete forms a separate group',
+    scenario: 'Framework+Business',
+    successCriteria:
+      'Insert+update events grouped together and chunked by batchSize=2, delete events form a separate batch',
+    feature: 'router',
+    module: 'destination',
+    version: 'v0',
+    input: {
+      request: {
+        body: {
+          input: [
+            {
+              message: generateRecordPayload({ action: 'insert', fields: { email: 'a@b.com' } }),
+              metadata: generateMetadata(1),
+              destination,
+              connection,
+            },
+            {
+              message: generateRecordPayload({ action: 'insert', fields: { email: 'c@d.com' } }),
+              metadata: generateMetadata(2),
+              destination,
+              connection,
+            },
+            {
+              message: generateRecordPayload({ action: 'update', fields: { email: 'e@f.com' } }),
+              metadata: generateMetadata(3),
+              destination,
+              connection,
+            },
+            {
+              message: generateRecordPayload({ action: 'delete', fields: { email: 'g@h.com' } }),
+              metadata: generateMetadata(4),
+              destination,
+              connection,
+            },
+          ],
+          destType,
+        },
+        method: 'POST',
+      },
+    },
+    output: {
+      response: {
+        status: 200,
+        body: {
+          output: [
+            {
+              batchedRequest: {
+                version: '1',
+                type: 'REST',
+                method: 'POST',
+                endpoint: insertEndpoint,
+                headers,
+                params: {},
+                body: {
+                  JSON: {
+                    audienceId: 'aud-42',
+                    users: [{ email: 'a@b.com' }, { email: 'c@d.com' }],
+                  },
+                  JSON_ARRAY: {},
+                  XML: {},
+                  FORM: {},
+                },
+                files: {},
+              },
+              metadata: [generateMetadata(1), generateMetadata(2)],
+              batched: true,
+              statusCode: 200,
+              destination,
+            },
+            {
+              batchedRequest: {
+                version: '1',
+                type: 'REST',
+                method: 'POST',
+                endpoint: insertEndpoint,
+                headers,
+                params: {},
+                body: {
+                  JSON: {
+                    audienceId: 'aud-42',
+                    users: { email: 'e@f.com' },
+                  },
+                  JSON_ARRAY: {},
+                  XML: {},
+                  FORM: {},
+                },
+                files: {},
+              },
+              metadata: [generateMetadata(3)],
+              batched: true,
+              statusCode: 200,
+              destination,
+            },
+            {
+              batchedRequest: {
+                version: '1',
+                type: 'REST',
+                method: 'DELETE',
+                endpoint: deleteEndpoint,
+                headers,
+                params: {},
+                body: {
+                  JSON: {
+                    audienceId: 'aud-42',
+                    users: { email: 'g@h.com' },
+                  },
+                  JSON_ARRAY: {},
+                  XML: {},
+                  FORM: {},
+                },
+                files: {},
+              },
+              metadata: [generateMetadata(4)],
+              batched: true,
+              statusCode: 200,
+              destination,
+            },
+          ],
+        },
+      },
+    },
+  },
+  {
+    id: 'custom-audience-router-test-2',
+    name: destType,
+    description: 'Returns 400 for events whose action has no matching config',
+    scenario: 'Framework+Business',
+    successCriteria:
+      'Event with an action key that is not configured fails individually with 400; siblings succeed',
+    feature: 'router',
+    module: 'destination',
+    version: 'v0',
+    input: {
+      request: {
+        body: {
+          input: [
+            {
+              message: generateRecordPayload({ action: 'insert', fields: { email: 'a@b.com' } }),
+              metadata: generateMetadata(1),
+              destination: {
+                ...destination,
+                Config: {
+                  ...destination.Config,
+                  actions: { insert: destination.Config.actions.insert! },
+                },
+              },
+              connection,
+            },
+            {
+              message: generateRecordPayload({ action: 'delete', fields: { email: 'g@h.com' } }),
+              metadata: generateMetadata(2),
+              destination: {
+                ...destination,
+                Config: {
+                  ...destination.Config,
+                  actions: { insert: destination.Config.actions.insert! },
+                },
+              },
+              connection,
+            },
+          ],
+          destType,
+        },
+        method: 'POST',
+      },
+    },
+    output: {
+      response: {
+        status: 200,
+        body: {
+          output: [
+            {
+              batchedRequest: {
+                version: '1',
+                type: 'REST',
+                method: 'POST',
+                endpoint: insertEndpoint,
+                headers,
+                params: {},
+                body: {
+                  JSON: { audienceId: 'aud-42', users: { email: 'a@b.com' } },
+                  JSON_ARRAY: {},
+                  XML: {},
+                  FORM: {},
+                },
+                files: {},
+              },
+              metadata: [generateMetadata(1)],
+              batched: true,
+              statusCode: 200,
+              destination: {
+                ...destination,
+                Config: {
+                  ...destination.Config,
+                  actions: { insert: destination.Config.actions.insert! },
+                },
+              },
+            },
+            {
+              metadata: [generateMetadata(2)],
+              batched: false,
+              statusCode: 400,
+              error: 'No action configuration found for action: delete',
+              statTags: errorStatTags,
+              destination: {
+                ...destination,
+                Config: {
+                  ...destination.Config,
+                  actions: { insert: destination.Config.actions.insert! },
+                },
+              },
+            },
+          ],
+        },
+      },
+    },
+  },
+  {
+    id: 'custom-audience-router-test-3',
+    name: destType,
+    description: 'Returns 400 when all fields strip to empty for a given event',
+    scenario: 'Framework+Business',
+    successCriteria:
+      'Event whose fields are all null/undefined/empty after processing fails with 400; siblings succeed',
+    feature: 'router',
+    module: 'destination',
+    version: 'v0',
+    input: {
+      request: {
+        body: {
+          input: [
+            {
+              message: generateRecordPayload({ action: 'insert', fields: { email: 'a@b.com' } }),
+              metadata: generateMetadata(1),
+              destination,
+              connection,
+            },
+            {
+              message: generateRecordPayload({
+                action: 'insert',
+                fields: { email: '', other: null },
+              }),
+              metadata: generateMetadata(2),
+              destination,
+              connection,
+            },
+          ],
+          destType,
+        },
+        method: 'POST',
+      },
+    },
+    output: {
+      response: {
+        status: 200,
+        body: {
+          output: [
+            {
+              batchedRequest: {
+                version: '1',
+                type: 'REST',
+                method: 'POST',
+                endpoint: insertEndpoint,
+                headers,
+                params: {},
+                body: {
+                  JSON: { audienceId: 'aud-42', users: { email: 'a@b.com' } },
+                  JSON_ARRAY: {},
+                  XML: {},
+                  FORM: {},
+                },
+                files: {},
+              },
+              metadata: [generateMetadata(1)],
+              batched: true,
+              statusCode: 200,
+              destination,
+            },
+            {
+              metadata: [generateMetadata(2)],
+              batched: false,
+              statusCode: 400,
+              error: 'All fields were stripped after processing; nothing to send',
+              statTags: errorStatTags,
+              destination,
+            },
+          ],
+        },
+      },
+    },
+  },
+  {
+    id: 'custom-audience-router-test-4',
+    name: destType,
+    description: 'Injects literal value from non-empty customMappings into each record',
+    scenario: 'Framework+Business',
+    successCriteria:
+      'customMappings entry { from: "subscribers", to: "listType" } injects "subscribers" as the listType value on each record before template evaluation',
+    feature: 'router',
+    module: 'destination',
+    version: 'v0',
+    input: {
+      request: {
+        body: {
+          input: [
+            {
+              message: generateRecordPayload({ action: 'insert', fields: { email: 'a@b.com' } }),
+              metadata: generateMetadata(1),
+              destination: customMappingsDestination,
+              connection: customMappingsConnection,
+            },
+            {
+              message: generateRecordPayload({ action: 'insert', fields: { email: 'c@d.com' } }),
+              metadata: generateMetadata(2),
+              destination: customMappingsDestination,
+              connection: customMappingsConnection,
+            },
+          ],
+          destType,
+        },
+        method: 'POST',
+      },
+    },
+    output: {
+      response: {
+        status: 200,
+        body: {
+          output: [
+            {
+              batchedRequest: {
+                version: '1',
+                type: 'REST',
+                method: 'POST',
+                endpoint: insertEndpoint,
+                headers,
+                params: {},
+                body: {
+                  JSON: {
+                    audienceId: 'aud-42',
+                    users: [
+                      { email: 'a@b.com', listType: 'subscribers' },
+                      { email: 'c@d.com', listType: 'subscribers' },
+                    ],
+                  },
+                  JSON_ARRAY: {},
+                  XML: {},
+                  FORM: {},
+                },
+                files: {},
+              },
+              metadata: [generateMetadata(1), generateMetadata(2)],
+              batched: true,
+              statusCode: 200,
+              destination: customMappingsDestination,
+            },
+          ],
+        },
+      },
+    },
+  },
+  {
+    id: 'custom-audience-router-test-5',
+    name: destType,
+    description: 'Hashes hashable fields when isHashRequired is true on the connection',
+    scenario: 'Framework+Business',
+    successCriteria:
+      'When connection.isHashRequired is true, fields configured with hashType=SHA256 are hashed before template evaluation; other fields pass through unchanged',
+    feature: 'router',
+    module: 'destination',
+    version: 'v0',
+    input: {
+      request: {
+        body: {
+          input: [
+            {
+              message: generateRecordPayload({ action: 'insert', fields: { email: 'a@b.com' } }),
+              metadata: generateMetadata(1),
+              destination,
+              connection: hashRequiredConnection,
+            },
+            {
+              message: generateRecordPayload({ action: 'insert', fields: { email: 'c@d.com' } }),
+              metadata: generateMetadata(2),
+              destination,
+              connection: hashRequiredConnection,
+            },
+          ],
+          destType,
+        },
+        method: 'POST',
+      },
+    },
+    output: {
+      response: {
+        status: 200,
+        body: {
+          output: [
+            {
+              batchedRequest: {
+                version: '1',
+                type: 'REST',
+                method: 'POST',
+                endpoint: insertEndpoint,
+                headers,
+                params: {},
+                body: {
+                  JSON: {
+                    audienceId: 'aud-42',
+                    users: [{ email: sha256('a@b.com') }, { email: sha256('c@d.com') }],
+                  },
+                  JSON_ARRAY: {},
+                  XML: {},
+                  FORM: {},
+                },
+                files: {},
+              },
+              metadata: [generateMetadata(1), generateMetadata(2)],
+              batched: true,
+              statusCode: 200,
+              destination,
+            },
+          ],
+        },
+      },
+    },
+  },
+];


### PR DESCRIPTION
## Summary

Adds router transform support for the **Custom Audience** destination, built on the native batching framework.

### Custom Audience integration

Each incoming record event goes through: action lookup → custom-mapping injection → field processing (empty-stripping + optional SHA256/SHA512/MD5 hashing via `processAudienceRecord`). The result is a typed `TransformedEvent` carrying the cleaned record.

Key design choices:
- **Eager endpoint resolution** — endpoints and request headers are computed once per configured action in the constructor, not per event.
- **Action-aware grouping** — a new `internalGroupKey` field keeps insert/update/delete in separate batches even when their (endpoint, method, headers) happen to match. Each action carries its own `requestBody` template, so mixing them would produce wrong payloads.
- **Per-action chunking** — uses `ChunkBatchStrategy` with `maxItems: actionConfig.batchSize` and a `wrapBody` that evaluates the action's `requestBody` json-template against the batched records and connection config.
- **Authentication** — supports noAuth, Basic, Bearer token, and API key header styles, resolved from destination config.
- **Custom mappings** — connection-level `customMappings` inject literal values onto each record before template evaluation. The `from`/`to` naming follows the upstream schema convention (documented with JSDoc since semantics are inverted from the usual source→target pattern).

### Framework extensions

- **Typed generics** on `BatchDestination`, `BatchDestinationConstructor`, and `processBatchedDestination` — added `TConfig` / `TConnectionConfig` type parameters so subclasses get typed `Destination.Config` and `Connection<T>`. Defaults to `Record<string, unknown>` to preserve backward compatibility (PostHog compiles unchanged).
- **Connection injection** — `connection` is extracted from the first event and passed into the constructor by the framework. All events in a single router-transform call share the same connection (rudder-server groups by source+destination), so this is safe.
- **`internalGroupKey`** on `TransformedEvent` — an optional discriminator included in the composite grouping key. Lets destinations add grouping dimensions beyond the user-visible request fields without polluting headers or params.

### Wiring

- Added `CUSTOM_AUDIENCE: true` to `batchedDestinationsMap` and `features.routerTransform` so the dispatcher routes through `processBatchedDestination`.
- Template execution uses `JsonTemplateEngine.createAsSync` in-process — `TODO(INT-6295)` marks the swap point for sandboxed evaluation.

### Known behavior: single-element JSONata array flattening

When a `requestBody` template maps over `$.records` and there is exactly one record, the json-template-engine returns a plain object instead of a single-element array (standard JSONata semantics). This is tested explicitly and template authors should account for it if the downstream API requires an array.

## Test plan
- [ ] `npm run lint` — clean
- [ ] `npm test -- --testPathPattern="custom_audience" --no-coverage` — 29 unit tests pass (21 utils + 8 routerTransform, both table-driven; includes explicit single-element JSONata flattening assertion)
- [ ] `npm test -- --testPathPattern="batchedDestinationsMap|nativeBatching|posthog" --no-coverage` — framework + PostHog regression tests pass with no changes
- [ ] `npm run test:ts -- component --destination=custom_audience` — 5 router scenarios pass: action grouping + chunking, missing-action 400, all-fields-stripped 400, customMappings literal injection, and isHashRequired SHA256 hashing
- [ ] `npm run test:ts -- component --destination=posthog` — PostHog component tests pass (no framework regression)

## Dependencies
- Stacked on top of PR #5185 (`feat/int-6296-isolate-vm-integration-for-template-parsing`). Merge order matters.
- **INT-6295** (Template Evaluator) for sandboxed execution — stubbed with a TODO
- **INT-6290** for the rudder-integrations-config destination definition. That schema currently keys `actions` uppercase; this implementation expects lowercase per audience-destination convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)