### PR TITLE
chore(delivery): restore request/response payload logs behind a workspace flag

### DIFF
--- a/src/controllers/delivery.ts
+++ b/src/controllers/delivery.ts
@@ -16,16 +16,35 @@ import {
 } from '../types';
 import tags from '../v0/util/tags';
 import { ControllerUtility } from './util';
+import logger from '../logger';
+import { isFeatureEnabled } from '../util/featureFlags';
 
 const NON_DETERMINABLE = 'Non-determinable';
 
+// Env var gating the request/response payload logs below. These emit full request/response
+// bodies which may contain sensitive customer data/PII, so they are enabled per-workspace
+// (value: "ALL" or a comma-separated list of workspace IDs) and logged at `warn` so they
+// surface at the default LOG_LEVEL when explicitly turned on for debugging.
+const DELIVERY_REQUEST_RESPONSE_LOG_FLAG = 'DELIVERY_REQUEST_RESPONSE_LOG_ENABLED';
+
 export class DeliveryController {
+  private static logDeliveryPayload(workspaceId: string, message: string, payload: unknown) {
+    if (isFeatureEnabled(DELIVERY_REQUEST_RESPONSE_LOG_FLAG, workspaceId)) {
+      logger.warn(message, payload);
+    }
+  }
+
   public static async deliverToDestination(ctx: Context) {
     let deliveryResponse: DeliveryV0Response;
     const requestMetadata = MiscService.getRequestMetadata(ctx);
     const deliveryRequest = ctx.request.body as ProxyV0Request;
     const { destination }: { destination: string } = ctx.params;
     const integrationService = ServiceSelector.getNativeDestinationService();
+    DeliveryController.logDeliveryPayload(
+      deliveryRequest.metadata.workspaceId,
+      'Native(Delivery):: Request to transformer for delivery::',
+      ctx.request.body,
+    );
     try {
       deliveryResponse = (await integrationService.deliver(
         deliveryRequest,
@@ -50,6 +69,11 @@ export class DeliveryController {
     ctx.body = { output: deliveryResponse };
     ControllerUtility.deliveryPostProcess(ctx, deliveryResponse.status);
 
+    DeliveryController.logDeliveryPayload(
+      deliveryRequest.metadata.workspaceId,
+      'Native(Delivery):: Response from transformer after delivery::',
+      ctx.body,
+    );
     return ctx;
   }
 
@@ -59,6 +83,11 @@ export class DeliveryController {
     const deliveryRequest = ctx.request.body as ProxyV1Request;
     const { destination }: { destination: string } = ctx.params;
     const integrationService = ServiceSelector.getNativeDestinationService();
+    DeliveryController.logDeliveryPayload(
+      deliveryRequest.metadata[0].workspaceId,
+      'Native(Delivery):: Request to transformer for delivery::',
+      ctx.request.body,
+    );
     try {
       deliveryResponse = (await integrationService.deliver(
         deliveryRequest,
@@ -87,6 +116,11 @@ export class DeliveryController {
       ControllerUtility.deliveryPostProcess(ctx);
     }
 
+    DeliveryController.logDeliveryPayload(
+      deliveryRequest.metadata[0].workspaceId,
+      'Native(Delivery):: Response from transformer::',
+      ctx.body,
+    );
     return ctx;
   }
 


### PR DESCRIPTION
## What are the changes introduced in this PR?

[PR #4754](https://github.com/rudderlabs/rudder-transformer/pull/4754) removed the debug logs that dumped the delivery request and response bodies, since those payloads can contain customer data/PII. This brings the logs back for `deliverToDestination` (v0) and `deliverToDestinationV1`, but in a controlled, opt-in way.

The logs are now gated **per-workspace** via the `DELIVERY_REQUEST_RESPONSE_LOG_ENABLED` env flag, evaluated through the existing `isFeatureEnabled` util:

- `ALL` — log for every workspace
- `<wsId1>,<wsId2>,...` — log only for the listed workspaces
- unset / anything else — disabled (default)

They are emitted at **`warn`** level so that, once a workspace is opted in, the logs actually surface at the default `LOG_LEVEL=warn` without needing to drop the global log level to `debug`. With no workspace opted in, nothing is logged — so there is no PII exposure by default.

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

Restores logging behaviour removed in #4754, now behind a per-workspace flag and at `warn` level instead of unconditional `debug`.

### Any new dependencies introduced with this change?

N/A

### Any new generic utility introduced or modified. Please explain the changes.

N/A — reuses the existing `isFeatureEnabled` util.

### Any technical or performance related pointers to consider with the change?

The flag is read per request via `isFeatureEnabled`; the body is only serialized into a log when the workspace is opted in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)