### PR TITLE
chore(klaviyo): migrate destination to TypeScript

### DIFF
--- a/memory-bank/23_js_to_ts_migration.md
+++ b/memory-bank/23_js_to_ts_migration.md
@@ -38,14 +38,16 @@ Functions from .js files will infer as 'any' - that's acceptable
 Many JS utility functions (`constructPayload`, `flattenJson`, etc.) return `{} | null` per TS inference. The original JS code never validates these returns — it trusts them non-null and would crash on the next access if not. Migration must preserve that trust.
 
 ❌ WRONG: Adding `if (!x) throw new TransformationError(...)` just to satisfy TS
-   - This changes the runtime error type (TransformationError vs the JS TypeError).
-   - It's defensive code the original didn't have — a refactor.
+
+- This changes the runtime error type (TransformationError vs the JS TypeError).
+- It's defensive code the original didn't have — a refactor.
 
 ✅ RIGHT: Use the non-null assertion `!`
+
 ```typescript
 let propertyPayload = constructPayload(message, MAPPING_CONFIG[category.name])!;
 attributes.properties = constructPayload(message.properties, MAPPING_CONFIG[categ.name])!;
-attributes.properties!.items = itemArr;  // mirrors original JS's implicit non-null trust
+attributes.properties!.items = itemArr; // mirrors original JS's implicit non-null trust
 ```
 
 `!` is a type-only assertion (no runtime check) — it tells TS "trust this is non-null" without changing behavior. The original JS already trusts this implicitly.
@@ -55,6 +57,7 @@ attributes.properties!.items = itemArr;  // mirrors original JS's implicit non-n
 If `constructPayload(...)` returns `{}` and you want to assign it to a `Record<string, unknown>` slot, do NOT do this:
 
 ❌ WRONG:
+
 ```typescript
 const target: { items?: unknown[]; [key: string]: unknown } = {};
 Object.assign(target, constructPayload(...));
@@ -113,7 +116,7 @@ let x: {
   batchedRequest: ReqConfig[];
   metadata?: unknown[];
   destination?: unknown;
-} = { batchedRequest: Object.values(initial) };  // same Object.values call as original
+} = { batchedRequest: Object.values(initial) }; // same Object.values call as original
 // ... rest of the function is byte-identical to original
 ```
 
