### PR TITLE
fix: guard getDestinationExternalIDInfoForRetl against malformed externalId

### DIFF
--- a/src/v0/util/index.js
+++ b/src/v0/util/index.js
@@ -1175,19 +1175,25 @@ const getDestinationExternalIDInfoForRetl = (message, destination) => {
   let destinationExternalId = null;
   let identifierType = null;
   let objectType = null;
-  if (message.context && message.context.externalId) {
-    externalIdArray = message.context.externalId;
+  const { externalId } = message.context || {};
+  if (externalId) {
+    if (Array.isArray(externalId)) {
+      externalIdArray = externalId;
+    } else if (isObject(externalId) && !isEmptyObject(externalId)) {
+      externalIdArray = [externalId];
+    }
   }
-  if (externalIdArray) {
-    externalIdArray.forEach((extIdObj) => {
-      const { type, id } = extIdObj;
-      if (type?.includes(`${destination}-`)) {
-        destinationExternalId = id;
-        objectType = type.replace(`${destination}-`, '');
-        identifierType = extIdObj.identifierType;
-      }
-    });
-  }
+  externalIdArray.forEach((extIdObj) => {
+    if (!isObject(extIdObj)) {
+      return;
+    }
+    const { type, id } = extIdObj;
+    if (typeof type === 'string' && type.includes(`${destination}-`)) {
+      destinationExternalId = id;
+      objectType = type.replace(`${destination}-`, '');
+      identifierType = extIdObj.identifierType;
+    }
+  });
   return { destinationExternalId, objectType, identifierType };
 };
 

--- a/src/v0/util/index.test.js
+++ b/src/v0/util/index.test.js
@@ -21,6 +21,7 @@ const { ERROR_MESSAGES, FEATURE_FILTER_CODE } = require('./constant');
 // Names of the utility functions to test
 const functionNames = [
   'getDestinationExternalID',
+  'getDestinationExternalIDInfoForRetl',
   'isHybridModeEnabled',
   'handleSourceKeysOperation',
   'getValueFromPropertiesOrTraits',

--- a/src/v0/util/testdata/getDestinationExternalIDInfoForRetl.json
+++ b/src/v0/util/testdata/getDestinationExternalIDInfoForRetl.json
@@ -1,0 +1,236 @@
+[
+  {
+    "description": "Should return externalId info when context.externalId is a valid array",
+    "input": [
+      {
+        "type": "identify",
+        "context": {
+          "externalId": [
+            {
+              "type": "HS-lead",
+              "id": "user-123",
+              "identifierType": "email"
+            }
+          ]
+        }
+      },
+      "HS"
+    ],
+    "output": {
+      "destinationExternalId": "user-123",
+      "objectType": "lead",
+      "identifierType": "email"
+    }
+  },
+  {
+    "description": "Should return all-null result when context.externalId is a string (malformed upstream payload)",
+    "input": [
+      {
+        "type": "identify",
+        "context": {
+          "externalId": "1974894"
+        }
+      },
+      "HS"
+    ],
+    "output": {
+      "destinationExternalId": null,
+      "objectType": null,
+      "identifierType": null
+    }
+  },
+  {
+    "description": "Should accept a single externalId object (auto-wrapped as array) — mirrors getDestinationExternalIDObjectForRetl behaviour",
+    "input": [
+      {
+        "type": "identify",
+        "context": {
+          "externalId": {
+            "type": "HS-lead",
+            "id": "user-123",
+            "identifierType": "email"
+          }
+        }
+      },
+      "HS"
+    ],
+    "output": {
+      "destinationExternalId": "user-123",
+      "objectType": "lead",
+      "identifierType": "email"
+    }
+  },
+  {
+    "description": "Should return all-null result when context.externalId is absent",
+    "input": [
+      {
+        "type": "identify",
+        "context": {}
+      },
+      "HS"
+    ],
+    "output": {
+      "destinationExternalId": null,
+      "objectType": null,
+      "identifierType": null
+    }
+  },
+  {
+    "description": "Should return all-null result when no entry matches the destination prefix",
+    "input": [
+      {
+        "type": "identify",
+        "context": {
+          "externalId": [
+            {
+              "type": "OTHER-lead",
+              "id": "user-123",
+              "identifierType": "email"
+            }
+          ]
+        }
+      },
+      "HS"
+    ],
+    "output": {
+      "destinationExternalId": null,
+      "objectType": null,
+      "identifierType": null
+    }
+  },
+  {
+    "description": "Should skip array entries that are null or undefined without throwing",
+    "input": [
+      {
+        "type": "identify",
+        "context": {
+          "externalId": [
+            null,
+            {
+              "type": "HS-lead",
+              "id": "user-123",
+              "identifierType": "email"
+            }
+          ]
+        }
+      },
+      "HS"
+    ],
+    "output": {
+      "destinationExternalId": "user-123",
+      "objectType": "lead",
+      "identifierType": "email"
+    }
+  },
+  {
+    "description": "Should skip array entries that are not objects (e.g. strings, numbers)",
+    "input": [
+      {
+        "type": "identify",
+        "context": {
+          "externalId": [
+            "1974894",
+            42,
+            {
+              "type": "HS-lead",
+              "id": "user-123",
+              "identifierType": "email"
+            }
+          ]
+        }
+      },
+      "HS"
+    ],
+    "output": {
+      "destinationExternalId": "user-123",
+      "objectType": "lead",
+      "identifierType": "email"
+    }
+  },
+  {
+    "description": "Should skip entries where 'type' field is missing",
+    "input": [
+      {
+        "type": "identify",
+        "context": {
+          "externalId": [{ "id": "user-123", "identifierType": "email" }]
+        }
+      },
+      "HS"
+    ],
+    "output": {
+      "destinationExternalId": null,
+      "objectType": null,
+      "identifierType": null
+    }
+  },
+  {
+    "description": "Should skip entries where 'type' is not a string (numeric type would otherwise crash on .includes)",
+    "input": [
+      {
+        "type": "identify",
+        "context": {
+          "externalId": [{ "type": 123, "id": "user-123", "identifierType": "email" }]
+        }
+      },
+      "HS"
+    ],
+    "output": {
+      "destinationExternalId": null,
+      "objectType": null,
+      "identifierType": null
+    }
+  },
+  {
+    "description": "Should skip random objects with no recognised fields",
+    "input": [
+      {
+        "type": "identify",
+        "context": {
+          "externalId": [{ "foo": "bar", "baz": 1 }]
+        }
+      },
+      "HS"
+    ],
+    "output": {
+      "destinationExternalId": null,
+      "objectType": null,
+      "identifierType": null
+    }
+  },
+  {
+    "description": "Should map objectType but leave id/identifierType undefined when matching entry omits them (current behaviour: no validation, just maps what is present)",
+    "input": [
+      {
+        "type": "identify",
+        "context": {
+          "externalId": [{ "type": "HS-lead" }]
+        }
+      },
+      "HS"
+    ],
+    "output": {
+      "objectType": "lead"
+    }
+  },
+  {
+    "description": "Should pick the last matching entry when multiple HS entries exist (existing behaviour preserved)",
+    "input": [
+      {
+        "type": "identify",
+        "context": {
+          "externalId": [
+            { "type": "HS-lead", "id": "first", "identifierType": "email" },
+            { "type": "HS-company", "id": "second", "identifierType": "domain" }
+          ]
+        }
+      },
+      "HS"
+    ],
+    "output": {
+      "destinationExternalId": "second",
+      "objectType": "company",
+      "identifierType": "domain"
+    }
+  }
+]


### PR DESCRIPTION
🔒 Scanned for secrets using gitleaks 8.30.1

## Write a brief explainer on your code changes

context.externalId was assumed to be an array, so non-array values (e.g. a scalar string sent by upstream SDKs) crashed with
`externalIdArray.forEach is not a function`, surfacing as a generic 500 status code across all destinations using this helper (HS, Iterable, Marketo, SFMC, TikTok/FB/ Criteo audience, GAdwords remarketing).

Mirror the input-shape guard already in getDestinationExternalIDObjectForRetl (array kept, single object wrapped, anything else -> []) and add per-entry guards so null/undefined entries, primitives, and non-string `type` values are skipped instead of throwing on destructuring or .includes.

For rETL flows the existing `rETL - external Id not found.` InstrumentationError still fires when no usable entry is found, preserving the 400 dataValidation behaviour. Non-rETL identify events with a malformed externalId now flow through the normal lookupField path instead of crashing.



## What is the related Linear task?

[Resolves INT-6448](https://linear.app/rudderstack/issue/INT-6448/hs-getting-an-error-when-externalid-coming-as-string)

## Please explain the objectives of your changes below

Put down any required details on the broader aspect of your changes. If there are any dependent changes, **mandatorily** mention them here

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

N/A

### Any new dependencies introduced with this change?

N/A

### Any new generic utility introduced or modified. Please explain the changes.

N/A

### Any technical or performance related pointers to consider with the change?

N/A

@coderabbitai review

<hr>

### Developer checklist

- [ ] My code follows the style guidelines of this project

- [ ] **No breaking changes are being introduced.**

- [ ] All related docs linked with the PR?

- [ ] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [ ] Is the PR limited to 10 file changes?

- [ ] Is the PR limited to one linear task?

- [ ] Are relevant unit and component test-cases added in **new readability format**?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.
