### PR TITLE
fix: add validation to customerIo for undefined properties

### DIFF
--- a/src/v0/destinations/customerio/util.js
+++ b/src/v0/destinations/customerio/util.js
@@ -285,7 +285,7 @@ const defaultResponseBuilder = (message, evName, userId, evType, destination, me
     // CustomerIO supports 100byte of event name for anonymous users
     if (messageType === EventType.SCREEN) {
       // 100 - len(`Viewed  Screen`) = 86
-      trimmedEvName = `Viewed ${truncate(message.event || message.properties.name, 86)} Screen`;
+      trimmedEvName = `Viewed ${truncate(message.event || message.properties?.name || '', 86)} Screen`;
     } else {
       if (typeof evName !== 'string') {
         throw new InstrumentationError('Event Name type should be a string');

--- a/src/v0/destinations/customerio/util.test.js
+++ b/src/v0/destinations/customerio/util.test.js
@@ -347,3 +347,32 @@ describe('Unit test cases for customerio defaultResponseBuilder with userId cont
     });
   });
 });
+
+describe('Unit test cases for customerio defaultResponseBuilder anonymous SCREEN edge cases', () => {
+  it('should not crash when properties is undefined for anonymous screen event', () => {
+    const expectedOutput = {
+      rawPayload: {
+        data: undefined,
+        name: 'Viewed  Screen',
+        type: 'event',
+        anonymous_id: 'anon123',
+      },
+      endpointDetails: {
+        endpoint: 'https://track.customer.io/api/v1/events',
+        path: 'v1/events',
+      },
+      requestConfig: { requestFormat: 'JSON', requestMethod: 'POST' },
+    };
+
+    const result = defaultResponseBuilder(
+      { anonymousId: 'anon123', type: 'screen' },
+      'Viewed undefined Screen',
+      undefined,
+      'event',
+      { Config: { apiKey: 'test-api-key', siteID: 'test-site-id' } },
+      'screen',
+    );
+
+    expect(result).toEqual(expectedOutput);
+  });
+});


### PR DESCRIPTION
## What are the changes introduced in this PR?

Fixes an uncontrolled `TypeError` in the Customer.io router transformer that crashes anonymous SCREEN events when `message.properties` is `undefined`.

The crash occurs at [`src/v0/destinations/customerio/util.js:288`](https://github.com/rudderlabs/rudder-transformer/blob/develop/src/v0/destinations/customerio/util.js#L288), where `message.properties.name` is dereferenced without optional chaining inside the anonymous-event branch of `defaultResponseBuilder`. The equivalent expression in `transform.js:102` already uses `message.properties?.name` — this duplicate in `util.js` was missing the guard.

**Fix**:
```diff
- trimmedEvName = `Viewed ${truncate(message.event || message.properties.name, 86)} Screen`;
+ trimmedEvName = `Viewed ${truncate(message.event || message.properties?.name || '', 86)} Screen`;
```

The trailing `|| ''` is required because `truncate-utf8-bytes` itself throws `Input must be string` when both `message.event` and `message.properties?.name` are absent — without the fallback, optional chaining alone would just swap one Bugsnag alert for another.

**Trigger conditions** (all four must hold):
1. `messageType === 'screen'`
2. No `userId` / `email` (anonymous-event branch)
3. `message.event` is falsy
4. `message.properties` is `undefined`

**Test coverage**: Added a regression unit test in `util.test.js`. Verified that reverting the source fix makes the new test fail with the exact production error, and re-applying the fix makes it pass.

## What is the related Linear task?

Resolves [INT-6351](https://linear.app/rudderstack/issue/INT-6351)

## Please explain the objectives of your changes below

Eliminate a production Bugsnag alert (`alert group I3YVCG2ZRHG6K`, observed on v1.132.0 against Customer.io PROD) caused by malformed anonymous SCREEN events reaching the router transformer.

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

No behavioral change for well-formed events. For the previously-crashing edge case (anonymous SCREEN with both `event` and `properties` missing), the transformer now produces a payload with `name: "Viewed  Screen"` instead of throwing — matching the spirit of the analogous guard in `transform.js:102`.

### Any new dependencies introduced with this change?

N/A

### Any new generic utility introduced or modified. Please explain the changes.

N/A

### Any technical or performance related pointers to consider with the change?

N/A

@coderabbitai review

<hr>

### Developer checklist

- [ ] My code follows the style guidelines of this project

- [ ] **No breaking changes are being introduced.**

- [ ] All related docs linked with the PR?

- [ ] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [ ] Is the PR limited to 10 file changes?

- [ ] Is the PR limited to one linear task?

- [ ] Are relevant unit and component test-cases added in **new readability format**?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.