@@ -254,13 +257,13 @@ const items: {
 ### Nullable Returns - Use Non-Null Assertion, NOT Fallback Operators or Validation
 
 ❌ WRONG: `const payload = constructPayload(traits, mappingJson) || {};`
-  (Fallback operator silently swallows the null case, changes runtime behavior.)
+(Fallback operator silently swallows the null case, changes runtime behavior.)
 
 ❌ WRONG: `if (!payload) throw new TransformationError(...)`
-  (Defensive code the original didn't have. Changes the error type vs the original JS TypeError.)
+(Defensive code the original didn't have. Changes the error type vs the original JS TypeError.)
 
 ✅ RIGHT: `const payload = constructPayload(traits, mappingJson)!;`
-  (Type-only assertion. Preserves original JS's implicit non-null trust. See critical principle #6.)
+(Type-only assertion. Preserves original JS's implicit non-null trust. See critical principle #6.)
 
 ### CRITICAL - Preserve Original JavaScript Behavior
 
@@ -480,10 +483,11 @@ getUserId(message, headers, baseEndpoint, undefined, metadata);
    Example: npm run test:ts -- src/cdk/v2/destinations/zoho
 
 10. ⚠️ No behavioral changes - Compare with original .js file side-by-side. The migrated `.ts` body should be byte-near-identical except for:
+
     - Type annotations
     - `require → import`, `module.exports → export`
     - `!` non-null assertions on JS-returned values
-    No `Object.assign` rewrites, no `if-throw` additions, no merging of two-statement assignments into one, no array literal substitutions for `Object.values`.
+      No `Object.assign` rewrites, no `if-throw` additions, no merging of two-statement assignments into one, no array literal substitutions for `Object.values`.
 
 11. ✅ Build passes: npm run build:ci
 

--- a/memory-bank/23_js_to_ts_migration.md
+++ b/memory-bank/23_js_to_ts_migration.md
@@ -10,10 +10,12 @@ Goal: Make minimal changes for successful migration while maintaining type safet
 
 Your ONLY job is to add TypeScript types. DO NOT change runtime behavior or refactor.
 
-### #2: ABSOLUTELY NO TYPECASTING
+### #2: NO `as` TYPECASTING
 
 ❌ FORBIDDEN: "as" assertions (as any, as unknown, as string, etc.)
 ✅ INSTEAD: Use proper type declarations, progressive refinement, or let JS imports infer as 'any'
+
+✅ ALLOWED: Non-null assertion `!` (see #6 below) and `as const` in tests
 
 ### #3: Progressive Type Refinement
 
@@ -30,6 +32,92 @@ Let TypeScript errors guide you to add ONLY the structure needed.
 ### #5: DO NOT create types for JavaScript imports
 
 Functions from .js files will infer as 'any' - that's acceptable
+
+### #6: PREFER `!` OVER if-throw VALIDATION
+
+Many JS utility functions (`constructPayload`, `flattenJson`, etc.) return `{} | null` per TS inference. The original JS code never validates these returns — it trusts them non-null and would crash on the next access if not. Migration must preserve that trust.
+
+❌ WRONG: Adding `if (!x) throw new TransformationError(...)` just to satisfy TS
+   - This changes the runtime error type (TransformationError vs the JS TypeError).
+   - It's defensive code the original didn't have — a refactor.
+
+✅ RIGHT: Use the non-null assertion `!`
+```typescript
+let propertyPayload = constructPayload(message, MAPPING_CONFIG[category.name])!;
+attributes.properties = constructPayload(message.properties, MAPPING_CONFIG[categ.name])!;
+attributes.properties!.items = itemArr;  // mirrors original JS's implicit non-null trust
+```
+
+`!` is a type-only assertion (no runtime check) — it tells TS "trust this is non-null" without changing behavior. The original JS already trusts this implicitly.
+
+### #7: NO `Object.assign` AS A TYPE-NARROWING WORKAROUND
+
+If `constructPayload(...)` returns `{}` and you want to assign it to a `Record<string, unknown>` slot, do NOT do this:
+
+❌ WRONG:
+```typescript
+const target: { items?: unknown[]; [key: string]: unknown } = {};
+Object.assign(target, constructPayload(...));
+attributes.properties = target;
+```
+
+This is structurally a refactor — it changes the object reference and copy semantics — and obscures the original direct assignment. It is forbidden under #1 (Migration ≠ Refactoring).
+
+✅ RIGHT: Declare the local variable's type widely enough to accept the JS function's return directly, with optional fields and (where needed) an index signature:
+
+```typescript
+let attributes: {
+  metric?: unknown;
+  properties?: { items?: unknown[] };
+  profile?: unknown;
+  value?: unknown;
+  time?: unknown;
+} = {};
+attributes.properties = constructPayload(...)!;       // direct, like the original
+attributes.properties!.items = itemArr;               // mirrors original mutation
+attributes = constructPayload(...)!;                  // direct replacement, like JS
+```
+
+### #8: HANDLING `{} | null` RETURNS FROM JS FUNCTIONS
+
+JS functions like `constructPayload` are typed as returning `{} | null` by TS inference (because they `return null` in one branch and `return payload` (an empty `{}`-typed object literal) in the other). This causes two recurring problems:
+
+1. **`null` in the union** — handle with `!` (see #6). Do not add `if-throw` checks.
+2. **`{}` lacks an index signature** — so it can't be directly assigned to `Record<string, unknown>` or a typed slot with an index signature.
+
+Resolution rules (in priority order):
+
+- Declare the receiving variable's type so the structural assignment works directly. Use a literal type with `?:` optional fields and (only where a numeric or dynamic key is mutated, e.g., `attributes.properties.items = ...`) an inner shape like `{ items?: unknown[] }`.
+- Use `!` to strip the `null` from the union at the assignment site.
+- DO NOT use `as` to coerce.
+- DO NOT use `any` for the receiving variable.
+- DO NOT use `Object.assign` to copy properties into a wider-typed object.
+- DO NOT add `if-throw` validation (see #6).
+
+### #9: RUNTIME MUTATION PATTERNS THAT TS CANNOT EXPRESS
+
+Some original JS patterns mutate a property's runtime shape in ways strict TS cannot model — e.g.:
+
+```javascript
+let x = defaultBatchRequestConfig();        // { batchedRequest: ReqConfig }
+x.batchedRequest = Object.values(x);        // batchedRequest is now ReqConfig[]
+x.batchedRequest[0].body.JSON = ...;        // array access
+```
+
+Here the property's type genuinely changes object → array. There is no `any`/`as`/`Object.assign`-free way to express this. The minimal acceptable adaptation is to introduce ONE helper local that lets you type the final shape from the start, while still using `Object.values` exactly as the original did:
+
+```typescript
+const initial = defaultBatchRequestConfig();
+type ReqConfig = typeof initial.batchedRequest;
+let x: {
+  batchedRequest: ReqConfig[];
+  metadata?: unknown[];
+  destination?: unknown;
+} = { batchedRequest: Object.values(initial) };  // same Object.values call as original
+// ... rest of the function is byte-identical to original
+```
+
+This is a SCOPED exception to #1 — use it only when the property's runtime type genuinely mutates and no typed declaration can accept both forms. The output object is bit-identical to the original.
 
 ═══════════════════════════════════════════════════════════════════════════
 
@@ -163,14 +251,16 @@ const items: {
 - Changes to source type automatically propagate
 - TypeScript can catch incompatibilities
 
-### Nullable Returns - Use Validation, NOT Fallback Operators
+### Nullable Returns - Use Non-Null Assertion, NOT Fallback Operators or Validation
 
-❌ WRONG: const payload = constructPayload(traits, mappingJson) || {};
-✅ RIGHT: const payload = constructPayload(traits, mappingJson);
-if (!payload) {
-throw new TransformationError('Failed to construct payload');
-}
-Note: Use TransformationError (5xx) for new errors, not InstrumentationError (4xx)
+❌ WRONG: `const payload = constructPayload(traits, mappingJson) || {};`
+  (Fallback operator silently swallows the null case, changes runtime behavior.)
+
+❌ WRONG: `if (!payload) throw new TransformationError(...)`
+  (Defensive code the original didn't have. Changes the error type vs the original JS TypeError.)
+
+✅ RIGHT: `const payload = constructPayload(traits, mappingJson)!;`
+  (Type-only assertion. Preserves original JS's implicit non-null trust. See critical principle #6.)
 
 ### CRITICAL - Preserve Original JavaScript Behavior
 
@@ -369,25 +459,32 @@ getUserId(message, headers, baseEndpoint, undefined, metadata);
 1. ❌ Search for " as " - If found, verify it's ONLY:
 
    - "as const" for literal types in tests
-   - "as any" for unavoidable edge cases (must be justified)
-   - Type assertions from JS import returns
-     All other "as" usages are WRONG!
+   - Import aliases (`import { x as y }`)
+     All other "as" usages are WRONG! (No `as Record<...>`, `as any`, `as unknown`, etc.)
 
-2. ❌ Search for "any" - If found outside catch blocks, use unknown instead.
+2. ❌ Search for "any" - If found outside catch blocks, use unknown or a wider typed declaration. Never `: any`.
 
 3. ❌ Search for "@ts-expect-error" or "@ts-ignore" - Fix the root cause instead.
 
-4. ✅ Arrays properly typed (string[] not unknown[] when appropriate)
+4. ❌ Search for `Object.assign(` - If found and used to coerce a JS function's return into a typed slot, replace with a wider local-variable type and direct assignment (see critical principle #7).
 
-5. ✅ Functions from .js imports left untyped (let them infer as 'any')
+5. ❌ Search for `new TransformationError(` introduced in the migration - If you added it to guard a nullable JS function return, replace with `!` (see critical principle #6). Only keep it if the original code already threw an error in the same path.
 
-6. ✅ All test files migrated - Check for remaining .test.js files
+6. ✅ Arrays properly typed (string[] not unknown[] when appropriate)
 
-7. ✅ All tests pass: npm run test:ts -- path/to/migrated/files
+7. ✅ Functions from .js imports left untyped (let them infer as 'any')
+
+8. ✅ All test files migrated - Check for remaining .test.js files
+
+9. ✅ All tests pass: npm run test:ts -- path/to/migrated/files
    Example: npm run test:ts -- src/cdk/v2/destinations/zoho
 
-8. ⚠️ No behavioral changes - Compare with original .js file side-by-side
+10. ⚠️ No behavioral changes - Compare with original .js file side-by-side. The migrated `.ts` body should be byte-near-identical except for:
+    - Type annotations
+    - `require → import`, `module.exports → export`
+    - `!` non-null assertions on JS-returned values
+    No `Object.assign` rewrites, no `if-throw` additions, no merging of two-statement assignments into one, no array literal substitutions for `Object.values`.
 
-9. ✅ Build passes: npm run build:ci
+11. ✅ Build passes: npm run build:ci
 
-10. ✅ Original .js files deleted after successful migration
+12. ✅ Original .js files deleted after successful migration

--- a/src/v0/destinations/klaviyo/batchUtil.test.ts
+++ b/src/v0/destinations/klaviyo/batchUtil.test.ts
@@ -1,10 +1,9 @@
-const { OperatorType } = require('@rudderstack/json-template-engine');
-const {
+import {
   groupSubscribeResponsesUsingListIdV2,
   populateArrWithRespectiveProfileData,
   generateBatchedSubscriptionRequest,
-} = require('./batchUtil');
-const { revision } = require('./config');
+} from './batchUtil';
+import { revision } from './config';
 
 describe('groupSubscribeResponsesUsingListIdV2', () => {
   // Groups subscription responses by listId correctly

--- a/src/v0/destinations/klaviyo/batchUtil.ts
+++ b/src/v0/destinations/klaviyo/batchUtil.ts
@@ -1,8 +1,8 @@
-const lodash = require('lodash');
-const { defaultRequestConfig, getSuccessRespEvents, isDefinedAndNotNull } = require('../../util');
-const { JSON_MIME_TYPE } = require('../../util/constant');
-const { BASE_ENDPOINT, CONFIG_CATEGORIES, MAX_BATCH_SIZE, revision } = require('./config');
-const { buildRequest, getSubscriptionPayload } = require('./util');
+import lodash from 'lodash';
+import { defaultRequestConfig, getSuccessRespEvents, isDefinedAndNotNull } from '../../util';
+import { JSON_MIME_TYPE } from '../../util/constant';
+import { BASE_ENDPOINT, CONFIG_CATEGORIES, MAX_BATCH_SIZE, revision } from './config';
+import { buildRequest, getSubscriptionPayload } from './util';
 
 /**
  * This function groups the subscription responses on list id
@@ -32,7 +32,7 @@ const generateBatchedSubscriptionRequest = (subscription, destination) => {
   const subscriptionPayloadResponse = defaultRequestConfig();
   const { privateApiKey } = destination.Config;
   // fetching listId from first event as listId is same for all the events
-  const profiles = []; // list of profiles to be subscribed
+  const profiles: unknown[] = []; // list of profiles to be subscribed
   const { listId, subscriptionProfileList, operation } = subscription;
   subscriptionProfileList.forEach((profileList) => profiles.push(...profileList));
   subscriptionPayloadResponse.body.JSON = getSubscriptionPayload(listId, profiles, operation);
@@ -91,7 +91,7 @@ const populateArrWithRespectiveProfileData = (
 
 /**
  * This function generates the final output batched payload for each object in profileSubscriptionAndMetadataArr
- * ex: 
+ * ex:
  * profileSubscriptionAndMetadataArr = [
       {
         subscription: { subscriptionProfileList, listId1, operation },
@@ -107,14 +107,14 @@ const populateArrWithRespectiveProfileData = (
         profiles: [respectiveProfiles for above metadata with no subscription]
       }
   ]
- * @param {*} profileSubscriptionAndMetadataArr 
- * @param {*} destination 
- * @returns 
+ * @param {*} profileSubscriptionAndMetadataArr
+ * @param {*} destination
+ * @returns
  */
 const buildProfileAndSubscriptionRequests = (profileSubscriptionAndMetadataArr, destination) => {
-  const finalResponseList = [];
+  const finalResponseList: unknown[] = [];
   profileSubscriptionAndMetadataArr.forEach((profileSubscriptionData) => {
-    const batchedRequest = [];
+    const batchedRequest: unknown[] = [];
     // we are keeping profiles request prior to subscription ones as first profile creation and then subscription should happen
     if (profileSubscriptionData.profiles?.length > 0) {
       batchedRequest.push(...getProfileRequests(profileSubscriptionData.profiles, destination));
@@ -184,7 +184,7 @@ const updateArrWithSubscriptions = (
  * @returns
  */
 const batchRequestV2 = (subscribeList, unsubscribeList, profilesList, destination) => {
-  const profileSubscriptionAndMetadataArr = [];
+  const profileSubscriptionAndMetadataArr: unknown[] = [];
   const metaDataIndexMap = new Map();
   updateArrWithSubscriptions(
     subscribeList,
@@ -205,7 +205,7 @@ const batchRequestV2 = (subscribeList, unsubscribeList, profilesList, destinatio
     metaDataIndexMap,
     profilesList,
   );
-  /* Till this point I have a profileSubscriptionAndMetadataArr 
+  /* Till this point I have a profileSubscriptionAndMetadataArr
   containing the the events in one object for which batching has to happen in following format
   [
       {
@@ -229,11 +229,11 @@ const batchRequestV2 = (subscribeList, unsubscribeList, profilesList, destinatio
     [
       [2 calls for identify with batching],
       [1 call identify calls with batching]
-    ] 
+    ]
   */
 };
 
-module.exports = {
+export {
   groupSubscribeResponsesUsingListIdV2,
   populateArrWithRespectiveProfileData,
   generateBatchedSubscriptionRequest,

--- a/src/v0/destinations/klaviyo/config.ts
+++ b/src/v0/destinations/klaviyo/config.ts
@@ -1,4 +1,4 @@
-const { getMappingConfig } = require('../../util');
+import { getMappingConfig } from '../../util';
 
 const BASE_ENDPOINT = 'https://a.klaviyo.com';
 
@@ -47,13 +47,13 @@ const ecomExclusionKeys = [
 ];
 
 const ecomEvents = ['product viewed', 'product clicked', 'product added', 'checkout started'];
-const eventNameMapping = {
+const eventNameMapping: Record<string, string> = {
   'product viewed': 'Viewed Product',
   'product clicked': 'Viewed Product',
   'product added': 'Added to Cart',
   'checkout started': 'Started Checkout',
 };
-const jsonNameMapping = {
+const jsonNameMapping: Record<string, string> = {
   'Viewed Product': 'VIEWED_PRODUCT',
   'Added to Cart': 'ADDED_TO_CART',
   'Started Checkout': 'STARTED_CHECKOUT',
@@ -94,7 +94,7 @@ const destType = 'klaviyo';
 // api version used
 const revision = '2024-10-15';
 
-module.exports = {
+export {
   BASE_ENDPOINT,
   MAX_BATCH_SIZE,
   CONFIG_CATEGORIES,

--- a/src/v0/destinations/klaviyo/klaviyoUtil.test.ts
+++ b/src/v0/destinations/klaviyo/klaviyoUtil.test.ts
@@ -1,4 +1,4 @@
-const { addSubscribeFlagToTraits } = require('./util');
+import { addSubscribeFlagToTraits, getProfileMetadataAndMetadataFields } from './util';
 
 describe('addSubscribeFlagToTraits', () => {
   // The function should add a 'subscribe' property to the 'properties' object if it exists in the input 'traitsInfo'.
@@ -154,8 +154,6 @@ describe('addSubscribeFlagToTraits', () => {
     expect(result.properties.subscribe).toBe(true);
   });
 });
-
-const { getProfileMetadataAndMetadataFields } = require('./util');
 
 describe('getProfileMetadataAndMetadataFields', () => {
   // Correctly generates metadata with fields to unset, append, and unappend when all fields are provided

--- a/src/v0/destinations/klaviyo/transform.ts
+++ b/src/v0/destinations/klaviyo/transform.ts
@@ -2,11 +2,7 @@
 /* eslint-disable no-underscore-dangle */
 /* eslint-disable  array-callback-return */
 import get from 'get-value';
-import {
-  ConfigurationError,
-  InstrumentationError,
-  TransformationError,
-} from '@rudderstack/integrations-lib';
+import { ConfigurationError, InstrumentationError } from '@rudderstack/integrations-lib';
 import { EventType, WhiteListedTraits, MappedToDestinationKey } from '../../../constants';
 import {
   CONFIG_CATEGORIES,
@@ -72,10 +68,7 @@ const identifyRequestHandler = async (
     traitsInfo = addSubscribeFlagToTraits(traitsInfo);
   }
 
-  let propertyPayload = constructPayload(message, MAPPING_CONFIG[category.name]);
-  if (!propertyPayload) {
-    throw new TransformationError('Failed to construct identify payload');
-  }
+  let propertyPayload = constructPayload(message, MAPPING_CONFIG[category.name])!;
   // Extract other K-V property from traits about user custom properties
   let customPropertyPayload = {};
   customPropertyPayload = extractCustomFields(
@@ -96,7 +89,7 @@ const identifyRequestHandler = async (
       _id: getFieldValueFromMessage(message, 'userId'),
     };
   }
-  const data: { type: string; attributes: { [key: string]: unknown } } = {
+  const data: any = {
     type: 'profile',
     attributes: {
       ...propertyPayload,
@@ -172,33 +165,20 @@ const identifyRequestHandler = async (
 // ----------------------
 
 const trackRequestHandler = (message, category, destination) => {
-  const payload: { properties?: unknown; data?: unknown } = {};
+  const payload: any = {};
   const { privateApiKey, flattenProperties } = destination.Config;
   let event = get(message, 'event');
   if (event && typeof event !== 'string') {
     throw new InstrumentationError('Event type should be a string');
   }
   event = event ? event.trim().toLowerCase() : event;
-  let attributes: {
-    metric?: unknown;
-    properties?: { items?: unknown[]; [key: string]: unknown };
-    profile?: unknown;
-    customProperties?: unknown;
-    value?: unknown;
-    time?: unknown;
-  } = {};
+  let attributes: any = {};
   if (ecomEvents.includes(event) && message.properties) {
     const eventName = eventNameMapping[event];
     const eventMap = jsonNameMapping[eventName];
     attributes.metric = { name: eventName };
     const categ = CONFIG_CATEGORIES[eventMap];
-    const ecomPayload = constructPayload(message.properties, MAPPING_CONFIG[categ.name]);
-    if (!ecomPayload) {
-      throw new TransformationError('Failed to construct ecom event properties payload');
-    }
-    const ecomProperties: { items?: unknown[]; [key: string]: unknown } = {};
-    Object.assign(ecomProperties, ecomPayload);
-    attributes.properties = ecomProperties;
+    attributes.properties = constructPayload(message.properties, MAPPING_CONFIG[categ.name]);
 
     // products mapping using Items.json
     // mapping properties.items to payload.properties.items and using properties.products as a fallback to properties.items
@@ -244,22 +224,15 @@ const trackRequestHandler = (message, category, destination) => {
   } else {
     const value =
       message.properties?.revenue || message.properties?.total || message.properties?.value;
-    const trackPayload = constructPayload(message, MAPPING_CONFIG[category.name]);
-    if (!trackPayload) {
-      throw new TransformationError('Failed to construct track event attributes payload');
-    }
-    attributes = {};
-    Object.assign(attributes, trackPayload);
+    attributes = constructPayload(message, MAPPING_CONFIG[category.name]);
     if (value) {
       attributes.value = value;
     }
   }
   // if flattenProperties is enabled from UI, flatten the event properties
-  if (flattenProperties) {
-    const flattened: { items?: unknown[]; [key: string]: unknown } = {};
-    Object.assign(flattened, flattenJson(attributes.properties, '.', 'normal', false));
-    attributes.properties = flattened;
-  }
+  attributes.properties = flattenProperties
+    ? flattenJson(attributes.properties, '.', 'normal', false)
+    : attributes.properties;
   // Map user properties to profile object
   attributes.profile = {
     ...createCustomerProperties(message, destination.Config),
@@ -273,7 +246,8 @@ const trackRequestHandler = (message, category, destination) => {
   if (message.timestamp) {
     attributes.time = message.timestamp;
   }
-  payload.data = { type: 'event', attributes };
+  payload.data = { type: 'event' };
+  payload.data.attributes = attributes;
   const response = defaultRequestConfig();
   response.endpoint = `${BASE_ENDPOINT}${category.apiUrl}`;
   response.endpointPath = category.apiUrl;

--- a/src/v0/destinations/klaviyo/transform.ts
+++ b/src/v0/destinations/klaviyo/transform.ts
@@ -1,10 +1,14 @@
 /* eslint-disable no-nested-ternary */
 /* eslint-disable no-underscore-dangle */
 /* eslint-disable  array-callback-return */
-const get = require('get-value');
-const { ConfigurationError, InstrumentationError } = require('@rudderstack/integrations-lib');
-const { EventType, WhiteListedTraits, MappedToDestinationKey } = require('../../../constants');
-const {
+import get from 'get-value';
+import {
+  ConfigurationError,
+  InstrumentationError,
+  TransformationError,
+} from '@rudderstack/integrations-lib';
+import { EventType, WhiteListedTraits, MappedToDestinationKey } from '../../../constants';
+import {
   CONFIG_CATEGORIES,
   BASE_ENDPOINT,
   MAPPING_CONFIG,
@@ -12,9 +16,9 @@ const {
   ecomEvents,
   eventNameMapping,
   jsonNameMapping,
-} = require('./config');
-const { processRouter: processRouterV2, processV2 } = require('./transformV2');
-const {
+} from './config';
+import { processRouter as processRouterV2, processV2 } from './transformV2';
+import {
   createCustomerProperties,
   subscribeUserToList,
   populateCustomFieldsFromTraits,
@@ -22,8 +26,8 @@ const {
   getIdFromNewOrExistingProfile,
   profileUpdateResponseBuilder,
   addSubscribeFlagToTraits,
-} = require('./util');
-const {
+} from './util';
+import {
   defaultRequestConfig,
   constructPayload,
   getFieldValueFromMessage,
@@ -38,8 +42,8 @@ const {
   groupEventsByType,
   flattenJson,
   isNewStatusCodesAccepted,
-} = require('../../util');
-const { JSON_MIME_TYPE, HTTP_STATUS_CODES } = require('../../util/constant');
+} from '../../util';
+import { JSON_MIME_TYPE, HTTP_STATUS_CODES } from '../../util/constant';
 
 /**
  * Main Identify request handler func
@@ -69,6 +73,9 @@ const identifyRequestHandler = async (
   }
 
   let propertyPayload = constructPayload(message, MAPPING_CONFIG[category.name]);
+  if (!propertyPayload) {
+    throw new TransformationError('Failed to construct identify payload');
+  }
   // Extract other K-V property from traits about user custom properties
   let customPropertyPayload = {};
   customPropertyPayload = extractCustomFields(
@@ -89,7 +96,7 @@ const identifyRequestHandler = async (
       _id: getFieldValueFromMessage(message, 'userId'),
     };
   }
-  const data = {
+  const data: { type: string; attributes: { [key: string]: unknown } } = {
     type: 'profile',
     attributes: {
       ...propertyPayload,
@@ -124,7 +131,11 @@ const identifyRequestHandler = async (
     metadata,
   });
 
-  const responseMap = {
+  const responseMap: {
+    profileUpdateResponse: Record<string, unknown>;
+    subscribeUserToListResponse?: unknown;
+    suppressEventResponse?: unknown;
+  } = {
     profileUpdateResponse: profileUpdateResponseBuilder(
       payload,
       profileId,
@@ -161,27 +172,40 @@ const identifyRequestHandler = async (
 // ----------------------
 
 const trackRequestHandler = (message, category, destination) => {
-  const payload = {};
+  const payload: { properties?: unknown; data?: unknown } = {};
   const { privateApiKey, flattenProperties } = destination.Config;
   let event = get(message, 'event');
   if (event && typeof event !== 'string') {
     throw new InstrumentationError('Event type should be a string');
   }
   event = event ? event.trim().toLowerCase() : event;
-  let attributes = {};
+  let attributes: {
+    metric?: unknown;
+    properties?: { items?: unknown[]; [key: string]: unknown };
+    profile?: unknown;
+    customProperties?: unknown;
+    value?: unknown;
+    time?: unknown;
+  } = {};
   if (ecomEvents.includes(event) && message.properties) {
     const eventName = eventNameMapping[event];
     const eventMap = jsonNameMapping[eventName];
     attributes.metric = { name: eventName };
     const categ = CONFIG_CATEGORIES[eventMap];
-    attributes.properties = constructPayload(message.properties, MAPPING_CONFIG[categ.name]);
+    const ecomPayload = constructPayload(message.properties, MAPPING_CONFIG[categ.name]);
+    if (!ecomPayload) {
+      throw new TransformationError('Failed to construct ecom event properties payload');
+    }
+    const ecomProperties: { items?: unknown[]; [key: string]: unknown } = {};
+    Object.assign(ecomProperties, ecomPayload);
+    attributes.properties = ecomProperties;
 
     // products mapping using Items.json
     // mapping properties.items to payload.properties.items and using properties.products as a fallback to properties.items
     // properties.items is to be deprecated soon
     if (message.properties?.products || message.properties?.items) {
       const items = message.properties.items || message.properties.products;
-      const itemArr = [];
+      const itemArr: unknown[] = [];
       if (Array.isArray(items)) {
         items.forEach((key) => {
           let item = constructPayload(key, MAPPING_CONFIG[CONFIG_CATEGORIES.ITEMS.name]);
@@ -220,15 +244,22 @@ const trackRequestHandler = (message, category, destination) => {
   } else {
     const value =
       message.properties?.revenue || message.properties?.total || message.properties?.value;
-    attributes = constructPayload(message, MAPPING_CONFIG[category.name]);
+    const trackPayload = constructPayload(message, MAPPING_CONFIG[category.name]);
+    if (!trackPayload) {
+      throw new TransformationError('Failed to construct track event attributes payload');
+    }
+    attributes = {};
+    Object.assign(attributes, trackPayload);
     if (value) {
       attributes.value = value;
     }
   }
   // if flattenProperties is enabled from UI, flatten the event properties
-  attributes.properties = flattenProperties
-    ? flattenJson(attributes.properties, '.', 'normal', false)
-    : attributes.properties;
+  if (flattenProperties) {
+    const flattened: { items?: unknown[]; [key: string]: unknown } = {};
+    Object.assign(flattened, flattenJson(attributes.properties, '.', 'normal', false));
+    attributes.properties = flattened;
+  }
   // Map user properties to profile object
   attributes.profile = {
     ...createCustomerProperties(message, destination.Config),
@@ -242,8 +273,7 @@ const trackRequestHandler = (message, category, destination) => {
   if (message.timestamp) {
     attributes.time = message.timestamp;
   }
-  payload.data = { type: 'event' };
-  payload.data.attributes = attributes;
+  payload.data = { type: 'event', attributes };
   const response = defaultRequestConfig();
   response.endpoint = `${BASE_ENDPOINT}${category.apiUrl}`;
   response.endpointPath = category.apiUrl;
@@ -284,7 +314,7 @@ const groupRequestHandler = (message, category, destination) => {
 const processEvent = async (event, reqMetadata) => {
   const { message, destination, metadata } = event;
   if (destination.Config?.apiVersion === 'v2') {
-    return processV2(event, reqMetadata);
+    return processV2(event);
   }
   if (!message.type) {
     throw new InstrumentationError('Event type is required');
@@ -341,10 +371,14 @@ const processRouter = async (inputs, reqMetadata) => {
   if (destination.Config?.apiVersion === 'v2') {
     return processRouterV2(inputs, reqMetadata);
   }
-  let batchResponseList = [];
-  const batchErrorRespList = [];
-  const subscribeRespList = [];
-  const nonSubscribeRespList = [];
+  let batchResponseList: unknown[] = [];
+  const batchErrorRespList: unknown[] = [];
+  const subscribeRespList: unknown[] = [];
+  const nonSubscribeRespList: {
+    message: { statusCode?: number; error?: unknown; [key: string]: unknown };
+    metadata: unknown;
+    destination: unknown;
+  }[] = [];
   await Promise.all(
     inputs.map(async (event) => {
       try {
@@ -373,7 +407,7 @@ const processRouter = async (inputs, reqMetadata) => {
       }
     }),
   );
-  const batchedSubscribeResponseList = [];
+  const batchedSubscribeResponseList: unknown[] = [];
   if (subscribeRespList.length > 0) {
     const batchedResponseList = batchSubscribeEvents(subscribeRespList);
     batchedSubscribeResponseList.push(...batchedResponseList);
@@ -416,8 +450,8 @@ const processRouterDest = async (inputs, reqMetadata) => {
   Output after transformation: [1, [2,4], [3,5,6]]
   */
   const inputsGroupedByType = groupEventsByType(inputs);
-  const respList = [];
-  const errList = [];
+  const respList: unknown[] = [];
+  const errList: unknown[] = [];
   await Promise.all(
     inputsGroupedByType.map(async (typedEventList) => {
       const { successEvents, errorEvents } = await processRouter(typedEventList, reqMetadata);
@@ -427,4 +461,4 @@ const processRouterDest = async (inputs, reqMetadata) => {
   );
   return [...respList, ...errList];
 };
-module.exports = { process, processRouterDest };
+export { process, processRouterDest };

--- a/src/v0/destinations/klaviyo/transform.ts
+++ b/src/v0/destinations/klaviyo/transform.ts
@@ -89,7 +89,10 @@ const identifyRequestHandler = async (
       _id: getFieldValueFromMessage(message, 'userId'),
     };
   }
-  const data: any = {
+  const data: {
+    type: string;
+    attributes: { properties?: unknown; [key: string]: unknown };
+  } = {
     type: 'profile',
     attributes: {
       ...propertyPayload,
@@ -165,20 +168,27 @@ const identifyRequestHandler = async (
 // ----------------------
 
 const trackRequestHandler = (message, category, destination) => {
-  const payload: any = {};
+  const payload: { properties?: unknown; data?: { type: string; attributes?: unknown } } = {};
   const { privateApiKey, flattenProperties } = destination.Config;
   let event = get(message, 'event');
   if (event && typeof event !== 'string') {
     throw new InstrumentationError('Event type should be a string');
   }
   event = event ? event.trim().toLowerCase() : event;
-  let attributes: any = {};
+  let attributes: {
+    metric?: unknown;
+    properties?: { items?: unknown[] };
+    profile?: unknown;
+    customProperties?: unknown;
+    value?: unknown;
+    time?: unknown;
+  } = {};
   if (ecomEvents.includes(event) && message.properties) {
     const eventName = eventNameMapping[event];
     const eventMap = jsonNameMapping[eventName];
     attributes.metric = { name: eventName };
     const categ = CONFIG_CATEGORIES[eventMap];
-    attributes.properties = constructPayload(message.properties, MAPPING_CONFIG[categ.name]);
+    attributes.properties = constructPayload(message.properties, MAPPING_CONFIG[categ.name])!;
 
     // products mapping using Items.json
     // mapping properties.items to payload.properties.items and using properties.products as a fallback to properties.items
@@ -199,7 +209,7 @@ const trackRequestHandler = (message, category, destination) => {
         payload.properties = {};
       }
       if (itemArr.length > 0) {
-        attributes.properties.items = itemArr;
+        attributes.properties!.items = itemArr;
       }
     }
 
@@ -224,7 +234,7 @@ const trackRequestHandler = (message, category, destination) => {
   } else {
     const value =
       message.properties?.revenue || message.properties?.total || message.properties?.value;
-    attributes = constructPayload(message, MAPPING_CONFIG[category.name]);
+    attributes = constructPayload(message, MAPPING_CONFIG[category.name])!;
     if (value) {
       attributes.value = value;
     }

--- a/src/v0/destinations/klaviyo/transformV2.ts
+++ b/src/v0/destinations/klaviyo/transformV2.ts
@@ -1,11 +1,15 @@
 /* eslint-disable no-nested-ternary */
 /* eslint-disable no-underscore-dangle */
 /* eslint-disable  array-callback-return */
-const get = require('get-value');
-const { ConfigurationError, InstrumentationError } = require('@rudderstack/integrations-lib');
-const { EventType, MappedToDestinationKey } = require('../../../constants');
-const { CONFIG_CATEGORIES, MAPPING_CONFIG } = require('./config');
-const {
+import get from 'get-value';
+import {
+  ConfigurationError,
+  InstrumentationError,
+  TransformationError,
+} from '@rudderstack/integrations-lib';
+import { EventType, MappedToDestinationKey } from '../../../constants';
+import { CONFIG_CATEGORIES, MAPPING_CONFIG } from './config';
+import {
   constructProfile,
   subscribeOrUnsubscribeUserToListV2,
   buildRequest,
@@ -13,9 +17,9 @@ const {
   getTrackRequests,
   fetchTransformedEvents,
   addSubscribeFlagToTraits,
-} = require('./util');
-const { batchRequestV2 } = require('./batchUtil');
-const {
+} from './util';
+import { batchRequestV2 } from './batchUtil';
+import {
   constructPayload,
   getFieldValueFromMessage,
   removeUndefinedAndNullValues,
@@ -24,7 +28,7 @@ const {
   adduserIdFromExternalId,
   flattenJson,
   isDefinedAndNotNull,
-} = require('../../util');
+} from '../../util';
 
 /**
  * Main Identify request handler func
@@ -48,7 +52,7 @@ const identifyRequestHandler = (message, category, destination) => {
     traitsInfo = addSubscribeFlagToTraits(traitsInfo);
   }
   const payload = removeUndefinedAndNullValues(constructProfile(message, destination, true));
-  const response = { profile: payload };
+  const response: { profile: unknown; subscription?: unknown } = { profile: payload };
   // check if user wants to subscribe/unsubscribe profile or do nothing and listId is present or not
   if (
     isDefinedAndNotNull(traitsInfo?.properties?.subscribe) &&
@@ -81,6 +85,9 @@ const trackOrScreenRequestHandler = (message, category, destination) => {
     throw new InstrumentationError('Event type should be a string');
   }
   const attributes = constructPayload(message, MAPPING_CONFIG[category.name]);
+  if (!attributes) {
+    throw new TransformationError('Failed to construct track/screen event attributes payload');
+  }
 
   // if flattenProperties is enabled from UI, flatten the event properties
   attributes.properties = flattenProperties
@@ -162,7 +169,7 @@ const processEvent = (event) => {
 const processV2 = (event) => {
   const response = processEvent(event);
   const { destination } = event;
-  const respList = [];
+  const respList: unknown[] = [];
   if (response.profile) {
     respList.push(buildRequest(response.profile, destination, CONFIG_CATEGORIES.IDENTIFYV2));
   }
@@ -199,12 +206,12 @@ const getEventChunks = (
 };
 
 const processRouter = (inputs, reqMetadata) => {
-  const batchResponseList = [];
-  const batchErrorRespList = [];
-  const subscribeRespList = [];
-  const unsubscriptionList = [];
-  const profileRespList = [];
-  const eventRespList = [];
+  const batchResponseList: unknown[] = [];
+  const batchErrorRespList: unknown[] = [];
+  const subscribeRespList: unknown[] = [];
+  const unsubscriptionList: unknown[] = [];
+  const profileRespList: unknown[] = [];
+  const eventRespList: unknown[] = [];
   const { destination } = inputs[0];
   inputs.map((event) => {
     try {
@@ -242,4 +249,4 @@ const processRouter = (inputs, reqMetadata) => {
   return { successEvents: batchResponseList, errorEvents: batchErrorRespList };
 };
 
-module.exports = { processV2, processRouter };
+export { processV2, processRouter };

--- a/src/v0/destinations/klaviyo/transformV2.ts
+++ b/src/v0/destinations/klaviyo/transformV2.ts
@@ -2,11 +2,7 @@
 /* eslint-disable no-underscore-dangle */
 /* eslint-disable  array-callback-return */
 import get from 'get-value';
-import {
-  ConfigurationError,
-  InstrumentationError,
-  TransformationError,
-} from '@rudderstack/integrations-lib';
+import { ConfigurationError, InstrumentationError } from '@rudderstack/integrations-lib';
 import { EventType, MappedToDestinationKey } from '../../../constants';
 import { CONFIG_CATEGORIES, MAPPING_CONFIG } from './config';
 import {
@@ -84,10 +80,7 @@ const trackOrScreenRequestHandler = (message, category, destination) => {
   if (event && typeof event !== 'string') {
     throw new InstrumentationError('Event type should be a string');
   }
-  const attributes = constructPayload(message, MAPPING_CONFIG[category.name]);
-  if (!attributes) {
-    throw new TransformationError('Failed to construct track/screen event attributes payload');
-  }
+  const attributes = constructPayload(message, MAPPING_CONFIG[category.name])!;
 
   // if flattenProperties is enabled from UI, flatten the event properties
   attributes.properties = flattenProperties

--- a/src/v0/destinations/klaviyo/util.ts
+++ b/src/v0/destinations/klaviyo/util.ts
@@ -238,7 +238,13 @@ const populateCustomFieldsFromTraits = (message) => {
 };
 
 const generateBatchedPaylaodForArray = (events) => {
-  let batchEventResponse: any = defaultBatchRequestConfig();
+  const initialBatchEventResponse = defaultBatchRequestConfig();
+  type ReqConfig = typeof initialBatchEventResponse.batchedRequest;
+  let batchEventResponse: {
+    batchedRequest: ReqConfig[];
+    metadata?: unknown[];
+    destination?: unknown;
+  } = { batchedRequest: Object.values(initialBatchEventResponse) };
   const batchResponseList: { data: { attributes: { subscriptions: unknown[] } } }[] = [];
   const metadata: unknown[] = [];
   // extracting destination from the first event in a batch
@@ -255,7 +261,6 @@ const generateBatchedPaylaodForArray = (events) => {
     metadata.push(ev.metadata);
   });
 
-  batchEventResponse.batchedRequest = Object.values(batchEventResponse);
   batchEventResponse.batchedRequest[0].body.JSON = {
     data: batchResponseList[0].data,
   };

--- a/src/v0/destinations/klaviyo/util.ts
+++ b/src/v0/destinations/klaviyo/util.ts
@@ -1,11 +1,7 @@
 import set from 'set-value';
 import lodash from 'lodash';
 import { parsePhoneNumberFromString } from 'libphonenumber-js';
-import {
-  NetworkError,
-  InstrumentationError,
-  TransformationError,
-} from '@rudderstack/integrations-lib';
+import { NetworkError, InstrumentationError } from '@rudderstack/integrations-lib';
 import { WhiteListedTraits } from '../../../constants';
 import {
   constructPayload,
@@ -213,10 +209,7 @@ const createCustomerProperties = (message, Config) => {
   let customerProperties = constructPayload(
     message,
     MAPPING_CONFIG[CONFIG_CATEGORIES.PROFILE.name],
-  );
-  if (!customerProperties) {
-    throw new TransformationError('Failed to construct customer properties payload');
-  }
+  )!;
   if (!enforceEmailAsPrimary) {
     customerProperties.$id = getFieldValueFromMessage(message, 'userId');
   } else {
@@ -245,13 +238,7 @@ const populateCustomFieldsFromTraits = (message) => {
 };
 
 const generateBatchedPaylaodForArray = (events) => {
-  const initialBatchEventResponse = defaultBatchRequestConfig();
-  type RequestConfig = typeof initialBatchEventResponse.batchedRequest;
-  let batchEventResponse: {
-    batchedRequest: RequestConfig[];
-    metadata?: unknown[];
-    destination?: unknown;
-  } = { batchedRequest: Object.values(initialBatchEventResponse) };
+  let batchEventResponse: any = defaultBatchRequestConfig();
   const batchResponseList: { data: { attributes: { subscriptions: unknown[] } } }[] = [];
   const metadata: unknown[] = [];
   // extracting destination from the first event in a batch
@@ -268,6 +255,7 @@ const generateBatchedPaylaodForArray = (events) => {
     metadata.push(ev.metadata);
   });
 
+  batchEventResponse.batchedRequest = Object.values(batchEventResponse);
   batchEventResponse.batchedRequest[0].body.JSON = {
     data: batchResponseList[0].data,
   };
@@ -452,10 +440,7 @@ const constructProfile = (message, destination, isIdentifyCall) => {
   const profileAttributes = constructPayload(
     message,
     MAPPING_CONFIG[CONFIG_CATEGORIES.PROFILEV2.name],
-  );
-  if (!profileAttributes) {
-    throw new TransformationError('Failed to construct profile attributes payload');
-  }
+  )!;
   if (
     isDefinedAndNotNull(profileAttributes.phone_number) &&
     !isValidE164PhoneNumber(profileAttributes.phone_number)

--- a/src/v0/destinations/klaviyo/util.ts
+++ b/src/v0/destinations/klaviyo/util.ts
@@ -1,9 +1,13 @@
-const set = require('set-value');
-const lodash = require('lodash');
-const { parsePhoneNumberFromString } = require('libphonenumber-js');
-const { NetworkError, InstrumentationError } = require('@rudderstack/integrations-lib');
-const { WhiteListedTraits } = require('../../../constants');
-const {
+import set from 'set-value';
+import lodash from 'lodash';
+import { parsePhoneNumberFromString } from 'libphonenumber-js';
+import {
+  NetworkError,
+  InstrumentationError,
+  TransformationError,
+} from '@rudderstack/integrations-lib';
+import { WhiteListedTraits } from '../../../constants';
+import {
   constructPayload,
   getFieldValueFromMessage,
   defaultPostRequestConfig,
@@ -17,20 +21,20 @@ const {
   getDestinationExternalID,
   getIntegrationsObj,
   defaultRequestConfig,
-} = require('../../util');
-const tags = require('../../util/tags');
-const { handleHttpRequest } = require('../../../adapters/network');
-const { JSON_MIME_TYPE, HTTP_STATUS_CODES } = require('../../util/constant');
-const { getDynamicErrorType } = require('../../../adapters/utils/networkUtils');
-const {
+} from '../../util';
+import tags from '../../util/tags';
+import { handleHttpRequest } from '../../../adapters/network';
+import { JSON_MIME_TYPE, HTTP_STATUS_CODES } from '../../util/constant';
+import { getDynamicErrorType } from '../../../adapters/utils/networkUtils';
+import {
   BASE_ENDPOINT,
   MAPPING_CONFIG,
   CONFIG_CATEGORIES,
   MAX_BATCH_SIZE,
   WhiteListedTraitsV2,
   revision,
-} = require('./config');
-const logger = require('../../../logger');
+} from './config';
+import logger from '../../../logger';
 
 const REVISION_CONSTANT = '2023-02-22';
 
@@ -150,14 +154,14 @@ const subscribeUserToList = (message, traitsInfo, destination) => {
   const { privateApiKey, consent } = destination.Config;
   let { listId } = destination.Config;
   const targetUrl = `${BASE_ENDPOINT}/api/profile-subscription-bulk-create-jobs`;
-  const subscriptionObj = {
+  const subscriptionObj: Record<string, unknown> = {
     email: getFieldValueFromMessage(message, 'email'),
     phone_number: getFieldValueFromMessage(message, 'phone'),
   };
 
   if (traitsInfo?.properties?.consent || consent) {
     const subscribeConsent = traitsInfo?.properties?.consent || consent;
-    const channels = {};
+    const channels: Record<string, string[]> = {};
 
     let subscribeConsentArr = subscribeConsent;
     if (!Array.isArray(subscribeConsentArr)) {
@@ -210,6 +214,9 @@ const createCustomerProperties = (message, Config) => {
     message,
     MAPPING_CONFIG[CONFIG_CATEGORIES.PROFILE.name],
   );
+  if (!customerProperties) {
+    throw new TransformationError('Failed to construct customer properties payload');
+  }
   if (!enforceEmailAsPrimary) {
     customerProperties.$id = getFieldValueFromMessage(message, 'userId');
   } else {
@@ -238,9 +245,15 @@ const populateCustomFieldsFromTraits = (message) => {
 };
 
 const generateBatchedPaylaodForArray = (events) => {
-  let batchEventResponse = defaultBatchRequestConfig();
-  const batchResponseList = [];
-  const metadata = [];
+  const initialBatchEventResponse = defaultBatchRequestConfig();
+  type RequestConfig = typeof initialBatchEventResponse.batchedRequest;
+  let batchEventResponse: {
+    batchedRequest: RequestConfig[];
+    metadata?: unknown[];
+    destination?: unknown;
+  } = { batchedRequest: Object.values(initialBatchEventResponse) };
+  const batchResponseList: { data: { attributes: { subscriptions: unknown[] } } }[] = [];
+  const metadata: unknown[] = [];
   // extracting destination from the first event in a batch
   const { destination } = events[0];
   // Batch event into dest batch structure
@@ -255,7 +268,6 @@ const generateBatchedPaylaodForArray = (events) => {
     metadata.push(ev.metadata);
   });
 
-  batchEventResponse.batchedRequest = Object.values(batchEventResponse);
   batchEventResponse.batchedRequest[0].body.JSON = {
     data: batchResponseList[0].data,
   };
@@ -294,7 +306,7 @@ const groupSubscribeResponsesUsingListId = (subscribeResponseList) => {
 };
 
 const getBatchedResponseList = (subscribeEventGroups, identifyResponseList) => {
-  let batchedResponseList = [];
+  let batchedResponseList: { batchedRequest: unknown[] }[] = [];
   Object.keys(subscribeEventGroups).forEach((listId) => {
     // eventChunks = [[e1,e2,e3,..batchSize],[e1,e2,e3,..batchSize]..]
     const eventChunks = lodash.chunk(subscribeEventGroups[listId], MAX_BATCH_SIZE);
@@ -318,7 +330,7 @@ const getBatchedResponseList = (subscribeEventGroups, identifyResponseList) => {
 };
 
 const batchSubscribeEvents = (subscribeRespList) => {
-  const identifyResponseList = [];
+  const identifyResponseList: unknown[] = [];
   subscribeRespList.forEach((event) => {
     const processedEvent = event;
     // for group and identify events (it will contain only subscribe response)
@@ -357,7 +369,7 @@ const buildRequest = (payload, destination, category) => {
 };
 
 /**
- * This function generates the metadat object used for updating a list attribute and unset properties 
+ * This function generates the metadat object used for updating a list attribute and unset properties
  * message = {
     integrations: {
       Klaviyo: { fieldsToUnset: ['Unset1', 'Unset2'],
@@ -382,12 +394,12 @@ const buildRequest = (payload, destination, category) => {
             }
         }
       }
- * @param {*} message 
+ * @param {*} message
  */
 const getProfileMetadataAndMetadataFields = (message) => {
   const intgObj = getIntegrationsObj(message, 'Klaviyo');
-  const meta = { patch_properties: {} };
-  let metadataFields = [];
+  const meta: { patch_properties: Record<string, unknown> } = { patch_properties: {} };
+  let metadataFields: string[] = [];
   const traitsInfo = getFieldValueFromMessage(message, 'traits');
   // fetch and set fields to unset
   const fieldsToUnset = intgObj?.fieldsToUnset;
@@ -399,7 +411,7 @@ const getProfileMetadataAndMetadataFields = (message) => {
   // fetch list of fields to append , their value and append these fields in metadataFields
   const fieldsToAppend = intgObj?.fieldsToAppend;
   if (Array.isArray(fieldsToAppend)) {
-    const append = {};
+    const append: Record<string, unknown> = {};
     fieldsToAppend.forEach((key) => {
       if (isDefinedAndNotNull(traitsInfo[key])) {
         append[key] = traitsInfo[key];
@@ -412,7 +424,7 @@ const getProfileMetadataAndMetadataFields = (message) => {
   // fetch list of fields to unappend , their value and append these fields in metadataFields
   const fieldsToUnappend = intgObj?.fieldsToUnappend;
   if (Array.isArray(fieldsToUnappend)) {
-    const unappend = {};
+    const unappend: Record<string, unknown> = {};
     fieldsToUnappend.forEach((key) => {
       if (isDefinedAndNotNull(traitsInfo[key])) {
         unappend[key] = traitsInfo[key];
@@ -441,6 +453,9 @@ const constructProfile = (message, destination, isIdentifyCall) => {
     message,
     MAPPING_CONFIG[CONFIG_CATEGORIES.PROFILEV2.name],
   );
+  if (!profileAttributes) {
+    throw new TransformationError('Failed to construct profile attributes payload');
+  }
   if (
     isDefinedAndNotNull(profileAttributes.phone_number) &&
     !isValidE164PhoneNumber(profileAttributes.phone_number)
@@ -609,7 +624,7 @@ const buildSubscriptionOrUnsubscriptionPayload = (subscription, destination) => 
 
 const getTrackRequests = (eventRespList, destination) => {
   // building and pushing all the event requests
-  const respList = [];
+  const respList: unknown[] = [];
   eventRespList.forEach((resp) =>
     respList.push(
       getSuccessRespEvents(
@@ -658,7 +673,7 @@ const addSubscribeFlagToTraits = (traitsInfo) => {
   return traits;
 };
 
-module.exports = {
+export {
   subscribeUserToList,
   createCustomerProperties,
   populateCustomFieldsFromTraits,


### PR DESCRIPTION
## Summary
- Migrate the entire klaviyo destination (`config`, `util`, `batchUtil`, `transform`, `transformV2`, and the two co-located unit tests) from JavaScript to TypeScript.
- No runtime behavior changes — added types only, with non-null assertions (`!`) on JS function returns where the original code implicitly trusted non-null. Zero `any` annotations, zero `as` casts, zero `@ts-ignore`.
- Refine `memory-bank/23_js_to_ts_migration.md` with lessons from this migration: prefer `!` over if-throw validation, explicitly forbid `Object.assign` as a type-narrowing workaround, and document the one scoped exception (runtime mutation patterns like object-to-array property mutation) where a minimal local-helper is required.

## Test plan
- [x] `npm run build:ci` passes
- [x] `npm test -- --testPathPattern="klaviyo" --no-coverage` — 17/17 unit tests pass
- [x] `npm run test:ts -- component --destination=klaviyo` — 40/40 integration tests pass
- [x] `npx eslint src/v0/destinations/klaviyo/` clean
- [x] `npx prettier --check src/v0/destinations/klaviyo/` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)