### PR TITLE
fix(custom_audience): parse-template API breaks for update action with useInsertConfig

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,47 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "if": "Bash(git commit*)",
+            "command": "npx lint-staged 2>&1 | tail -10; if [ ${PIPESTATUS[0]} -ne 0 ]; then echo 'BLOCK: lint-staged failed — fix lint/formatting issues before committing'; exit 2; fi",
+            "statusMessage": "Running lint-staged on staged files"
+          }
+        ]
+      }
+    ]
+  },
+  "permissions": {
+    "allow": [
+      "Bash(npm run lint:*)",
+      "Bash(npm run test:*)",
+      "Bash(npm test:*)",
+      "Bash(npm run typecheck)",
+      "Bash(npm run build:*)",
+      "Bash(npx jest:*)",
+      "Bash(npx eslint:*)",
+      "Bash(npx prettier:*)",
+      "Bash(npx tsc:*)",
+      "Bash(gh pr:*)",
+      "Bash(gh issue:*)",
+      "Bash(gh api:*)",
+      "Bash(gh run:*)"
+    ],
+    "deny": [
+      "Edit(node_modules/**)",
+      "Edit(dist/**)",
+      "Edit(allure-results/**)",
+      "Edit(reports/**)",
+      "Edit(test_reports/**)",
+      "Edit(package-lock.json)",
+      "Read(node_modules/**)",
+      "Read(dist/**)",
+      "Read(allure-results/**)",
+      "Read(reports/**)",
+      "Read(test_reports/**)"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -129,7 +129,7 @@ dist-test
 !.vscode/launch.json
 
 # Claude Code local settings
-.claude/settings.json
+.claude/settings.local.json
 
 # yarn v2
 .yarn/cache

--- a/src/controllers/__tests__/eventTest.test.ts
+++ b/src/controllers/__tests__/eventTest.test.ts
@@ -32,7 +32,24 @@ beforeEach(() => {
 
 const ENDPOINT = '/test-router/custom_audience/parse-template';
 
+const makeActions = (requestBody: string) => ({
+  insert: {
+    endpoint: '/members',
+    method: 'POST',
+    requestBody,
+    batchSize: 100,
+    fields: [],
+  },
+});
+
 describe('POST /test-router/custom_audience/parse-template', () => {
+  const template = `{
+    "data": [$$.records.({
+      "email": email,
+      "phone": phone_sha256
+    })]
+  }`;
+
   it('should return valid=true with recordFields for a valid template', async () => {
     mockParseTemplate.mockResolvedValue({
       valid: true,
@@ -42,19 +59,15 @@ describe('POST /test-router/custom_audience/parse-template', () => {
     const response = await request(server)
       .post(ENDPOINT)
       .send({
-        requestBody: `{
-          "data": $.records.({
-            "email": .email,
-            "phone": .phone_sha256
-          })
-        }`,
+        action: 'insert',
+        actions: makeActions(template),
         workspaceId: 'test-workspace',
       });
 
     expect(response.status).toBe(200);
     expect(response.body.valid).toBe(true);
     expect(response.body.recordFields.sort()).toEqual(['email', 'phone_sha256']);
-    expect(mockParseTemplate).toHaveBeenCalledWith(expect.any(String), 'test-workspace');
+    expect(mockParseTemplate).toHaveBeenCalledWith(template, 'test-workspace');
   });
 
   it('should return valid=false with errors for an invalid template', async () => {
@@ -65,38 +78,70 @@ describe('POST /test-router/custom_audience/parse-template', () => {
 
     const response = await request(server)
       .post(ENDPOINT)
-      .send({ requestBody: '{ ...$.records }', workspaceId: 'test-workspace' });
+      .send({
+        action: 'insert',
+        actions: makeActions('{ ...$.records }'),
+        workspaceId: 'test-workspace',
+      });
 
     expect(response.status).toBe(200);
     expect(response.body.valid).toBe(false);
     expect(response.body.errors[0]).toMatch(/spread_expr/);
   });
 
+  it('should resolve useInsertConfig and validate with insert requestBody', async () => {
+    mockParseTemplate.mockResolvedValue({
+      valid: true,
+      recordFields: ['email'],
+    });
+
+    const actions = {
+      insert: makeActions(template).insert,
+      update: {
+        useInsertConfig: true,
+        endpoint: '/members',
+        method: 'PUT',
+        requestBody: '',
+        batchSize: 100,
+        fields: [],
+      },
+    };
+
+    const response = await request(server)
+      .post(ENDPOINT)
+      .send({ action: 'update', actions, workspaceId: 'test-workspace' });
+
+    expect(response.status).toBe(200);
+    expect(response.body.valid).toBe(true);
+    // Should have been called with insert's template, not update's empty one
+    expect(mockParseTemplate).toHaveBeenCalledWith(template, 'test-workspace');
+  });
+
   const badRequestCases = [
     {
-      name: 'missing requestBody',
-      body: { workspaceId: 'ws' },
-      expectedError: 'requestBody: Required',
+      name: 'missing action',
+      body: { actions: makeActions('x'), workspaceId: 'ws' },
+      expectedError: /action/,
     },
     {
-      name: 'empty string requestBody',
-      body: { requestBody: '', workspaceId: 'ws' },
-      expectedError: 'requestBody: requestBody must be a non-empty string',
-    },
-    {
-      name: 'non-string requestBody',
-      body: { requestBody: 123, workspaceId: 'ws' },
-      expectedError: 'requestBody: Expected string, received number',
+      name: 'missing actions',
+      body: { action: 'insert', workspaceId: 'ws' },
+      expectedError: /actions/,
     },
     {
       name: 'missing workspaceId',
-      body: { requestBody: '{ "a": 1 }' },
-      expectedError: 'workspaceId: Required',
+      body: { action: 'insert', actions: makeActions('x') },
+      expectedError: /workspaceId/,
     },
     {
       name: 'empty string workspaceId',
-      body: { requestBody: '{ "a": 1 }', workspaceId: '' },
-      expectedError: 'workspaceId: workspaceId must be a non-empty string',
+      body: { action: 'insert', actions: makeActions('x'), workspaceId: '' },
+      expectedError: /workspaceId/,
+    },
+    {
+      name: 'invalid action value',
+      body: { action: 'upsert', actions: makeActions('x'), workspaceId: 'ws' },
+      expectedError: /action/,
     },
   ];
 
@@ -104,7 +149,7 @@ describe('POST /test-router/custom_audience/parse-template', () => {
     const response = await request(server).post(ENDPOINT).send(body);
 
     expect(response.status).toBe(400);
-    expect(response.body.error).toBe(expectedError);
+    expect(response.body.error).toMatch(expectedError);
   });
 });
 

--- a/src/controllers/__tests__/eventTest.test.ts
+++ b/src/controllers/__tests__/eventTest.test.ts
@@ -121,27 +121,28 @@ describe('POST /test-router/custom_audience/parse-template', () => {
     {
       name: 'missing action',
       body: { actions: makeActions('x'), workspaceId: 'ws' },
-      expectedError: /action/,
+      expectedError: 'action: Required',
     },
     {
       name: 'missing actions',
       body: { action: 'insert', workspaceId: 'ws' },
-      expectedError: /actions/,
+      expectedError: 'actions: Required',
     },
     {
       name: 'missing workspaceId',
       body: { action: 'insert', actions: makeActions('x') },
-      expectedError: /workspaceId/,
+      expectedError: 'workspaceId: Required',
     },
     {
       name: 'empty string workspaceId',
       body: { action: 'insert', actions: makeActions('x'), workspaceId: '' },
-      expectedError: /workspaceId/,
+      expectedError: 'workspaceId: workspaceId must be a non-empty string',
     },
     {
       name: 'invalid action value',
       body: { action: 'upsert', actions: makeActions('x'), workspaceId: 'ws' },
-      expectedError: /action/,
+      expectedError:
+        "action: Invalid enum value. Expected 'insert' | 'update' | 'delete', received 'upsert'",
     },
   ];
 
@@ -149,7 +150,7 @@ describe('POST /test-router/custom_audience/parse-template', () => {
     const response = await request(server).post(ENDPOINT).send(body);
 
     expect(response.status).toBe(400);
-    expect(response.body.error).toMatch(expectedError);
+    expect(response.body.error).toBe(expectedError);
   });
 });
 

--- a/src/controllers/eventTest.ts
+++ b/src/controllers/eventTest.ts
@@ -4,13 +4,26 @@ import { z } from 'zod';
 import { EventTesterService } from '../services/eventTest/eventTester';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { CatchErr, FixMe } from '../types';
+import { RecordAction } from '../types/rudderEvents';
 import { sandboxedParseTemplate } from '../v0/destinations/custom_audience/template/templateSandboxClient';
 import { lookupActionConfig } from '../v0/destinations/custom_audience/utils';
-import type { Action, CustomAudienceDestConfig } from '../v0/destinations/custom_audience/types';
+import type { CustomAudienceDestConfig } from '../v0/destinations/custom_audience/types';
+
+const actionConfigSchema = z.object({
+  endpoint: z.string(),
+  method: z.string(),
+  requestBody: z.string(),
+  batchSize: z.number(),
+  fields: z.array(z.object({ name: z.string() }).passthrough()),
+});
 
 const parseTemplateBodySchema = z.object({
-  action: z.enum(['insert', 'update', 'delete']),
-  actions: z.record(z.unknown()),
+  action: z.nativeEnum(RecordAction),
+  actions: z.object({
+    insert: actionConfigSchema.optional(),
+    update: actionConfigSchema.extend({ useInsertConfig: z.boolean().optional() }).optional(),
+    delete: actionConfigSchema.optional(),
+  }),
   workspaceId: z.string().min(1, 'workspaceId must be a non-empty string'),
 });
 
@@ -71,7 +84,7 @@ export class EventTestController {
     }
     const { action, actions, workspaceId } = parsed.data;
     const actionConfig = lookupActionConfig(
-      action as Action,
+      action,
       { actions } as CustomAudienceDestConfig,
     );
     ctx.body = await sandboxedParseTemplate(actionConfig.requestBody, workspaceId);

--- a/src/controllers/eventTest.ts
+++ b/src/controllers/eventTest.ts
@@ -5,9 +5,12 @@ import { EventTesterService } from '../services/eventTest/eventTester';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { CatchErr, FixMe } from '../types';
 import { sandboxedParseTemplate } from '../v0/destinations/custom_audience/template/templateSandboxClient';
+import { lookupActionConfig } from '../v0/destinations/custom_audience/utils';
+import type { Action, CustomAudienceDestConfig } from '../v0/destinations/custom_audience/types';
 
 const parseTemplateBodySchema = z.object({
-  requestBody: z.string().min(1, 'requestBody must be a non-empty string'),
+  action: z.enum(['insert', 'update', 'delete']),
+  actions: z.record(z.unknown()),
   workspaceId: z.string().min(1, 'workspaceId must be a non-empty string'),
 });
 
@@ -66,6 +69,11 @@ export class EventTestController {
       ctx.body = { error: formatZodError(parsed.error) };
       return;
     }
-    ctx.body = await sandboxedParseTemplate(parsed.data.requestBody, parsed.data.workspaceId);
+    const { action, actions, workspaceId } = parsed.data;
+    const actionConfig = lookupActionConfig(
+      action as Action,
+      { actions } as CustomAudienceDestConfig,
+    );
+    ctx.body = await sandboxedParseTemplate(actionConfig.requestBody, workspaceId);
   }
 }

--- a/src/controllers/eventTest.ts
+++ b/src/controllers/eventTest.ts
@@ -6,24 +6,13 @@ import { EventTesterService } from '../services/eventTest/eventTester';
 import { CatchErr, FixMe } from '../types';
 import { RecordAction } from '../types/rudderEvents';
 import { sandboxedParseTemplate } from '../v0/destinations/custom_audience/template/templateSandboxClient';
-import { lookupActionConfig } from '../v0/destinations/custom_audience/utils';
+import { actionsSchema } from '../v0/destinations/custom_audience/types';
 import type { CustomAudienceDestConfig } from '../v0/destinations/custom_audience/types';
-
-const actionConfigSchema = z.object({
-  endpoint: z.string(),
-  method: z.string(),
-  requestBody: z.string(),
-  batchSize: z.number(),
-  fields: z.array(z.object({ name: z.string() }).passthrough()),
-});
+import { lookupActionConfig } from '../v0/destinations/custom_audience/utils';
 
 const parseTemplateBodySchema = z.object({
   action: z.nativeEnum(RecordAction),
-  actions: z.object({
-    insert: actionConfigSchema.optional(),
-    update: actionConfigSchema.extend({ useInsertConfig: z.boolean().optional() }).optional(),
-    delete: actionConfigSchema.optional(),
-  }),
+  actions: actionsSchema,
   workspaceId: z.string().min(1, 'workspaceId must be a non-empty string'),
 });
 

--- a/src/controllers/eventTest.ts
+++ b/src/controllers/eventTest.ts
@@ -7,7 +7,6 @@ import { CatchErr, FixMe } from '../types';
 import { RecordAction } from '../types/rudderEvents';
 import { sandboxedParseTemplate } from '../v0/destinations/custom_audience/template/templateSandboxClient';
 import { actionsSchema } from '../v0/destinations/custom_audience/types';
-import type { CustomAudienceDestConfig } from '../v0/destinations/custom_audience/types';
 import { lookupActionConfig } from '../v0/destinations/custom_audience/utils';
 
 const parseTemplateBodySchema = z.object({
@@ -72,10 +71,7 @@ export class EventTestController {
       return;
     }
     const { action, actions, workspaceId } = parsed.data;
-    const actionConfig = lookupActionConfig(
-      action,
-      { actions } as CustomAudienceDestConfig,
-    );
+    const actionConfig = lookupActionConfig(action, actions);
     ctx.body = await sandboxedParseTemplate(actionConfig.requestBody, workspaceId);
   }
 }

--- a/src/v0/destinations/custom_audience/routerTransform.ts
+++ b/src/v0/destinations/custom_audience/routerTransform.ts
@@ -56,7 +56,7 @@ class CustomAudienceIntegration extends BatchDestination<
       Object.keys(this.destination.Config.actions).map((action) => [
         action,
         resolveEndpoint(
-          lookupActionConfig(action as Action, this.destination.Config).endpoint,
+          lookupActionConfig(action as Action, this.destination.Config.actions).endpoint,
           this.destination.Config.baseUrl,
           this.connectionConfig,
         ),
@@ -66,7 +66,7 @@ class CustomAudienceIntegration extends BatchDestination<
 
   transformEvent(input: CustomAudienceRouterRequest): TransformedEvent<Record<string, string>> {
     const { message } = input;
-    const actionConfig = lookupActionConfig(message.action, this.destination.Config);
+    const actionConfig = lookupActionConfig(message.action, this.destination.Config.actions);
     const fieldsWithCustomMappings = injectCustomMappings(
       message.identifiers!,
       this.connectionConfig.customMappings,
@@ -101,7 +101,7 @@ class CustomAudienceIntegration extends BatchDestination<
 
     return new CustomBatchStrategy<Record<string, string>>(async (payloads) => {
       const action = payloads[0].internalGroupKey as Action;
-      const actionConfig = lookupActionConfig(action, Config);
+      const actionConfig = lookupActionConfig(action, Config.actions);
 
       // Chunk outside the isolate so the existing native-batching split logic
       // is reused. Each chunk's records are passed through to the isolate

--- a/src/v0/destinations/custom_audience/types.ts
+++ b/src/v0/destinations/custom_audience/types.ts
@@ -24,9 +24,10 @@ export const actionConfigSchema = z.object({
   fields: z.array(actionFieldConfigSchema),
 });
 
-const updateActionConfigSchema = actionConfigSchema.extend({
-  useInsertConfig: z.boolean().optional(),
-});
+const updateActionConfigSchema = z.union([
+  actionConfigSchema.extend({ useInsertConfig: z.literal(false).optional() }),
+  actionConfigSchema.partial().extend({ useInsertConfig: z.literal(true) }),
+]);
 
 export const actionsSchema = z.object({
   insert: actionConfigSchema.optional(),

--- a/src/v0/destinations/custom_audience/types.ts
+++ b/src/v0/destinations/custom_audience/types.ts
@@ -9,40 +9,35 @@ export type Action = `${RecordAction}`;
 
 export type AuthenticationType = (typeof AUTHENTICATION_TYPES)[keyof typeof AUTHENTICATION_TYPES];
 
-export type HttpMethod = 'POST' | 'PUT' | 'PATCH' | 'GET' | 'DELETE';
-
-export type ActionFieldConfig = {
-  name: string;
-  isRequired: boolean;
-  hashType: HashingType;
-  isCustom: boolean;
-};
-
-export type ActionConfig = {
-  endpoint: string;
-  method: HttpMethod;
-  requestBody: string;
-  batchSize: number;
-  fields: ActionFieldConfig[];
-};
-
-export type UpdateActionConfig = ActionConfig & {
-  useInsertConfig?: boolean;
-};
+export const actionFieldConfigSchema = z.object({
+  name: z.string(),
+  isRequired: z.boolean(),
+  hashType: z.nativeEnum(HashingType),
+  isCustom: z.boolean(),
+});
 
 export const actionConfigSchema = z.object({
   endpoint: z.string(),
-  method: z.string(),
+  method: z.enum(['POST', 'PUT', 'PATCH', 'GET', 'DELETE']),
   requestBody: z.string(),
   batchSize: z.number(),
-  fields: z.array(z.object({ name: z.string() }).passthrough()),
+  fields: z.array(actionFieldConfigSchema),
+});
+
+const updateActionConfigSchema = actionConfigSchema.extend({
+  useInsertConfig: z.boolean().optional(),
 });
 
 export const actionsSchema = z.object({
   insert: actionConfigSchema.optional(),
-  update: actionConfigSchema.extend({ useInsertConfig: z.boolean().optional() }).optional(),
+  update: updateActionConfigSchema.optional(),
   delete: actionConfigSchema.optional(),
 });
+
+export type HttpMethod = z.infer<typeof actionConfigSchema>['method'];
+export type ActionFieldConfig = z.infer<typeof actionFieldConfigSchema>;
+export type ActionConfig = z.infer<typeof actionConfigSchema>;
+export type UpdateActionConfig = z.infer<typeof updateActionConfigSchema>;
 
 export type CustomAudienceHeader = {
   key: string;
@@ -53,11 +48,7 @@ export type CustomAudienceDestConfig = {
   baseUrl: string;
   authenticationType: AuthenticationType;
   headers?: CustomAudienceHeader[];
-  actions: {
-    insert?: ActionConfig;
-    update?: UpdateActionConfig;
-    delete?: ActionConfig;
-  };
+  actions: z.infer<typeof actionsSchema>;
   basicAuthUserName?: string;
   basicAuthPassword?: string;
   bearerToken?: string;

--- a/src/v0/destinations/custom_audience/types.ts
+++ b/src/v0/destinations/custom_audience/types.ts
@@ -25,8 +25,8 @@ export const actionConfigSchema = z.object({
 });
 
 const updateActionConfigSchema = z.union([
-  actionConfigSchema.extend({ useInsertConfig: z.literal(false).optional() }),
-  actionConfigSchema.partial().extend({ useInsertConfig: z.literal(true) }),
+  actionConfigSchema.extend({ useInsertConfig: z.boolean().optional() }),
+  z.object({ useInsertConfig: z.literal(true) }),
 ]);
 
 export const actionsSchema = z.object({

--- a/src/v0/destinations/custom_audience/types.ts
+++ b/src/v0/destinations/custom_audience/types.ts
@@ -1,3 +1,4 @@
+import { z } from 'zod';
 import { HashingType } from '../../util/audienceUtils';
 import type { Connection, Destination } from '../../../types/controlPlaneConfig';
 import type { Metadata, RecordAction, RudderRecordV2 } from '../../../types/rudderEvents';
@@ -28,6 +29,20 @@ export type ActionConfig = {
 export type UpdateActionConfig = ActionConfig & {
   useInsertConfig?: boolean;
 };
+
+export const actionConfigSchema = z.object({
+  endpoint: z.string(),
+  method: z.string(),
+  requestBody: z.string(),
+  batchSize: z.number(),
+  fields: z.array(z.object({ name: z.string() }).passthrough()),
+});
+
+export const actionsSchema = z.object({
+  insert: actionConfigSchema.optional(),
+  update: actionConfigSchema.extend({ useInsertConfig: z.boolean().optional() }).optional(),
+  delete: actionConfigSchema.optional(),
+});
 
 export type CustomAudienceHeader = {
   key: string;

--- a/src/v0/destinations/custom_audience/utils.test.ts
+++ b/src/v0/destinations/custom_audience/utils.test.ts
@@ -50,9 +50,7 @@ describe('lookupActionConfig', () => {
     {
       name: 'returns insert config when update has useInsertConfig: true',
       updateConfig: {
-        ...baseDestConfig.actions.insert!,
-        endpoint: '/update-path',
-        useInsertConfig: true,
+        useInsertConfig: true as const,
       },
       expectedEndpoint: '/audiences/{{connection.audienceId}}/members',
     },
@@ -81,13 +79,10 @@ describe('lookupActionConfig', () => {
   });
 
   it('throws when useInsertConfig is true but insert config is missing', () => {
-    const config: CustomAudienceDestConfig = {
-      ...baseDestConfig,
-      actions: {
-        update: { ...baseDestConfig.actions.insert!, useInsertConfig: true },
-      },
+    const actions: CustomAudienceDestConfig['actions'] = {
+      update: { useInsertConfig: true },
     };
-    expect(() => lookupActionConfig('update', config.actions)).toThrow(InstrumentationError);
+    expect(() => lookupActionConfig('update', actions)).toThrow(InstrumentationError);
   });
 });
 

--- a/src/v0/destinations/custom_audience/utils.test.ts
+++ b/src/v0/destinations/custom_audience/utils.test.ts
@@ -86,7 +86,7 @@ describe('lookupActionConfig', () => {
     const config: CustomAudienceDestConfig = {
       ...baseDestConfig,
       actions: {
-        update: { ...baseDestConfig.actions.insert!, useInsertConfig: true as const },
+        update: { ...baseDestConfig.actions.insert!, useInsertConfig: true },
       },
     };
     expect(() => lookupActionConfig('update', config.actions)).toThrow(InstrumentationError);

--- a/src/v0/destinations/custom_audience/utils.test.ts
+++ b/src/v0/destinations/custom_audience/utils.test.ts
@@ -43,7 +43,9 @@ describe('lookupActionConfig', () => {
   });
 
   it('throws InstrumentationError when action key is missing', () => {
-    expect(() => lookupActionConfig('delete', baseDestConfig.actions)).toThrow(InstrumentationError);
+    expect(() => lookupActionConfig('delete', baseDestConfig.actions)).toThrow(
+      InstrumentationError,
+    );
   });
 
   const useInsertConfigCases = [

--- a/src/v0/destinations/custom_audience/utils.test.ts
+++ b/src/v0/destinations/custom_audience/utils.test.ts
@@ -38,12 +38,12 @@ const destinationMeta = { id: 'dest-1', type: 'CUSTOM_AUDIENCE', workspaceId: 'w
 
 describe('lookupActionConfig', () => {
   it('returns the action config when present', () => {
-    const result = lookupActionConfig('insert', baseDestConfig);
+    const result = lookupActionConfig('insert', baseDestConfig.actions);
     expect(result.endpoint).toBe('/audiences/{{connection.audienceId}}/members');
   });
 
   it('throws InstrumentationError when action key is missing', () => {
-    expect(() => lookupActionConfig('delete', baseDestConfig)).toThrow(InstrumentationError);
+    expect(() => lookupActionConfig('delete', baseDestConfig.actions)).toThrow(InstrumentationError);
   });
 
   const useInsertConfigCases = [
@@ -77,7 +77,7 @@ describe('lookupActionConfig', () => {
       ...baseDestConfig,
       actions: { ...baseDestConfig.actions, update: updateConfig },
     };
-    expect(lookupActionConfig('update', config).endpoint).toBe(expectedEndpoint);
+    expect(lookupActionConfig('update', config.actions).endpoint).toBe(expectedEndpoint);
   });
 
   it('throws when useInsertConfig is true but insert config is missing', () => {
@@ -87,7 +87,7 @@ describe('lookupActionConfig', () => {
         update: { ...baseDestConfig.actions.insert!, useInsertConfig: true },
       },
     };
-    expect(() => lookupActionConfig('update', config)).toThrow(InstrumentationError);
+    expect(() => lookupActionConfig('update', config.actions)).toThrow(InstrumentationError);
   });
 });
 

--- a/src/v0/destinations/custom_audience/utils.test.ts
+++ b/src/v0/destinations/custom_audience/utils.test.ts
@@ -54,7 +54,7 @@ describe('lookupActionConfig', () => {
       updateConfig: {
         ...baseDestConfig.actions.insert!,
         endpoint: '/update-path',
-        useInsertConfig: true as const,
+        useInsertConfig: true,
       },
       expectedEndpoint: '/audiences/{{connection.audienceId}}/members',
     },

--- a/src/v0/destinations/custom_audience/utils.test.ts
+++ b/src/v0/destinations/custom_audience/utils.test.ts
@@ -50,6 +50,8 @@ describe('lookupActionConfig', () => {
     {
       name: 'returns insert config when update has useInsertConfig: true',
       updateConfig: {
+        ...baseDestConfig.actions.insert!,
+        endpoint: '/update-path',
         useInsertConfig: true as const,
       },
       expectedEndpoint: '/audiences/{{connection.audienceId}}/members',
@@ -79,10 +81,13 @@ describe('lookupActionConfig', () => {
   });
 
   it('throws when useInsertConfig is true but insert config is missing', () => {
-    const actions: CustomAudienceDestConfig['actions'] = {
-      update: { useInsertConfig: true },
+    const config: CustomAudienceDestConfig = {
+      ...baseDestConfig,
+      actions: {
+        update: { ...baseDestConfig.actions.insert!, useInsertConfig: true as const },
+      },
     };
-    expect(() => lookupActionConfig('update', actions)).toThrow(InstrumentationError);
+    expect(() => lookupActionConfig('update', config.actions)).toThrow(InstrumentationError);
   });
 });
 

--- a/src/v0/destinations/custom_audience/utils.ts
+++ b/src/v0/destinations/custom_audience/utils.ts
@@ -30,7 +30,7 @@ export const lookupActionConfig = (
     }
     return insertConfig;
   }
-  return actionConfig as ActionConfig;
+  return actionConfig;
 };
 
 // Replaces {{dotted.path}} placeholders with values from the connection object,

--- a/src/v0/destinations/custom_audience/utils.ts
+++ b/src/v0/destinations/custom_audience/utils.ts
@@ -30,7 +30,7 @@ export const lookupActionConfig = (
     }
     return insertConfig;
   }
-  return actionConfig;
+  return actionConfig as ActionConfig;
 };
 
 // Replaces {{dotted.path}} placeholders with values from the connection object,

--- a/src/v0/destinations/custom_audience/utils.ts
+++ b/src/v0/destinations/custom_audience/utils.ts
@@ -16,15 +16,15 @@ import type {
 
 export const lookupActionConfig = (
   action: Action,
-  destConfig: CustomAudienceDestConfig,
+  actions: CustomAudienceDestConfig['actions'],
 ): ActionConfig => {
-  const actionConfig = destConfig.actions[action];
+  const actionConfig = actions[action];
   if (!actionConfig) {
     throw new InstrumentationError(ERROR_MESSAGES.NO_ACTION_CONFIG(action));
   }
   // When the update action opts into reusing the insert config, substitute it.
-  if (action === 'update' && destConfig.actions.update?.useInsertConfig) {
-    const insertConfig = destConfig.actions.insert;
+  if (action === 'update' && actions.update?.useInsertConfig) {
+    const insertConfig = actions.insert;
     if (!insertConfig) {
       throw new InstrumentationError(ERROR_MESSAGES.NO_ACTION_CONFIG('insert'));
     }

--- a/src/v0/destinations/custom_audience/utils.ts
+++ b/src/v0/destinations/custom_audience/utils.ts
@@ -23,7 +23,7 @@ export const lookupActionConfig = (
     throw new InstrumentationError(ERROR_MESSAGES.NO_ACTION_CONFIG(action));
   }
   // When the update action opts into reusing the insert config, substitute it.
-  if (action === 'update' && actions.update?.useInsertConfig) {
+  if ('useInsertConfig' in actionConfig && actionConfig.useInsertConfig) {
     const insertConfig = actions.insert;
     if (!insertConfig) {
       throw new InstrumentationError(ERROR_MESSAGES.NO_ACTION_CONFIG('insert'));


### PR DESCRIPTION
## Summary

- The parse-template API accepted a raw `requestBody`, forcing callers to replicate action config resolution logic (like `useInsertConfig`), which was missed in #5234. Changed the API to accept `{ action, actions, workspaceId }` and resolve internally via `lookupActionConfig` — single source of truth.
- Derived `ActionConfig` and related types from Zod schemas (`z.infer`) to eliminate duplication between runtime types and validation schemas. Simplified `lookupActionConfig` to accept `actions` directly instead of the full `destConfig`.
- Added shared `.claude/settings.json` with a pre-commit lint hook (runs `lint-staged` on staged files before every commit) and a curated permission allow list for team use.

Depends on rudderlabs/rudder-config-backend#6244 for the caller-side update.

Resolves [INT-6431](https://linear.app/rudderstack/issue/INT-6431)

## Test plan

- [x] parse-template API tests updated for new `{ action, actions, workspaceId }` contract
- [x] New test: `useInsertConfig: true` on update action resolves to insert's template
- [x] Validation tests: missing action, missing actions, invalid action value return 400
- [x] `lookupActionConfig` tests updated: useInsertConfig true/false/absent cases
- [x] All 33 unit tests passing, no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)