### PR TITLE
fix(zoho): prevent COQL injection in legacy deletion lookup

### DIFF
--- a/src/cdk/v2/destinations/zoho/utils.test.ts
+++ b/src/cdk/v2/destinations/zoho/utils.test.ts
@@ -104,6 +104,46 @@ describe('searchRecordIdV2', () => {
   };
   const mockQuery = "SELECT id FROM Leads WHERE Email = 'test@example.com'";
 
+  // Many-field identifier payload used to exercise the recursive AND grouping. Every key is
+  // mapped as an identifier below so the allowlist keeps them all (see identifierMappings override).
+  const multiRecordIdentifierFields = {
+    Name: 'rid1927ce14265c006ae11555ec6e1cdbbac',
+    Name1: 'Liam Bailey',
+    Has_Chargeback: true,
+    Last_Client_Purchase: '2021-06-15T00:00:00Z',
+    Purchase_Category: ['category1', 'category2'],
+    Lifetime_Client_Revenue: 1200,
+    Name2: 'Olivia Smith',
+    Has_Chargeback2: false,
+    Last_Client_Purchase2: '2022-01-10T00:00:00Z',
+    Purchase_Category2: ['category3', 'category4'],
+    Lifetime_Client_Revenue2: 800,
+    Name3: 'Noah Johnson',
+    Has_Chargeback3: true,
+    Last_Client_Purchase3: '2023-03-22T00:00:00Z',
+    Purchase_Category3: ['category5'],
+    Lifetime_Client_Revenue3: 1500,
+    Name4: 'Emma Davis',
+    Has_Chargeback4: false,
+    Last_Client_Purchase4: '2023-07-01T00:00:00Z',
+    Purchase_Category4: ['category6', 'category7'],
+    Lifetime_Client_Revenue4: 900,
+    Name5: 'James Wilson',
+    Has_Chargeback5: true,
+    Last_Client_Purchase5: '2022-11-05T00:00:00Z',
+    Purchase_Category5: ['category8'],
+    Lifetime_Client_Revenue5: 1100,
+    Name6: 'Sophia Miller',
+    Has_Chargeback6: false,
+    Last_Client_Purchase6: '2024-01-12T00:00:00Z',
+    Purchase_Category6: ['category9', 'category10'],
+    Lifetime_Client_Revenue6: 1300,
+  };
+  const multiRecordIdentifierMappings = Object.keys(multiRecordIdentifierFields).map((field) => ({
+    from: field,
+    to: field,
+  }));
+
   beforeEach(() => {
     jest.clearAllMocks();
   });
@@ -221,39 +261,8 @@ describe('searchRecordIdV2', () => {
       },
     },
     {
-      fields: {
-        Name: 'rid1927ce14265c006ae11555ec6e1cdbbac',
-        Name1: 'Liam Bailey',
-        Has_Chargeback: true,
-        Last_Client_Purchase: '2021-06-15T00:00:00Z',
-        Purchase_Category: ['category1', 'category2'],
-        Lifetime_Client_Revenue: 1200,
-        Name2: 'Olivia Smith',
-        Has_Chargeback2: false,
-        Last_Client_Purchase2: '2022-01-10T00:00:00Z',
-        Purchase_Category2: ['category3', 'category4'],
-        Lifetime_Client_Revenue2: 800,
-        Name3: 'Noah Johnson',
-        Has_Chargeback3: true,
-        Last_Client_Purchase3: '2023-03-22T00:00:00Z',
-        Purchase_Category3: ['category5'],
-        Lifetime_Client_Revenue3: 1500,
-        Name4: 'Emma Davis',
-        Has_Chargeback4: false,
-        Last_Client_Purchase4: '2023-07-01T00:00:00Z',
-        Purchase_Category4: ['category6', 'category7'],
-        Lifetime_Client_Revenue4: 900,
-        Name5: 'James Wilson',
-        Has_Chargeback5: true,
-        Last_Client_Purchase5: '2022-11-05T00:00:00Z',
-        Purchase_Category5: ['category8'],
-        Lifetime_Client_Revenue5: 1100,
-        Name6: 'Sophia Miller',
-        Has_Chargeback6: false,
-        Last_Client_Purchase6: '2024-01-12T00:00:00Z',
-        Purchase_Category6: ['category9', 'category10'],
-        Lifetime_Client_Revenue6: 1300,
-      },
+      fields: multiRecordIdentifierFields,
+      identifierMappings: multiRecordIdentifierMappings,
       module: mockConConfig.destination.object,
       query:
         "SELECT id FROM Leads WHERE ((Name = 'rid1927ce14265c006ae11555ec6e1cdbbac' AND Name1 = 'Liam Bailey') AND ((Has_Chargeback = 'true' AND Last_Client_Purchase = '2021-06-15T00:00:00Z') AND ((Purchase_Category = 'category1;category2' AND Lifetime_Client_Revenue = 1200) AND ((Name2 = 'Olivia Smith' AND Has_Chargeback2 = 'false') AND ((Last_Client_Purchase2 = '2022-01-10T00:00:00Z' AND Purchase_Category2 = 'category3;category4') AND ((Lifetime_Client_Revenue2 = 800 AND Name3 = 'Noah Johnson') AND ((Has_Chargeback3 = 'true' AND Last_Client_Purchase3 = '2023-03-22T00:00:00Z') AND ((Purchase_Category3 = 'category5' AND Lifetime_Client_Revenue3 = 1500) AND ((Name4 = 'Emma Davis' AND Has_Chargeback4 = 'false') AND ((Last_Client_Purchase4 = '2023-07-01T00:00:00Z' AND Purchase_Category4 = 'category6;category7') AND ((Lifetime_Client_Revenue4 = 900 AND Name5 = 'James Wilson') AND ((Has_Chargeback5 = 'true' AND Last_Client_Purchase5 = '2022-11-05T00:00:00Z') AND Purchase_Category5 = 'category8'))))))))))))",
@@ -303,7 +312,7 @@ describe('searchRecordIdV2', () => {
     },
   ];
 
-  testCases.forEach(({ name, response, error, expected, query, fields }) => {
+  testCases.forEach(({ name, response, error, expected, query, fields, identifierMappings }) => {
     it(name, async () => {
       if (error) {
         jest.mocked(handleHttpRequest).mockRejectedValueOnce(error);
@@ -315,7 +324,10 @@ describe('searchRecordIdV2', () => {
         identifiers: fields,
         metadata: mockMetadata,
         destination: { Config: mockConfig } as unknown as Destination,
-        destConfig: mockConConfig.destination,
+        destConfig: {
+          ...mockConConfig.destination,
+          identifierMappings: identifierMappings ?? mockConConfig.destination.identifierMappings,
+        },
       });
       expect(handleHttpRequest).toHaveBeenCalledWith(
         'post',
@@ -378,6 +390,82 @@ describe('searchRecordIdV2', () => {
       });
       expect(result).toEqual(expected);
     });
+  });
+});
+
+/**
+ * COQL injection defenses for the legacy single-event deletion path (INT-6478 / SEC-292).
+ *
+ * Identifier keys AND values from `event.message.identifiers` are user-controlled. These tests
+ * verify the two defenses that close the injection:
+ *   1. string/array VALUES are escaped so a quote cannot break out of the string literal, and
+ *   2. KEYS are allowlisted against the configured identifierMappings so an attacker-controlled
+ *      key cannot be interpolated into the clause.
+ */
+describe('searchRecordIdV2 - COQL injection defenses', () => {
+  const mockMetadata = { secret: { accessToken: 'mock-token' } };
+  const mockConfig = { region: 'US' as const };
+  const destConfig = {
+    object: 'Leads',
+    identifierMappings: [{ to: 'Email', from: 'Email' }],
+    multiSelectFieldLevelDecision: [],
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.mocked(handleHttpRequest).mockResolvedValue({
+      httpResponse: Promise.resolve({}),
+      processedResponse: {
+        status: 200,
+        response: { data: [{ id: '<RECORD_ID>' }] },
+      },
+    } as never);
+  });
+
+  const getSentQuery = () =>
+    (jest.mocked(handleHttpRequest).mock.calls[0][2] as { select_query: string }).select_query;
+
+  it('escapes single quotes in identifier values so they cannot break out of the string literal', async () => {
+    // SEC-292 PoC payload: without escaping this matches every record in the module.
+    await searchRecordIdV2({
+      identifiers: { Email: "x' OR id IS NOT NULL OR id != '" },
+      metadata: mockMetadata,
+      destination: { Config: mockConfig } as unknown as Destination,
+      destConfig,
+    });
+
+    // The quotes are backslash-escaped, so the value stays a single inert string literal.
+    expect(getSentQuery()).toBe(
+      "SELECT id FROM Leads WHERE Email = 'x\\' OR id IS NOT NULL OR id != \\''",
+    );
+  });
+
+  it('drops an identifier key that is not in the configured identifierMappings', async () => {
+    const result = await searchRecordIdV2({
+      identifiers: { "Email = 'x' OR 1=1 OR Email": 'ignored' },
+      metadata: mockMetadata,
+      destination: { Config: mockConfig } as unknown as Destination,
+      destConfig,
+    });
+
+    // Only key is not an allowlisted identifier -> no query is built and no request is sent.
+    expect(handleHttpRequest).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      status: false,
+      message: 'Identifier values are not provided for Leads',
+      errorType: 'instrumentation',
+    });
+  });
+
+  it('keeps only allowlisted keys when a payload mixes a valid and an injected key', async () => {
+    await searchRecordIdV2({
+      identifiers: { Email: 'real@example.com', "Foo = 'x' OR Email": 'x' },
+      metadata: mockMetadata,
+      destination: { Config: mockConfig } as unknown as Destination,
+      destConfig,
+    });
+
+    expect(getSentQuery()).toBe("SELECT id FROM Leads WHERE Email = 'real@example.com'");
   });
 });
 

--- a/src/cdk/v2/destinations/zoho/utils.ts
+++ b/src/cdk/v2/destinations/zoho/utils.ts
@@ -194,31 +194,51 @@ const groupConditionsWithOR = (conditions: string[]) => {
 };
 
 /**
+ * Escapes a value for safe interpolation inside a single-quoted COQL string literal.
+ * Escapes backslashes first, then single quotes, so attacker-controlled identifier values
+ * cannot break out of the quoted context and inject additional COQL.
+ *
+ * @param {unknown} value - The value to escape
+ * @returns {string} The escaped string, safe to place between single quotes
+ */
+const escapeCOQLStringValue = (value: unknown): string =>
+  String(value).replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+
+/**
  * Generates a WHERE clause for COQL queries from field-value pairs.
  * Handles different data types (strings, numbers, arrays) according to Zoho COQL syntax.
  * Cleans input by removing undefined, null, and empty values.
  *
+ * Keys are allowlisted against the configured identifier fields and string/array values are
+ * escaped, so neither side of `key = 'value'` can be used to inject COQL.
+ *
  * @param {Record<string, unknown>} fields - Field-value pairs to convert to WHERE conditions
+ * @param {string[]} allowedFields - Configured identifier field names; keys not in this list are dropped
  * @returns {string} WHERE clause with nested AND conditions, or empty string if no valid fields
  * @see https://help.zoho.com/portal/en/kb/creator/developer-guide/forms/add-and-manage-fields/articles/understand-fields#Types_of_fields
  * @see https://www.zoho.com/crm/developer/docs/api/v6/Get-Records-through-COQL-Query.html
  *
  * @example
- * generateWhereClause({ Email: 'test@example.com', Phone: '123' })
+ * generateWhereClause({ Email: 'test@example.com', Phone: '123' }, ['Email', 'Phone'])
  * // Returns: "WHERE (Email = 'test@example.com' AND Phone = '123')"
  */
-const generateWhereClause = (fields: Record<string, unknown>) => {
+const generateWhereClause = (fields: Record<string, unknown>, allowedFields: string[]) => {
   const cleanedFields = removeUndefinedNullEmptyExclBoolInt(fields) as Record<string, unknown>;
-  const conditions = Object.keys(cleanedFields).map((key) => {
-    const value = cleanedFields[key];
-    if (Array.isArray(value)) {
-      return `${key} = '${value.join(';')}'`;
-    }
-    if (typeof value === 'number') {
-      return `${key} = ${value}`;
-    }
-    return `${key} = '${value}'`;
-  });
+  const allowedFieldSet = new Set(allowedFields);
+  const conditions = Object.keys(cleanedFields)
+    // Only allow configured identifier fields through; an attacker-controlled key (e.g.
+    // "Email = 'x' OR 1=1 OR Email") is never interpolated into the query.
+    .filter((key) => allowedFieldSet.has(key))
+    .map((key) => {
+      const value = cleanedFields[key];
+      if (Array.isArray(value)) {
+        return `${key} = '${escapeCOQLStringValue(value.join(';'))}'`;
+      }
+      if (typeof value === 'number') {
+        return `${key} = ${value}`;
+      }
+      return `${key} = '${escapeCOQLStringValue(value)}'`;
+    });
 
   return conditions.length > 0 ? `WHERE ${groupConditions(conditions)}` : '';
 };
@@ -229,17 +249,22 @@ const generateWhereClause = (fields: Record<string, unknown>) => {
  *
  * @param {string} module - Zoho module name (e.g., 'Leads', 'Contacts')
  * @param {Record<string, unknown>} fields - Identifier field-value pairs
+ * @param {string[]} allowedFields - Configured identifier field names used to allowlist keys
  * @returns {string} Complete COQL query string or empty string if no valid WHERE clause
  *
  * @example
- * generateSqlQuery('Leads', { Email: 'test@example.com', Phone: '123' })
+ * generateSqlQuery('Leads', { Email: 'test@example.com', Phone: '123' }, ['Email', 'Phone'])
  * // Returns: "SELECT id FROM Leads WHERE (Email = 'test@example.com' AND Phone = '123')"
  */
-const generateSqlQuery = (module: string, fields: Record<string, unknown>) => {
+const generateSqlQuery = (
+  module: string,
+  fields: Record<string, unknown>,
+  allowedFields: string[],
+) => {
   // Generate the WHERE clause based on the fields
   // Limiting to 25 fields
   const entries = Object.entries(fields).slice(0, 25);
-  const whereClause = generateWhereClause(Object.fromEntries(entries));
+  const whereClause = generateWhereClause(Object.fromEntries(entries), allowedFields);
   if (whereClause === '') {
     return '';
   }
@@ -333,9 +358,11 @@ const searchRecordIdV2 = async ({
 > => {
   try {
     const region = getRegion(destination);
-    const { object } = destConfig;
+    const { object, identifierMappings } = destConfig;
 
-    const selectQuery = generateSqlQuery(object, identifiers);
+    // Allowlist of configured identifier fields; any other key in `identifiers` is dropped.
+    const allowedFields = identifierMappings.map(({ to }) => to);
+    const selectQuery = generateSqlQuery(object, identifiers, allowedFields);
     const result = await sendCOQLRequest(region, metadata.secret.accessToken, object, selectQuery);
     return result;
   } catch (error: any) {
@@ -442,8 +469,8 @@ const buildBatchedCOQLQueryWithIN = (
       .map((v) => {
         // Numbers don't need quotes
         if (typeof v === 'number') return v;
-        // Escape backslashes first, then single quotes
-        return `'${String(v).replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`;
+        // Escape backslashes and single quotes to prevent breaking out of the string literal
+        return `'${escapeCOQLStringValue(v)}'`;
       })
       .join(', ');
 

--- a/test/integrations/destinations/zoho/network.ts
+++ b/test/integrations/destinations/zoho/network.ts
@@ -257,6 +257,32 @@ export const networkCallsData = [
     },
   },
   {
+    // COQL injection regression: this mock only matches the *escaped* query.
+    // The single quotes from the identifier value are backslash-escaped, keeping them inside the
+    // string literal instead of breaking out into `OR id IS NOT NULL ...`.
+    httpReq: {
+      url: 'https://www.zohoapis.in/crm/v6/coql',
+      headers: {
+        Authorization: 'Zoho-oauthtoken correct-access-token',
+      },
+      data: {
+        select_query: "SELECT id FROM Leads WHERE Email = 'x\\' OR id IS NOT NULL OR id != \\''",
+      },
+      method: 'POST',
+    },
+    httpRes: {
+      data: {
+        data: [
+          {
+            id: '<ESCAPED_LOOKUP_RECORD_ID>',
+          },
+        ],
+      },
+      status: 200,
+      statusText: 'OK',
+    },
+  },
+  {
     httpReq: {
       url: 'https://www.zohoapis.in/crm/v6/coql',
       headers: {

--- a/test/integrations/destinations/zoho/router/data.ts
+++ b/test/integrations/destinations/zoho/router/data.ts
@@ -1,6 +1,13 @@
 import { upsertData } from './upsert';
 import { deleteData } from './deletion';
 import { deleteDataBatch } from './deletionBatch';
+import { identifierEscapingData } from './identifierEscaping';
 import { accountTestData } from './account';
 
-export const data = [...upsertData, ...deleteData, ...deleteDataBatch, ...accountTestData];
+export const data = [
+  ...upsertData,
+  ...deleteData,
+  ...deleteDataBatch,
+  ...identifierEscapingData,
+  ...accountTestData,
+];

--- a/test/integrations/destinations/zoho/router/identifierEscaping.ts
+++ b/test/integrations/destinations/zoho/router/identifierEscaping.ts
@@ -1,0 +1,108 @@
+import { defaultMockFns } from '../mocks';
+import { commonDeletionDestConfig, commonDeletionConnectionConfigV2, destType } from '../common';
+
+// Regression guard for the COQL injection issue (INT-6478 / SEC-292).
+//
+// A user-controlled identifier value containing a single quote must be escaped before it is
+// interpolated into the COQL WHERE clause, so it cannot break out of the string literal and
+// match unintended records. The network mock only matches the *escaped* query string, so if the
+// escaping regresses the transformer would emit the raw (unsafe) query, the mock would miss, and
+// this test would fail.
+export const identifierEscapingData = [
+  {
+    name: destType,
+    id: 'zoho_identifier_escaping_injection',
+    description:
+      'escapes single quotes in identifier values so a deletion lookup cannot break out of the COQL string literal',
+    feature: 'router',
+    module: 'destination',
+    version: 'v0',
+    input: {
+      request: {
+        body: {
+          input: [
+            {
+              message: {
+                action: 'delete',
+                context: {
+                  sources: {
+                    job_run_id: 'cgiiurt8um7k7n5dq480',
+                    task_run_id: 'cgiiurt8um7k7n5dq48g',
+                    job_id: '2MUWghI7u85n91dd1qzGyswpZan',
+                    version: '895/merge',
+                  },
+                },
+                recordId: '2',
+                rudderId: '2',
+                identifiers: {
+                  // Injection payload: without escaping this becomes
+                  //   WHERE Email = 'x' OR id IS NOT NULL OR id != ''
+                  // which matches every record in the module.
+                  Email: "x' OR id IS NOT NULL OR id != '",
+                },
+                fields: {
+                  First_Name: 'subcribed',
+                  Last_Name: ' User',
+                },
+                type: 'record',
+              },
+              metadata: {
+                jobId: 1,
+                userId: 'u1',
+                secret: {
+                  accessToken: 'correct-access-token',
+                },
+              },
+              destination: commonDeletionDestConfig,
+              connection: commonDeletionConnectionConfigV2,
+            },
+          ],
+          destType,
+        },
+        method: 'POST',
+      },
+    },
+    output: {
+      response: {
+        status: 200,
+        body: {
+          output: [
+            {
+              batchedRequest: {
+                version: '1',
+                type: 'REST',
+                method: 'DELETE',
+                endpoint:
+                  'https://www.zohoapis.in/crm/v6/Leads?ids=<ESCAPED_LOOKUP_RECORD_ID>&wf_trigger=false',
+                headers: {
+                  Authorization: 'Zoho-oauthtoken correct-access-token',
+                },
+                params: {},
+                body: {
+                  JSON: {},
+                  JSON_ARRAY: {},
+                  XML: {},
+                  FORM: {},
+                },
+                files: {},
+              },
+              metadata: [
+                {
+                  jobId: 1,
+                  userId: 'u1',
+                  secret: {
+                    accessToken: 'correct-access-token',
+                  },
+                },
+              ],
+              batched: true,
+              statusCode: 200,
+              destination: commonDeletionDestConfig,
+            },
+          ],
+        },
+      },
+    },
+    mockFns: defaultMockFns,
+  },
+];


### PR DESCRIPTION
🔒 Scanned for secrets using gitleaks 8.28.0

## What are the changes introduced in this PR?

Fixes a COQL injection vulnerability in the Zoho **legacy single-event deletion** path. `searchRecordIdV2` built the COQL `WHERE` clause by interpolating both keys and values from `event.message.identifiers` (untrusted input) directly into the query string, with no escaping or allowlisting. The matched record IDs then flow into a `DELETE ...?ids=` request, so a crafted identifier could match unintended records.

Two complementary defenses, mirroring the patterns already used in the safe batched path (`buildBatchedCOQLQueryWithIN`):

- **Value escaping** — added a shared `escapeCOQLStringValue` helper (escapes backslash, then single-quote) applied to string/array values in `generateWhereClause`, so a value cannot break out of its string literal. The batched path's inline copy was refactored to reuse this helper.
- **Key allowlisting** — `generateWhereClause`/`generateSqlQuery` now take an `allowedFields` list; `searchRecordIdV2` passes the configured `identifierMappings` field names. Identifier keys not in the mapping are dropped, so an attacker-controlled key can't be injected into the clause. If all keys drop, the query is empty and the existing "Identifier values are not provided" instrumentation error fires.

Both are required: escaping closes value-side injection; allowlisting closes key-side injection (which escaping alone cannot).

**Tests**
- Unit (`utils.test.ts`): value quote escaped; non-mapped key dropped; mixed payload keeps only allowlisted keys.
- Integration: new regression fixture `router/identifierEscaping.ts` whose network mock matches **only the escaped query** — any escaping regression makes the mock miss and fails the test.

Verified: 62 unit + 28 integration tests pass; lint clean.

## What is the related Linear task?

Resolves INT-6478

## Please explain the objectives of your changes below

Close the injection on the default deletion codepath with a minimal, low-risk change. Numeric values were already safe (`typeof value === 'number'`). No existing fixtures needed changes — real deletion traffic uses allowlisted identifiers with plain values, so escaping/allowlisting are no-ops for legitimate events.

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

Identifier keys not present in the destination's configured `identifierMappings` are now dropped from the deletion lookup query (previously they were interpolated as-is). This is a no-op for legitimate traffic, where identifiers are built from that same mapping.

### Any new dependencies introduced with this change?

N/A

### Any new generic utility introduced or modified. Please explain the changes.

Added `escapeCOQLStringValue` (module-local to the Zoho destination) to centralize COQL string-literal escaping; reused by both the legacy and batched query builders.

### Any technical or performance related pointers to consider with the change?

Follow-up (separate ticket): evaluate routing all workspaces through the safe batched path via `DEST_ZOHO_DELETION_BATCHING_SUPPORTED_WORKSPACE_IDS` and deprecating the legacy path. Optional defense-in-depth raised: capping deletions per event and a dropped-key metric.

@coderabbitai review

<hr>

### Developer checklist

- [ ] My code follows the style guidelines of this project

- [ ] **No breaking changes are being introduced.**

- [ ] All related docs linked with the PR?

- [ ] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [ ] Is the PR limited to 10 file changes?

- [ ] Is the PR limited to one linear task?

- [ ] Are relevant unit and component test-cases added in **new readability format**?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.
