### PR TITLE
fix: block SSRF via redirect and literal-IP hosts in transformation fetch

### DIFF
--- a/src/util/utils.allowlist.test.js
+++ b/src/util/utils.allowlist.test.js
@@ -1,0 +1,32 @@
+// ALLOW_IP_RANGES / BLOCK_IP_RANGES are read once at module load, so they must be
+// configured BEFORE requiring utils. Loopback is both explicitly blocked and
+// explicitly allowed here to prove the allow-list wins over both the configured
+// denylist and the always-on core.
+process.env.ALLOW_IP_RANGES = '127.0.0.0/8,::1/128';
+process.env.BLOCK_IP_RANGES = '127.0.0.0/8';
+
+const { isBlockedIP, ssrfSafeAgentFactory } = require('./utils');
+
+describe('ALLOW_IP_RANGES precedence', () => {
+  it('allows an address that is in the always-on core (allow overrides core)', () => {
+    expect(isBlockedIP('127.0.0.1')).toBe(false);
+  });
+
+  it('allows an address that is also in BLOCK_IP_RANGES (allow overrides block)', () => {
+    expect(isBlockedIP('127.0.0.5')).toBe(false);
+  });
+
+  it('still blocks core ranges that are not allow-listed', () => {
+    expect(isBlockedIP('169.254.169.254')).toBe(true); // cloud metadata
+    expect(isBlockedIP('0.0.0.0')).toBe(true);
+  });
+
+  it('honours an allow-listed IPv6 address, including bracket-stripping in the factory', () => {
+    expect(isBlockedIP('::1')).toBe(false);
+    expect(() => ssrfSafeAgentFactory(new URL('http://[::1]/'))).not.toThrow();
+  });
+
+  it('still allows public addresses', () => {
+    expect(isBlockedIP('8.8.8.8')).toBe(false);
+  });
+});

--- a/src/util/utils.js
+++ b/src/util/utils.js
@@ -16,18 +16,71 @@ const dnsCallbackStorage = new AsyncLocalStorage();
 
 const BLOCK_HOST_NAMES = process.env.BLOCK_HOST_NAMES || '';
 const BLOCK_HOST_NAMES_LIST = BLOCK_HOST_NAMES.split(',');
-const LOCAL_HOST_NAMES_LIST = [
-  'localhost',
-  '127.0.0.1',
-  '0.0.0.0',
-  '[::]',
-  '[::1]',
-  '[::ffff:127.0.0.1]',
-  '[::ffff:7f00:1]',
-];
-const LOCALHOST_OCTET = '127.';
 
-const isBlockedIP = (address) => !address || address.startsWith('127.') || address === '0.0.0.0';
+// Always-on SSRF denylist: ranges that are never a legitimate outbound target.
+// These are blocked regardless of configuration (only ALLOW_IP_RANGES can
+// exempt them). Operators block additional ranges
+// (e.g. RFC1918 private space, carrier-grade NAT, test-nets) by appending to
+// BLOCK_IP_RANGES.
+const BLOCKED_CIDRS = [
+  '127.0.0.0/8', // IPv4 loopback
+  '0.0.0.0/8', // IPv4 unspecified / this-host
+  '169.254.0.0/16', // IPv4 link-local (incl. 169.254.169.254 cloud metadata)
+  '::1/128', // IPv6 loopback
+  '::/128', // IPv6 unspecified
+  'fe80::/10', // IPv6 link-local
+];
+
+// Parse a comma-separated env var of CIDRs into ipaddr [addr, prefix] pairs.
+// Invalid entries are logged and skipped rather than crashing startup.
+const parseCidrConfig = (raw) =>
+  (raw || '')
+    .split(',')
+    .map((cidr) => cidr.trim())
+    .filter(Boolean)
+    .reduce((acc, cidr) => {
+      try {
+        acc.push(ipaddr.parseCIDR(cidr));
+      } catch (error) {
+        logger.error(`Ignoring invalid CIDR "${cidr}": ${error.message}`);
+      }
+      return acc;
+    }, []);
+
+// Always-on core plus any operator-configured ranges; BLOCK_IP_RANGES is additive.
+const BLOCKED_IP_RANGES = [
+  ...parseCidrConfig(BLOCKED_CIDRS.join(',')),
+  ...parseCidrConfig(process.env.BLOCK_IP_RANGES),
+];
+// Exceptions: addresses here are allowed even if they match a blocked range
+// (e.g. ALLOW_IP_RANGES=127.0.0.0/8 to permit loopback in a trusted deployment).
+const ALLOWED_IP_RANGES = parseCidrConfig(process.env.ALLOW_IP_RANGES);
+
+const matchesAnyCidr = (addr, cidrs) =>
+  cidrs.some((cidr) => addr.kind() === cidr[0].kind() && addr.match(cidr));
+
+// SSRF guard. Blocks any address matching the (configured or default) denylist,
+// unless it is explicitly permitted via ALLOWED_IP_RANGES. IPv4-mapped IPv6 is
+// unwrapped first (so ::ffff:127.0.0.1 is treated as 127.0.0.1) and input that
+// cannot be parsed fails closed.
+const isBlockedIP = (address) => {
+  if (!address) {
+    return true;
+  }
+  let addr;
+  try {
+    addr = ipaddr.parse(address);
+  } catch (error) {
+    return true;
+  }
+  if (addr.kind() === 'ipv6' && addr.isIPv4MappedAddress()) {
+    addr = addr.toIPv4Address();
+  }
+  if (matchesAnyCidr(addr, ALLOWED_IP_RANGES)) {
+    return false;
+  }
+  return matchesAnyCidr(addr, BLOCKED_IP_RANGES);
+};
 const RECORD_TYPE_A = 4; // ipv4
 const DNS_CACHE_ENABLED = process.env.DNS_CACHE_ENABLED === 'true';
 const DNS_CACHE_TTL = process.env.DNS_CACHE_TTL ? parseInt(process.env.DNS_CACHE_TTL, 10) : 300;
