### PR TITLE
chore(version-audit): dedup, smart master creation, project/label assignment

### DIFF
--- a/.github/scripts/integrations_version_audit_plan.md
+++ b/.github/scripts/integrations_version_audit_plan.md
@@ -163,6 +163,7 @@ Categorization logic:
     getCurrentUserId,
     getCurrentCycleId,
     findOpenSubticketGlobally,
+    listIssuesByParent,
     updateIssue,
     updateIssueDescription,
   } = require('./.github/scripts/linearApi');
@@ -189,8 +190,11 @@ Categorization logic:
 8. **Update existing subtickets in place**
 
 - For each integration with an existing open subticket, update it under its current parent master ticket. Do not move it.
+- Track the parent master IDs of all updated subtickets so their descriptions can be refreshed in step 8b.
 
   ```javascript
+  const affectedMasterIds = new Set(); // parent masters whose subtickets were updated
+
   for (const { integration, existingSub } of updatableIntegrations) {
     const integrationName = integration.Destination;
     console.log(`Updating existing subticket: ${existingSub.identifier} for ${integrationName}`);
@@ -199,7 +203,8 @@ Categorization logic:
       priority: calculatedPriority,
       dueDate: calculatedDueDate,
     });
-    // Track as "updated" in summary
+    affectedMasterIds.add(existingSub.parentId);
+    // Track as "updated" (not "created") in summary — store { identifier, url } for logging
   }
   ```
 
@@ -261,15 +266,25 @@ Categorization logic:
   - Ticket descriptions include all relevant information from documentation review
 - **CRITICAL**: If tickets were not created (no ticket URLs in output), the audit has FAILED and must be retried
 
-8b. **Update new master ticket description with subticket URLs** (AFTER all subtickets are created)
+8b. **Refresh descriptions of all affected master tickets** (AFTER all subtickets are created/updated)
 
-- Only applies if a new master ticket was created in step 8a (`newMasterTicket` is not null).
-- The master ticket description template (see below) includes per-integration ticket URLs. These URLs are only available after subtickets are created.
-- After all subtickets are processed, rebuild the master description using the collected subticket URLs and update:
+- Refresh the description of every master ticket that had subtickets created or updated during this run. This includes:
+  - The new master ticket (if one was created in step 8a)
+  - Any older master tickets whose subtickets were updated in step 8 (tracked via `affectedMasterIds`)
+- For each affected master, fetch its current subtickets via `listIssuesByParent`, rebuild the description using the master description template, and update it.
+
   ```javascript
+  // Collect all master IDs that need a description refresh
+  const mastersToRefresh = new Set(affectedMasterIds);
   if (newMasterTicket) {
-    const finalMasterDescription = buildMasterDescription(subticketResults);
-    await updateIssueDescription(newMasterTicket.id, finalMasterDescription);
+    mastersToRefresh.add(newMasterTicket.id);
+  }
+
+  for (const masterId of mastersToRefresh) {
+    const subtickets = await listIssuesByParent(masterId);
+    const refreshedDescription = buildMasterDescription(subtickets, analysisResults);
+    await updateIssueDescription(masterId, refreshedDescription);
+    console.log(`Refreshed master ticket description: ${masterId}`);
   }
   ```
 
@@ -306,8 +321,13 @@ Categorization logic:
   } else {
     console.log(`  - No new master ticket created (all integrations had existing subtickets)`);
   }
+  console.log(`  - Masters refreshed: ${mastersToRefresh.size}`);
   console.log(`  - Subtickets created: ${subticketsCreated}`);
   console.log(`  - Subtickets updated (existing): ${subticketsUpdated}`);
