### PR TITLE
feat(custom_audience): support useInsertConfig toggle for UPDATE action

### DIFF
--- a/src/v0/destinations/custom_audience/routerTransform.test.ts
+++ b/src/v0/destinations/custom_audience/routerTransform.test.ts
@@ -275,8 +275,8 @@ describe('CustomAudienceIntegration via processBatchedDestination', () => {
     });
 
     const inputs = [
-      buildInput(1, 'update', { email: 'a@b.com' }, destination),
-      buildInput(2, 'update', { email: 'c@d.com' }, destination),
+      buildInput(1, 'update', { email: hashedEmail('a@b.com') }, destination),
+      buildInput(2, 'update', { email: hashedEmail('c@d.com') }, destination),
     ];
 
     const results = await processBatchedDestination(inputs, Integration, {});

--- a/src/v0/destinations/custom_audience/routerTransform.test.ts
+++ b/src/v0/destinations/custom_audience/routerTransform.test.ts
@@ -253,4 +253,37 @@ describe('CustomAudienceIntegration via processBatchedDestination', () => {
 
     await expect(processBatchedDestination(inputs, Integration, {})).rejects.toThrow();
   });
+
+  it('uses insert config for update events when useInsertConfig is true', async () => {
+    const destination = buildDestination({
+      actions: {
+        insert: baseInsertAction,
+        update: {
+          endpoint: '/audiences/{{connection.audienceId}}/update-members',
+          method: 'PUT',
+          requestBody: '{ "should": "not appear" }',
+          batchSize: 10,
+          fields: baseInsertAction.fields,
+          useInsertConfig: true,
+        },
+        delete: baseDeleteAction,
+      },
+    });
+
+    const inputs = [
+      buildInput(1, 'update', { email: 'a@b.com' }, destination),
+      buildInput(2, 'update', { email: 'c@d.com' }, destination),
+    ];
+
+    const results = await processBatchedDestination(inputs, Integration, {});
+
+    const success = results.find((r) => r.statusCode === 200);
+    const batched = success?.batchedRequest;
+    if (!batched || Array.isArray(batched)) throw new Error('expected single batchedRequest');
+    // Should use insert config's endpoint and method, not update's
+    expect(batched.endpoint).toBe('https://api.example.com/audiences/aud-42/members');
+    expect(batched.method).toBe('POST');
+    const body = batched.body?.JSON as { users: { email: string }[] };
+    expect(body.users).toHaveLength(2);
+  });
 });

