### PR TITLE
chore(ci): staging deploy sets wrong image tag for user-transformer

### DIFF
--- a/.github/workflows/prepare-for-staging-deploy.yml
+++ b/.github/workflows/prepare-for-staging-deploy.yml
@@ -140,10 +140,10 @@ jobs:
         run: |
           cd helm-charts/shared-services/per-az/environment/staging
           yq eval -i ".rudder-transformer.image.tag=\"$TAG_NAME\"" staging.yaml
-          yq eval -i ".user-transformer.image.tag=\"$TAG_NAME\"" staging.yaml
+          yq eval -i ".user-transformer.image.tag=\"$UT_TAG_NAME\"" staging.yaml
           cd ../../../../config-be-rudder-transformer/environment/staging
           yq eval -i ".config-be-rudder-transformer.image.tag=\"$TAG_NAME\"" base.yaml
-          yq eval -i ".config-be-user-transformer.image.tag=\"$TAG_NAME\"" base.yaml
+          yq eval -i ".config-be-user-transformer.image.tag=\"$UT_TAG_NAME\"" base.yaml
 
       - name: Create staging branch on remote
         if: steps.check-branch.outputs.exists == 'false'


### PR DESCRIPTION
## Summary
- The staging deployment workflow used `$TAG_NAME` (`staging-X.Y.Z`) for user-transformer helm values, but the user-transformer Docker image is built and pushed with `$UT_TAG_NAME` (`ut-staging-X.Y.Z`)
- This caused staging to deploy the **main transformer image** for user-transformer services instead of the correct user-transformer image
- Fixed both `user-transformer.image.tag` in `staging.yaml` and `config-be-user-transformer.image.tag` in `base.yaml` to use `$UT_TAG_NAME`

## Test plan
- [ ] Verify the staging deploy workflow runs successfully on a release branch PR
- [ ] Confirm the devops PR created by the workflow has the correct `ut-staging-X.Y.Z` tag for user-transformer entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)