### PR TITLE
feat(test-router): support batching-framework destinations

### DIFF
--- a/src/services/eventTest/__tests__/eventTester.test.ts
+++ b/src/services/eventTest/__tests__/eventTester.test.ts
@@ -1,0 +1,125 @@
+import { isBatchingFrameworkEnabled } from '../../../constants/batchedDestinationsMap';
+import { FetchHandler } from '../../../helpers/fetchHandlers';
+import { processBatchedDestination } from '../../destination/nativeBatching/processBatchedDestination';
+import type { BatchDestinationConstructor } from '../../destination/nativeBatching/batchDestination';
+import { EventTesterService } from '../eventTester';
+
+jest.mock('../../../constants/batchedDestinationsMap');
+jest.mock('../../destination/nativeBatching/processBatchedDestination');
+
+const runDestTransform = (
+  EventTesterService as unknown as {
+    runDestTransform: (v: string, d: string, ev: unknown) => Promise<unknown[]>;
+  }
+).runDestTransform.bind(EventTesterService);
+
+const mockIsBatchingEnabled = isBatchingFrameworkEnabled as jest.Mock;
+const mockProcessBatched = processBatchedDestination as jest.Mock;
+
+const sampleOutput = {
+  version: '1',
+  type: 'REST',
+  method: 'POST',
+  endpoint: 'https://api.example.com/x',
+  headers: {},
+  params: {},
+  body: { JSON: { a: 1 }, JSON_ARRAY: {}, XML: {}, FORM: {} },
+  files: {},
+};
+
+describe('EventTesterService.runDestTransform', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.clearAllMocks();
+  });
+
+  describe('batching-framework path', () => {
+    beforeEach(() => {
+      mockIsBatchingEnabled.mockReturnValue(true);
+      jest
+        .spyOn(FetchHandler, 'getBatchDestinationHandler')
+        .mockReturnValue(class FakeIntegration {} as unknown as BatchDestinationConstructor);
+    });
+
+    it('returns batchedRequest payloads as a flat array on success', async () => {
+      mockProcessBatched.mockResolvedValue([{ batchedRequest: sampleOutput }]);
+
+      const result = await runDestTransform('v0', 'custom_audience', {
+        message: { type: 'record' },
+        destination: { WorkspaceId: 'ws-1' },
+        connection: {},
+      });
+
+      expect(result).toEqual([sampleOutput]);
+    });
+
+    it('throws with the error message when a response carries an error', async () => {
+      mockProcessBatched.mockResolvedValue([{ error: 'message.type: expected "record"' }]);
+
+      await expect(
+        runDestTransform('v0', 'custom_audience', { destination: { WorkspaceId: 'ws-1' } }),
+      ).rejects.toThrow('message.type: expected "record"');
+    });
+
+    it('passes the event with synthetic metadata into processBatchedDestination', async () => {
+      mockProcessBatched.mockResolvedValue([{ batchedRequest: sampleOutput }]);
+
+      const ev = {
+        message: { type: 'record' },
+        destination: { WorkspaceId: 'ws-1' },
+        connection: { foo: 'bar' },
+      };
+      await runDestTransform('v0', 'custom_audience', ev);
+
+      expect(mockProcessBatched).toHaveBeenCalledWith(
+        [{ ...ev, metadata: { workspaceId: 'ws-1' } }],
+        expect.any(Function),
+        {},
+      );
+    });
+  });
+
+  describe('legacy processor path', () => {
+    beforeEach(() => {
+      mockIsBatchingEnabled.mockReturnValue(false);
+    });
+
+    it.each([
+      { name: 'single object', mockOutput: sampleOutput, expected: [sampleOutput] },
+      {
+        name: 'array of outputs',
+        mockOutput: [sampleOutput, { ...sampleOutput, endpoint: '/y' }],
+        expected: [sampleOutput, { ...sampleOutput, endpoint: '/y' }],
+      },
+    ])('normalizes process() $name into an array', async ({ mockOutput, expected }) => {
+      jest
+        .spyOn(
+          EventTesterService as unknown as { getDestHandler: (...a: unknown[]) => unknown },
+          'getDestHandler',
+        )
+        .mockReturnValue({ process: jest.fn().mockResolvedValue(mockOutput) });
+
+      const result = await runDestTransform('v0', 'webhook', {
+        destination: { WorkspaceId: 'ws-1' },
+      });
+
+      expect(result).toEqual(expected);
+    });
+
+    it('forwards version and destination to getDestHandler and passes ev to process', async () => {
+      const processSpy = jest.fn().mockResolvedValue(sampleOutput);
+      const getDestHandlerSpy = jest
+        .spyOn(
+          EventTesterService as unknown as { getDestHandler: (...a: unknown[]) => unknown },
+          'getDestHandler',
+        )
+        .mockReturnValue({ process: processSpy });
+
+      const ev = { message: { type: 'track' }, destination: { WorkspaceId: 'ws-1' } };
+      await runDestTransform('v0', 'webhook', ev);
+
+      expect(getDestHandlerSpy).toHaveBeenCalledWith('v0', 'webhook');
+      expect(processSpy).toHaveBeenCalledWith(ev);
+    });
+  });
+});

