### PR TITLE
fix(af): track event without properties crashes with 500 transformation error

### DIFF
--- a/src/v0/destinations/af/transform.js
+++ b/src/v0/destinations/af/transform.js
@@ -126,13 +126,18 @@ function getEventValueMapFromMappingJson(message, mappingJson, isMultiSupport, c
   let eventValue = {};
   const { addPropertiesAtRoot, afCurrencyAtRoot, listOfProps } = config;
   const clonedProp = message.properties && lodash.cloneDeep(message.properties);
+  // A track event may legitimately arrive without `properties`; fall back to an empty object so
+  // the property look-ups below don't dereference `undefined`. `clonedProp` itself is left falsy
+  // when properties are absent so the empty `properties` wrapper continues to be dropped (yielding
+  // an empty eventValue) rather than emitting `{ "properties": {} }`.
+  const safeClonedProp = clonedProp || {};
   if (addPropertiesAtRoot) {
-    eventValue = clonedProp;
+    eventValue = safeClonedProp;
   } else {
     if (Array.isArray(listOfProps) && listOfProps.length > 0) {
       listOfProps.forEach((prop) => {
-        eventValue[prop.property] = clonedProp[prop.property];
-        delete clonedProp[prop.property];
+        eventValue[prop.property] = safeClonedProp[prop.property];
+        delete safeClonedProp[prop.property];
       });
     }
     eventValue.properties = clonedProp;
@@ -142,11 +147,11 @@ function getEventValueMapFromMappingJson(message, mappingJson, isMultiSupport, c
   sourceKeys.forEach((sourceKey) => {
     set(eventValue, mappingJson[sourceKey], get(message, sourceKey));
   });
-  if (isMultiSupport && clonedProp?.products?.length > 0) {
+  if (isMultiSupport && safeClonedProp?.products?.length > 0) {
     const contentIds = [];
     const quantities = [];
     const prices = [];
-    clonedProp.products.forEach((product) => {
+    safeClonedProp.products.forEach((product) => {
       contentIds.push(product.product_id);
       quantities.push(product.quantity);
       prices.push(product.price);
@@ -159,7 +164,7 @@ function getEventValueMapFromMappingJson(message, mappingJson, isMultiSupport, c
     };
   }
   if (afCurrencyAtRoot) {
-    eventValue.af_currency = clonedProp.currency;
+    eventValue.af_currency = safeClonedProp.currency;
   }
   eventValue = removeUndefinedValues(eventValue);
   if (Object.keys(eventValue).length > 0) {

--- a/test/integrations/destinations/af/processor/data.ts
+++ b/test/integrations/destinations/af/processor/data.ts
@@ -2049,6 +2049,74 @@ export const existingTestCases = [
       },
     },
   },
+  {
+    name: 'af',
+    description: 'Track event without properties and a configured listOfProps does not crash',
+    id: 'trackWithoutPropertiesAndListOfProps',
+    feature: 'processor',
+    module: 'destination',
+    version: 'v0',
+    input: {
+      request: {
+        body: [
+          {
+            message: {
+              type: 'track',
+              event: 'Some Custom Event',
+              sentAt: '2020-08-14T05:30:30.118Z',
+              context: commonContextWithExternalId,
+              messageId: '7208bbb6-2c4e-45bb-bf5b-ad426f3593e9',
+              timestamp: '2020-08-14T05:30:30.118Z',
+              anonymousId: '50be5c78-6c3f-4b60-be84-97805a316fb1',
+              integrations: { AF: { af_uid: 'afUid' } },
+            },
+            destination: {
+              Config: {
+                devKey: 'abcde',
+                androidAppId: 'com.rudderlabs.javascript',
+                addPropertiesAtRoot: false,
+                listOfProps: [{ property: 'value' }],
+              },
+            },
+          },
+        ],
+        method: 'POST',
+      },
+    },
+    output: {
+      response: {
+        status: 200,
+        body: [
+          {
+            output: {
+              version: '1',
+              type: 'REST',
+              method: 'POST',
+              endpoint: 'https://api2.appsflyer.com/inappevent/com.rudderlabs.javascript',
+              endpointPath: 'v1/inappevent',
+              headers: commonHeader,
+              params: {},
+              body: {
+                JSON: {
+                  bundleIdentifier: 'com.rudderlabs.javascript',
+                  eventValue: '',
+                  eventName: 'Some Custom Event',
+                  eventTime: '2020-08-14T05:30:30.118Z',
+                  appsflyer_id: 'afUid',
+                },
+                XML: {},
+                JSON_ARRAY: {},
+                FORM: {},
+              },
+              files: {},
+              userId: '',
+            },
+            statusCode: 200,
+          },
+        ],
+      },
+    },
+  },
 ];
 
 export const data = [...existingTestCases, ...newConfigValidationTests];


### PR DESCRIPTION
## Summary
- Fix a production 500 (`Cannot read properties of undefined (reading 'value')`) in the AppsFlyer destination when a `track` event arrives without `properties`. The property look-ups for `listOfProps`, `addPropertiesAtRoot`, and `afCurrencyAtRoot` previously dereferenced an undefined value; they now fall back to a safe empty object.
- Property-less events still produce an empty `eventValue` (no `{ "properties": {} }` wrapper), so payloads for events that already transformed successfully are unchanged.
- Add a processor test covering a property-less `track` event with a configured `listOfProps`.

## Test plan
- [x] `npm run test:ts -- component --destination=af` — 35/35 pass
- [x] `npx eslint src/v0/destinations/af/transform.js` — clean
- [x] Reproduced the original 500 against the prior code and confirmed it now returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)
