### PR TITLE
fix(custom_audience): sandbox bundle not found

### DIFF
--- a/src/v0/destinations/custom_audience/template/ivmScriptRunner.test.ts
+++ b/src/v0/destinations/custom_audience/template/ivmScriptRunner.test.ts
@@ -81,16 +81,7 @@ jest.mock('isolated-vm', () => {
   return { __esModule: true, default: { Isolate: MockIsolate } };
 });
 
-// fs: mock readFileSync (getBundleCode) so we don't need the real esbuild bundle on disk.
-jest.mock('fs', () => {
-  const actual = jest.requireActual('fs');
-  return {
-    ...actual,
-    readFileSync: jest.fn().mockReturnValue('// mock bundle'),
-  };
-});
-
-import { IvmScriptRunner } from './ivmScriptRunner';
+import { IvmScriptRunner, BUNDLE_PATH } from './ivmScriptRunner';
 
 describe('IvmScriptRunner', () => {
   let runner: IvmScriptRunner;
@@ -98,7 +89,7 @@ describe('IvmScriptRunner', () => {
   beforeEach(() => {
     isolateCreateCount = 0;
     runner = new IvmScriptRunner({
-      bundlePath: '/fake/bundle.js',
+      bundlePath: BUNDLE_PATH,
       memoryLimitMb: 8,
       initTimeoutMs: 5_000,
       execTimeoutMs: 1_000,

--- a/src/v0/destinations/custom_audience/template/ivmScriptRunner.ts
+++ b/src/v0/destinations/custom_audience/template/ivmScriptRunner.ts
@@ -141,9 +141,14 @@ export class IvmScriptRunner {
 // comfortably inside the same envelope.
 // ---------------------------------------------------------------------------
 
-// Resolve relative to __dirname so the path is stable regardless of process.cwd().
-// Works under both ts-jest (src/) and compiled runtime (dist/).
-const BUNDLE_PATH = path.resolve(__dirname, '../../../../../dist/templateEngineSandbox.bundle.js');
+// Production runs from dist/src/…/template — 5 levels up reaches dist/.
+// Tests run from src/…/template via ts-jest — 5 levels up reaches <root>, needs dist/ prefix.
+const BUNDLE_FILENAME = 'templateEngineSandbox.bundle.js';
+const ROOT_FROM_HERE = '../../../../../';
+const PRODUCTION_BUNDLE = path.resolve(__dirname, ROOT_FROM_HERE, BUNDLE_FILENAME);
+export const BUNDLE_PATH = fs.existsSync(PRODUCTION_BUNDLE)
+  ? PRODUCTION_BUNDLE
+  : path.resolve(__dirname, ROOT_FROM_HERE, 'dist', BUNDLE_FILENAME);
 
 export const templateSandboxRunner = new IvmScriptRunner({
   bundlePath: BUNDLE_PATH,


### PR DESCRIPTION
## Summary
- Fixed bundle path resolution in `ivmScriptRunner.ts` that broke during a merge conflict — the compiled runtime runs from `dist/src/.../template/` where 5 levels up reaches `dist/`, not the repo root where the old single path pointed
https://github.com/rudderlabs/rudder-transformer/pull/5222/changes#diff-62fdf0f1f248195020c34ab8d7fbb528788446d44db27c1ae2c1218acfe316faR144
- Removed unnecessary `fs` mock from `ivmScriptRunner.test.ts` — the test now imports the real `BUNDLE_PATH` and uses it directly, so a broken path resolution would be caught by unit tests

## Test plan
- [x] `npm test -- --testPathPattern="custom_audience"` — all 103 tests pass
- [x] Manual verification: started transformer locally, sent a router transform request, confirmed correct response

🤖 Generated with [Claude Code](https://claude.com/claude-code)