--- a/src/services/eventTest/eventTester.ts
+++ b/src/services/eventTest/eventTester.ts
@@ -1,10 +1,51 @@
 import { sendToDestination, userTransformHandler } from '../../routerUtils';
 import { FixMe } from '../../types';
+import { isBatchingFrameworkEnabled } from '../../constants/batchedDestinationsMap';
+import { FetchHandler } from '../../helpers/fetchHandlers';
+import { processBatchedDestination } from '../destination/nativeBatching/processBatchedDestination';
+import type { RouterTransformationRequestData } from '../../types/destinationTransformation';
+import type { Destination, Connection } from '../../types/controlPlaneConfig';
+import type { Metadata, RudderMessage } from '../../types/rudderEvents';
+
+type DestTransformInput = {
+  message: RudderMessage;
+  destination: Destination & { WorkspaceId: string };
+  connection?: Connection;
+};
 
 export class EventTesterService {
   private static getDestHandler(version, destination) {
     // eslint-disable-next-line global-require, import/no-dynamic-require
     return require(`../../${version}/destinations/${destination}/transform`);
+  }
+
+  private static async runDestTransform(
+    version: string,
+    dest: string,
+    ev: DestTransformInput,
+  ): Promise<unknown[]> {
+    const { WorkspaceId: workspaceId } = ev.destination;
+    if (!workspaceId) {
+      throw new Error('destination.WorkspaceId is required');
+    }
+    if (isBatchingFrameworkEnabled(dest, workspaceId)) {
+      const IntegrationClass = FetchHandler.getBatchDestinationHandler(dest);
+      const input: RouterTransformationRequestData = {
+        message: ev.message,
+        // Synthetic minimal metadata — the test endpoint doesn't carry full router metadata.
+        metadata: { workspaceId } as Metadata,
+        destination: ev.destination,
+        connection: ev.connection,
+      };
+      const responses = await processBatchedDestination([input], IntegrationClass, {});
+      const failed = responses.find((r) => r.error);
+      if (failed) {
+        throw new Error(failed.error);
+      }
+      return responses.map((r) => r.batchedRequest);
+    }
+    const output = await this.getDestHandler(version, dest).process(ev);
+    return Array.isArray(output) ? output : [output];
   }
 
   private static transformDestination(dest) {
@@ -47,10 +88,11 @@ export class EventTesterService {
     }
     await Promise.all(
       events.map(async (event) => {
-        const { message, destination, stage, libraries } = event;
+        const { message, destination, connection, stage, libraries } = event;
         const ev = {
           message,
           destination: this.transformDestination(destination),
+          connection,
           libraries,
         };
 
@@ -98,13 +140,7 @@ export class EventTesterService {
         if (stage.dest_transform) {
           if (!errorFound) {
             try {
-              const desthandler = this.getDestHandler(version, dest);
-              const transformedOutput = await desthandler.process(ev);
-              if (Array.isArray(transformedOutput)) {
-                response.dest_transformed_payload = transformedOutput;
-              } else {
-                response.dest_transformed_payload = [transformedOutput];
-              }
+              response.dest_transformed_payload = await this.runDestTransform(version, dest, ev);
             } catch (err: any) {
               errorFound = true;
               response.dest_transformed_payload = {


### PR DESCRIPTION
## Summary
- The test-router endpoint (`POST /test-router/:version/:destination`) now routes through `processBatchedDestination` when the destination uses the batching framework (e.g. `custom_audience`). This lets destinations that only ship `routerTransform.ts` — without a parallel `transform.ts` — be exercised via the test endpoint.
- Extracted `runDestTransform` to encapsulate both the batching-framework and legacy processor paths. It checks `isBatchingFrameworkEnabled` and delegates accordingly, normalizing the output to a flat array in both cases.
- `connection` from the test request is threaded through to the destination so batching destinations that depend on it can be instantiated. The field is optional — the config-backend does not send it today.
- `destination.WorkspaceId` is validated with an assertion before use, and a synthetic minimal `Metadata` (only `workspaceId`) is constructed for the batching framework since the test endpoint doesn't carry full router metadata.
- Added unit tests covering both the batching-framework and legacy processor paths.

Stacked on top of #5193 (target branch: `feat/int-6302-router-transform-isolate-vm`).

## Test plan
- [x] `POST /test-router/v0/custom_audience` happy path returns templated body with resolved endpoint, hashed bearer auth, and custom headers
- [x] Schema validation error surfaces inline (`message.type: Invalid literal value, expected "record"; ...`)
- [x] Non-batching destination (`webhook`) still goes through the legacy processor path
- [x] `npm test -- --testPathPattern="eventTester" --no-coverage` — 6 passed
- [x] `npm test -- --testPathPattern="custom_audience" --no-coverage` — 110 passed
- [x] `npm run test:ts -- component --destination=custom_audience` — 5 passed
- [x] `npm run lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)