### PR TITLE
fix(intercom): searchContact crashes when API returns 200 with no data array

### DIFF
--- a/src/cdk/v2/destinations/intercom/utils.js
+++ b/src/cdk/v2/destinations/intercom/utils.js
@@ -367,16 +367,15 @@ const searchContact = async (message, destination, metadata) => {
   );
   const processedUserResponse = processAxiosResponse(response);
   if (isHttpStatusSuccess(processedUserResponse.status)) {
-    if (processedUserResponse.response?.data.length > 1) {
+    const contacts = processedUserResponse.response?.data;
+    if (contacts?.length > 1) {
       warn('[INTERCOM] Multiple contacts found for the message', {
         sourceId: metadata.sourceId,
         destinationId: metadata.destinationId,
         workspaceId: metadata.workspaceId,
       });
     }
-    return processedUserResponse.response?.data.length > 0
-      ? processedUserResponse.response?.data[0]?.id
-      : null;
+    return contacts?.length > 0 ? contacts[0]?.id : null;
   }
 
   throw new NetworkError(

--- a/src/cdk/v2/destinations/intercom/utils.test.js
+++ b/src/cdk/v2/destinations/intercom/utils.test.js
@@ -761,6 +761,37 @@ describe('searchContact utility test', () => {
       }),
     );
   });
+
+  it('Should return null when API returns 200 but response body has no data field', async () => {
+    const message = {
+      context: {
+        traits: { email: 'test@rudderlabs.com' },
+      },
+      metadata: {
+        sourceId: 'source-123',
+        destinationId: 'dest-123',
+        workspaceId: 'workspace-123',
+      },
+    };
+    const destination = { Config: { apiKey: 'testApiKey', apiServer: 'us' } };
+
+    axios.post.mockResolvedValue({
+      status: 200,
+      data: {
+        type: 'list',
+        total_count: 0,
+        pages: {
+          type: 'pages',
+          page: 1,
+          per_page: 50,
+          total_pages: 0,
+        },
+      },
+    });
+
+    const result = await searchContact(message, destination, message.metadata);
+    expect(result).toBeNull();
+  });
 });
 
 describe('createOrUpdateCompany utility test', () => {


### PR DESCRIPTION
## Summary
- Fixes INT-6367: `TypeError: Cannot read properties of undefined (reading 'length')` in `searchContact` causing 500s in production router transformation
- Root cause: incomplete optional chaining on `processedUserResponse.response?.data.length` — crashes when Intercom returns a 2xx response with no `data` array in the body
- Extracts `processedUserResponse.response?.data` into a `contacts` variable with proper optional chaining, and adds a unit test for the missing-data scenario

## Test plan
- [x] Unit tests pass: `npm test -- --testPathPattern="src/cdk/v2/destinations/intercom" --no-coverage` (54/54)
- [ ] Integration tests: `npm run test:ts -- component --destination=intercom`

🤖 Generated with [Claude Code](https://claude.com/claude-code)