### PR TITLE
feat(klaviyo): add opt-in v3 strict consent flow

### DIFF
--- a/src/v0/destinations/klaviyo/README.md
+++ b/src/v0/destinations/klaviyo/README.md
@@ -255,7 +255,7 @@ However, if track events include profile attributes, those attributes should sti
    | V2  | `POST /api/profile-import` - Create/update profile                         | `POST /api/profile-subscription-bulk-create-jobs` (subscribe) or `POST /api/profile-subscription-bulk-delete-jobs` (unsubscribe) |
 
    - **Note**: V1 only supports subscription (`subscribe: true`). V2 and V3 both support subscribe and unsubscribe based on the `subscribe` trait value.
-   - **V3 Note**: Subscription payloads always include a `subscriptions` object built from consent config (and trait overrides). Empty consent or consent/identifier mismatch is forwarded to Klaviyo as-is and can return 400 to surface misconfiguration.
+   - **V3 Note**: Subscription payloads always include a `subscriptions` object built from consent config (and trait overrides). If the resolved subscriptions are empty (no consent provided, or consent channels don't match available identifiers), the transformer rejects the event with an `InstrumentationError` before it reaches Klaviyo.
 
 2. **Group Events**:
 

--- a/src/v0/destinations/klaviyo/README.md
+++ b/src/v0/destinations/klaviyo/README.md
@@ -15,7 +15,8 @@ Implementation in **JavaScript**
 
 - **API Version**: Specifies the Klaviyo API revision to use
   - `v1`: Uses revision `2023-02-22` (deprecated, scheduled for removal)
-  - `v2`: Uses revision `2024-10-15` (recommended, default)
+  - `v2`: Uses revision `2024-10-15` (deprecated, scheduled for removal)
+  - `v3`: Uses revision `2026-04-15` (default)
 
 ### Optional Settings
 
@@ -29,7 +30,7 @@ Implementation in **JavaScript**
 
 - **Enforce Email As Primary**: When enabled, uses email or phone as primary identifier instead of external_id (default: `false`)
 
-- **Consent**: Array of consent channels to apply (default: `["email"]`)
+- **Consent**: Array of consent channels to manage (default: `["email"]`)
 
   - Options: `email`, `sms`
   - Controls which marketing channels users are subscribed to
@@ -58,7 +59,7 @@ Implementation in **JavaScript**
   - Subscription events: 100 profiles per batch
   - Profile and Track events: Not batched together with subscriptions
 
-Both API versions use `MAX_BATCH_SIZE` (100) when chunking subscription requests. V1 batches subscribe requests to `POST /api/profile-subscription-bulk-create-jobs`. V2 batches both subscribe requests to `POST /api/profile-subscription-bulk-create-jobs` and unsubscribe requests to `POST /api/profile-subscription-bulk-delete-jobs`. Profile and track events are sent individually.
+All API versions use `MAX_BATCH_SIZE` (100) when chunking subscription requests. V1 batches subscribe requests to `POST /api/profile-subscription-bulk-create-jobs`. V2 and V3 batch both subscribe requests to `POST /api/profile-subscription-bulk-create-jobs` and unsubscribe requests to `POST /api/profile-subscription-bulk-delete-jobs`. Profile and track events are sent individually.
 
 ### Rate Limits
 
@@ -253,7 +254,8 @@ However, if track events include profile attributes, those attributes should sti
    | V1  | `POST /api/profiles` or `PATCH /api/profiles/{id}` - Create/update profile | `POST /api/profile-subscription-bulk-create-jobs` - Subscribe to list                                                            |
    | V2  | `POST /api/profile-import` - Create/update profile                         | `POST /api/profile-subscription-bulk-create-jobs` (subscribe) or `POST /api/profile-subscription-bulk-delete-jobs` (unsubscribe) |
 
-   - **Note**: V1 only supports subscription (`subscribe: true`). V2 supports both subscribe and unsubscribe based on the `subscribe` trait value.
+   - **Note**: V1 only supports subscription (`subscribe: true`). V2 and V3 both support subscribe and unsubscribe based on the `subscribe` trait value.
+   - **V3 Note**: Subscription payloads always include a `subscriptions` object built from consent config (and trait overrides). Empty consent or consent/identifier mismatch is forwarded to Klaviyo as-is and can return 400 to surface misconfiguration.
 
 2. **Group Events**:
 
@@ -297,8 +299,9 @@ Klaviyo provides **2 years** of support for each API revision:
 | ---------- | ---------- | ------------------ |
 | 2023-02-22 | Deprecated | ~February 2025     |
 | 2024-10-15 | Stable     | ~October 2026      |
+| 2026-04-15 | Stable     | ~April 2028        |
 
-**Recommendation**: Use `apiVersion: v2` for new integrations and upgrade existing integrations to avoid deprecation.
+**Recommendation**: Continue using `apiVersion: v2` to preserve existing behavior. Use `apiVersion: v3` only when you are ready for strict consent enforcement on both subscribe and unsubscribe requests.
 
 ### Breaking Changes Between Versions
 

--- a/src/v0/destinations/klaviyo/batchUtil.test.ts
+++ b/src/v0/destinations/klaviyo/batchUtil.test.ts
@@ -3,7 +3,6 @@ import {
   populateArrWithRespectiveProfileData,
   generateBatchedSubscriptionRequest,
 } from './batchUtil';
-import { revision } from './config';
 
 describe('groupSubscribeResponsesUsingListIdV2', () => {
   // Groups subscription responses by listId correctly
@@ -99,6 +98,7 @@ describe('generateBatchedSubscriptionRequest', () => {
     const destination = {
       Config: {
         privateApiKey: 'test-api-key',
+        apiVersion: 'v2',
       },
     };
     const expectedRequest = {
@@ -111,7 +111,7 @@ describe('generateBatchedSubscriptionRequest', () => {
         Authorization: 'Klaviyo-API-Key test-api-key',
         'Content-Type': 'application/json',
         Accept: 'application/json',
-        revision,
+        revision: '2024-10-15',
       },
       params: {},
       body: {
@@ -151,6 +151,7 @@ describe('generateBatchedSubscriptionRequest', () => {
     const destination = {
       Config: {
         privateApiKey: 'test-api-key',
+        apiVersion: 'v2',
       },
     };
     const expectedRequest = {
@@ -163,7 +164,7 @@ describe('generateBatchedSubscriptionRequest', () => {
         Authorization: 'Klaviyo-API-Key test-api-key',
         'Content-Type': 'application/json',
         Accept: 'application/json',
-        revision,
+        revision: '2024-10-15',
       },
       params: {},
       body: {
@@ -189,5 +190,41 @@ describe('generateBatchedSubscriptionRequest', () => {
     };
     const result = generateBatchedSubscriptionRequest(subscription, destination);
     expect(result).toEqual(expectedRequest);
+  });
+
+  it('should use v3 revision for v3 destination batching', () => {
+    const subscription = {
+      listId: 'test-list-id',
+      subscriptionProfileList: [[{ id: 'profile1' }]],
+      operation: 'unsubscribe',
+    };
+    const destination = {
+      Config: {
+        privateApiKey: 'test-api-key',
+        apiVersion: 'v3',
+      },
+    };
+
+    const result = generateBatchedSubscriptionRequest(subscription, destination);
+    expect(result.headers.revision).toBe('2026-04-15');
+    expect(result.endpointPath).toBe('/api/profile-subscription-bulk-delete-jobs');
+  });
+
+  it('should throw for unsupported apiVersion', () => {
+    const subscription = {
+      listId: 'test-list-id',
+      subscriptionProfileList: [[{ id: 'profile1' }]],
+      operation: 'subscribe',
+    };
+    const destination = {
+      Config: {
+        privateApiKey: 'test-api-key',
+        apiVersion: 'v4',
+      },
+    };
+
+    expect(() => generateBatchedSubscriptionRequest(subscription, destination)).toThrow(
+      'Unsupported Klaviyo apiVersion: v4',
+    );
   });
 });

--- a/src/v0/destinations/klaviyo/batchUtil.ts
+++ b/src/v0/destinations/klaviyo/batchUtil.ts
@@ -1,7 +1,7 @@
 import lodash from 'lodash';
 import { defaultRequestConfig, getSuccessRespEvents, isDefinedAndNotNull } from '../../util';
 import { JSON_MIME_TYPE } from '../../util/constant';
-import { BASE_ENDPOINT, CONFIG_CATEGORIES, MAX_BATCH_SIZE, revision } from './config';
+import { BASE_ENDPOINT, CONFIG_CATEGORIES, MAX_BATCH_SIZE, getKlaviyoRevision } from './config';
 import { buildRequest, getSubscriptionPayload } from './util';
 
 /**
@@ -30,7 +30,7 @@ const groupSubscribeResponsesUsingListIdV2 = (subscribeResponseList) => {
  */
 const generateBatchedSubscriptionRequest = (subscription, destination) => {
   const subscriptionPayloadResponse = defaultRequestConfig();
-  const { privateApiKey } = destination.Config;
+  const { privateApiKey, apiVersion } = destination.Config;
   // fetching listId from first event as listId is same for all the events
   const profiles: unknown[] = []; // list of profiles to be subscribed
   const { listId, subscriptionProfileList, operation } = subscription;
@@ -43,7 +43,7 @@ const generateBatchedSubscriptionRequest = (subscription, destination) => {
     Authorization: `Klaviyo-API-Key ${privateApiKey}`,
     'Content-Type': JSON_MIME_TYPE,
     Accept: JSON_MIME_TYPE,
-    revision,
+    revision: getKlaviyoRevision(apiVersion),
   };
   return subscriptionPayloadResponse;
 };

--- a/src/v0/destinations/klaviyo/config.ts
+++ b/src/v0/destinations/klaviyo/config.ts
@@ -91,8 +91,50 @@ const WhiteListedTraitsV2 = [
   'address',
 ];
 const destType = 'klaviyo';
-// api version used
-const revision = '2024-10-15';
+const KLAVIYO_API_VERSION = {
+  V1: 'v1',
+  V2: 'v2',
+  V3: 'v3',
+};
+const KLAVIYO_VERSION_CONFIG = {
+  [KLAVIYO_API_VERSION.V1]: {
+    revision: '2023-02-22',
+    usesProfileImportApi: false,
+    shouldAttachSubscriptions: (operation) => operation === 'subscribe',
+  },
+  [KLAVIYO_API_VERSION.V2]: {
+    revision: '2024-10-15',
+    usesProfileImportApi: true,
+    shouldAttachSubscriptions: (operation) => operation === 'subscribe',
+  },
+  [KLAVIYO_API_VERSION.V3]: {
+    revision: '2026-04-15',
+    usesProfileImportApi: true,
+    shouldAttachSubscriptions: () => true,
+  },
+};
+
+const getKlaviyoVersionConfig = (apiVersion) => {
+  const versionConfig = KLAVIYO_VERSION_CONFIG[apiVersion];
+  if (!versionConfig) {
+    throw new Error(`Unsupported Klaviyo apiVersion: ${apiVersion}`);
+  }
+  return versionConfig;
+};
+
+const usesProfileImportApi = (apiVersion) => {
+  if (apiVersion === undefined || apiVersion === null) {
+    return false;
+  }
+  return getKlaviyoVersionConfig(apiVersion).usesProfileImportApi;
+};
+
+const getKlaviyoRevision = (apiVersion) => {
+  if (apiVersion === undefined || apiVersion === null) {
+    return KLAVIYO_VERSION_CONFIG[KLAVIYO_API_VERSION.V1].revision;
+  }
+  return getKlaviyoVersionConfig(apiVersion).revision;
+};
 
 export {
   BASE_ENDPOINT,
@@ -105,7 +147,10 @@ export {
   eventNameMapping,
   jsonNameMapping,
   destType,
-  revision,
+  KLAVIYO_API_VERSION,
+  usesProfileImportApi,
+  getKlaviyoVersionConfig,
+  getKlaviyoRevision,
   WhiteListedTraitsV2,
   useUpdatedKlaviyoAPI,
 };

--- a/src/v0/destinations/klaviyo/config.ts
+++ b/src/v0/destinations/klaviyo/config.ts
@@ -1,3 +1,4 @@
+import { InstrumentationError } from '@rudderstack/integrations-lib';
 import { getMappingConfig } from '../../util';
 
 const BASE_ENDPOINT = 'https://a.klaviyo.com';
@@ -100,24 +101,35 @@ const KLAVIYO_VERSION_CONFIG = {
   [KLAVIYO_API_VERSION.V1]: {
     revision: '2023-02-22',
     usesProfileImportApi: false,
-    shouldAttachSubscriptions: (operation) => operation === 'subscribe',
+    shouldAttachSubscriptions: (operation, resolvedConsent) =>
+      operation === 'subscribe' && !!resolvedConsent,
+    validateSubscriptions: () => {},
   },
   [KLAVIYO_API_VERSION.V2]: {
     revision: '2024-10-15',
     usesProfileImportApi: true,
-    shouldAttachSubscriptions: (operation) => operation === 'subscribe',
+    shouldAttachSubscriptions: (operation, resolvedConsent) =>
+      operation === 'subscribe' && !!resolvedConsent,
+    validateSubscriptions: () => {},
   },
   [KLAVIYO_API_VERSION.V3]: {
     revision: '2026-04-15',
     usesProfileImportApi: true,
     shouldAttachSubscriptions: () => true,
+    validateSubscriptions: (profileAttributes) => {
+      if (!profileAttributes.subscriptions) {
+        throw new InstrumentationError(
+          'No subscriptions could be resolved for v3 API version. Ensure consent channels (email/sms) match the identifiers present in the event',
+        );
+      }
+    },
   },
 };
 
 const getKlaviyoVersionConfig = (apiVersion) => {
   const versionConfig = KLAVIYO_VERSION_CONFIG[apiVersion];
   if (!versionConfig) {
-    throw new Error(`Unsupported Klaviyo apiVersion: ${apiVersion}`);
+    throw new InstrumentationError(`Unsupported Klaviyo apiVersion: ${apiVersion}`);
   }
   return versionConfig;
 };

--- a/src/v0/destinations/klaviyo/config.ts
+++ b/src/v0/destinations/klaviyo/config.ts
@@ -160,6 +160,7 @@ export {
   jsonNameMapping,
   destType,
   KLAVIYO_API_VERSION,
+  KLAVIYO_VERSION_CONFIG,
   usesProfileImportApi,
   getKlaviyoVersionConfig,
   getKlaviyoRevision,

--- a/src/v0/destinations/klaviyo/docs/businesslogic.md
+++ b/src/v0/destinations/klaviyo/docs/businesslogic.md
@@ -244,7 +244,7 @@ If `apiVersion` is absent at runtime, transformer fallback remains on legacy (`v
 - `traits.properties.listId` overrides destination `listId` config when present
 - `traits.properties.consent` controls channels: `["email"]`, `["sms"]`, or `["email", "sms"]`
 - V2 only sets profile `subscriptions` during subscribe flows.
-- V3 always sets profile `subscriptions` for both subscribe and unsubscribe flows using consent config (or trait override), even when consent is empty or does not match available identifiers.
+- V3 always sets profile `subscriptions` for both subscribe and unsubscribe flows using consent config (or trait override). If the resolved subscriptions are empty (no consent provided, or consent channels don't match available identifiers), the transformer rejects the event with an `InstrumentationError`.
 
 #### Identify Payload Structure
 

--- a/src/v0/destinations/klaviyo/docs/businesslogic.md
+++ b/src/v0/destinations/klaviyo/docs/businesslogic.md
@@ -6,14 +6,16 @@ This document outlines the business logic and mappings used in the Klaviyo desti
 
 ## API Versions
 
-The Klaviyo destination supports two API versions:
+The Klaviyo destination supports three API versions:
 
 | Config Value | API Revision | Status            |
 | ------------ | ------------ | ----------------- |
 | `v1`         | `2023-02-22` | Deprecated        |
-| `v2`         | `2024-10-15` | Current (Default) |
+| `v2`         | `2024-10-15` | Deprecated        |
+| `v3`         | `2026-04-15` | Current (Default) |
 
 The API version is selected via `destination.Config.apiVersion` and affects endpoints, request formats, and available features.
+If `apiVersion` is absent at runtime, transformer fallback remains on legacy (`v1`) flow.
 
 ## API Endpoints and Request Flow
 
@@ -56,7 +58,7 @@ The API version is selected via `destination.Config.apiVersion` and affects endp
    POST https://a.klaviyo.com/api/profile-subscription-bulk-create-jobs
    ```
 
-#### V2 API Flow
+#### V2 / V3 API Flow
 
 **Primary Endpoint**: `POST /api/profile-import`
 **Subscribe Endpoint**: `POST /api/profile-subscription-bulk-create-jobs`
@@ -74,7 +76,7 @@ The API version is selected via `destination.Config.apiVersion` and affects endp
      Authorization: Klaviyo-API-Key {privateApiKey}
      Content-Type: application/json
      Accept: application/json
-     revision: 2024-10-15
+     revision: 2024-10-15 (v2) or 2026-04-15 (v3)
    ```
 
 **RudderStack Input → V2 Profile Import** (Identify call):
@@ -237,11 +239,12 @@ The API version is selected via `destination.Config.apiVersion` and affects endp
 }
 ```
 
-**V2 Subscription Notes**:
+**V2 / V3 Subscription Notes**:
 
 - `traits.properties.listId` overrides destination `listId` config when present
 - `traits.properties.consent` controls channels: `["email"]`, `["sms"]`, or `["email", "sms"]`
-- At least one of `email` or `phone_number` is required for both subscribe and unsubscribe
+- V2 only sets profile `subscriptions` during subscribe flows.
+- V3 always sets profile `subscriptions` for both subscribe and unsubscribe flows using consent config (or trait override), even when consent is empty or does not match available identifiers.
 
 #### Identify Payload Structure
 

--- a/src/v0/destinations/klaviyo/klaviyoUtil.test.ts
+++ b/src/v0/destinations/klaviyo/klaviyoUtil.test.ts
@@ -250,22 +250,6 @@ describe('subscribeOrUnsubscribeUserToListV2', () => {
       },
     },
     {
-      name: 'v3 subscribe with email consent but only phone identifier',
-      operation: 'subscribe',
-      traitsConsent: ['email'],
-      email: undefined,
-      phone: '+12125550000',
-      expectedSubscriptions: undefined,
-    },
-    {
-      name: 'v3 unsubscribe with sms consent but only email identifier',
-      operation: 'unsubscribe',
-      traitsConsent: ['sms'],
-      email: 'user@domain.com',
-      phone: undefined,
-      expectedSubscriptions: undefined,
-    },
-    {
       name: 'v3 unsubscribe with both identifiers and consent override',
       operation: 'unsubscribe',
       traitsConsent: ['email', 'sms'],
@@ -275,22 +259,6 @@ describe('subscribeOrUnsubscribeUserToListV2', () => {
         email: { marketing: { consent: 'UNSUBSCRIBED' } },
         sms: { marketing: { consent: 'UNSUBSCRIBED' } },
       },
-    },
-    {
-      name: 'v3 subscribe with empty consent list',
-      operation: 'subscribe',
-      traitsConsent: [],
-      email: 'user@domain.com',
-      phone: '+12125550000',
-      expectedSubscriptions: undefined,
-    },
-    {
-      name: 'v3 unsubscribe with empty consent list',
-      operation: 'unsubscribe',
-      traitsConsent: [],
-      email: 'user@domain.com',
-      phone: '+12125550000',
-      expectedSubscriptions: undefined,
     },
   ])(
     'should apply strict channel consent matrix: $name',
@@ -331,6 +299,49 @@ describe('subscribeOrUnsubscribeUserToListV2', () => {
           },
         ],
       });
+    },
+  );
+
+  it.each([
+    {
+      name: 'v3 subscribe with email consent but only phone identifier',
+      operation: 'subscribe',
+      traitsConsent: ['email'],
+      email: undefined,
+      phone: '+12125550000',
+    },
+    {
+      name: 'v3 unsubscribe with sms consent but only email identifier',
+      operation: 'unsubscribe',
+      traitsConsent: ['sms'],
+      email: 'user@domain.com',
+      phone: undefined,
+    },
+    {
+      name: 'v3 subscribe with empty consent list',
+      operation: 'subscribe',
+      traitsConsent: [],
+      email: 'user@domain.com',
+      phone: '+12125550000',
+    },
+    {
+      name: 'v3 unsubscribe with empty consent list',
+      operation: 'unsubscribe',
+      traitsConsent: [],
+      email: 'user@domain.com',
+      phone: '+12125550000',
+    },
+  ])(
+    'should throw when v3 subscriptions resolve to empty: $name',
+    ({ operation, traitsConsent, email, phone }) => {
+      const message = { type: 'identify', traits: { email, phone } };
+      const traitsInfo = { properties: { listId: 'traits-list-id', consent: traitsConsent } };
+
+      expect(() =>
+        subscribeOrUnsubscribeUserToListV2(message, traitsInfo, destination, operation),
+      ).toThrow(
+        'No subscriptions could be resolved for v3 API version. Ensure consent channels (email/sms) match the identifiers present in the event',
+      );
     },
   );
 

--- a/src/v0/destinations/klaviyo/klaviyoUtil.test.ts
+++ b/src/v0/destinations/klaviyo/klaviyoUtil.test.ts
@@ -1,4 +1,8 @@
-import { addSubscribeFlagToTraits, getProfileMetadataAndMetadataFields } from './util';
+import {
+  addSubscribeFlagToTraits,
+  getProfileMetadataAndMetadataFields,
+  subscribeOrUnsubscribeUserToListV2,
+} from './util';
 
 describe('addSubscribeFlagToTraits', () => {
   // The function should add a 'subscribe' property to the 'properties' object if it exists in the input 'traitsInfo'.
@@ -221,5 +225,150 @@ describe('getProfileMetadataAndMetadataFields', () => {
 
     result = getProfileMetadataAndMetadataFields(undefined);
     expect(result).toEqual({ meta: { patch_properties: {} }, metadataFields: [] });
+  });
+});
+
+describe('subscribeOrUnsubscribeUserToListV2', () => {
+  const destination = {
+    Config: {
+      apiVersion: 'v3',
+      listId: 'dest-list-id',
+      consent: ['email', 'sms'],
+    },
+  };
+
+  it.each([
+    {
+      name: 'v3 subscribe with both identifiers and consent override',
+      operation: 'subscribe',
+      traitsConsent: ['email', 'sms'],
+      email: 'user@domain.com',
+      phone: '+12125550000',
+      expectedSubscriptions: {
+        email: { marketing: { consent: 'SUBSCRIBED' } },
+        sms: { marketing: { consent: 'SUBSCRIBED' } },
+      },
+    },
+    {
+      name: 'v3 subscribe with email consent but only phone identifier',
+      operation: 'subscribe',
+      traitsConsent: ['email'],
+      email: undefined,
+      phone: '+12125550000',
+      expectedSubscriptions: undefined,
+    },
+    {
+      name: 'v3 unsubscribe with sms consent but only email identifier',
+      operation: 'unsubscribe',
+      traitsConsent: ['sms'],
+      email: 'user@domain.com',
+      phone: undefined,
+      expectedSubscriptions: undefined,
+    },
+    {
+      name: 'v3 unsubscribe with both identifiers and consent override',
+      operation: 'unsubscribe',
+      traitsConsent: ['email', 'sms'],
+      email: 'user@domain.com',
+      phone: '+12125550000',
+      expectedSubscriptions: {
+        email: { marketing: { consent: 'UNSUBSCRIBED' } },
+        sms: { marketing: { consent: 'UNSUBSCRIBED' } },
+      },
+    },
+    {
+      name: 'v3 subscribe with empty consent list',
+      operation: 'subscribe',
+      traitsConsent: [],
+      email: 'user@domain.com',
+      phone: '+12125550000',
+      expectedSubscriptions: undefined,
+    },
+    {
+      name: 'v3 unsubscribe with empty consent list',
+      operation: 'unsubscribe',
+      traitsConsent: [],
+      email: 'user@domain.com',
+      phone: '+12125550000',
+      expectedSubscriptions: undefined,
+    },
+  ])(
+    'should apply strict channel consent matrix: $name',
+    ({ operation, traitsConsent, email, phone, expectedSubscriptions }) => {
+      const message = {
+        type: 'identify',
+        traits: {
+          email,
+          phone,
+        },
+      };
+
+      const traitsInfo = {
+        properties: {
+          listId: 'traits-list-id',
+          consent: traitsConsent,
+        },
+      };
+
+      const result = subscribeOrUnsubscribeUserToListV2(
+        message,
+        traitsInfo,
+        destination,
+        operation,
+      );
+
+      expect(result).toEqual({
+        listId: 'traits-list-id',
+        operation,
+        profile: [
+          {
+            type: 'profile',
+            attributes: {
+              ...(email && { email }),
+              ...(phone && { phone_number: phone }),
+              ...(expectedSubscriptions && { subscriptions: expectedSubscriptions }),
+            },
+          },
+        ],
+      });
+    },
+  );
+
+  it('should preserve v2 unsubscribe behavior without subscriptions in profile attributes', () => {
+    const message = {
+      type: 'identify',
+      traits: {
+        email: 'user@domain.com',
+        phone: '+12125550000',
+      },
+    };
+    const traitsInfo = {
+      properties: {
+        listId: 'traits-list-id',
+        consent: ['email'],
+      },
+    };
+    const v2Destination = {
+      Config: {
+        apiVersion: 'v2',
+        listId: 'dest-list-id',
+        consent: ['email', 'sms'],
+      },
+    };
+
+    const result = subscribeOrUnsubscribeUserToListV2(
+      message,
+      traitsInfo,
+      v2Destination,
+      'unsubscribe',
+    );
+
+    expect(result.profile[0]).toEqual({
+      type: 'profile',
+      attributes: {
+        email: 'user@domain.com',
+        phone_number: '+12125550000',
+      },
+    });
   });
 });

--- a/src/v0/destinations/klaviyo/transform.ts
+++ b/src/v0/destinations/klaviyo/transform.ts
@@ -12,8 +12,9 @@ import {
   ecomEvents,
   eventNameMapping,
   jsonNameMapping,
+  usesProfileImportApi,
 } from './config';
-import { processRouter as processRouterV2, processV2 } from './transformV2';
+import { processRouter as processRouterImportApi, processImportApi } from './transformV2';
 import {
   createCustomerProperties,
   subscribeUserToList,
@@ -297,8 +298,8 @@ const groupRequestHandler = (message, category, destination) => {
 // Main event processor using specific handler funcs
 const processEvent = async (event, reqMetadata) => {
   const { message, destination, metadata } = event;
-  if (destination.Config?.apiVersion === 'v2') {
-    return processV2(event);
+  if (usesProfileImportApi(destination.Config?.apiVersion)) {
+    return processImportApi(event);
   }
   if (!message.type) {
     throw new InstrumentationError('Event type is required');
@@ -352,8 +353,8 @@ const getEventChunks = (event, subscribeRespList, nonSubscribeRespList) => {
 const processRouter = async (inputs, reqMetadata) => {
   const { destination } = inputs[0];
   // This is used to switch to latest API version
-  if (destination.Config?.apiVersion === 'v2') {
-    return processRouterV2(inputs, reqMetadata);
+  if (usesProfileImportApi(destination.Config?.apiVersion)) {
+    return processRouterImportApi(inputs, reqMetadata);
   }
   let batchResponseList: unknown[] = [];
   const batchErrorRespList: unknown[] = [];

--- a/src/v0/destinations/klaviyo/transformV2.ts
+++ b/src/v0/destinations/klaviyo/transformV2.ts
@@ -159,7 +159,7 @@ const processEvent = (event) => {
   return response;
 };
 // {subscription:{}, event:{}, profile:{}}
-const processV2 = (event) => {
+const processImportApi = (event) => {
   const response = processEvent(event);
   const { destination } = event;
   const respList: unknown[] = [];
@@ -242,4 +242,4 @@ const processRouter = (inputs, reqMetadata) => {
   return { successEvents: batchResponseList, errorEvents: batchErrorRespList };
 };
 
-export { processV2, processRouter };
+export { processImportApi, processRouter };

--- a/src/v0/destinations/klaviyo/util.ts
+++ b/src/v0/destinations/klaviyo/util.ts
@@ -524,7 +524,7 @@ const subscribeOrUnsubscribeUserToListV2 = (message, traitsInfo, destination, op
     phone_number: phone,
   };
 
-  if (versionConfig.shouldAttachSubscriptions(operation) && resolvedConsent) {
+  if (versionConfig.shouldAttachSubscriptions(operation, resolvedConsent)) {
     updateProfileWithConsents(
       profileAttributes,
       resolvedConsent,
@@ -533,6 +533,8 @@ const subscribeOrUnsubscribeUserToListV2 = (message, traitsInfo, destination, op
       phone,
     );
   }
+
+  versionConfig.validateSubscriptions(profileAttributes);
 
   const profile = removeUndefinedAndNullValues({
     type: 'profile',

--- a/src/v0/destinations/klaviyo/util.ts
+++ b/src/v0/destinations/klaviyo/util.ts
@@ -28,11 +28,16 @@ import {
   CONFIG_CATEGORIES,
   MAX_BATCH_SIZE,
   WhiteListedTraitsV2,
-  revision,
+  getKlaviyoVersionConfig,
+  getKlaviyoRevision,
 } from './config';
 import logger from '../../../logger';
 
 const REVISION_CONSTANT = '2023-02-22';
+const KLAVIYO_MARKETING_CHANNELS = {
+  EMAIL: 'email',
+  SMS: 'sms',
+};
 
 /**
  * This function is used to check if the phone number is in E.164 format. It uses libphonenumber-js library to parse the phone number
@@ -344,7 +349,7 @@ const batchSubscribeEvents = (subscribeRespList) => {
   return batchedResponseList;
 };
 const buildRequest = (payload, destination, category) => {
-  const { privateApiKey } = destination.Config;
+  const { privateApiKey, apiVersion } = destination.Config;
   const response = defaultRequestConfig();
 
   response.endpoint = `${BASE_ENDPOINT}${category.apiUrl}`;
@@ -354,7 +359,7 @@ const buildRequest = (payload, destination, category) => {
     Authorization: `Klaviyo-API-Key ${privateApiKey}`,
     Accept: JSON_MIME_TYPE,
     'Content-Type': JSON_MIME_TYPE,
-    revision,
+    revision: getKlaviyoRevision(apiVersion),
   };
   response.body.JSON = removeUndefinedAndNullValues(payload);
 
@@ -492,22 +497,13 @@ const constructProfile = (message, destination, isIdentifyCall) => {
   return { data };
 };
 
-/** This function update profile with consents for subscribing to email and/or phone
- * @param {*} profileAttributes
- * @param {*} subscribeConsent
- * @param {*} email
- * @param {*} phone
- */
-const updateProfileWithConsents = (profileAttributes, subscribeConsent, email, phone) => {
-  let consent = subscribeConsent;
-  if (!Array.isArray(consent)) {
-    consent = [consent];
+const updateProfileWithConsents = (profileAttributes, consent, consentStatus, email, phone) => {
+  const channels = Array.isArray(consent) ? consent : [consent];
+  if (channels.includes(KLAVIYO_MARKETING_CHANNELS.EMAIL) && email) {
+    set(profileAttributes, 'subscriptions.email.marketing.consent', consentStatus);
   }
-  if (consent.includes('email') && email) {
-    set(profileAttributes, 'subscriptions.email.marketing.consent', 'SUBSCRIBED');
-  }
-  if (consent.includes('sms') && phone) {
-    set(profileAttributes, 'subscriptions.sms.marketing.consent', 'SUBSCRIBED');
+  if (channels.includes(KLAVIYO_MARKETING_CHANNELS.SMS) && phone) {
+    set(profileAttributes, 'subscriptions.sms.marketing.consent', consentStatus);
   }
 };
 /**
@@ -517,19 +513,25 @@ const updateProfileWithConsents = (profileAttributes, subscribeConsent, email, p
  */
 const subscribeOrUnsubscribeUserToListV2 = (message, traitsInfo, destination, operation) => {
   // listId from message properties are preferred over Config listId
-  const { consent } = destination.Config;
+  const { consent, apiVersion } = destination.Config;
+  const versionConfig = getKlaviyoVersionConfig(apiVersion);
   let { listId } = destination.Config;
-  const subscribeConsent = traitsInfo.consent || traitsInfo.properties?.consent || consent;
+  const resolvedConsent = traitsInfo?.consent || traitsInfo?.properties?.consent || consent;
   const email = getFieldValueFromMessage(message, 'email');
   const phone = getFieldValueFromMessage(message, 'phone');
-  const profileAttributes = {
+  const profileAttributes: Record<string, unknown> = {
     email,
     phone_number: phone,
   };
 
-  // used only for subscription and not for unsubscription
-  if (operation === 'subscribe' && subscribeConsent) {
-    updateProfileWithConsents(profileAttributes, subscribeConsent, email, phone);
+  if (versionConfig.shouldAttachSubscriptions(operation) && resolvedConsent) {
+    updateProfileWithConsents(
+      profileAttributes,
+      resolvedConsent,
+      operation === 'subscribe' ? 'SUBSCRIBED' : 'UNSUBSCRIBED',
+      email,
+      phone,
+    );
   }
 
   const profile = removeUndefinedAndNullValues({
@@ -592,7 +594,7 @@ const getSubscriptionPayload = (listId, profiles, operation) => ({
  */
 const buildSubscriptionOrUnsubscriptionPayload = (subscription, destination) => {
   const response = defaultRequestConfig();
-  const { privateApiKey } = destination.Config;
+  const { privateApiKey, apiVersion } = destination.Config;
   const { apiUrl } = CONFIG_CATEGORIES[subscription.operation.toUpperCase()];
   response.endpoint = `${BASE_ENDPOINT}${apiUrl}`;
   response.endpointPath = apiUrl;
@@ -601,7 +603,7 @@ const buildSubscriptionOrUnsubscriptionPayload = (subscription, destination) => 
     Authorization: `Klaviyo-API-Key ${privateApiKey}`,
     Accept: JSON_MIME_TYPE,
     'Content-Type': JSON_MIME_TYPE,
-    revision,
+    revision: getKlaviyoRevision(apiVersion),
   };
   response.body.JSON = getSubscriptionPayload(
     subscription.listId,

--- a/src/v0/destinations/klaviyo/util.ts
+++ b/src/v0/destinations/klaviyo/util.ts
@@ -28,12 +28,13 @@ import {
   CONFIG_CATEGORIES,
   MAX_BATCH_SIZE,
   WhiteListedTraitsV2,
+  KLAVIYO_API_VERSION,
+  KLAVIYO_VERSION_CONFIG,
   getKlaviyoVersionConfig,
   getKlaviyoRevision,
 } from './config';
 import logger from '../../../logger';
 
-const REVISION_CONSTANT = '2023-02-22';
 const KLAVIYO_MARKETING_CHANNELS = {
   EMAIL: 'email',
   SMS: 'sms',
@@ -140,7 +141,7 @@ const profileUpdateResponseBuilder = (payload, profileId, category, privateApiKe
     Authorization: `Klaviyo-API-Key ${privateApiKey}`,
     'Content-Type': JSON_MIME_TYPE,
     Accept: JSON_MIME_TYPE,
-    revision: REVISION_CONSTANT,
+    revision: KLAVIYO_VERSION_CONFIG[KLAVIYO_API_VERSION.V1].revision,
   };
   identifyResponse.body.JSON = removeUndefinedAndNullValues(payload);
   return identifyResponse;
@@ -201,7 +202,7 @@ const subscribeUserToList = (message, traitsInfo, destination) => {
     Authorization: `Klaviyo-API-Key ${privateApiKey}`,
     'Content-Type': JSON_MIME_TYPE,
     Accept: JSON_MIME_TYPE,
-    revision: REVISION_CONSTANT,
+    revision: KLAVIYO_VERSION_CONFIG[KLAVIYO_API_VERSION.V1].revision,
   };
   response.body.JSON = removeUndefinedAndNullValues(payload);
 
@@ -279,7 +280,7 @@ const generateBatchedPaylaodForArray = (events) => {
     Authorization: `Klaviyo-API-Key ${destination.Config.privateApiKey}`,
     'Content-Type': JSON_MIME_TYPE,
     Accept: JSON_MIME_TYPE,
-    revision: REVISION_CONSTANT,
+    revision: KLAVIYO_VERSION_CONFIG[KLAVIYO_API_VERSION.V1].revision,
   };
 
   batchEventResponse = {

--- a/test/integrations/destinations/klaviyo/processor/data.ts
+++ b/test/integrations/destinations/klaviyo/processor/data.ts
@@ -5,9 +5,11 @@ import { screenTestData } from './screenTestData';
 import { trackTestData } from './trackTestData';
 import { validationTestData } from './validationTestData';
 import { dataV2 } from './dataV2';
+import { dataV3 } from './dataV3';
 
 export const data = [
   ...dataV2,
+  ...dataV3,
   ...identifyData,
   ...trackTestData,
   ...screenTestData,

--- a/test/integrations/destinations/klaviyo/processor/dataV3.ts
+++ b/test/integrations/destinations/klaviyo/processor/dataV3.ts
@@ -1,0 +1,521 @@
+import { Destination } from '../../../../../src/types';
+import { ProcessorTestData } from '../../../testTypes';
+import {
+  generateMetadata,
+  generateSimplifiedGroupPayload,
+  generateSimplifiedIdentifyPayload,
+  overrideDestination,
+  transformResultBuilder,
+} from '../../../testUtils';
+import { secret1, authHeader1 } from '../maskedSecrets';
+
+const destination: Destination = {
+  ID: '123',
+  Name: 'klaviyo',
+  DestinationDefinition: {
+    ID: '123',
+    Name: 'klaviyo',
+    DisplayName: 'klaviyo',
+    Config: {},
+  },
+  Config: {
+    apiVersion: 'v3',
+    privateApiKey: secret1,
+    consent: ['email', 'sms'],
+  },
+  Enabled: true,
+  WorkspaceID: '123',
+  Transformations: [],
+};
+
+const headers = {
+  Authorization: authHeader1,
+  'Content-Type': 'application/json',
+  Accept: 'application/json',
+  revision: '2026-04-15',
+};
+
+const subscriptionRelations = {
+  list: {
+    data: {
+      type: 'list',
+      id: 'group_list_id',
+    },
+  },
+};
+
+const subscriptionEndpoint = 'https://a.klaviyo.com/api/profile-subscription-bulk-create-jobs';
+const unsubscriptionEndpoint = 'https://a.klaviyo.com/api/profile-subscription-bulk-delete-jobs';
+const profileImportEndpoint = 'https://a.klaviyo.com/api/profile-import';
+
+const identifyTraits = {
+  firstName: 'Test',
+  lastName: 'Rudderlabs',
+  email: 'test@rudderstack.com',
+  phone: '+12 345 578 900',
+  userId: 'user@1',
+  title: 'Developer',
+  organization: 'Rudder',
+  city: 'Tokyo',
+  region: 'Kanto',
+  country: 'JP',
+  zip: '100-0001',
+  Flagged: false,
+  Residence: 'Shibuya',
+  street: '63, Shibuya',
+  properties: {
+    listId: 'XUepkK',
+    subscribe: true,
+    consent: ['email', 'sms'],
+  },
+};
+
+const identifyProfileAttributes = {
+  external_id: 'user@1',
+  anonymous_id: '97c46c81-3140-456d-b2a9-690d70aaca35',
+  email: 'test@rudderstack.com',
+  first_name: 'Test',
+  last_name: 'Rudderlabs',
+  phone_number: '+12 345 578 900',
+  title: 'Developer',
+  organization: 'Rudder',
+  location: {
+    city: 'Tokyo',
+    region: 'Kanto',
+    country: 'JP',
+    zip: '100-0001',
+    address1: '63, Shibuya',
+  },
+  properties: {
+    Flagged: false,
+    Residence: 'Shibuya',
+  },
+};
+
+const identifyListRelations = {
+  list: {
+    data: {
+      type: 'list',
+      id: 'XUepkK',
+    },
+  },
+};
+
+export const dataV3: ProcessorTestData[] = [
+  {
+    id: 'klaviyo-group-v3-test-1',
+    name: 'klaviyo',
+    description:
+      'v3 group subscribe should include subscribed channels from config consent in subscription payload',
+    scenario: 'Business',
+    successCriteria:
+      'Response should contain a v3 subscription payload with revision 2026-04-15 and both email/sms SUBSCRIBED',
+    feature: 'processor',
+    module: 'destination',
+    version: 'v0',
+    input: {
+      request: {
+        body: [
+          {
+            destination,
+            message: generateSimplifiedGroupPayload({
+              userId: 'user123',
+              groupId: 'group_list_id',
+              traits: {
+                subscribe: true,
+              },
+              context: {
+                traits: {
+                  email: 'test@rudderstack.com',
+                  phone: '+12 345 678 900',
+                },
+              },
+              timestamp: '2020-01-21T00:21:34.208Z',
+            }),
+            metadata: generateMetadata(1),
+          },
+        ],
+        method: 'POST',
+      },
+    },
+    output: {
+      response: {
+        status: 200,
+        body: [
+          {
+            output: transformResultBuilder({
+              JSON: {
+                data: {
+                  type: 'profile-subscription-bulk-create-job',
+                  attributes: {
+                    profiles: {
+                      data: [
+                        {
+                          type: 'profile',
+                          attributes: {
+                            email: 'test@rudderstack.com',
+                            phone_number: '+12 345 678 900',
+                            subscriptions: {
+                              email: { marketing: { consent: 'SUBSCRIBED' } },
+                              sms: { marketing: { consent: 'SUBSCRIBED' } },
+                            },
+                          },
+                        },
+                      ],
+                    },
+                  },
+                  relationships: subscriptionRelations,
+                },
+              },
+              endpoint: subscriptionEndpoint,
+              endpointPath: '/api/profile-subscription-bulk-create-jobs',
+              headers,
+              method: 'POST',
+              userId: '',
+            }),
+            statusCode: 200,
+            metadata: generateMetadata(1),
+          },
+        ],
+      },
+    },
+  },
+  {
+    id: 'klaviyo-group-v3-test-2',
+    name: 'klaviyo',
+    description:
+      'v3 group unsubscribe should include UNSUBSCRIBED consent for configured sms channel',
+    scenario: 'Business',
+    successCriteria:
+      'Response should contain v3 unsubscription payload with UNSUBSCRIBED consent and revision 2026-04-15',
+    feature: 'processor',
+    module: 'destination',
+    version: 'v0',
+    input: {
+      request: {
+        body: [
+          {
+            destination: overrideDestination(destination, { consent: ['sms'] }),
+            message: generateSimplifiedGroupPayload({
+              userId: 'user123',
+              groupId: 'group_list_id',
+              traits: {
+                subscribe: false,
+              },
+              context: {
+                traits: {
+                  email: 'test@rudderstack.com',
+                  phone: '+12 345 678 900',
+                },
+              },
+              timestamp: '2020-01-21T00:21:34.208Z',
+            }),
+            metadata: generateMetadata(2),
+          },
+        ],
+        method: 'POST',
+      },
+    },
+    output: {
+      response: {
+        status: 200,
+        body: [
+          {
+            output: transformResultBuilder({
+              JSON: {
+                data: {
+                  type: 'profile-subscription-bulk-delete-job',
+                  attributes: {
+                    profiles: {
+                      data: [
+                        {
+                          type: 'profile',
+                          attributes: {
+                            email: 'test@rudderstack.com',
+                            phone_number: '+12 345 678 900',
+                            subscriptions: {
+                              sms: { marketing: { consent: 'UNSUBSCRIBED' } },
+                            },
+                          },
+                        },
+                      ],
+                    },
+                  },
+                  relationships: subscriptionRelations,
+                },
+              },
+              endpoint: unsubscriptionEndpoint,
+              endpointPath: '/api/profile-subscription-bulk-delete-jobs',
+              headers,
+              method: 'POST',
+              userId: '',
+            }),
+            statusCode: 200,
+            metadata: generateMetadata(2),
+          },
+        ],
+      },
+    },
+  },
+  {
+    id: 'klaviyo-identify-v3-test-1',
+    name: 'klaviyo',
+    description:
+      'v3 identify subscribe should use profile-import revision and include subscribed channels in subscription payload',
+    scenario: 'Business',
+    successCriteria:
+      'Response should include profile-import plus subscription create payload with SUBSCRIBED channels',
+    feature: 'processor',
+    module: 'destination',
+    version: 'v0',
+    input: {
+      request: {
+        body: [
+          {
+            destination,
+            message: generateSimplifiedIdentifyPayload({
+              sentAt: '2021-01-03T17:02:53.195Z',
+              userId: 'user@1',
+              anonymousId: '97c46c81-3140-456d-b2a9-690d70aaca35',
+              originalTimestamp: '2021-01-03T17:02:53.193Z',
+              context: {
+                traits: identifyTraits,
+              },
+            }),
+            metadata: generateMetadata(3),
+          },
+        ],
+        method: 'POST',
+      },
+    },
+    output: {
+      response: {
+        status: 200,
+        body: [
+          {
+            output: transformResultBuilder({
+              userId: '',
+              method: 'POST',
+              endpoint: profileImportEndpoint,
+              endpointPath: '/api/profile-import',
+              headers,
+              JSON: {
+                data: {
+                  type: 'profile',
+                  attributes: identifyProfileAttributes,
+                  meta: {
+                    patch_properties: {},
+                  },
+                },
+              },
+            }),
+            statusCode: 200,
+            metadata: generateMetadata(3),
+          },
+          {
+            output: transformResultBuilder({
+              userId: '',
+              method: 'POST',
+              endpoint: subscriptionEndpoint,
+              endpointPath: '/api/profile-subscription-bulk-create-jobs',
+              headers,
+              JSON: {
+                data: {
+                  type: 'profile-subscription-bulk-create-job',
+                  attributes: {
+                    profiles: {
+                      data: [
+                        {
+                          type: 'profile',
+                          attributes: {
+                            email: 'test@rudderstack.com',
+                            phone_number: '+12 345 578 900',
+                            subscriptions: {
+                              email: { marketing: { consent: 'SUBSCRIBED' } },
+                              sms: { marketing: { consent: 'SUBSCRIBED' } },
+                            },
+                          },
+                        },
+                      ],
+                    },
+                  },
+                  relationships: identifyListRelations,
+                },
+              },
+            }),
+            statusCode: 200,
+            metadata: generateMetadata(3),
+          },
+        ],
+      },
+    },
+  },
+  {
+    id: 'klaviyo-identify-v3-test-2',
+    name: 'klaviyo',
+    description:
+      'v3 identify unsubscribe should include unsubscribed channels in subscription delete payload',
+    scenario: 'Business',
+    successCriteria:
+      'Response should include profile-import plus subscription delete payload with UNSUBSCRIBED channels',
+    feature: 'processor',
+    module: 'destination',
+    version: 'v0',
+    input: {
+      request: {
+        body: [
+          {
+            destination,
+            message: generateSimplifiedIdentifyPayload({
+              sentAt: '2021-01-03T17:02:53.195Z',
+              userId: 'user@1',
+              anonymousId: '97c46c81-3140-456d-b2a9-690d70aaca35',
+              originalTimestamp: '2021-01-03T17:02:53.193Z',
+              context: {
+                traits: {
+                  ...identifyTraits,
+                  properties: { ...identifyTraits.properties, subscribe: false },
+                },
+              },
+            }),
+            metadata: generateMetadata(4),
+          },
+        ],
+        method: 'POST',
+      },
+    },
+    output: {
+      response: {
+        status: 200,
+        body: [
+          {
+            output: transformResultBuilder({
+              userId: '',
+              method: 'POST',
+              endpoint: profileImportEndpoint,
+              endpointPath: '/api/profile-import',
+              headers,
+              JSON: {
+                data: {
+                  type: 'profile',
+                  attributes: identifyProfileAttributes,
+                  meta: {
+                    patch_properties: {},
+                  },
+                },
+              },
+            }),
+            statusCode: 200,
+            metadata: generateMetadata(4),
+          },
+          {
+            output: transformResultBuilder({
+              userId: '',
+              method: 'POST',
+              endpoint: unsubscriptionEndpoint,
+              endpointPath: '/api/profile-subscription-bulk-delete-jobs',
+              headers,
+              JSON: {
+                data: {
+                  type: 'profile-subscription-bulk-delete-job',
+                  attributes: {
+                    profiles: {
+                      data: [
+                        {
+                          type: 'profile',
+                          attributes: {
+                            email: 'test@rudderstack.com',
+                            phone_number: '+12 345 578 900',
+                            subscriptions: {
+                              email: { marketing: { consent: 'UNSUBSCRIBED' } },
+                              sms: { marketing: { consent: 'UNSUBSCRIBED' } },
+                            },
+                          },
+                        },
+                      ],
+                    },
+                  },
+                  relationships: identifyListRelations,
+                },
+              },
+            }),
+            statusCode: 200,
+            metadata: generateMetadata(4),
+          },
+        ],
+      },
+    },
+  },
+  {
+    id: 'klaviyo-v1-routing-regression-test-1',
+    name: 'klaviyo',
+    description: 'v1 apiVersion should continue using legacy subscription payload shape',
+    scenario: 'Business',
+    successCriteria:
+      'Response should route through legacy flow and send list_id/subscriptions payload with revision 2023-02-22',
+    feature: 'processor',
+    module: 'destination',
+    version: 'v0',
+    input: {
+      request: {
+        body: [
+          {
+            destination: overrideDestination(destination, { apiVersion: 'v1', consent: undefined }),
+            message: generateSimplifiedGroupPayload({
+              userId: 'user123',
+              groupId: 'group_list_id',
+              traits: {
+                subscribe: true,
+              },
+              context: {
+                traits: {
+                  email: 'test@rudderstack.com',
+                  phone: '+12 345 678 900',
+                  consent: ['email'],
+                },
+              },
+              timestamp: '2020-01-21T00:21:34.208Z',
+            }),
+            metadata: generateMetadata(5),
+          },
+        ],
+        method: 'POST',
+      },
+    },
+    output: {
+      response: {
+        status: 200,
+        body: [
+          {
+            output: transformResultBuilder({
+              JSON: {
+                data: {
+                  type: 'profile-subscription-bulk-create-job',
+                  attributes: {
+                    list_id: 'group_list_id',
+                    subscriptions: [
+                      {
+                        email: 'test@rudderstack.com',
+                        phone_number: '+12 345 678 900',
+                      },
+                    ],
+                  },
+                },
+              },
+              endpoint: subscriptionEndpoint,
+              endpointPath: '/api/profile-subscription-bulk-create-jobs',
+              headers: {
+                ...headers,
+                revision: '2023-02-22',
+              },
+              method: 'POST',
+              userId: '',
+            }),
+            statusCode: 200,
+            metadata: generateMetadata(5),
+          },
+        ],
+      },
+    },
+  },
+];

--- a/test/integrations/destinations/klaviyo/router/commonConfig.ts
+++ b/test/integrations/destinations/klaviyo/router/commonConfig.ts
@@ -40,9 +40,10 @@ const destinationV2: Destination = {
   Transformations: [],
 };
 const getRequest = (apiVersion) => {
+  const destinationByVersion = apiVersion === 'v2' ? destinationV2 : destination;
   return [
     {
-      destination: apiVersion === 'v2' ? destinationV2 : destination,
+      destination: destinationByVersion,
       metadata: generateMetadata(1),
       message: {
         type: 'identify',
@@ -88,7 +89,7 @@ const getRequest = (apiVersion) => {
       },
     },
     {
-      destination: apiVersion === 'v2' ? destinationV2 : destination,
+      destination: destinationByVersion,
       metadata: generateMetadata(2),
       message: {
         type: 'identify',
@@ -134,7 +135,7 @@ const getRequest = (apiVersion) => {
       },
     },
     {
-      destination: apiVersion === 'v2' ? destinationV2 : destination,
+      destination: destinationByVersion,
       metadata: generateMetadata(3),
       message: {
         userId: 'user123',
@@ -154,7 +155,7 @@ const getRequest = (apiVersion) => {
       },
     },
     {
-      destination: apiVersion === 'v2' ? destinationV2 : destination,
+      destination: destinationByVersion,
       metadata: generateMetadata(4),
       message: {
         userId: 'user123',
@@ -174,7 +175,7 @@ const getRequest = (apiVersion) => {
       },
     },
     {
-      destination: apiVersion === 'v2' ? destinationV2 : destination,
+      destination: destinationByVersion,
       metadata: generateMetadata(5),
       message: {
         userId: 'user123',

--- a/test/integrations/destinations/klaviyo/router/data.ts
+++ b/test/integrations/destinations/klaviyo/router/data.ts
@@ -3,6 +3,7 @@ import { RouterTestData } from '../../../testTypes';
 import { routerRequest } from './commonConfig';
 import { generateMetadata } from '../../../testUtils';
 import { dataV2 } from './dataV2';
+import { dataV3 } from './dataV3';
 import { secret1, authHeader1 } from '../maskedSecrets';
 
 const destination: Destination = {
@@ -255,4 +256,5 @@ export const data: RouterTestData[] = [
     },
   },
   ...dataV2,
+  ...dataV3,
 ];

--- a/test/integrations/destinations/klaviyo/router/dataV3.ts
+++ b/test/integrations/destinations/klaviyo/router/dataV3.ts
@@ -1,0 +1,230 @@
+import { Destination, RouterTransformationRequest, RudderMessage } from '../../../../../src/types';
+import { RouterTestData } from '../../../testTypes';
+import {
+  generateMetadata,
+  generateSimplifiedGroupPayload,
+  transformResultBuilder,
+} from '../../../testUtils';
+import { secret1, authHeader1 } from '../maskedSecrets';
+
+const destination: Destination = {
+  ID: '123',
+  Name: 'klaviyo',
+  DestinationDefinition: {
+    ID: '123',
+    Name: 'klaviyo',
+    DisplayName: 'klaviyo',
+    Config: {},
+  },
+  Config: {
+    privateApiKey: secret1,
+    apiVersion: 'v3',
+    consent: ['email'],
+  },
+  Enabled: true,
+  WorkspaceID: '123',
+  Transformations: [],
+};
+
+const headers = {
+  Authorization: authHeader1,
+  'Content-Type': 'application/json',
+  Accept: 'application/json',
+  revision: '2026-04-15',
+};
+
+const subscribeEndpoint = 'https://a.klaviyo.com/api/profile-subscription-bulk-create-jobs';
+const unsubscribeEndpoint = 'https://a.klaviyo.com/api/profile-subscription-bulk-delete-jobs';
+
+const subscriptionRelations = {
+  list: {
+    data: {
+      type: 'list',
+      id: 'group_list_id',
+    },
+  },
+};
+
+const getRouterRequest = (
+  message: RudderMessage,
+  destinationOverride?: Destination,
+): RouterTransformationRequest => ({
+  input: [
+    {
+      destination: destinationOverride || destination,
+      metadata: generateMetadata(1),
+      message,
+    },
+  ],
+  destType: 'klaviyo',
+});
+
+export const dataV3: RouterTestData[] = [
+  {
+    id: 'klaviyo-router-v3-test-1',
+    name: 'klaviyo',
+    description:
+      'v3 router group subscribe should include subscribed email channel from config consent',
+    scenario: 'Framework',
+    successCriteria:
+      'Output should keep v3 revision and include email SUBSCRIBED in the bulk subscribe payload',
+    feature: 'router',
+    module: 'destination',
+    version: 'v0',
+    input: {
+      request: {
+        body: getRouterRequest(
+          generateSimplifiedGroupPayload({
+            userId: 'user123',
+            groupId: 'group_list_id',
+            traits: {
+              subscribe: true,
+            },
+            context: {
+              traits: {
+                email: 'test@rudderstack.com',
+              },
+            },
+            timestamp: '2020-01-21T00:21:34.208Z',
+          }),
+        ),
+        method: 'POST',
+      },
+    },
+    output: {
+      response: {
+        status: 200,
+        body: {
+          output: [
+            {
+              batchedRequest: [
+                transformResultBuilder({
+                  JSON: {
+                    data: {
+                      type: 'profile-subscription-bulk-create-job',
+                      attributes: {
+                        profiles: {
+                          data: [
+                            {
+                              type: 'profile',
+                              attributes: {
+                                email: 'test@rudderstack.com',
+                                subscriptions: {
+                                  email: { marketing: { consent: 'SUBSCRIBED' } },
+                                },
+                              },
+                            },
+                          ],
+                        },
+                      },
+                      relationships: subscriptionRelations,
+                    },
+                  },
+                  endpoint: subscribeEndpoint,
+                  endpointPath: '/api/profile-subscription-bulk-create-jobs',
+                  headers,
+                  method: 'POST',
+                }),
+              ],
+              metadata: [generateMetadata(1)],
+              batched: true,
+              statusCode: 200,
+              destination,
+            },
+          ],
+        },
+      },
+    },
+  },
+  {
+    id: 'klaviyo-router-v3-test-2',
+    name: 'klaviyo',
+    description:
+      'v3 router group unsubscribe should carry UNSUBSCRIBED consent for configured channels',
+    scenario: 'Framework',
+    successCriteria:
+      'Output should keep v3 revision and include UNSUBSCRIBED consent in the unsubscribe payload',
+    feature: 'router',
+    module: 'destination',
+    version: 'v0',
+    input: {
+      request: {
+        body: getRouterRequest(
+          generateSimplifiedGroupPayload({
+            userId: 'user123',
+            groupId: 'group_list_id',
+            traits: {
+              subscribe: false,
+            },
+            context: {
+              traits: {
+                email: 'test@rudderstack.com',
+                phone: '+12 345 678 900',
+              },
+            },
+            timestamp: '2020-01-21T00:21:34.208Z',
+          }),
+          {
+            ...destination,
+            Config: {
+              ...destination.Config,
+              consent: ['email'],
+            },
+          },
+        ),
+        method: 'POST',
+      },
+    },
+    output: {
+      response: {
+        status: 200,
+        body: {
+          output: [
+            {
+              batchedRequest: [
+                transformResultBuilder({
+                  JSON: {
+                    data: {
+                      type: 'profile-subscription-bulk-delete-job',
+                      attributes: {
+                        profiles: {
+                          data: [
+                            {
+                              type: 'profile',
+                              attributes: {
+                                email: 'test@rudderstack.com',
+                                phone_number: '+12 345 678 900',
+                                subscriptions: {
+                                  email: { marketing: { consent: 'UNSUBSCRIBED' } },
+                                },
+                              },
+                            },
+                          ],
+                        },
+                      },
+                      relationships: subscriptionRelations,
+                    },
+                  },
+                  endpoint: unsubscribeEndpoint,
+                  endpointPath: '/api/profile-subscription-bulk-delete-jobs',
+                  headers,
+                  method: 'POST',
+                }),
+              ],
+              metadata: [generateMetadata(1)],
+              batched: true,
+              statusCode: 200,
+              destination: {
+                ...destination,
+                Config: {
+                  ...destination.Config,
+                  consent: ['email'],
+                },
+              },
+            },
+          ],
+        },
+      },
+    },
+  },
+];


### PR DESCRIPTION
## Summary
- Add opt-in `apiVersion: v3` (revision `2026-04-15`) for Klaviyo that enforces strict subscription consent: subscribe and unsubscribe payloads always carry `subscriptions` with consent values derived from destination config or trait-level overrides
- Consent gating and subscription validation are driven entirely through the `KLAVIYO_VERSION_CONFIG` interface (`shouldAttachSubscriptions`, `validateSubscriptions`) — no version-specific `if` checks in the transformation logic
- v1/v2 behavior is unchanged: subscriptions are only attached on subscribe when consent is present, and missing consent is silently skipped
- Hardcoded `REVISION_CONSTANT` in util replaced with `KLAVIYO_VERSION_CONFIG[V1].revision` so revision values are defined in one place

## Test plan
- [x] `npm run lint` passes
- [x] `npm test -- --testPathPattern="klaviyo" --no-coverage` — unit tests pass
- [x] `npm run test:ts -- component --destination=klaviyo` — integration tests pass (including v3 processor and router fixtures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