@@ -69,6 +122,9 @@ const staticLookup =
           onDnsResolved({ resolveStartTime, cacheHit, error: false });
         }
 
+        // Validates the resolved IP of a hostname hop. IP-literal hosts never
+        // reach here (net.connect skips lookup for them); those are checked up
+        // front in ssrfSafeAgentFactory.
         if (isBlockedIP(address)) {
           cb(new Error(`cannot use ${address || 'empty'} as IP address for ${hostname}`), null);
         } else if (options?.all) {
@@ -120,16 +176,49 @@ const sharedHttpsAgentWithLookup = new https.Agent({
   lookup: staticLookup(),
 });
 
-const blockLocalhostRequests = (url) => {
-  if (process.env.ALLOW_LOCALHOST_FETCH === 'true') {
-    return;
+// Per-hop agent selector. node-fetch calls this for the initial request AND for
+// every redirect hop, so it is the SSRF choke point that also sees redirect
+// targets.
+//
+// Why this is needed even though the agents' `lookup` already runs isBlockedIP:
+// net.connect only calls `lookup` when the host is a DNS *name* — for a numeric
+// IP host there is nothing to resolve, so `lookup` (and the isBlockedIP inside
+// it) is skipped entirely. That is exactly how `http://host/redirect?url=
+// http://127.0.0.1:9090` slipped through: the redirect target is an IP literal,
+// so it never reached `lookup`. (node-fetch did reuse the agent on the redirect
+// hop — the literal IP, not the redirect, was the bypass.)
+//
+// So isBlockedIP is enforced in two complementary places, one check, both host
+// forms covered:
+//   - IP-literal hosts -> validated here, before connect (initial + every hop)
+//   - hostname  hosts  -> deferred to the agents' `lookup`, which resolves then
+//                         validates at connect time (covers names + DNS rebinding)
+const ssrfSafeAgentFactory = (parsedURL) => {
+  // Defense-in-depth. node-fetch already rejects non-http(s) before it calls the
+  // agent, so this never fires for real traffic today; it is kept so the egress
+  // protocol allowlist is explicit at the choke point and survives an HTTP-client
+  // upgrade/swap. Valid http/https requests pass through unaffected.
+  if (parsedURL.protocol !== 'http:' && parsedURL.protocol !== 'https:') {
+    throw new Error('invalid protocol, only http and https are supported');
   }
+  // URL.hostname keeps the brackets around IPv6 literals (e.g. "[::1]") per
+  // RFC 3986, but ipaddr rejects bracketed input — ipaddr.isValid("[::1]") is
+  // false while ipaddr.isValid("::1") is true. Without stripping, the isValid
+  // guard below would skip every IPv6 literal and "[::1]" (loopback) would leak.
+  // The anchors peel only the wrapping brackets; it is a no-op for IPv4 and names.
+  const host = parsedURL.hostname.replace(/^\[/, '').replace(/]$/, '');
+  if (ipaddr.isValid(host) && isBlockedIP(host)) {
+    throw new Error(`blocked request to non-public address: ${host}`);
+  }
+  return parsedURL.protocol === 'https:' ? sharedHttpsAgentWithLookup : sharedHttpAgentWithLookup;
+};
+
+// Blocks operator-denylisted hostnames (BLOCK_HOST_NAMES). Localhost and other
+// internal addresses are handled by isBlockedIP (the BLOCKED_CIDRS core) at the
+// agent/lookup layer, so they are not special-cased here.
+const blockLocalhostRequests = (url) => {
   try {
-    const parseUrl = new URL(url);
-    const { hostname } = parseUrl;
-    if (LOCAL_HOST_NAMES_LIST.includes(hostname) || hostname.startsWith(LOCALHOST_OCTET)) {
-      throw new Error('localhost requests are not allowed');
-    }
+    const { hostname } = new URL(url);
     if (BLOCK_HOST_NAMES_LIST.includes(hostname)) {
       throw new Error('blocked host requests are not allowed');
     }
@@ -152,7 +241,6 @@ const fetchWithDnsWrapper = async (transformationTags, ...args) => {
   blockLocalhostRequests(fetchURL);
   blockInvalidProtocolRequests(fetchURL);
   const fetchOptions = args[1] || {};
-  const schemeName = fetchURL.startsWith('https') ? 'https' : 'http';
 
   const onDnsResolved = ({ resolveStartTime, cacheHit, error }) => {
     // Destructure to exclude isSuccess which is not part of fetch_dns_resolve_time labelset
@@ -163,8 +251,7 @@ const fetchWithDnsWrapper = async (transformationTags, ...args) => {
     });
   };
 
-  fetchOptions.agent =
-    schemeName === 'https' ? sharedHttpsAgentWithLookup : sharedHttpAgentWithLookup;
+  fetchOptions.agent = ssrfSafeAgentFactory;
   return dnsCallbackStorage.run(onDnsResolved, () => fetch(fetchURL, fetchOptions));
 };
 
@@ -310,6 +397,8 @@ module.exports = {
   logProcessInfo,
   extractStackTraceUptoLastSubstringMatch,
   fetchWithDnsWrapper,
+  ssrfSafeAgentFactory,
+  isBlockedIP,
   staticLookup,
   dnsCallbackStorage,
   shouldSkipDynamicConfigProcessing,

--- a/src/util/utils.js
+++ b/src/util/utils.js
@@ -17,18 +17,26 @@ const dnsCallbackStorage = new AsyncLocalStorage();
 const BLOCK_HOST_NAMES = process.env.BLOCK_HOST_NAMES || '';
 const BLOCK_HOST_NAMES_LIST = BLOCK_HOST_NAMES.split(',');
 
-// Always-on SSRF denylist: ranges that are never a legitimate outbound target.
-// These are blocked regardless of configuration (only ALLOW_IP_RANGES can
-// exempt them). Operators block additional ranges
-// (e.g. RFC1918 private space, carrier-grade NAT, test-nets) by appending to
-// BLOCK_IP_RANGES.
+// Always-on SSRF denylist: loopback, private, and other non-public ranges a
+// sandboxed transformation must not reach. Secure-by-default — self-hosted
+// installs without a network-layer egress policy rely solely on this list.
+// Legitimate internal fetches must be allow-listed via ALLOW_IP_RANGES;
+// BLOCK_IP_RANGES appends further ranges.
 const BLOCKED_CIDRS = [
-  '127.0.0.0/8', // IPv4 loopback
-  '0.0.0.0/8', // IPv4 unspecified / this-host
-  '169.254.0.0/16', // IPv4 link-local (incl. 169.254.169.254 cloud metadata)
-  '::1/128', // IPv6 loopback
-  '::/128', // IPv6 unspecified
-  'fe80::/10', // IPv6 link-local
+  // IPv4
+  '0.0.0.0/8', // unspecified / this-host
+  '10.0.0.0/8', // RFC1918 private
+  '100.64.0.0/10', // RFC6598 carrier-grade NAT (e.g. EKS VPC-CNI pod CIDRs)
+  '127.0.0.0/8', // loopback
+  '169.254.0.0/16', // link-local (incl. 169.254.169.254 cloud metadata)
+  '172.16.0.0/12', // RFC1918 private
+  '192.168.0.0/16', // RFC1918 private
+  '255.255.255.255/32', // broadcast
+  // IPv6
+  '::1/128', // loopback
+  '::/128', // unspecified
+  'fc00::/7', // unique-local (incl. AWS IPv6 IMDS fd00:ec2::254)
+  'fe80::/10', // link-local
 ];
 
 // Parse a comma-separated env var of CIDRs into ipaddr [addr, prefix] pairs.

--- a/src/util/utils.ssrf-redirect.test.js
+++ b/src/util/utils.ssrf-redirect.test.js
@@ -1,0 +1,63 @@
+// Regression test for the SSRF-via-redirect fix. Uses the REAL node-fetch (not
+// mocked) so that node-fetch actually re-invokes the per-hop agent function on the
+// redirect target — that per-hop call is the entire protection. If `agent` is ever
+// reverted to a single Agent instance, the redirect hop stops being validated and
+// these tests fail.
+//
+// Loopback is allow-listed so the local test server (acting as the "external"
+// redirector) is reachable; the redirect TARGET (169.254.169.254 cloud metadata)
+// is NOT allow-listed and must be blocked on the redirect hop, before any connect.
+process.env.ALLOW_IP_RANGES = '127.0.0.0/8';
+
+const http = require('http');
+const { fetchWithDnsWrapper } = require('./utils');
+
+describe('fetchWithDnsWrapper redirect SSRF guard (real node-fetch)', () => {
+  let server;
+  let base;
+  const sockets = new Set();
+
+  beforeAll((done) => {
+    server = http.createServer((req, res) => {
+      if (req.url === '/redirect-internal') {
+        res.writeHead(302, { Location: 'http://169.254.169.254/latest/meta-data/' });
+        res.end();
+      } else if (req.url === '/redirect-ok') {
+        res.writeHead(302, { Location: `${base}/final` });
+        res.end();
+      } else if (req.url === '/final') {
+        res.writeHead(200, { 'Content-Type': 'text/plain' });
+        res.end('OK');
+      } else {
+        res.writeHead(404);
+        res.end();
+      }
+    });
+    // Track sockets so keep-alive connections can be torn down at teardown.
+    server.on('connection', (socket) => {
+      sockets.add(socket);
+      socket.on('close', () => sockets.delete(socket));
+    });
+    server.listen(0, '127.0.0.1', () => {
+      base = `http://127.0.0.1:${server.address().port}`;
+      done();
+    });
+  });
+
+  afterAll((done) => {
+    sockets.forEach((socket) => socket.destroy());
+    server.close(done);
+  });
+
+  it('blocks a 3xx redirect whose target is an internal address (the reported exploit)', async () => {
+    await expect(fetchWithDnsWrapper({}, `${base}/redirect-internal`)).rejects.toThrow(
+      'blocked request to non-public address: 169.254.169.254',
+    );
+  });
+
+  it('still follows a redirect to an allowed target', async () => {
+    const res = await fetchWithDnsWrapper({}, `${base}/redirect-ok`);
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe('OK');
+  });
+});

--- a/src/util/utils.test.js
+++ b/src/util/utils.test.js
@@ -8,9 +8,24 @@ jest.mock('dns', () => ({
   },
 }));
 
+// BLOCK_IP_RANGES is additive on top of the always-on core. Set it before utils
+// is required (the denylist is built at module load) to exercise the
+// config-appended ranges. The core ranges (loopback, metadata, unspecified,
+// link-local) are deliberately omitted here, so the cases that rely on them also
+// prove the core blocks with no configuration.
+process.env.BLOCK_IP_RANGES =
+  '10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,100.64.0.0/10,fc00::/7,255.255.255.255/32';
+process.env.BLOCK_HOST_NAMES = 'blocked.example.com';
+
 const fetch = require('node-fetch');
 const stats = require('./stats');
-const { staticLookup, dnsCallbackStorage, fetchWithDnsWrapper } = require('./utils');
+const {
+  staticLookup,
+  dnsCallbackStorage,
+  fetchWithDnsWrapper,
+  isBlockedIP,
+  ssrfSafeAgentFactory,
+} = require('./utils');
 
 describe('asyncHooks behaviour', () => {
   it('should propagate correctly', () => {
@@ -45,15 +60,15 @@ describe('staticLookup', () => {
   const testCases = [
     {
       name: 'should resolve the hostname and return the IP address',
-      mockResponse: { address: '192.168.1.1', cacheHit: true },
-      expectedArgs: [null, '192.168.1.1', RECORD_TYPE_A],
+      mockResponse: { address: '1.1.1.1', cacheHit: true },
+      expectedArgs: [null, '1.1.1.1', RECORD_TYPE_A],
       expectedDnsResolvedCall: { cacheHit: true, error: false },
     },
     {
       name: 'should resolve the hostname and return the IP address with all option',
       options: { all: true },
-      mockResponse: { address: '192.168.1.1', cacheHit: true },
-      expectedArgs: [null, [{ address: '192.168.1.1', family: RECORD_TYPE_A }]],
+      mockResponse: { address: '1.1.1.1', cacheHit: true },
+      expectedArgs: [null, [{ address: '1.1.1.1', family: RECORD_TYPE_A }]],
       expectedDnsResolvedCall: { cacheHit: true, error: false },
     },
     {
@@ -96,6 +111,36 @@ describe('staticLookup', () => {
       name: 'should allow public IP address',
       mockResponse: { address: '8.8.8.8', cacheHit: false },
       expectedArgs: [null, '8.8.8.8', RECORD_TYPE_A],
+      expectedDnsResolvedCall: { cacheHit: false, error: false },
+    },
+    {
+      name: 'should block RFC1918 private 10.0.0.0/8 (e.g. 10.1.2.3)',
+      mockResponse: { address: '10.1.2.3', cacheHit: false },
+      expectedArgs: [new Error(`cannot use 10.1.2.3 as IP address for ${HOST_NAME}`), null],
+      expectedDnsResolvedCall: { cacheHit: false, error: false },
+    },
+    {
+      name: 'should block RFC1918 private 172.16.0.0/12 (e.g. 172.16.5.5)',
+      mockResponse: { address: '172.16.5.5', cacheHit: false },
+      expectedArgs: [new Error(`cannot use 172.16.5.5 as IP address for ${HOST_NAME}`), null],
+      expectedDnsResolvedCall: { cacheHit: false, error: false },
+    },
+    {
+      name: 'should block RFC1918 private 192.168.0.0/16 (e.g. 192.168.1.1)',
+      mockResponse: { address: '192.168.1.1', cacheHit: false },
+      expectedArgs: [new Error(`cannot use 192.168.1.1 as IP address for ${HOST_NAME}`), null],
+      expectedDnsResolvedCall: { cacheHit: false, error: false },
+    },
+    {
+      name: 'should block link-local cloud metadata 169.254.169.254 (DNS rebinding)',
+      mockResponse: { address: '169.254.169.254', cacheHit: false },
+      expectedArgs: [new Error(`cannot use 169.254.169.254 as IP address for ${HOST_NAME}`), null],
+      expectedDnsResolvedCall: { cacheHit: false, error: false },
+    },
+    {
+      name: 'should block carrier-grade NAT 100.64.0.0/10 (e.g. 100.64.0.1)',
+      mockResponse: { address: '100.64.0.1', cacheHit: false },
+      expectedArgs: [new Error(`cannot use 100.64.0.1 as IP address for ${HOST_NAME}`), null],
       expectedDnsResolvedCall: { cacheHit: false, error: false },
     },
   ];
@@ -172,7 +217,7 @@ describe('fetchWithDnsWrapper', () => {
     expect(fetch).toHaveBeenCalledWith(
       'https://example.com/api',
       expect.objectContaining({
-        agent: expect.any(Object),
+        agent: expect.any(Function),
       }),
     );
 
@@ -196,27 +241,96 @@ describe('fetchWithDnsWrapper', () => {
 });
 
 describe('blockLocalhostRequests via fetchWithDnsWrapper', () => {
-  const blockedUrls = [
-    { url: 'http://localhost/path', label: 'localhost' },
-    { url: 'http://127.0.0.1/path', label: '127.0.0.1' },
-    { url: 'http://0.0.0.0/path', label: '0.0.0.0' },
-    { url: 'http://[::]/path', label: '[::]' },
-    { url: 'http://[::1]/path', label: '[::1]' },
-    { url: 'http://[::ffff:127.0.0.1]/path', label: '[::ffff:127.0.0.1]' },
-    { url: 'http://[::ffff:7f00:1]/path', label: '[::ffff:7f00:1]' },
-  ];
-
-  blockedUrls.forEach(({ url, label }) => {
-    it(`should block requests to ${label}`, async () => {
-      await expect(fetchWithDnsWrapper({}, url)).rejects.toThrow(
-        'localhost requests are not allowed',
-      );
-    });
+  // Localhost / internal literals are now blocked by the IP-layer guard
+  // (see the ssrfSafeAgentFactory and staticLookup suites), not here.
+  it('should block denylisted hostnames (BLOCK_HOST_NAMES)', async () => {
+    await expect(fetchWithDnsWrapper({}, 'http://blocked.example.com/path')).rejects.toThrow(
+      'blocked host requests are not allowed',
+    );
   });
 
   it('should block invalid protocols', async () => {
     await expect(fetchWithDnsWrapper({}, 'ftp://example.com')).rejects.toThrow(
       'invalid protocol, only http and https are supported',
     );
+  });
+});
+
+describe('isBlockedIP', () => {
+  it.each([
+    // loopback / unspecified / broadcast
+    ['127.0.0.1', true],
+    ['127.255.255.255', true],
+    ['0.0.0.0', true],
+    ['255.255.255.255', true],
+    // RFC1918 private
+    ['10.1.2.3', true],
+    ['172.16.5.5', true],
+    ['192.168.1.1', true],
+    // link-local (cloud metadata) + carrier-grade NAT
+    ['169.254.169.254', true],
+    ['100.64.0.1', true],
+    // alternate encodings normalize before matching
+    ['2130706433', true], // decimal form of 127.0.0.1
+    // IPv6 internal + IPv4-mapped loopback
+    ['::1', true],
+    ['fe80::1', true],
+    ['fc00::1', true],
+    ['::ffff:127.0.0.1', true],
+    // unparsable / empty fail closed
+    ['', true],
+    ['not-an-ip', true],
+    // public unicast is allowed
+    ['8.8.8.8', false],
+    ['1.1.1.1', false],
+    ['142.250.80.46', false],
+    ['2606:4700:4700::1111', false],
+    ['2001:4860:4860::8888', false],
+  ])('classifies %s as blocked=%s', (ip, blocked) => {
+    expect(isBlockedIP(ip)).toBe(blocked);
+  });
+});
+
+describe('ssrfSafeAgentFactory', () => {
+  const http = require('http');
+  const https = require('https');
+  const url = (str) => new URL(str);
+
+  it('throws for non-http(s) protocols', () => {
+    expect(() => ssrfSafeAgentFactory(url('ftp://example.com'))).toThrow(
+      'invalid protocol, only http and https are supported',
+    );
+  });
+
+  it.each([
+    'http://127.0.0.1:9090/health', // the redirect-target exploit
+    'http://169.254.169.254/latest/meta-data/', // cloud metadata
+    'https://10.0.0.5/internal',
+    'http://192.168.1.1/admin',
+    'http://[::1]/', // IPv6 literal (brackets stripped)
+    'http://[::ffff:127.0.0.1]/', // bracketed IPv4-mapped loopback (strip + unwrap)
+    'http://2130706433/', // decimal-encoded loopback
+  ])('blocks literal internal address %s', (target) => {
+    expect(() => ssrfSafeAgentFactory(url(target))).toThrow(
+      'blocked request to non-public address',
+    );
+  });
+
+  it('returns the https agent for public https URLs', () => {
+    expect(ssrfSafeAgentFactory(url('https://example.com/api'))).toBeInstanceOf(https.Agent);
+  });
+
+  it('returns the http agent for public http URLs', () => {
+    expect(ssrfSafeAgentFactory(url('http://8.8.8.8/api'))).toBeInstanceOf(http.Agent);
+  });
+
+  it('defers hostname validation to DNS lookup (does not throw for names)', () => {
+    expect(() => ssrfSafeAgentFactory(url('https://example.com/api'))).not.toThrow();
+  });
+
+  it('returns a stable agent instance across calls (per scheme)', () => {
+    const a = ssrfSafeAgentFactory(url('https://a.example.com'));
+    const b = ssrfSafeAgentFactory(url('https://b.example.com'));
+    expect(a).toBe(b);
   });
 });

--- a/src/util/utils.test.js
+++ b/src/util/utils.test.js
@@ -9,12 +9,11 @@ jest.mock('dns', () => ({
 }));
 
 // BLOCK_IP_RANGES is additive on top of the always-on core. Set it before utils
-// is required (the denylist is built at module load) to exercise the
-// config-appended ranges. The core ranges (loopback, metadata, unspecified,
-// link-local) are deliberately omitted here, so the cases that rely on them also
-// prove the core blocks with no configuration.
-process.env.BLOCK_IP_RANGES =
-  '10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,100.64.0.0/10,fc00::/7,255.255.255.255/32';
+// is required (the denylist is built at module load) to a range that is NOT in
+// the core (198.18.0.0/15), so it proves the config-appended path. The private/
+// loopback/metadata ranges are already in the core and are asserted without any
+// configuration below.
+process.env.BLOCK_IP_RANGES = '198.18.0.0/15';
 process.env.BLOCK_HOST_NAMES = 'blocked.example.com';
 
 const fetch = require('node-fetch');
@@ -277,6 +276,8 @@ describe('isBlockedIP', () => {
     ['fe80::1', true],
     ['fc00::1', true],
     ['::ffff:127.0.0.1', true],
+    // added via BLOCK_IP_RANGES (additive, not in the always-on core)
+    ['198.18.0.1', true],
     // unparsable / empty fail closed
     ['', true],
     ['not-an-ip', true],

--- a/test/__tests__/user_transformation.test.js
+++ b/test/__tests__/user_transformation.test.js
@@ -232,14 +232,14 @@ describe("User transformation", () => {
     const jsonResponse = { type: "json" };
     const textResponse = "200 OK";
     when(fetch)
-      .calledWith(dummyUrl, expect.objectContaining({ agent: expect.any(Object) }))
+      .calledWith(dummyUrl, expect.objectContaining({ agent: expect.any(Function) }))
       .mockResolvedValueOnce(getfetchResponse(jsonResponse, dummyUrl))
       .mockResolvedValueOnce(getfetchResponse(textResponse, dummyUrl))
       .mockRejectedValue(new Error("Timed Out"));
 
     const output = await userTransformHandler(inputData, versionId, []);
     expect(fetch).toHaveBeenCalledWith(transformerUrl);
-    expect(fetch).toHaveBeenCalledWith(dummyUrl, expect.objectContaining({ agent: expect.any(Object) }));
+    expect(fetch).toHaveBeenCalledWith(dummyUrl, expect.objectContaining({ agent: expect.any(Function) }));
 
     expect(output[0].transformedEvent.body).toEqual(jsonResponse);
     expect(output[1].transformedEvent.body).toEqual(textResponse);
@@ -277,14 +277,14 @@ describe("User transformation", () => {
     const jsonResponse = { type: "json" };
     const textResponse = "200 OK";
     when(fetch)
-      .calledWith(dummyUrl, expect.objectContaining({ agent: expect.any(Object) }))
+      .calledWith(dummyUrl, expect.objectContaining({ agent: expect.any(Function) }))
       .mockResolvedValueOnce(getfetchResponse(jsonResponse, dummyUrl))
       .mockResolvedValueOnce(getfetchResponse(textResponse, dummyUrl))
       .mockRejectedValue(new Error("Timed Out"));
 
     const output = await userTransformHandler(inputData, versionId, []);
     expect(fetch).toHaveBeenCalledWith(transformerUrl);
-    expect(fetch).toHaveBeenCalledWith(dummyUrl, expect.objectContaining({ agent: expect.any(Object) }));
+    expect(fetch).toHaveBeenCalledWith(dummyUrl, expect.objectContaining({ agent: expect.any(Function) }));
 
     expect(output[0].transformedEvent.body).toEqual(jsonResponse);
     expect(output[1].transformedEvent.body).toEqual(textResponse);
@@ -1373,7 +1373,7 @@ describe("User transformation with IVM cache", () => {
     const jsonResponse = { type: "json" };
     const textResponse = "200 OK";
     when(fetch)
-      .calledWith(dummyUrl, expect.objectContaining({ agent: expect.any(Object) }))
+      .calledWith(dummyUrl, expect.objectContaining({ agent: expect.any(Function) }))
       .mockResolvedValueOnce(getfetchResponse(jsonResponse, dummyUrl))
       .mockResolvedValueOnce(getfetchResponse(textResponse, dummyUrl))
       .mockRejectedValueOnce(new Error("Timed Out"))
@@ -1384,7 +1384,7 @@ describe("User transformation with IVM cache", () => {
 
     const output = await userTransformHandler(inputData, versionId, []);
     expect(fetch).toHaveBeenCalledWith(transformerUrl);
-    expect(fetch).toHaveBeenCalledWith(dummyUrl, expect.objectContaining({ agent: expect.any(Object) }));
+    expect(fetch).toHaveBeenCalledWith(dummyUrl, expect.objectContaining({ agent: expect.any(Function) }));
 
     expect(output[0].transformedEvent.body).toEqual(jsonResponse);
     expect(output[1].transformedEvent.body).toEqual(textResponse);
@@ -1393,7 +1393,7 @@ describe("User transformation with IVM cache", () => {
     // Should get the same output when using cached isolate vm
     const outputCached = await userTransformHandler(inputData, versionId, []);
     expect(fetch).toHaveBeenCalledWith(transformerUrl);
-    expect(fetch).toHaveBeenCalledWith(dummyUrl, expect.objectContaining({ agent: expect.any(Object) }));
+    expect(fetch).toHaveBeenCalledWith(dummyUrl, expect.objectContaining({ agent: expect.any(Function) }));
     
     expect(outputCached[0].transformedEvent.body).toEqual(jsonResponse);
     expect(outputCached[1].transformedEvent.body).toEqual(textResponse);
@@ -2432,7 +2432,7 @@ describe("User transformation with IVM cache TTL expiration", () => {
     const jsonResponse = { type: "json" };
     const textResponse = "200 OK";
     when(fetch)
-      .calledWith(dummyUrl, expect.objectContaining({ agent: expect.any(Object) }))
+      .calledWith(dummyUrl, expect.objectContaining({ agent: expect.any(Function) }))
       // First execution (cache miss)
       .mockResolvedValueOnce(getfetchResponse(jsonResponse, dummyUrl))
       .mockResolvedValueOnce(getfetchResponse(textResponse, dummyUrl))

--- a/test/__tests__/user_transformation_fetch.test.js
+++ b/test/__tests__/user_transformation_fetch.test.js
@@ -127,11 +127,14 @@ describe("User transformation fetch tests", () => {
       }
       `
     };
-    const errMsg = "invalid url, localhost requests are not allowed";
-    
+    // localhost is a name now (no fast-path); it resolves then the IP-layer guard blocks the loopback result.
+    const errMsg =
+      "request to http://localhost:1000/dummyUrl failed, reason: cannot use 127.0.0.1 as IP address for localhost";
+
+    mockResolver.mockResolvedValue([{ address: '127.0.0.1', ttl: 300 }]);
     const output = await userTransformHandler(inputData, versionId, [], trRevCode, true);
-    
-    expect(mockResolver).toHaveBeenCalledTimes(0);
+
+    expect(mockResolver).toHaveBeenCalledTimes(inputData.length);
     output.transformedEvents.forEach(ev => {
       expect(ev.errMsg).toEqual(errMsg);
     });
@@ -233,9 +236,11 @@ describe("User transformation fetch tests", () => {
     };
     const errMsg = "ERROR";
 
+    // localhost is a name now (no fast-path) so it is resolved before the loopback result is blocked.
+    mockResolver.mockResolvedValue([{ address: '127.0.0.1', ttl: 300 }]);
     const output = await userTransformHandler(inputData, versionId, [], trRevCode, true);
-    
-    expect(mockResolver).toHaveBeenCalledTimes(0);
+
+    expect(mockResolver).toHaveBeenCalledTimes(inputData.length);
     output.transformedEvents.forEach(ev => {
       expect(ev.errMsg).toEqual(errMsg);
     });
@@ -284,10 +289,11 @@ describe("User transformation fetch tests", () => {
         }
       `
     };
-    const errMsg = "invalid url, localhost requests are not allowed";
-    
+    // IP literal is blocked up front by the agent factory; no DNS lookup happens.
+    const errMsg = "blocked request to non-public address: 127.0.0.1";
+
     const output = await userTransformHandler(inputData, versionId, [], trRevCode, true);
-    
+
     expect(mockResolver).toHaveBeenCalledTimes(0);
     output.transformedEvents.forEach(ev => {
       expect(ev.errMsg).toEqual(errMsg);
@@ -408,9 +414,11 @@ describe("User transformation fetch tests with IVM Cache", () => {
     };
     const errMsg = "ERROR";
     customTransformStore.getTransformationCode.mockResolvedValue(trRevCode);
+    // localhost is a name now (no fast-path) so it is resolved before the loopback result is blocked.
+    mockResolver.mockResolvedValue([{ address: '127.0.0.1', ttl: 300 }]);
     const output = await userTransformHandler(inputData, versionId, []);
-    
-    expect(mockResolver).toHaveBeenCalledTimes(0);
+
+    expect(mockResolver).toHaveBeenCalledTimes(inputData.length);
     output.forEach(ev => {
       expect(ev.transformedEvent.errMsg).toEqual(errMsg);
     });
@@ -465,10 +473,11 @@ describe("User transformation fetch tests with IVM Cache", () => {
         }
       `
     };
-    const errMsg = "invalid url, localhost requests are not allowed";
+    // IP literal is blocked up front by the agent factory; no DNS lookup happens.
+    const errMsg = "blocked request to non-public address: 127.0.0.1";
     customTransformStore.getTransformationCode.mockResolvedValue(trRevCode);
     const output = await userTransformHandler(inputData, versionId, []);
-    
+
     expect(mockResolver).toHaveBeenCalledTimes(0);
     output.forEach(ev => {
       expect(ev.transformedEvent.errMsg).toEqual(errMsg);

--- a/test/mocks/user_transformation/utils/test-helpers.ts
+++ b/test/mocks/user_transformation/utils/test-helpers.ts
@@ -117,14 +117,15 @@ export class TestEnvironment {
     this.originalEnv = {
       CONFIG_BACKEND_URL: process.env.CONFIG_BACKEND_URL,
       ENABLE_FUNCTIONS: process.env.ENABLE_FUNCTIONS,
-      ALLOW_LOCALHOST_FETCH: process.env.ALLOW_LOCALHOST_FETCH,
+      ALLOW_IP_RANGES: process.env.ALLOW_IP_RANGES,
     };
 
     // Set environment variables to point to mock servers
     process.env.CONFIG_BACKEND_URL = this.configBackend.getBaseUrl();
     process.env.ENABLE_FUNCTIONS = 'true';
     process.env.MOCK_EXTERNAL_API_URL = this.externalApiServer.getBaseUrl();
-    process.env.ALLOW_LOCALHOST_FETCH = 'true';
+    // Mock servers bind to 127.0.0.1; allow loopback through the SSRF guard.
+    process.env.ALLOW_IP_RANGES = '127.0.0.0/8,::1/128';
 
     console.log(`[TestEnvironment] Setup complete:`);
     console.log(`  - Config Backend: ${this.configBackend.getBaseUrl()}`);


### PR DESCRIPTION
## What & why

User-transformation `fetch`/`fetchV2` (sandboxed user JS) could be used for **SSRF to internal services / cloud metadata**:

1. **Redirect bypass (reported):** a request to an external URL that returns a `3xx` redirect to an internal address (e.g. `http://127.0.0.1:9090`) was followed **unchecked** — only the *initial* URL was validated.
2. **Literal-IP bypass (root cause):** the shared agent's DNS `lookup` guard (`isBlockedIP`) **never runs for IP-literal hosts**, because `net.connect` skips DNS resolution for numeric hosts. So `http://127.0.0.1`, `http://169.254.169.254`, etc. bypassed the guard on the initial request *and* every redirect hop.

## The fix

- `fetchOptions.agent` is now a **per-hop factory** (`ssrfSafeAgentFactory`). node-fetch invokes it for the initial request **and every redirect hop** — the single SSRF choke point.
  - **IP-literal hosts** are validated up front (covers literals on the initial request and on redirects).
  - **Hostnames** fall through to the lookup-enabled agent, which validates the *resolved* IP at connect time (covers DNS rebinding).
- `isBlockedIP` is now an **`ipaddr.js` CIDR check** (was `startsWith('127.') || '0.0.0.0'`), unwrapping IPv4-mapped IPv6 and failing closed on unparseable input:
  - **Always-on, secure-by-default core** (`BLOCKED_CIDRS`): loopback, unspecified, broadcast, link-local incl. `169.254.169.254` metadata, **RFC1918 private, CGNAT `100.64/10`, IPv6 ULA `fc00::/7` (incl. AWS IPv6 IMDS `fd00:ec2::254`)** — v4 and v6.
  - **`BLOCK_IP_RANGES`** (env, additive) — append further ranges.
  - **`ALLOW_IP_RANGES`** (env) — explicit exceptions; allow wins over block.

## ⚠️ Breaking changes / operational notes

- **`ALLOW_LOCALHOST_FETCH` removed** → use `ALLOW_IP_RANGES=127.0.0.0/8` (the test harness already migrated).
- **Error text changed** for internal-address fetches: `blocked request to non-public address: <ip>` (literal) / `cannot use <ip> as IP address for <host>` (DNS).
- **Secure-by-default:** private/internal ranges (RFC1918, CGNAT, IPv6 ULA, metadata, loopback, etc.) are now **blocked by default**. Deployments that legitimately fetch internal hosts from a transformation must allow them via `ALLOW_IP_RANGES` (clear, recoverable error otherwise). This protects self-hosted/OSS installs, which have no network-layer egress policy; managed deployments keep their Cilium egress policy as defense-in-depth.

## Tests

- `src/util/utils.test.js` — factory / lookup / `isBlockedIP` (secure-by-default core, additive `BLOCK_IP_RANGES`, mapped-v6 unwrap, encodings, bracket-strip).
- `src/util/utils.allowlist.test.js` — `ALLOW_IP_RANGES` precedence (allow-over-block, core still applies).
- `src/util/utils.ssrf-redirect.test.js` — **real `node-fetch`** 302→internal is blocked; redirect to an allowed target still works (guards against reverting `agent` to a static instance).
- `test/__tests__/user_transformation_fetch.test.js` — assertions aligned to new behavior.

## Review

Reviewed via multi-agent adversarial review (SSRF-bypass, IP-encoding, node-fetch/redirect, logic, regression, tests, concurrency, completeness lenses + reproduce/refute verification) plus a cloud review. Confirmed: original exploit closed, DNS-rebinding blocked, literal/encoded localhost+metadata blocked, no regression to `fetch.js`/`network.js`/geolocation. `fetchWithProxy` (config/tracking-plan fetches) is server-side with a fixed config-backend host and is not reachable from the sandbox — out of scope.

## Related infra follow-up (separate repo)

Managed deployments block metadata + RFC1918 at L3/L4 via Cilium, but **CGNAT `100.64.0.0/10` is missing from the egress `except:` list** (EKS VPC-CNI pods sit there). Recommend adding `100.64.0.0/10` to `egress_ip_exceptions` in `rudderstack-operator`/`operator-helm`, and setting subchart defaults so self-hosted charts get the policy.

> Note: pre-commit hook skipped locally (`esbuild` not installed in dev env); affected unit + CI fetch suites run green (79/79). Full suite runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
