### PR TITLE
fix(custom_audience): read message.identifiers instead of message.fields

### DIFF
--- a/src/v0/destinations/custom_audience/routerTransform.test.ts
+++ b/src/v0/destinations/custom_audience/routerTransform.test.ts
@@ -83,7 +83,7 @@ const buildMetadata = (jobId: number): Metadata =>
 const buildInput = (
   jobId: number,
   action: Action,
-  fields: Record<string, unknown>,
+  identifiers: Record<string, unknown>,
   destination: CustomAudienceDestination = buildDestination(),
   connection: CustomAudienceConnection = buildConnection(),
 ): RouterTransformationRequestData =>
@@ -91,7 +91,7 @@ const buildInput = (
     message: {
       type: 'record',
       action,
-      fields,
+      identifiers,
       channel: 'sources',
       context: {},
       recordId: String(jobId),

--- a/src/v0/destinations/custom_audience/routerTransform.ts
+++ b/src/v0/destinations/custom_audience/routerTransform.ts
@@ -68,7 +68,7 @@ class CustomAudienceIntegration extends BatchDestination<
     const { message } = input;
     const actionConfig = lookupActionConfig(message.action, this.destination.Config);
     const fieldsWithCustomMappings = injectCustomMappings(
-      message.fields!,
+      message.identifiers!,
       this.connectionConfig.customMappings,
     );
     const record = processFields(
@@ -140,7 +140,7 @@ class CustomAudienceIntegration extends BatchDestination<
           .object({
             type: z.literal('record'),
             action: z.enum([EVENT_TYPES.INSERT, EVENT_TYPES.UPDATE, EVENT_TYPES.DELETE]),
-            fields: z.record(z.unknown()),
+            identifiers: z.record(z.unknown()),
           })
           .passthrough(),
       })

--- a/test/integrations/destinations/custom_audience/router/data.ts
+++ b/test/integrations/destinations/custom_audience/router/data.ts
@@ -41,25 +41,25 @@ export const data: RouterTestData[] = [
         body: {
           input: [
             {
-              message: generateRecordPayload({ action: 'insert', fields: { email: 'a@b.com' } }),
+              message: generateRecordPayload({ action: 'insert', identifiers: { email: 'a@b.com' } }),
               metadata: generateMetadata(1),
               destination,
               connection,
             },
             {
-              message: generateRecordPayload({ action: 'insert', fields: { email: 'c@d.com' } }),
+              message: generateRecordPayload({ action: 'insert', identifiers: { email: 'c@d.com' } }),
               metadata: generateMetadata(2),
               destination,
               connection,
             },
             {
-              message: generateRecordPayload({ action: 'update', fields: { email: 'e@f.com' } }),
+              message: generateRecordPayload({ action: 'update', identifiers: { email: 'e@f.com' } }),
               metadata: generateMetadata(3),
               destination,
               connection,
             },
             {
-              message: generateRecordPayload({ action: 'delete', fields: { email: 'g@h.com' } }),
+              message: generateRecordPayload({ action: 'delete', identifiers: { email: 'g@h.com' } }),
               metadata: generateMetadata(4),
               destination,
               connection,
@@ -167,7 +167,7 @@ export const data: RouterTestData[] = [
         body: {
           input: [
             {
-              message: generateRecordPayload({ action: 'insert', fields: { email: 'a@b.com' } }),
+              message: generateRecordPayload({ action: 'insert', identifiers: { email: 'a@b.com' } }),
               metadata: generateMetadata(1),
               destination: {
                 ...destination,
@@ -179,7 +179,7 @@ export const data: RouterTestData[] = [
               connection,
             },
             {
-              message: generateRecordPayload({ action: 'delete', fields: { email: 'g@h.com' } }),
+              message: generateRecordPayload({ action: 'delete', identifiers: { email: 'g@h.com' } }),
               metadata: generateMetadata(2),
               destination: {
                 ...destination,
@@ -262,7 +262,7 @@ export const data: RouterTestData[] = [
         body: {
           input: [
             {
-              message: generateRecordPayload({ action: 'insert', fields: { email: 'a@b.com' } }),
+              message: generateRecordPayload({ action: 'insert', identifiers: { email: 'a@b.com' } }),
               metadata: generateMetadata(1),
               destination,
               connection,
@@ -336,13 +336,13 @@ export const data: RouterTestData[] = [
         body: {
           input: [
             {
-              message: generateRecordPayload({ action: 'insert', fields: { email: 'a@b.com' } }),
+              message: generateRecordPayload({ action: 'insert', identifiers: { email: 'a@b.com' } }),
               metadata: generateMetadata(1),
               destination: customMappingsDestination,
               connection: customMappingsConnection,
             },
             {
-              message: generateRecordPayload({ action: 'insert', fields: { email: 'c@d.com' } }),
+              message: generateRecordPayload({ action: 'insert', identifiers: { email: 'c@d.com' } }),
               metadata: generateMetadata(2),
               destination: customMappingsDestination,
               connection: customMappingsConnection,
@@ -405,13 +405,13 @@ export const data: RouterTestData[] = [
         body: {
           input: [
             {
-              message: generateRecordPayload({ action: 'insert', fields: { email: 'a@b.com' } }),
+              message: generateRecordPayload({ action: 'insert', identifiers: { email: 'a@b.com' } }),
               metadata: generateMetadata(1),
               destination,
               connection: hashRequiredConnection,
             },
             {
-              message: generateRecordPayload({ action: 'insert', fields: { email: 'c@d.com' } }),
+              message: generateRecordPayload({ action: 'insert', identifiers: { email: 'c@d.com' } }),
               metadata: generateMetadata(2),
               destination,
               connection: hashRequiredConnection,

--- a/test/integrations/destinations/custom_audience/router/data.ts
+++ b/test/integrations/destinations/custom_audience/router/data.ts
@@ -41,25 +41,37 @@ export const data: RouterTestData[] = [
         body: {
           input: [
             {
-              message: generateRecordPayload({ action: 'insert', identifiers: { email: 'a@b.com' } }),
+              message: generateRecordPayload({
+                action: 'insert',
+                identifiers: { email: 'a@b.com' },
+              }),
               metadata: generateMetadata(1),
               destination,
               connection,
             },
             {
-              message: generateRecordPayload({ action: 'insert', identifiers: { email: 'c@d.com' } }),
+              message: generateRecordPayload({
+                action: 'insert',
+                identifiers: { email: 'c@d.com' },
+              }),
               metadata: generateMetadata(2),
               destination,
               connection,
             },
             {
-              message: generateRecordPayload({ action: 'update', identifiers: { email: 'e@f.com' } }),
+              message: generateRecordPayload({
+                action: 'update',
+                identifiers: { email: 'e@f.com' },
+              }),
               metadata: generateMetadata(3),
               destination,
               connection,
             },
             {
-              message: generateRecordPayload({ action: 'delete', identifiers: { email: 'g@h.com' } }),
+              message: generateRecordPayload({
+                action: 'delete',
+                identifiers: { email: 'g@h.com' },
+              }),
               metadata: generateMetadata(4),
               destination,
               connection,
@@ -167,7 +179,10 @@ export const data: RouterTestData[] = [
         body: {
           input: [
             {
-              message: generateRecordPayload({ action: 'insert', identifiers: { email: 'a@b.com' } }),
+              message: generateRecordPayload({
+                action: 'insert',
+                identifiers: { email: 'a@b.com' },
+              }),
               metadata: generateMetadata(1),
               destination: {
                 ...destination,
@@ -179,7 +194,10 @@ export const data: RouterTestData[] = [
               connection,
             },
             {
-              message: generateRecordPayload({ action: 'delete', identifiers: { email: 'g@h.com' } }),
+              message: generateRecordPayload({
+                action: 'delete',
+                identifiers: { email: 'g@h.com' },
+              }),
               metadata: generateMetadata(2),
               destination: {
                 ...destination,
@@ -262,7 +280,10 @@ export const data: RouterTestData[] = [
         body: {
           input: [
             {
-              message: generateRecordPayload({ action: 'insert', identifiers: { email: 'a@b.com' } }),
+              message: generateRecordPayload({
+                action: 'insert',
+                identifiers: { email: 'a@b.com' },
+              }),
               metadata: generateMetadata(1),
               destination,
               connection,
@@ -336,13 +357,19 @@ export const data: RouterTestData[] = [
         body: {
           input: [
             {
-              message: generateRecordPayload({ action: 'insert', identifiers: { email: 'a@b.com' } }),
+              message: generateRecordPayload({
+                action: 'insert',
+                identifiers: { email: 'a@b.com' },
+              }),
               metadata: generateMetadata(1),
               destination: customMappingsDestination,
               connection: customMappingsConnection,
             },
             {
-              message: generateRecordPayload({ action: 'insert', identifiers: { email: 'c@d.com' } }),
+              message: generateRecordPayload({
+                action: 'insert',
+                identifiers: { email: 'c@d.com' },
+              }),
               metadata: generateMetadata(2),
               destination: customMappingsDestination,
               connection: customMappingsConnection,
@@ -405,13 +432,19 @@ export const data: RouterTestData[] = [
         body: {
           input: [
             {
-              message: generateRecordPayload({ action: 'insert', identifiers: { email: 'a@b.com' } }),
+              message: generateRecordPayload({
+                action: 'insert',
+                identifiers: { email: 'a@b.com' },
+              }),
               metadata: generateMetadata(1),
               destination,
               connection: hashRequiredConnection,
             },
             {
-              message: generateRecordPayload({ action: 'insert', identifiers: { email: 'c@d.com' } }),
+              message: generateRecordPayload({
+                action: 'insert',
+                identifiers: { email: 'c@d.com' },
+              }),
               metadata: generateMetadata(2),
               destination,
               connection: hashRequiredConnection,


### PR DESCRIPTION
## Summary
- Switch the custom_audience transformer to read `message.identifiers` instead of `message.fields` for user identity data (email, phone), aligning with the Record spec where `identifiers` carries audience-matching data and `fields` carries traits
- Update the Zod input schema to validate `identifiers` instead of `fields`
- Update unit and integration tests to pass identity data via `identifiers`

## Test plan
- [x] Unit tests pass (`npm test -- --testPathPattern="custom_audience"` — 126 tests)
- [x] Integration tests pass (`npm run test:ts -- component --destination=custom_audience` — 5 tests)
- [x] Lint clean

Closes INT-6386

🤖 Generated with [Claude Code](https://claude.com/claude-code)