+  console.log(`\nSubticket URLs:`);
+  for (const sub of allSubticketResults) {
+    console.log(`  - ${sub.integrationName}: ${sub.identifier} - ${sub.url} (${sub.action})`);
+  }
   if (errors.length > 0) {
     console.log(`\nErrors Encountered: ${errors.length}`);
     errors.forEach((err) => console.log(`  - ${err}`));
@@ -458,7 +478,7 @@ Use the existing `.github/scripts/linearApi.js` module for ticket creation and d
 - `searchIssues({ titleContains, teamId, states, limit })` - Search for existing tickets by title substring, optionally filtered by workflow states
 - `findOpenAuditMasterTicket()` - Find the most recent open master audit ticket (title contains "Integration Version Audit [Rudder Transformer]", no parent, in open states: Queued/In Progress/Todo/Backlog/Triage). Returns the ticket object or null.
 - `findOpenSubticketByIntegration(parentId, integrationName)` - Find an existing open subticket for a specific integration under a given parent ticket. Returns the ticket object or null.
-- `findOpenSubticketGlobally(integrationName)` - Find an existing open subticket for a specific integration across ALL parent tickets (not scoped to one master). Returns the ticket object or null. **Use this in step 7 to classify integrations before deciding whether a new master ticket is needed.**
+- `findOpenSubticketGlobally(integrationName)` - Find an existing open subticket for a specific integration across ALL audit master tickets. Validates that the parent is an audit master (title contains "Integration Version Audit [Rudder Transformer]", no parent). When multiple matches exist, returns the newest one (highest identifier number). Returns the ticket object (including `parentId`) or null. **Use this in step 7 to classify integrations before deciding whether a new master ticket is needed.**
 
 **Querying:**
 

--- a/.github/scripts/integrations_version_audit_plan.md
+++ b/.github/scripts/integrations_version_audit_plan.md
@@ -150,12 +150,11 @@ Categorization logic:
 
 **⚠️ DEDUPLICATION**: Before creating any ticket, always check for existing open tickets. Never create a duplicate.
 
-7. **Check for existing open master ticket** (EXECUTE FIRST)
+7. **Classify integrations and check for existing subtickets** (EXECUTE FIRST)
 
-- Read `.github/scripts/linearApi.js` to understand the API structure — including the dedup functions: `findOpenAuditMasterTicket`, `findOpenSubticketByIntegration`, and `searchIssues`
-- **IMMEDIATELY** call `findOpenAuditMasterTicket()` to search for an existing open master ticket
-  - This searches for tickets with title containing "Integration Version Audit [Rudder Transformer]" in open states (Queued, In Progress, Todo, Backlog, Triage)
-  - It filters to top-level tickets only (no parent) and returns the most recent match
+- Read `.github/scripts/linearApi.js` to understand the API structure — including the dedup functions: `findOpenSubticketGlobally`, `findOpenSubticketByIntegration`, and `searchIssues`
+- For each integration categorized as "Action Required", search globally for an existing open subticket using `findOpenSubticketGlobally(integrationName)`. This searches across ALL open master tickets, not just one.
+- Separate integrations into two lists: **updates** (existing subticket found) and **new** (no existing subticket found).
 
   ```javascript
   const {
@@ -163,86 +162,89 @@ Categorization logic:
     getStateId,
     getCurrentUserId,
     getCurrentCycleId,
-    findOpenAuditMasterTicket,
-    findOpenSubticketByIntegration,
-    listIssuesByParent,
+    findOpenSubticketGlobally,
     updateIssue,
     updateIssueDescription,
   } = require('./.github/scripts/linearApi');
 
-  // Step 1: Check for existing open master ticket
-  const existingMaster = await findOpenAuditMasterTicket();
-  ```
+  // Classify each action-required integration
+  const updatableIntegrations = []; // existing open subticket found
+  const newIntegrations = [];       // no existing subticket
 
-- **If an open master ticket exists** (`existingMaster` is not null):
-  - Reuse it: set `masterTicket = existingMaster`
-  - Log: `Reusing existing master ticket: ${existingMaster.identifier} - ${existingMaster.url}`
-  - Fetch its existing subtickets: `const existingSubtickets = await listIssuesByParent(existingMaster.id)`
-  - Do NOT update the master description yet — it will be updated in step 8b after subticket URLs are available
-  - Proceed to step 8 (subticket creation with dedup)
-
-- **If no open master ticket exists** (`existingMaster` is null):
-  - Create a new master ticket (same as before):
-
-  ```javascript
-  // Query for required IDs
-  const statusStateId = await getStateId('Queued', LINEAR_TEAM_ID);
-  const currentUserId = await getCurrentUserId();
-  const currentCycleId = await getCurrentCycleId(LINEAR_TEAM_ID);
-
-  if (!statusStateId)
-    console.warn('Warning: Could not find "Queued" state. Ticket will be created without status.');
-  if (!currentUserId)
-    console.warn(
-      'Warning: Could not retrieve current user ID. Ticket will be created without assignee.',
-    );
-  if (!currentCycleId)
-    console.warn('Warning: Could not find current cycle. Ticket will be created without cycle.');
-
-  const masterTicket = await createIssue({
-    title: 'Integration Version Audit [Rudder Transformer] [Current Date in DD/MM/YYYY]',
-    description: masterDescription, // Use Master Ticket Description Template (see below)
-    priority: 3, // Medium priority
-    stateId: statusStateId, // Status: Queued
-    cycleId: currentCycleId, // Current cycle
-    labelIds: [], // Optional: add label IDs if labels exist in Linear
-  });
-  ```
-
-  - Store returned ticket ID (`masterTicket.id`) for use as parent in subtickets
-  - The returned object includes: `id`, `identifier` (e.g., "INT-4499"), `title`, and `url`
-
-8. **Create or update subtickets for each integration requiring action** (EXECUTE NOW - DO NOT DEFER)
-
-- For each integration categorized as "Action Required":
-  - **First, check for an existing open subticket** by calling `findOpenSubticketByIntegration(masterTicket.id, integrationName)`
-    - This searches for open tickets with the integration name in the title that are children of the master ticket
-
-  ```javascript
   for (const integration of actionRequiredIntegrations) {
     const integrationName = integration.Destination;
-
-    // Check for existing open subticket under the master ticket
-    const existingSub = await findOpenSubticketByIntegration(masterTicket.id, integrationName);
+    const existingSub = await findOpenSubticketGlobally(integrationName);
 
     if (existingSub) {
-      // Update existing subticket with latest analysis, priority, and due date
-      console.log(`Updating existing subticket: ${existingSub.identifier} for ${integrationName}`);
-      await updateIssue(existingSub.id, {
-        description: ticketDescription,
-        priority: calculatedPriority,
-        dueDate: calculatedDueDate,
-      });
-      // Track as "updated" (not "created") in summary
+      updatableIntegrations.push({ integration, existingSub });
     } else {
-      // No existing subticket — create a new one
+      newIntegrations.push(integration);
+    }
+  }
+
+  console.log(`Integrations to update: ${updatableIntegrations.length}`);
+  console.log(`New integrations: ${newIntegrations.length}`);
+  ```
+
+8. **Update existing subtickets in place**
+
+- For each integration with an existing open subticket, update it under its current parent master ticket. Do not move it.
+
+  ```javascript
+  for (const { integration, existingSub } of updatableIntegrations) {
+    const integrationName = integration.Destination;
+    console.log(`Updating existing subticket: ${existingSub.identifier} for ${integrationName}`);
+    await updateIssue(existingSub.id, {
+      description: ticketDescription,
+      priority: calculatedPriority,
+      dueDate: calculatedDueDate,
+    });
+    // Track as "updated" in summary
+  }
+  ```
+
+8a. **Create a new master ticket only if there are new integrations**
+
+- **If `newIntegrations` is empty**: no new master ticket is needed. Log: `No new integrations found — skipping master ticket creation.`
+- **If `newIntegrations` has entries**: create a new master ticket for this audit run, then create subtickets under it.
+
+  ```javascript
+  let newMasterTicket = null;
+
+  if (newIntegrations.length > 0) {
+    const statusStateId = await getStateId('Queued', LINEAR_TEAM_ID);
+    const currentUserId = await getCurrentUserId();
+    const currentCycleId = await getCurrentCycleId(LINEAR_TEAM_ID);
+
+    if (!statusStateId)
+      console.warn('Warning: Could not find "Queued" state. Ticket will be created without status.');
+    if (!currentUserId)
+      console.warn(
+        'Warning: Could not retrieve current user ID. Ticket will be created without assignee.',
+      );
+    if (!currentCycleId)
+      console.warn('Warning: Could not find current cycle. Ticket will be created without cycle.');
+
+    newMasterTicket = await createIssue({
+      title: 'Integration Version Audit [Rudder Transformer] [Current Date in DD/MM/YYYY]',
+      description: '', // Placeholder — updated in step 8c after subticket URLs are available
+      priority: 3, // Medium priority
+      stateId: statusStateId, // Status: Queued
+      cycleId: currentCycleId, // Current cycle
+      labelIds: [],
+    });
+    console.log(`Created new master ticket: ${newMasterTicket.identifier} - ${newMasterTicket.url}`);
+
+    // Create subtickets for new integrations under the new master
+    for (const integration of newIntegrations) {
+      const integrationName = integration.Destination;
       console.log(`Creating new subticket for ${integrationName}`);
       await createIssue({
         title: `${integrationName} Version Audit [Rudder Transformer]`,
         description: ticketDescription,
-        parentId: masterTicket.id,
+        parentId: newMasterTicket.id,
         priority: calculatedPriority, // 1-4 based on urgency (1=Urgent, 4=Low)
-        dueDate: calculatedDueDate, // ISO format string (YYYY-MM-DD) or null
+        dueDate: calculatedDueDate,   // ISO format string (YYYY-MM-DD) or null
         labelIds: [],
       });
       // Track as "created" in summary
@@ -253,23 +255,23 @@ Categorization logic:
 - Handle errors gracefully: if one ticket creation/update fails, log the error and continue with remaining integrations
 - Consider adding a small delay between ticket creations to avoid rate limiting
 - **Verification**: After all tickets are created/updated, verify that:
-  - Master ticket exists (either reused or newly created) with actual ticket URL
   - All integrations requiring action have corresponding subtickets — **MUST have actual ticket URLs**
   - Each subticket contains detailed analysis from codebase search and web_search findings
   - Priority and due dates are correctly assigned based on sunset dates and version gaps
   - Ticket descriptions include all relevant information from documentation review
 - **CRITICAL**: If tickets were not created (no ticket URLs in output), the audit has FAILED and must be retried
 
-8b. **Update master ticket description with subticket URLs** (AFTER all subtickets are created/updated)
+8b. **Update new master ticket description with subticket URLs** (AFTER all subtickets are created)
 
-- The master ticket description template (see below) includes per-integration ticket URLs. These URLs are only available after subtickets are created in step 8.
+- Only applies if a new master ticket was created in step 8a (`newMasterTicket` is not null).
+- The master ticket description template (see below) includes per-integration ticket URLs. These URLs are only available after subtickets are created.
 - After all subtickets are processed, rebuild the master description using the collected subticket URLs and update:
   ```javascript
-  // Rebuild masterDescription now that all subticket URLs are known
-  const finalMasterDescription = buildMasterDescription(subticketResults);
-  await updateIssueDescription(masterTicket.id, finalMasterDescription);
+  if (newMasterTicket) {
+    const finalMasterDescription = buildMasterDescription(subticketResults);
+    await updateIssueDescription(newMasterTicket.id, finalMasterDescription);
+  }
   ```
-- This applies to both new and reused master tickets.
 
 9. **Log analysis summary** (AFTER tickets are created/updated)
 
@@ -299,10 +301,13 @@ Categorization logic:
   console.log(`  - Medium (3): ${mediumCount}`);
   console.log(`  - Low (4): ${lowCount}`);
   console.log(`\nTickets:`);
-  console.log(`  - Master Ticket: ${masterTicket.identifier} - ${masterTicket.url} (${masterReused ? 'REUSED' : 'CREATED'})`);
+  if (newMasterTicket) {
+    console.log(`  - New Master Ticket: ${newMasterTicket.identifier} - ${newMasterTicket.url}`);
+  } else {
+    console.log(`  - No new master ticket created (all integrations had existing subtickets)`);
+  }
   console.log(`  - Subtickets created: ${subticketsCreated}`);
   console.log(`  - Subtickets updated (existing): ${subticketsUpdated}`);
-  console.log(`  - Duplicates avoided: ${subticketsUpdated}`);
   if (errors.length > 0) {
     console.log(`\nErrors Encountered: ${errors.length}`);
     errors.forEach((err) => console.log(`  - ${err}`));
@@ -453,6 +458,7 @@ Use the existing `.github/scripts/linearApi.js` module for ticket creation and d
 - `searchIssues({ titleContains, teamId, states, limit })` - Search for existing tickets by title substring, optionally filtered by workflow states
 - `findOpenAuditMasterTicket()` - Find the most recent open master audit ticket (title contains "Integration Version Audit [Rudder Transformer]", no parent, in open states: Queued/In Progress/Todo/Backlog/Triage). Returns the ticket object or null.
 - `findOpenSubticketByIntegration(parentId, integrationName)` - Find an existing open subticket for a specific integration under a given parent ticket. Returns the ticket object or null.
+- `findOpenSubticketGlobally(integrationName)` - Find an existing open subticket for a specific integration across ALL parent tickets (not scoped to one master). Returns the ticket object or null. **Use this in step 7 to classify integrations before deciding whether a new master ticket is needed.**
 
 **Querying:**
 
@@ -475,7 +481,7 @@ Use the existing `.github/scripts/linearApi.js` module for ticket creation and d
 - **Tickets are created immediately** after analysis completes, not deferred to a script execution
 - The `LINEAR_TEAM_ID` environment variable must be set in the workflow environment
 - If the agent attempts to create a script file instead of making API calls directly, it should be corrected to make the calls immediately
-- **DEDUPLICATION IS MANDATORY**: Before creating any ticket (master or subticket), the agent MUST call the appropriate dedup function (`findOpenAuditMasterTicket` or `findOpenSubticketByIntegration`) to check for existing open tickets. If an open ticket exists, update it instead of creating a duplicate. Only create a new ticket when no open match is found.
+- **DEDUPLICATION IS MANDATORY**: Before creating any subticket, the agent MUST call `findOpenSubticketGlobally(integrationName)` to check for existing open subtickets across all master tickets. If an open subticket exists, update it in place. Only create a new subticket (under a new master) when no open match is found. A new master ticket is only created when there are new integrations that need subtickets.
 
 ## Notes
 

--- a/.github/scripts/integrations_version_audit_plan.md
+++ b/.github/scripts/integrations_version_audit_plan.md
@@ -166,6 +166,7 @@ Categorization logic:
     findOpenAuditMasterTicket,
     findOpenSubticketByIntegration,
     listIssuesByParent,
+    updateIssue,
     updateIssueDescription,
   } = require('./.github/scripts/linearApi');
 
@@ -177,7 +178,7 @@ Categorization logic:
   - Reuse it: set `masterTicket = existingMaster`
   - Log: `Reusing existing master ticket: ${existingMaster.identifier} - ${existingMaster.url}`
   - Fetch its existing subtickets: `const existingSubtickets = await listIssuesByParent(existingMaster.id)`
-  - Update the master ticket description with the latest analysis: `await updateIssueDescription(existingMaster.id, masterDescription)`
+  - Do NOT update the master description yet — it will be updated in step 8b after subticket URLs are available
   - Proceed to step 8 (subticket creation with dedup)
 
 - **If no open master ticket exists** (`existingMaster` is null):
@@ -225,9 +226,13 @@ Categorization logic:
     const existingSub = await findOpenSubticketByIntegration(masterTicket.id, integrationName);
 
     if (existingSub) {
-      // Update existing subticket description with latest analysis
+      // Update existing subticket with latest analysis, priority, and due date
       console.log(`Updating existing subticket: ${existingSub.identifier} for ${integrationName}`);
-      await updateIssueDescription(existingSub.id, ticketDescription);
+      await updateIssue(existingSub.id, {
+        description: ticketDescription,
+        priority: calculatedPriority,
+        dueDate: calculatedDueDate,
+      });
       // Track as "updated" (not "created") in summary
     } else {
       // No existing subticket — create a new one
@@ -254,6 +259,17 @@ Categorization logic:
   - Priority and due dates are correctly assigned based on sunset dates and version gaps
   - Ticket descriptions include all relevant information from documentation review
 - **CRITICAL**: If tickets were not created (no ticket URLs in output), the audit has FAILED and must be retried
+
+8b. **Update master ticket description with subticket URLs** (AFTER all subtickets are created/updated)
+
+- The master ticket description template (see below) includes per-integration ticket URLs. These URLs are only available after subtickets are created in step 8.
+- After all subtickets are processed, rebuild the master description using the collected subticket URLs and update:
+  ```javascript
+  // Rebuild masterDescription now that all subticket URLs are known
+  const finalMasterDescription = buildMasterDescription(subticketResults);
+  await updateIssueDescription(masterTicket.id, finalMasterDescription);
+  ```
+- This applies to both new and reused master tickets.
 
 9. **Log analysis summary** (AFTER tickets are created/updated)
 
@@ -429,7 +445,8 @@ Use the existing `.github/scripts/linearApi.js` module for ticket creation and d
     - `assigneeId` (optional) - User ID to assign the ticket to
     - `cycleId` (optional) - Cycle ID to associate the ticket with
 - `listIssuesByParent(parentId, limit)` - List all subtickets for a parent ticket
-- `updateIssueDescription(issueId, description)` - Update an existing ticket's description
+- `updateIssue(issueId, fields)` - Update any fields on an existing ticket (e.g., `{ description, priority, dueDate }`)
+- `updateIssueDescription(issueId, description)` - Convenience wrapper for `updateIssue` that only updates the description
 
 **Duplicate Detection (MUST use before creating tickets):**
 

--- a/.github/scripts/integrations_version_audit_plan.md
+++ b/.github/scripts/integrations_version_audit_plan.md
@@ -144,37 +144,51 @@ Categorization logic:
   - Missing documentation links
   - Needs manual review to determine status
 
-### Phase 4: Linear Ticket Creation (MUST EXECUTE IMMEDIATELY)
+### Phase 4: Duplicate Detection and Linear Ticket Creation (MUST EXECUTE IMMEDIATELY)
 
 **⚠️ CRITICAL**: This phase MUST be executed during the audit. Do NOT create a script file. Do NOT defer ticket creation. Make Linear API calls directly using the agent's capabilities.
 
-7. **Create master Linear ticket** (EXECUTE NOW - DO NOT DEFER)
+**⚠️ DEDUPLICATION**: Before creating any ticket, always check for existing open tickets. Never create a duplicate.
 
-- Read `.github/scripts/linearApi.js` to understand the Linear API structure
-- **IMMEDIATELY** make Linear API calls using the agent's capabilities:
-  - Call `getStateId('Queued', LINEAR_TEAM_ID)` to get state ID
-  - Call `getCurrentUserId()` to get current user ID
-  - Call `getCurrentCycleId(LINEAR_TEAM_ID)` to get cycle ID
-- **IMMEDIATELY** create the master ticket by calling `createIssue` with the following structure:
+7. **Check for existing open master ticket** (EXECUTE FIRST)
 
-  **Reference implementation from linearApi.js (agent uses this structure to make API calls directly):**
+- Read `.github/scripts/linearApi.js` to understand the API structure — including the dedup functions: `findOpenAuditMasterTicket`, `findOpenSubticketByIntegration`, and `searchIssues`
+- **IMMEDIATELY** call `findOpenAuditMasterTicket()` to search for an existing open master ticket
+  - This searches for tickets with title containing "Integration Version Audit [Rudder Transformer]" in open states (Queued, In Progress, Todo, Backlog, Triage)
+  - It filters to top-level tickets only (no parent) and returns the most recent match
 
   ```javascript
-  // Agent reads this structure and makes Linear API calls directly using its capabilities
-  // DO NOT create a script file - execute API calls immediately
   const {
     createIssue,
     getStateId,
     getCurrentUserId,
     getCurrentCycleId,
+    findOpenAuditMasterTicket,
+    findOpenSubticketByIntegration,
+    listIssuesByParent,
+    updateIssueDescription,
   } = require('./.github/scripts/linearApi');
 
+  // Step 1: Check for existing open master ticket
+  const existingMaster = await findOpenAuditMasterTicket();
+  ```
+
+- **If an open master ticket exists** (`existingMaster` is not null):
+  - Reuse it: set `masterTicket = existingMaster`
+  - Log: `Reusing existing master ticket: ${existingMaster.identifier} - ${existingMaster.url}`
+  - Fetch its existing subtickets: `const existingSubtickets = await listIssuesByParent(existingMaster.id)`
+  - Update the master ticket description with the latest analysis: `await updateIssueDescription(existingMaster.id, masterDescription)`
+  - Proceed to step 8 (subticket creation with dedup)
+
+- **If no open master ticket exists** (`existingMaster` is null):
+  - Create a new master ticket (same as before):
+
+  ```javascript
   // Query for required IDs
   const statusStateId = await getStateId('Queued', LINEAR_TEAM_ID);
   const currentUserId = await getCurrentUserId();
   const currentCycleId = await getCurrentCycleId(LINEAR_TEAM_ID);
 
-  // If any IDs are null, log warnings but proceed with ticket creation
   if (!statusStateId)
     console.warn('Warning: Could not find "Queued" state. Ticket will be created without status.');
   if (!currentUserId)
@@ -197,38 +211,55 @@ Categorization logic:
   - Store returned ticket ID (`masterTicket.id`) for use as parent in subtickets
   - The returned object includes: `id`, `identifier` (e.g., "INT-4499"), `title`, and `url`
 
-8. **Create subtickets for each integration requiring action** (EXECUTE NOW - DO NOT DEFER)
+8. **Create or update subtickets for each integration requiring action** (EXECUTE NOW - DO NOT DEFER)
 
 - For each integration categorized as "Action Required":
-- **IMMEDIATELY** create subticket by calling `createIssue` (reference `createIssue` function structure):
-  **Reference implementation from linearApi.js (agent makes API calls directly):**
-  ```javascript
-  // Agent reads this structure and makes Linear API calls directly
-  // Execute immediately - do NOT create a script file
-  await createIssue({
-    title: `${integrationName} Version Audit [Rudder Transformer]`, // No brackets needed, Linear will format
-    description: ticketDescription, // Use Individual Integration Ticket Template (see below)
-    parentId: masterTicket.id, // From step 7
-    priority: calculatedPriority, // 1-4 based on urgency (1=Urgent, 4=Low)
-    dueDate: calculatedDueDate, // ISO format string (YYYY-MM-DD) or null
-    labelIds: [], // Optional: add label IDs if labels exist
-  });
-  ```
-- Create all subtickets in batch after analysis completes
-  - Handle errors gracefully: if one ticket creation fails, log the error and continue with remaining integrations
-  - Consider adding a small delay between ticket creations to avoid rate limiting
-  - **Verification**: After all tickets are created, verify that:
-    - Master ticket was created successfully (check for ticket ID and URL) - **MUST have actual ticket URL, not placeholder**
-    - All integrations requiring action have corresponding subtickets - **MUST have actual ticket URLs**
-    - Each subticket contains detailed analysis from codebase search and web_search findings
-    - Priority and due dates are correctly assigned based on sunset dates and version gaps
-    - Ticket descriptions include all relevant information from documentation review
-  - **CRITICAL**: If tickets were not created (no ticket URLs in output), the audit has FAILED and must be retried
+  - **First, check for an existing open subticket** by calling `findOpenSubticketByIntegration(masterTicket.id, integrationName)`
+    - This searches for open tickets with the integration name in the title that are children of the master ticket
 
-9. **Log analysis summary** (AFTER tickets are created)
+  ```javascript
+  for (const integration of actionRequiredIntegrations) {
+    const integrationName = integration.Destination;
+
+    // Check for existing open subticket under the master ticket
+    const existingSub = await findOpenSubticketByIntegration(masterTicket.id, integrationName);
+
+    if (existingSub) {
+      // Update existing subticket description with latest analysis
+      console.log(`Updating existing subticket: ${existingSub.identifier} for ${integrationName}`);
+      await updateIssueDescription(existingSub.id, ticketDescription);
+      // Track as "updated" (not "created") in summary
+    } else {
+      // No existing subticket — create a new one
+      console.log(`Creating new subticket for ${integrationName}`);
+      await createIssue({
+        title: `${integrationName} Version Audit [Rudder Transformer]`,
+        description: ticketDescription,
+        parentId: masterTicket.id,
+        priority: calculatedPriority, // 1-4 based on urgency (1=Urgent, 4=Low)
+        dueDate: calculatedDueDate, // ISO format string (YYYY-MM-DD) or null
+        labelIds: [],
+      });
+      // Track as "created" in summary
+    }
+  }
+  ```
+
+- Handle errors gracefully: if one ticket creation/update fails, log the error and continue with remaining integrations
+- Consider adding a small delay between ticket creations to avoid rate limiting
+- **Verification**: After all tickets are created/updated, verify that:
+  - Master ticket exists (either reused or newly created) with actual ticket URL
+  - All integrations requiring action have corresponding subtickets — **MUST have actual ticket URLs**
+  - Each subticket contains detailed analysis from codebase search and web_search findings
+  - Priority and due dates are correctly assigned based on sunset dates and version gaps
+  - Ticket descriptions include all relevant information from documentation review
+- **CRITICAL**: If tickets were not created (no ticket URLs in output), the audit has FAILED and must be retried
+
+9. **Log analysis summary** (AFTER tickets are created/updated)
 
 - After all analysis and ticket creation is complete, log a summary of what was done to console:
 - **MUST include actual Linear ticket URLs** - if URLs are missing, ticket creation failed
+- **MUST distinguish** between reused/updated tickets and newly created ones
 
   ```javascript
   console.log('\n=== Integration SDK Version Audit Summary ===');
@@ -251,9 +282,11 @@ Categorization logic:
   console.log(`  - High (2): ${highCount}`);
   console.log(`  - Medium (3): ${mediumCount}`);
   console.log(`  - Low (4): ${lowCount}`);
-  console.log(`\nTickets Created:`);
-  console.log(`  - Master Ticket: ${masterTicket.identifier} - ${masterTicket.url}`);
-  console.log(`  - Subtickets: ${subticketsCreated} tickets created`);
+  console.log(`\nTickets:`);
+  console.log(`  - Master Ticket: ${masterTicket.identifier} - ${masterTicket.url} (${masterReused ? 'REUSED' : 'CREATED'})`);
+  console.log(`  - Subtickets created: ${subticketsCreated}`);
+  console.log(`  - Subtickets updated (existing): ${subticketsUpdated}`);
+  console.log(`  - Duplicates avoided: ${subticketsUpdated}`);
   if (errors.length > 0) {
     console.log(`\nErrors Encountered: ${errors.length}`);
     errors.forEach((err) => console.log(`  - ${err}`));
@@ -263,7 +296,7 @@ Categorization logic:
 
 10. **Verify analysis completion and ticket creation**
 
-- **CRITICAL**: Verify that all versioned integrations were analyzed AND all required Linear tickets were created successfully
+- **CRITICAL**: Verify that all versioned integrations were analyzed AND all required Linear tickets were created/updated successfully
 - **MUST verify**: Summary log includes actual Linear ticket URLs (not placeholders, not "pending", not "to be created")
 - If ticket URLs are missing from the summary, ticket creation FAILED and the audit is incomplete
 - Ensure the summary log includes any errors encountered during the process
@@ -380,9 +413,11 @@ Handle various date formats when parsing sunset dates. When multiple dates are p
 
 ## Linear API Integration
 
-Use the existing `.github/scripts/linearApi.js` module for ticket creation. Functions are called directly during the AI-assisted analysis process.
+Use the existing `.github/scripts/linearApi.js` module for ticket creation and deduplication. Functions are called directly during the AI-assisted analysis process.
 
 ### Module Exports
+
+**Ticket Creation & Update:**
 
 - `createIssue({ title, description, parentId, priority, labelIds, dueDate, stateId, assigneeId, cycleId })` - Create a new Linear ticket
   - **Note**: Team ID is taken from `LINEAR_TEAM_ID` environment variable (not passed as parameter)
@@ -393,12 +428,21 @@ Use the existing `.github/scripts/linearApi.js` module for ticket creation. Func
     - `stateId` (optional) - State/workflow status ID (e.g., "triage")
     - `assigneeId` (optional) - User ID to assign the ticket to
     - `cycleId` (optional) - Cycle ID to associate the ticket with
+- `listIssuesByParent(parentId, limit)` - List all subtickets for a parent ticket
+- `updateIssueDescription(issueId, description)` - Update an existing ticket's description
+
+**Duplicate Detection (MUST use before creating tickets):**
+
+- `searchIssues({ titleContains, teamId, states, limit })` - Search for existing tickets by title substring, optionally filtered by workflow states
+- `findOpenAuditMasterTicket()` - Find the most recent open master audit ticket (title contains "Integration Version Audit [Rudder Transformer]", no parent, in open states: Queued/In Progress/Todo/Backlog/Triage). Returns the ticket object or null.
+- `findOpenSubticketByIntegration(parentId, integrationName)` - Find an existing open subticket for a specific integration under a given parent ticket. Returns the ticket object or null.
+
+**Querying:**
+
 - `getStateId(stateName, teamId)` - Query Linear API to find state ID by name (e.g., "Queued")
 - `getCurrentUserId()` - Query Linear API to get the current authenticated user's ID (uses `viewer` query)
 - `getUserId(userName)` - Query Linear API to find user ID by name (for searching specific users)
 - `getCurrentCycleId(teamId)` - Query Linear API to find the current/active cycle ID
-- `listIssuesByParent(parentId, limit)` - List all subtickets for a parent ticket
-- `updateIssueDescription(issueId, description)` - Update an existing ticket's description
 
 ### Environment Variables Required
 
@@ -414,6 +458,7 @@ Use the existing `.github/scripts/linearApi.js` module for ticket creation. Func
 - **Tickets are created immediately** after analysis completes, not deferred to a script execution
 - The `LINEAR_TEAM_ID` environment variable must be set in the workflow environment
 - If the agent attempts to create a script file instead of making API calls directly, it should be corrected to make the calls immediately
+- **DEDUPLICATION IS MANDATORY**: Before creating any ticket (master or subticket), the agent MUST call the appropriate dedup function (`findOpenAuditMasterTicket` or `findOpenSubticketByIntegration`) to check for existing open tickets. If an open ticket exists, update it instead of creating a duplicate. Only create a new ticket when no open match is found.
 
 ## Notes
 

--- a/.github/scripts/integrations_version_audit_plan.md
+++ b/.github/scripts/integrations_version_audit_plan.md
@@ -173,7 +173,7 @@ Categorization logic:
 
   // Classify each action-required integration
   const updatableIntegrations = []; // existing open subticket found
-  const newIntegrations = [];       // no existing subticket
+  const newIntegrations = []; // no existing subticket
 
   for (const integration of actionRequiredIntegrations) {
     const integrationName = integration.Destination;
@@ -225,7 +225,9 @@ Categorization logic:
     const currentCycleId = await getCurrentCycleId(LINEAR_TEAM_ID);
 
     if (!statusStateId)
-      console.warn('Warning: Could not find "Queued" state. Ticket will be created without status.');
+      console.warn(
+        'Warning: Could not find "Queued" state. Ticket will be created without status.',
+      );
     if (!currentUserId)
       console.warn(
         'Warning: Could not retrieve current user ID. Ticket will be created without assignee.',
@@ -242,7 +244,9 @@ Categorization logic:
       projectId: MAINTENANCE_PROJECT_ID,
       labelIds: [KTLO_LABEL_ID, VERSION_UPGRADE_LABEL_ID],
     });
-    console.log(`Created new master ticket: ${newMasterTicket.identifier} - ${newMasterTicket.url}`);
+    console.log(
+      `Created new master ticket: ${newMasterTicket.identifier} - ${newMasterTicket.url}`,
+    );
 
     // Create subtickets for new integrations under the new master
     for (const integration of newIntegrations) {
@@ -253,7 +257,7 @@ Categorization logic:
         description: ticketDescription,
         parentId: newMasterTicket.id,
         priority: calculatedPriority, // 1-4 based on urgency (1=Urgent, 4=Low)
-        dueDate: calculatedDueDate,   // ISO format string (YYYY-MM-DD) or null
+        dueDate: calculatedDueDate, // ISO format string (YYYY-MM-DD) or null
         labelIds: [],
       });
       // Track as "created" in summary

--- a/.github/scripts/integrations_version_audit_plan.md
+++ b/.github/scripts/integrations_version_audit_plan.md
@@ -166,6 +166,9 @@ Categorization logic:
     listIssuesByParent,
     updateIssue,
     updateIssueDescription,
+    MAINTENANCE_PROJECT_ID,
+    KTLO_LABEL_ID,
+    VERSION_UPGRADE_LABEL_ID,
   } = require('./.github/scripts/linearApi');
 
   // Classify each action-required integration
@@ -232,11 +235,12 @@ Categorization logic:
 
     newMasterTicket = await createIssue({
       title: 'Integration Version Audit [Rudder Transformer] [Current Date in DD/MM/YYYY]',
-      description: '', // Placeholder — updated in step 8c after subticket URLs are available
+      description: '', // Placeholder — updated in step 8b after subticket URLs are available
       priority: 3, // Medium priority
       stateId: statusStateId, // Status: Queued
       cycleId: currentCycleId, // Current cycle
-      labelIds: [],
+      projectId: MAINTENANCE_PROJECT_ID,
+      labelIds: [KTLO_LABEL_ID, VERSION_UPGRADE_LABEL_ID],
     });
     console.log(`Created new master ticket: ${newMasterTicket.identifier} - ${newMasterTicket.url}`);
 
@@ -479,6 +483,12 @@ Use the existing `.github/scripts/linearApi.js` module for ticket creation and d
 - `findOpenAuditMasterTicket()` - Find the most recent open master audit ticket (title contains "Integration Version Audit [Rudder Transformer]", no parent, in open states: Queued/In Progress/Todo/Backlog/Triage). Returns the ticket object or null.
 - `findOpenSubticketByIntegration(parentId, integrationName)` - Find an existing open subticket for a specific integration under a given parent ticket. Returns the ticket object or null.
 - `findOpenSubticketGlobally(integrationName)` - Find an existing open subticket for a specific integration across ALL audit master tickets. Validates that the parent is an audit master (title contains "Integration Version Audit [Rudder Transformer]", no parent). When multiple matches exist, returns the newest one (highest identifier number). Returns the ticket object (including `parentId`) or null. **Use this in step 7 to classify integrations before deciding whether a new master ticket is needed.**
+
+**Hardcoded Constants (for master ticket creation):**
+
+- `MAINTENANCE_PROJECT_ID` - Project ID for the maintenance project
+- `KTLO_LABEL_ID` - Label ID for KTLO under Type
+- `VERSION_UPGRADE_LABEL_ID` - Label ID for VersionUpgrade under KTLO Type
 
 **Querying:**
 

--- a/.github/scripts/linearApi.js
+++ b/.github/scripts/linearApi.js
@@ -107,10 +107,11 @@ async function findOpenAuditMasterTicket() {
     titleContains: 'Integration Version Audit [Rudder Transformer]',
     states: openStates,
   });
-  // Filter to only top-level tickets (no parent) and sort by most recent
+  // Filter to only top-level tickets (no parent) and sort by highest issue number
+  const getNumber = (id) => parseInt(id.replace(/\D+/g, ''), 10) || 0;
   const masterTickets = results
     .filter((issue) => !issue.parentId)
-    .sort((a, b) => b.identifier.localeCompare(a.identifier));
+    .sort((a, b) => getNumber(b.identifier) - getNumber(a.identifier));
   return masterTickets.length > 0 ? masterTickets[0] : null;
 }
 
@@ -195,9 +196,9 @@ async function listIssuesByParent(parentId, limit = 250) {
   }
 }
 
-async function updateIssueDescription(issueId, description) {
+async function updateIssue(issueId, fields) {
   try {
-    const result = await linearClient.updateIssue(issueId, { description });
+    const result = await linearClient.updateIssue(issueId, fields);
     // Linear SDK updateIssue returns { _issue: { id }, success, lastSyncId }
     // Check if result has an 'issue' property (promise/getter) or use _issue.id
     const updatedIssueId = result.issue
@@ -212,14 +213,19 @@ async function updateIssueDescription(issueId, description) {
       url: issue.url,
     };
   } catch (error) {
-    console.error(`Error updating issue description for "${issueId}":`, error.message);
+    console.error(`Error updating issue "${issueId}":`, error.message);
     throw error;
   }
+}
+
+async function updateIssueDescription(issueId, description) {
+  return updateIssue(issueId, { description });
 }
 
 module.exports = {
   createIssue,
   listIssuesByParent,
+  updateIssue,
   updateIssueDescription,
   getStateId,
   getUserId,

--- a/.github/scripts/linearApi.js
+++ b/.github/scripts/linearApi.js
@@ -14,6 +14,8 @@ if (!LINEAR_TEAM_ID) {
 const { LinearClient } = require('@linear/sdk');
 const linearClient = new LinearClient({ apiKey: LINEAR_API_KEY });
 
+const OPEN_STATES = ['Queued', 'In Progress', 'Todo', 'Backlog', 'Triage'];
+
 async function getStateId(stateName, teamId) {
   try {
     const team = await linearClient.team(teamId);
@@ -102,10 +104,9 @@ async function searchIssues({ titleContains, teamId, states, limit = 50 }) {
 }
 
 async function findOpenAuditMasterTicket() {
-  const openStates = ['Queued', 'In Progress', 'Todo', 'Backlog', 'Triage'];
   const results = await searchIssues({
     titleContains: 'Integration Version Audit [Rudder Transformer]',
-    states: openStates,
+    states: OPEN_STATES,
   });
   // Filter to only top-level tickets (no parent) and sort by highest issue number
   const getNumber = (id) => parseInt(id.replace(/\D+/g, ''), 10) || 0;
@@ -116,10 +117,9 @@ async function findOpenAuditMasterTicket() {
 }
 
 async function findOpenSubticketByIntegration(parentId, integrationName) {
-  const openStates = ['Queued', 'In Progress', 'Todo', 'Backlog', 'Triage'];
   const results = await searchIssues({
     titleContains: `${integrationName} Version Audit`,
-    states: openStates,
+    states: OPEN_STATES,
   });
   return results.find((issue) => issue.parentId === parentId) || null;
 }

--- a/.github/scripts/linearApi.js
+++ b/.github/scripts/linearApi.js
@@ -124,6 +124,15 @@ async function findOpenSubticketByIntegration(parentId, integrationName) {
   return results.find((issue) => issue.parentId === parentId) || null;
 }
 
+async function findOpenSubticketGlobally(integrationName) {
+  const results = await searchIssues({
+    titleContains: `${integrationName} Version Audit`,
+    states: OPEN_STATES,
+  });
+  // Return any open subticket for this integration, regardless of parent
+  return results.find((issue) => issue.parentId) || null;
+}
+
 async function createIssue({
   title,
   description,
@@ -234,4 +243,5 @@ module.exports = {
   searchIssues,
   findOpenAuditMasterTicket,
   findOpenSubticketByIntegration,
+  findOpenSubticketGlobally,
 };

--- a/.github/scripts/linearApi.js
+++ b/.github/scripts/linearApi.js
@@ -69,6 +69,60 @@ async function getCurrentCycleId(teamId) {
   }
 }
 
+async function searchIssues({ titleContains, teamId, states, limit = 50 }) {
+  try {
+    const filter = {
+      team: { id: { eq: teamId || LINEAR_TEAM_ID } },
+      title: { containsIgnoreCase: titleContains },
+    };
+    if (states && states.length > 0) {
+      filter.state = { name: { in: states } };
+    }
+    const issues = await linearClient.issues({ filter, first: limit });
+    return Promise.all(
+      issues.nodes.map(async (issue) => {
+        const state = await issue.state;
+        const parent = await issue.parent;
+        return {
+          id: issue.id,
+          identifier: issue.identifier,
+          title: issue.title,
+          priority: issue.priority,
+          url: issue.url,
+          dueDate: issue.dueDate,
+          state: { name: state?.name },
+          parentId: parent?.id || null,
+        };
+      }),
+    );
+  } catch (error) {
+    console.error(`Error searching issues with title "${titleContains}":`, error.message);
+    return [];
+  }
+}
+
+async function findOpenAuditMasterTicket() {
+  const openStates = ['Queued', 'In Progress', 'Todo', 'Backlog', 'Triage'];
+  const results = await searchIssues({
+    titleContains: 'Integration Version Audit [Rudder Transformer]',
+    states: openStates,
+  });
+  // Filter to only top-level tickets (no parent) and sort by most recent
+  const masterTickets = results
+    .filter((issue) => !issue.parentId)
+    .sort((a, b) => b.identifier.localeCompare(a.identifier));
+  return masterTickets.length > 0 ? masterTickets[0] : null;
+}
+
+async function findOpenSubticketByIntegration(parentId, integrationName) {
+  const openStates = ['Queued', 'In Progress', 'Todo', 'Backlog', 'Triage'];
+  const results = await searchIssues({
+    titleContains: `${integrationName} Version Audit`,
+    states: openStates,
+  });
+  return results.find((issue) => issue.parentId === parentId) || null;
+}
+
 async function createIssue({
   title,
   description,
@@ -171,4 +225,7 @@ module.exports = {
   getUserId,
   getCurrentUserId,
   getCurrentCycleId,
+  searchIssues,
+  findOpenAuditMasterTicket,
+  findOpenSubticketByIntegration,
 };

--- a/.github/scripts/linearApi.js
+++ b/.github/scripts/linearApi.js
@@ -125,12 +125,28 @@ async function findOpenSubticketByIntegration(parentId, integrationName) {
 }
 
 async function findOpenSubticketGlobally(integrationName) {
+  // Find all open audit master tickets to validate parentage
+  const masterResults = await searchIssues({
+    titleContains: 'Integration Version Audit [Rudder Transformer]',
+    states: OPEN_STATES,
+  });
+  const auditMasterIds = new Set(
+    masterResults.filter((issue) => !issue.parentId).map((issue) => issue.id),
+  );
+
+  // Search for matching subtickets
   const results = await searchIssues({
     titleContains: `${integrationName} Version Audit`,
     states: OPEN_STATES,
   });
-  // Return any open subticket for this integration, regardless of parent
-  return results.find((issue) => issue.parentId) || null;
+
+  // Only accept subtickets whose parent is an audit master, pick newest
+  const getNumber = (id) => parseInt(id.replace(/\D+/g, ''), 10) || 0;
+  const validSubs = results
+    .filter((issue) => issue.parentId && auditMasterIds.has(issue.parentId))
+    .sort((a, b) => getNumber(b.identifier) - getNumber(a.identifier));
+
+  return validSubs.length > 0 ? validSubs[0] : null;
 }
 
 async function createIssue({

--- a/.github/scripts/linearApi.js
+++ b/.github/scripts/linearApi.js
@@ -16,6 +16,11 @@ const linearClient = new LinearClient({ apiKey: LINEAR_API_KEY });
 
 const OPEN_STATES = ['Queued', 'In Progress', 'Todo', 'Backlog', 'Triage'];
 
+// Hardcoded Linear IDs for master ticket creation
+const MAINTENANCE_PROJECT_ID = 'f99cafb5-7d4a-4549-8c77-afe2644feba9'; // Integrations: Maintenance Project
+const KTLO_LABEL_ID = '68c1ca4f-cc21-4c28-9ce5-618a8b39c788'; // Type: KTLO
+const VERSION_UPGRADE_LABEL_ID = '2ee64e36-d577-4b4b-9ae4-e7292db061d4'; // KTLO Type: VersionUpgrade
+
 async function getStateId(stateName, teamId) {
   try {
     const team = await linearClient.team(teamId);
@@ -260,4 +265,7 @@ module.exports = {
   findOpenAuditMasterTicket,
   findOpenSubticketByIntegration,
   findOpenSubticketGlobally,
+  MAINTENANCE_PROJECT_ID,
+  KTLO_LABEL_ID,
+  VERSION_UPGRADE_LABEL_ID,
 };

--- a/.github/workflows/integrations_version_audit.yml
+++ b/.github/workflows/integrations_version_audit.yml
@@ -40,8 +40,9 @@ jobs:
           2. You MUST create Linear tickets DIRECTLY using Linear API calls during this execution
           3. DO NOT create any script files (no .js files, no audit.js, no integrations_version_audit.js)
           4. Read @.github/scripts/linearApi.js to understand the API structure
-          5. Make Linear API calls directly using your capabilities to create tickets immediately after analysis
-          6. Your output MUST include actual Linear ticket URLs (like https://linear.app/...)
-          7. If you create a script file instead of creating tickets, the task has FAILED
+          5. Before creating any ticket, check for existing open duplicates and update them instead of creating new ones.
+          6. Make Linear API calls directly using your capabilities to create/update tickets immediately after analysis
+          7. Your output MUST include actual Linear ticket URLs (like https://linear.app/...)
+          8. If you create a script file instead of creating tickets, the task has FAILED
 
-          Execute the audit plan: analyze integrations, then immediately create Linear tickets using direct API calls. Include ticket URLs in your final output." --force
+          Execute the audit plan: analyze integrations, then create or update Linear tickets using direct API calls. Include ticket URLs in your final output." --force


### PR DESCRIPTION
## Summary
- Add dedup functions to `linearApi.js` — `findOpenSubticketGlobally` validates parent is an audit master and picks the newest match when duplicates exist
- Rewrite Phase 4: existing subtickets update in place, new ones go under a freshly created master (only when genuinely new integrations exist); all affected master descriptions are refreshed
- Hardcode project ID (Integrations: Maintenance Project) and label IDs (KTLO, VersionUpgrade) for master ticket creation

## Test plan
- [ ] Run workflow via `workflow_dispatch` — verify existing subtickets update in place and parent master descriptions refresh
- [ ] Verify new integrations create a new master with correct project and labels
- [ ] Verify no new master when all integrations already have open subtickets
- [ ] Verify summary output always includes subticket URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)