### PR TITLE
fix(custom_audience): boolean false silently dropped from audience record output

### DIFF
--- a/src/v0/util/audienceUtils.test.ts
+++ b/src/v0/util/audienceUtils.test.ts
@@ -92,6 +92,28 @@ describe('processAudienceRecord', () => {
       );
       expect(result.age).toBe('42');
     });
+
+    it('stringifies boolean false instead of dropping it', () => {
+      const result = processAudienceRecord(
+        { opt_out: false },
+        {
+          fieldConfigs: { opt_out: { normalize: (v) => v, hashingType: HashingType.NONE } },
+          destination: makeDestination(),
+        },
+      );
+      expect(result.opt_out).toBe('false');
+    });
+
+    it('stringifies boolean true', () => {
+      const result = processAudienceRecord(
+        { opt_in: true },
+        {
+          fieldConfigs: { opt_in: { normalize: (v) => v, hashingType: HashingType.NONE } },
+          destination: makeDestination(),
+        },
+      );
+      expect(result.opt_in).toBe('true');
+    });
   });
 
   describe('hashing', () => {

--- a/src/v0/util/audienceUtils.ts
+++ b/src/v0/util/audienceUtils.ts
@@ -117,7 +117,7 @@ export const processAudienceRecord = (
   const result: Record<string, string> = {};
 
   Object.entries(record).forEach(([fieldName, rawValue]) => {
-    if (!isDefinedAndNotNull(rawValue) || rawValue === '' || rawValue === false) {
+    if (!isDefinedAndNotNull(rawValue) || rawValue === '') {
       return;
     }
 


### PR DESCRIPTION
## Summary

- Boolean `false` values in audience record fields were silently dropped by `processAudienceRecord` because the early-return guard in `audienceUtils.ts` explicitly filtered out `false` alongside `null`/`undefined`/empty-string
- Removed the `rawValue === false` check so boolean values flow through to `String()` coercion and appear as `"false"`/`"true"` in the output
- Added unit tests covering boolean `false` and `true` stringification

Fixes [INT-6457](https://linear.app/rudderstack/issue/INT-6457/boolean-false-values-in-record-fields-are-silently-dropped-from-output)

## Test plan

- [x] Unit tests pass: `npm test -- --testPathPattern="audienceUtils" --no-coverage`
- [x] Lint clean: `npm run lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)