### PR TITLE
fix(ci): prod UT deploy reads user-transformer.enabled from wrong yq path

### DIFF
--- a/.github/workflows/prepare-for-prod-ut-deploy.yml
+++ b/.github/workflows/prepare-for-prod-ut-deploy.yml
@@ -264,7 +264,7 @@ jobs:
             for f in "./$directory"/*; do
               [[ -f $f ]] || continue
 
-              enabled="$(yq e '.spec.user-transformer.enabled' $f)"
+              enabled="$(yq e '.spec.global.user-transformer.enabled' $f)"
               if [ "$enabled" == "true" ]; then
                 enabled_ut_customers+=( $f )
               fi


### PR DESCRIPTION
## Summary
- The prod UT deploy workflow checked `.spec.user-transformer.enabled` in customer object YAML files, but the actual schema nests this field under `.spec.global.user-transformer.enabled`
- This caused the workflow to never detect UT-enabled customers, skipping their user-transformer image tag updates during prod deployments

## Test plan
- [ ] Verify the corrected yq path matches the actual customer object schema in `rudder-devops`
- [ ] Confirm the prod UT deploy workflow correctly identifies UT-enabled customers on the next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)