### PR TITLE
fix(eventTest): guard against path traversal in getDestHandler

### DIFF
--- a/src/services/eventTest/eventTester.ts
+++ b/src/services/eventTest/eventTester.ts
@@ -15,6 +15,12 @@ type DestTransformInput = {
 
 export class EventTesterService {
   private static getDestHandler(version, destination) {
+    // Guard against path traversal — version and destination are user-provided
+    // and are interpolated into the require() path below.
+    const safePath = /^[\w-]+$/;
+    if (!safePath.test(version) || !safePath.test(destination)) {
+      throw new Error(`Invalid version (${version}) or destination (${destination})`);
+    }
     // eslint-disable-next-line global-require, import/no-dynamic-require
     return require(`../../${version}/destinations/${destination}/transform`);
   }


### PR DESCRIPTION
## Summary
- The `version` and `destination` URL params in the test event API (`/test-router/:version/:destination`) are interpolated into a `require()` path without validation
- An attacker can use `%2F`-encoded slashes to traverse the filesystem — loading arbitrary modules, disclosing server paths via error messages, or probing file existence
- Adds an allowlist regex (`/^[\w-]+$/`) in `getDestHandler` that rejects any input containing `.`, `/`, `%`, or other non-alphanumeric characters

Resolves https://github.com/rudderlabs/rudder-transformer/security/code-scanning/13188

## Test plan
- [x] All 13 existing `eventTest` tests pass
- [x] Verified all destination names in `src/v0/destinations/` match the regex
- [x] Verified the 4 exploit vectors (path disclosure, arbitrary module load, file existence oracle, version param traversal) are blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)