--- a/src/v0/destinations/custom_audience/routerTransform.test.ts
+++ b/src/v0/destinations/custom_audience/routerTransform.test.ts
@@ -246,8 +246,12 @@ describe('CustomAudienceIntegration via processBatchedDestination', () => {
   );
 
   it('throws when requestBody template fails at runtime', async () => {
-    const destination = buildDestination();
-    destination.Config.actions.insert!.requestBody = '$$.records[0].$notARealMethod()';
+    const destination = buildDestination({
+      actions: {
+        insert: { ...baseInsertAction, requestBody: '$$.records[0].$notARealMethod()' },
+        delete: baseDeleteAction,
+      },
+    });
 
     const inputs = [buildInput(1, 'insert', { email: hashedEmail('a@b.com') }, destination)];
 

--- a/src/v0/destinations/custom_audience/routerTransform.ts
+++ b/src/v0/destinations/custom_audience/routerTransform.ts
@@ -53,10 +53,10 @@ class CustomAudienceIntegration extends BatchDestination<
 
   private buildEndpointsByAction(): Partial<Record<Action, string>> {
     return Object.fromEntries(
-      Object.entries(this.destination.Config.actions).map(([action, actionConfig]) => [
+      Object.keys(this.destination.Config.actions).map((action) => [
         action,
         resolveEndpoint(
-          actionConfig!.endpoint,
+          lookupActionConfig(action as Action, this.destination.Config).endpoint,
           this.destination.Config.baseUrl,
           this.connectionConfig,
         ),
@@ -97,12 +97,11 @@ class CustomAudienceIntegration extends BatchDestination<
 
   getBatchStrategy(): BatchStrategy<Record<string, string>> {
     const { Config, WorkspaceID: workspaceId } = this.destination;
-    const { actions } = Config;
     const { connectionConfig } = this;
 
     return new CustomBatchStrategy<Record<string, string>>(async (payloads) => {
       const action = payloads[0].internalGroupKey as Action;
-      const actionConfig = actions[action]!;
+      const actionConfig = lookupActionConfig(action, Config);
 
       // Chunk outside the isolate so the existing native-batching split logic
       // is reused. Each chunk's records are passed through to the isolate

--- a/src/v0/destinations/custom_audience/template/templateEngineSandbox.ts
+++ b/src/v0/destinations/custom_audience/template/templateEngineSandbox.ts
@@ -42,7 +42,7 @@ globalThis.evaluateTemplateInSandbox = async (
     );
     return { ok: true, bodies };
   } catch (e: unknown) {
-    const error = e instanceof Error ? e.message : String(e);
+    const error = (e as { message?: string })?.message || String(e);
     return { ok: false, error };
   }
 };

--- a/src/v0/destinations/custom_audience/template/templateSandboxClient.test.ts
+++ b/src/v0/destinations/custom_audience/template/templateSandboxClient.test.ts
@@ -102,12 +102,12 @@ describe('templateSandboxClient', () => {
       expect(bodies).toEqual(expected);
     });
 
-    it('throws InstrumentationError when the template fails at runtime', async () => {
+    it('throws InstrumentationError with a descriptive message when the template fails at runtime', async () => {
       const template = '$$.records[0].$notARealMethod()';
 
       await expect(
         sandboxedEvaluateTemplate(template, [[{ email: 'a@b.com' }]], {}, 'ws-eval'),
-      ).rejects.toThrow(InstrumentationError);
+      ).rejects.toThrow(/Attempted to invoke a non-function/);
     });
 
     it('throws InstrumentationError for unparseable templates', async () => {

--- a/src/v0/destinations/custom_audience/types.ts
+++ b/src/v0/destinations/custom_audience/types.ts
@@ -25,6 +25,10 @@ export type ActionConfig = {
   fields: ActionFieldConfig[];
 };
 
+export type UpdateActionConfig = ActionConfig & {
+  useInsertConfig?: boolean;
+};
+
 export type CustomAudienceHeader = {
   key: string;
   value: string;
@@ -34,7 +38,11 @@ export type CustomAudienceDestConfig = {
   baseUrl: string;
   authenticationType: AuthenticationType;
   headers?: CustomAudienceHeader[];
-  actions: Partial<Record<Action, ActionConfig>>;
+  actions: {
+    insert?: ActionConfig;
+    update?: UpdateActionConfig;
+    delete?: ActionConfig;
+  };
   basicAuthUserName?: string;
   basicAuthPassword?: string;
   bearerToken?: string;

--- a/src/v0/destinations/custom_audience/utils.test.ts
+++ b/src/v0/destinations/custom_audience/utils.test.ts
@@ -49,12 +49,20 @@ describe('lookupActionConfig', () => {
   const useInsertConfigCases = [
     {
       name: 'returns insert config when update has useInsertConfig: true',
-      updateConfig: { ...baseDestConfig.actions.insert!, endpoint: '/update-path', useInsertConfig: true },
+      updateConfig: {
+        ...baseDestConfig.actions.insert!,
+        endpoint: '/update-path',
+        useInsertConfig: true,
+      },
       expectedEndpoint: '/audiences/{{connection.audienceId}}/members',
     },
     {
       name: 'returns update config when useInsertConfig is false',
-      updateConfig: { ...baseDestConfig.actions.insert!, endpoint: '/update-path', useInsertConfig: false },
+      updateConfig: {
+        ...baseDestConfig.actions.insert!,
+        endpoint: '/update-path',
+        useInsertConfig: false,
+      },
       expectedEndpoint: '/update-path',
     },
     {

--- a/src/v0/destinations/custom_audience/utils.test.ts
+++ b/src/v0/destinations/custom_audience/utils.test.ts
@@ -45,6 +45,42 @@ describe('lookupActionConfig', () => {
   it('throws InstrumentationError when action key is missing', () => {
     expect(() => lookupActionConfig('delete', baseDestConfig)).toThrow(InstrumentationError);
   });
+
+  const useInsertConfigCases = [
+    {
+      name: 'returns insert config when update has useInsertConfig: true',
+      updateConfig: { ...baseDestConfig.actions.insert!, endpoint: '/update-path', useInsertConfig: true },
+      expectedEndpoint: '/audiences/{{connection.audienceId}}/members',
+    },
+    {
+      name: 'returns update config when useInsertConfig is false',
+      updateConfig: { ...baseDestConfig.actions.insert!, endpoint: '/update-path', useInsertConfig: false },
+      expectedEndpoint: '/update-path',
+    },
+    {
+      name: 'returns update config when useInsertConfig is absent',
+      updateConfig: { ...baseDestConfig.actions.insert!, endpoint: '/update-path' },
+      expectedEndpoint: '/update-path',
+    },
+  ];
+
+  it.each(useInsertConfigCases)('$name', ({ updateConfig, expectedEndpoint }) => {
+    const config: CustomAudienceDestConfig = {
+      ...baseDestConfig,
+      actions: { ...baseDestConfig.actions, update: updateConfig },
+    };
+    expect(lookupActionConfig('update', config).endpoint).toBe(expectedEndpoint);
+  });
+
+  it('throws when useInsertConfig is true but insert config is missing', () => {
+    const config: CustomAudienceDestConfig = {
+      ...baseDestConfig,
+      actions: {
+        update: { ...baseDestConfig.actions.insert!, useInsertConfig: true },
+      },
+    };
+    expect(() => lookupActionConfig('update', config)).toThrow(InstrumentationError);
+  });
 });
 
 describe('resolveEndpoint', () => {

--- a/src/v0/destinations/custom_audience/utils.ts
+++ b/src/v0/destinations/custom_audience/utils.ts
@@ -22,6 +22,14 @@ export const lookupActionConfig = (
   if (!actionConfig) {
     throw new InstrumentationError(ERROR_MESSAGES.NO_ACTION_CONFIG(action));
   }
+  // When the update action opts into reusing the insert config, substitute it.
+  if (action === 'update' && destConfig.actions.update?.useInsertConfig) {
+    const insertConfig = destConfig.actions.insert;
+    if (!insertConfig) {
+      throw new InstrumentationError(ERROR_MESSAGES.NO_ACTION_CONFIG('insert'));
+    }
+    return insertConfig;
+  }
   return actionConfig;
 };
 

--- a/test/integrations/destinations/custom_audience/common.ts
+++ b/test/integrations/destinations/custom_audience/common.ts
@@ -4,6 +4,7 @@ import type {
   ActionConfig,
   CustomAudienceConnection,
   CustomAudienceDestination,
+  UpdateActionConfig,
 } from '../../../../src/v0/destinations/custom_audience/types';
 import { bearerToken } from './maskedSecrets';
 
@@ -111,5 +112,28 @@ export const hashRequiredConnection: CustomAudienceConnection = {
   ...connection,
   config: {
     destination: { ...connection.config.destination, isHashRequired: true },
+  },
+};
+
+// Update action with useInsertConfig: true — uses a distinct endpoint/method so
+// tests can prove the insert config was substituted.
+const useInsertConfigUpdateAction: UpdateActionConfig = {
+  endpoint: '/audiences/{{connection.audienceId}}/update-members',
+  method: 'PUT',
+  requestBody: '{ "should": "not appear" }',
+  batchSize: 10,
+  fields: insertActionConfig.fields,
+  useInsertConfig: true,
+};
+
+export const useInsertConfigDestination: CustomAudienceDestination = {
+  ...destination,
+  Config: {
+    ...destination.Config,
+    actions: {
+      insert: insertActionConfig,
+      update: useInsertConfigUpdateAction,
+      delete: deleteActionConfig,
+    },
   },
 };

--- a/test/integrations/destinations/custom_audience/router/data.ts
+++ b/test/integrations/destinations/custom_audience/router/data.ts
@@ -508,7 +508,7 @@ export const data: RouterTestData[] = [
             {
               message: generateRecordPayload({
                 action: 'update',
-                identifiers: { email: 'a@b.com' },
+                identifiers: { email: sha256('a@b.com') },
               }),
               metadata: generateMetadata(1),
               destination: useInsertConfigDestination,
@@ -517,7 +517,7 @@ export const data: RouterTestData[] = [
             {
               message: generateRecordPayload({
                 action: 'update',
-                identifiers: { email: 'c@d.com' },
+                identifiers: { email: sha256('c@d.com') },
               }),
               metadata: generateMetadata(2),
               destination: useInsertConfigDestination,
@@ -545,7 +545,7 @@ export const data: RouterTestData[] = [
                 body: {
                   JSON: {
                     audienceId: 'aud-42',
-                    users: [{ email: 'a@b.com' }, { email: 'c@d.com' }],
+                    users: [{ email: sha256('a@b.com') }, { email: sha256('c@d.com') }],
                   },
                   JSON_ARRAY: {},
                   XML: {},

--- a/test/integrations/destinations/custom_audience/router/data.ts
+++ b/test/integrations/destinations/custom_audience/router/data.ts
@@ -11,6 +11,7 @@ import {
   customMappingsDestination,
   customMappingsConnection,
   hashRequiredConnection,
+  useInsertConfigDestination,
 } from '../common';
 
 const errorStatTags = {
@@ -483,6 +484,79 @@ export const data: RouterTestData[] = [
               batched: true,
               statusCode: 200,
               destination,
+            },
+          ],
+        },
+      },
+    },
+  },
+  {
+    id: 'custom-audience-router-test-6',
+    name: destType,
+    description:
+      'Uses insert config for update events when useInsertConfig is true on the update action',
+    scenario: 'Framework+Business',
+    successCriteria:
+      'Update events use the insert action endpoint (POST /members) instead of the update action endpoint (PUT /update-members)',
+    feature: 'router',
+    module: 'destination',
+    version: 'v0',
+    input: {
+      request: {
+        body: {
+          input: [
+            {
+              message: generateRecordPayload({
+                action: 'update',
+                identifiers: { email: 'a@b.com' },
+              }),
+              metadata: generateMetadata(1),
+              destination: useInsertConfigDestination,
+              connection,
+            },
+            {
+              message: generateRecordPayload({
+                action: 'update',
+                identifiers: { email: 'c@d.com' },
+              }),
+              metadata: generateMetadata(2),
+              destination: useInsertConfigDestination,
+              connection,
+            },
+          ],
+          destType,
+        },
+        method: 'POST',
+      },
+    },
+    output: {
+      response: {
+        status: 200,
+        body: {
+          output: [
+            {
+              batchedRequest: {
+                version: '1',
+                type: 'REST',
+                method: 'POST',
+                endpoint: insertEndpoint,
+                headers,
+                params: {},
+                body: {
+                  JSON: {
+                    audienceId: 'aud-42',
+                    users: [{ email: 'a@b.com' }, { email: 'c@d.com' }],
+                  },
+                  JSON_ARRAY: {},
+                  XML: {},
+                  FORM: {},
+                },
+                files: {},
+              },
+              metadata: [generateMetadata(1), generateMetadata(2)],
+              batched: true,
+              statusCode: 200,
+              destination: useInsertConfigDestination,
             },
           ],
         },


### PR DESCRIPTION
## Summary
- Adds `UpdateActionConfig` type with an optional `useInsertConfig` boolean, scoped to the update action slot only
- Extends `lookupActionConfig()` to substitute the insert config when `useInsertConfig` is true on the update action
- Routes `buildEndpointsByAction()` and `getBatchStrategy()` through `lookupActionConfig` so the substitution applies consistently to endpoint, method, requestBody template, batchSize, and fields
- No changes to INSERT or DELETE action processing

## Test plan
- [x] Unit tests in `utils.test.ts`: useInsertConfig true/false/absent, and missing insert config error
- [x] Unit test in `routerTransform.test.ts`: update events with useInsertConfig use insert config's endpoint, method, and template
- [x] Component test fixture (`useInsertConfigDestination`) and test case in `router/data.ts`
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)