### PR TITLE
fix(gaoc): google ads delivery errors show generic messages, hiding the actual error detail

### DIFF
--- a/src/controllers/delivery.ts
+++ b/src/controllers/delivery.ts
@@ -16,35 +16,16 @@ import {
 } from '../types';
 import tags from '../v0/util/tags';
 import { ControllerUtility } from './util';
-import logger from '../logger';
-import { isFeatureEnabled } from '../util/featureFlags';
 
 const NON_DETERMINABLE = 'Non-determinable';
 
-// Env var gating the request/response payload logs below. These emit full request/response
-// bodies which may contain sensitive customer data/PII, so they are enabled per-workspace
-// (value: "ALL" or a comma-separated list of workspace IDs) and logged at `warn` so they
-// surface at the default LOG_LEVEL when explicitly turned on for debugging.
-const DELIVERY_REQUEST_RESPONSE_LOG_FLAG = 'DELIVERY_REQUEST_RESPONSE_LOG_ENABLED';
-
 export class DeliveryController {
-  private static logDeliveryPayload(workspaceId: string, message: string, payload: unknown) {
-    if (isFeatureEnabled(DELIVERY_REQUEST_RESPONSE_LOG_FLAG, workspaceId)) {
-      logger.warn(message, payload);
-    }
-  }
-
   public static async deliverToDestination(ctx: Context) {
     let deliveryResponse: DeliveryV0Response;
     const requestMetadata = MiscService.getRequestMetadata(ctx);
     const deliveryRequest = ctx.request.body as ProxyV0Request;
     const { destination }: { destination: string } = ctx.params;
     const integrationService = ServiceSelector.getNativeDestinationService();
-    DeliveryController.logDeliveryPayload(
-      deliveryRequest.metadata.workspaceId,
-      'Native(Delivery):: Request to transformer for delivery::',
-      ctx.request.body,
-    );
     try {
       deliveryResponse = (await integrationService.deliver(
         deliveryRequest,
@@ -69,11 +50,6 @@ export class DeliveryController {
     ctx.body = { output: deliveryResponse };
     ControllerUtility.deliveryPostProcess(ctx, deliveryResponse.status);
 
-    DeliveryController.logDeliveryPayload(
-      deliveryRequest.metadata.workspaceId,
-      'Native(Delivery):: Response from transformer after delivery::',
-      ctx.body,
-    );
     return ctx;
   }
 
@@ -83,11 +59,6 @@ export class DeliveryController {
     const deliveryRequest = ctx.request.body as ProxyV1Request;
     const { destination }: { destination: string } = ctx.params;
     const integrationService = ServiceSelector.getNativeDestinationService();
-    DeliveryController.logDeliveryPayload(
-      deliveryRequest.metadata[0].workspaceId,
-      'Native(Delivery):: Request to transformer for delivery::',
-      ctx.request.body,
-    );
     try {
       deliveryResponse = (await integrationService.deliver(
         deliveryRequest,
@@ -116,11 +87,6 @@ export class DeliveryController {
       ControllerUtility.deliveryPostProcess(ctx);
     }
 
-    DeliveryController.logDeliveryPayload(
-      deliveryRequest.metadata[0].workspaceId,
-      'Native(Delivery):: Response from transformer::',
-      ctx.body,
-    );
     return ctx;
   }
 

--- a/src/controllers/delivery.ts
+++ b/src/controllers/delivery.ts
@@ -16,16 +16,35 @@ import {
 } from '../types';
 import tags from '../v0/util/tags';
 import { ControllerUtility } from './util';
+import logger from '../logger';
+import { isFeatureEnabled } from '../util/featureFlags';
 
 const NON_DETERMINABLE = 'Non-determinable';
 
+// Env var gating the request/response payload logs below. These emit full request/response
+// bodies which may contain sensitive customer data/PII, so they are enabled per-workspace
+// (value: "ALL" or a comma-separated list of workspace IDs) and logged at `warn` so they
+// surface at the default LOG_LEVEL when explicitly turned on for debugging.
+const DELIVERY_REQUEST_RESPONSE_LOG_FLAG = 'DELIVERY_REQUEST_RESPONSE_LOG_ENABLED';
+
 export class DeliveryController {
+  private static logDeliveryPayload(workspaceId: string, message: string, payload: unknown) {
+    if (isFeatureEnabled(DELIVERY_REQUEST_RESPONSE_LOG_FLAG, workspaceId)) {
+      logger.warn(message, payload);
+    }
+  }
+
   public static async deliverToDestination(ctx: Context) {
     let deliveryResponse: DeliveryV0Response;
     const requestMetadata = MiscService.getRequestMetadata(ctx);
     const deliveryRequest = ctx.request.body as ProxyV0Request;
     const { destination }: { destination: string } = ctx.params;
     const integrationService = ServiceSelector.getNativeDestinationService();
+    DeliveryController.logDeliveryPayload(
+      deliveryRequest.metadata.workspaceId,
+      'Native(Delivery):: Request to transformer for delivery::',
+      ctx.request.body,
+    );
     try {
       deliveryResponse = (await integrationService.deliver(
         deliveryRequest,
@@ -50,6 +69,11 @@ export class DeliveryController {
     ctx.body = { output: deliveryResponse };
     ControllerUtility.deliveryPostProcess(ctx, deliveryResponse.status);
 
+    DeliveryController.logDeliveryPayload(
+      deliveryRequest.metadata.workspaceId,
+      'Native(Delivery):: Response from transformer after delivery::',
+      ctx.body,
+    );
     return ctx;
   }
 
@@ -59,6 +83,11 @@ export class DeliveryController {
     const deliveryRequest = ctx.request.body as ProxyV1Request;
     const { destination }: { destination: string } = ctx.params;
     const integrationService = ServiceSelector.getNativeDestinationService();
+    DeliveryController.logDeliveryPayload(
+      deliveryRequest.metadata[0].workspaceId,
+      'Native(Delivery):: Request to transformer for delivery::',
+      ctx.request.body,
+    );
     try {
       deliveryResponse = (await integrationService.deliver(
         deliveryRequest,
@@ -87,6 +116,11 @@ export class DeliveryController {
       ControllerUtility.deliveryPostProcess(ctx);
     }
 
+    DeliveryController.logDeliveryPayload(
+      deliveryRequest.metadata[0].workspaceId,
+      'Native(Delivery):: Response from transformer::',
+      ctx.body,
+    );
     return ctx;
   }
 

--- a/src/v1/destinations/google_adwords_offline_conversions/networkHandler.js
+++ b/src/v1/destinations/google_adwords_offline_conversions/networkHandler.js
@@ -36,6 +36,20 @@ const conversionCustomVariableCache = new Cache(
   CONVERSION_CUSTOM_VARIABLE_CACHE_TTL,
 );
 
+/**
+ * Stringifies the Google Ads API error response for use in error messages.
+ * Instead of trying to parse various response shapes, we stringify the entire
+ * error object to ensure nothing is lost regardless of format changes.
+ */
+const stringifyGoogleAdsError = (response) => {
+  if (typeof response === 'string') return response;
+  try {
+    return JSON.stringify(response);
+  } catch {
+    return String(response);
+  }
+};
+
 const createJob = async ({ endpoint, headers, payload, metadata }) => {
   const endPoint = `${endpoint}:create`;
   let createJobResponse = await httpPOST(
@@ -55,7 +69,7 @@ const createJob = async ({ endpoint, headers, payload, metadata }) => {
   const { response, status } = createJobResponse;
   if (!isHttpStatusSuccess(status)) {
     throw new AbortedError(
-      `[Google Ads Offline Conversions]:: ${response?.error?.message || response?.[0]?.error?.message} during google_ads_offline_store_conversions Job Creation`,
+      `[Google Ads Offline Conversions]:: ${stringifyGoogleAdsError(response)} during google_ads_offline_store_conversions Job Creation`,
       status,
       response,
       getAuthErrCategory(createJobResponse),
@@ -83,7 +97,7 @@ const addConversionToJob = async ({ endpoint, headers, jobId, payload, metadata 
   const { response, status } = addConversionToJobResponse;
   if (!isHttpStatusSuccess(status)) {
     throw new AbortedError(
-      `[Google Ads Offline Conversions]:: ${response?.error?.message} during google_ads_offline_store_conversions Add Conversion`,
+      `[Google Ads Offline Conversions]:: ${stringifyGoogleAdsError(response)} during google_ads_offline_store_conversions Add Conversion`,
       status,
       response,
       getAuthErrCategory(addConversionToJobResponse),
@@ -141,7 +155,7 @@ const getConversionCustomVariable = async ({ headers, params, metadata }) => {
     const { response, status } = searchStreamResponse;
     if (!isHttpStatusSuccess(status)) {
       throw new NetworkError(
-        `[Google Ads Offline Conversions]:: ${response?.[0]?.error?.message} during google_ads_offline_conversions response transformation`,
+        `[Google Ads Offline Conversions]:: ${stringifyGoogleAdsError(response)} during google_ads_offline_conversions response transformation`,
         status,
         {
           [tags.TAG_NAMES.ERROR_TYPE]: getDynamicErrorType(status),
@@ -367,7 +381,7 @@ const responseHandler = (responseParams) => {
   // return status, original destination response, message
   const { response } = destinationResponse;
   throw new AbortedError(
-    `[Google Ads Offline Conversions]:: ${response?.error?.message} during google_ads_offline_conversions response transformation`,
+    `[Google Ads Offline Conversions]:: ${stringifyGoogleAdsError(response)} during google_ads_offline_conversions response transformation`,
     status,
     response,
     getAuthErrCategory(destinationResponse),

--- a/src/v1/destinations/google_adwords_offline_conversions/networkHandler.js
+++ b/src/v1/destinations/google_adwords_offline_conversions/networkHandler.js
@@ -37,11 +37,9 @@ const conversionCustomVariableCache = new Cache(
 );
 
 /**
- * Stringifies the Google Ads API error response for use in error messages.
- * Instead of trying to parse various response shapes, we stringify the entire
- * error object to ensure nothing is lost regardless of format changes.
+ * Extracts the full error detail from a Google Ads API error response.
  */
-const stringifyGoogleAdsError = (response) => {
+const getGoogleAdsError = (response) => {
   if (typeof response === 'string') return response;
   try {
     return JSON.stringify(response);
@@ -69,7 +67,7 @@ const createJob = async ({ endpoint, headers, payload, metadata }) => {
   const { response, status } = createJobResponse;
   if (!isHttpStatusSuccess(status)) {
     throw new AbortedError(
-      `[Google Ads Offline Conversions]:: ${stringifyGoogleAdsError(response)} during google_ads_offline_store_conversions Job Creation`,
+      `[Google Ads Offline Conversions]:: ${getGoogleAdsError(response)} during google_ads_offline_store_conversions Job Creation`,
       status,
       response,
       getAuthErrCategory(createJobResponse),
@@ -97,7 +95,7 @@ const addConversionToJob = async ({ endpoint, headers, jobId, payload, metadata 
   const { response, status } = addConversionToJobResponse;
   if (!isHttpStatusSuccess(status)) {
     throw new AbortedError(
-      `[Google Ads Offline Conversions]:: ${stringifyGoogleAdsError(response)} during google_ads_offline_store_conversions Add Conversion`,
+      `[Google Ads Offline Conversions]:: ${getGoogleAdsError(response)} during google_ads_offline_store_conversions Add Conversion`,
       status,
       response,
       getAuthErrCategory(addConversionToJobResponse),
@@ -155,7 +153,7 @@ const getConversionCustomVariable = async ({ headers, params, metadata }) => {
     const { response, status } = searchStreamResponse;
     if (!isHttpStatusSuccess(status)) {
       throw new NetworkError(
-        `[Google Ads Offline Conversions]:: ${stringifyGoogleAdsError(response)} during google_ads_offline_conversions response transformation`,
+        `[Google Ads Offline Conversions]:: ${getGoogleAdsError(response)} during google_ads_offline_conversions response transformation`,
         status,
         {
           [tags.TAG_NAMES.ERROR_TYPE]: getDynamicErrorType(status),
@@ -381,7 +379,7 @@ const responseHandler = (responseParams) => {
   // return status, original destination response, message
   const { response } = destinationResponse;
   throw new AbortedError(
-    `[Google Ads Offline Conversions]:: ${stringifyGoogleAdsError(response)} during google_ads_offline_conversions response transformation`,
+    `[Google Ads Offline Conversions]:: ${getGoogleAdsError(response)} during google_ads_offline_conversions response transformation`,
     status,
     response,
     getAuthErrCategory(destinationResponse),

--- a/test/integrations/destinations/google_adwords_offline_conversions/dataDelivery/batchFetching/business.ts
+++ b/test/integrations/destinations/google_adwords_offline_conversions/dataDelivery/batchFetching/business.ts
@@ -279,11 +279,11 @@ export const testScenariosForV1API = [
         body: {
           output: {
             message:
-              '[Google Ads Offline Conversions]:: Request contains an invalid argument. during google_ads_offline_store_conversions Add Conversion',
+              '[Google Ads Offline Conversions]:: {"error":{"code":400,"message":"Request contains an invalid argument.","status":"INVALID_ARGUMENT","details":[{"@type":"type.googleapis.com/google.ads.googleads.v16.errors.GoogleAdsFailure","errors":[{"errorCode":{"offlineUserDataJobError":"INVALID_SHA256_FORMAT"},"message":"The SHA256 encoded value is malformed.","location":{"fieldPathElements":[{"fieldName":"operations","index":0},{"fieldName":"create"},{"fieldName":"user_identifiers","index":0},{"fieldName":"hashed_email"}]}}],"requestId":"68697987"}]}} during google_ads_offline_store_conversions Add Conversion',
             response: [
               {
                 error:
-                  '[Google Ads Offline Conversions]:: Request contains an invalid argument. during google_ads_offline_store_conversions Add Conversion',
+                  '[Google Ads Offline Conversions]:: {"error":{"code":400,"message":"Request contains an invalid argument.","status":"INVALID_ARGUMENT","details":[{"@type":"type.googleapis.com/google.ads.googleads.v16.errors.GoogleAdsFailure","errors":[{"errorCode":{"offlineUserDataJobError":"INVALID_SHA256_FORMAT"},"message":"The SHA256 encoded value is malformed.","location":{"fieldPathElements":[{"fieldName":"operations","index":0},{"fieldName":"create"},{"fieldName":"user_identifiers","index":0},{"fieldName":"hashed_email"}]}}],"requestId":"68697987"}]}} during google_ads_offline_store_conversions Add Conversion',
                 metadata: generateMetadata(1),
                 statusCode: 400,
               },

--- a/test/integrations/destinations/google_adwords_offline_conversions/dataDelivery/batchFetching/oauth.ts
+++ b/test/integrations/destinations/google_adwords_offline_conversions/dataDelivery/batchFetching/oauth.ts
@@ -129,11 +129,11 @@ export const v1oauthScenarios = [
           output: {
             authErrorCategory: 'REFRESH_TOKEN',
             message:
-              '[Google Ads Offline Conversions]:: Request had invalid authentication credentials. Expected OAuth 2 access token, login cookie or other valid authentication credential. See https://developers.google.com/identity/sign-in/web/devconsole-project. during google_ads_offline_store_conversions Job Creation',
+              '[Google Ads Offline Conversions]:: {"error":{"code":401,"message":"Request had invalid authentication credentials. Expected OAuth 2 access token, login cookie or other valid authentication credential. See https://developers.google.com/identity/sign-in/web/devconsole-project.","status":"UNAUTHENTICATED"}} during google_ads_offline_store_conversions Job Creation',
             response: [
               {
                 error:
-                  '[Google Ads Offline Conversions]:: Request had invalid authentication credentials. Expected OAuth 2 access token, login cookie or other valid authentication credential. See https://developers.google.com/identity/sign-in/web/devconsole-project. during google_ads_offline_store_conversions Job Creation',
+                  '[Google Ads Offline Conversions]:: {"error":{"code":401,"message":"Request had invalid authentication credentials. Expected OAuth 2 access token, login cookie or other valid authentication credential. See https://developers.google.com/identity/sign-in/web/devconsole-project.","status":"UNAUTHENTICATED"}} during google_ads_offline_store_conversions Job Creation',
                 metadata: generateMetadata(1),
                 statusCode: 401,
               },
@@ -178,11 +178,11 @@ export const v1oauthScenarios = [
           output: {
             authErrorCategory: 'AUTH_STATUS_INACTIVE',
             message:
-              '[Google Ads Offline Conversions]:: Request had insufficient authentication scopes during google_ads_offline_store_conversions Job Creation',
+              '[Google Ads Offline Conversions]:: {"error":{"code":403,"message":"Request had insufficient authentication scopes","status":"PERMISSION_DENIED"}} during google_ads_offline_store_conversions Job Creation',
             response: [
               {
                 error:
-                  '[Google Ads Offline Conversions]:: Request had insufficient authentication scopes during google_ads_offline_store_conversions Job Creation',
+                  '[Google Ads Offline Conversions]:: {"error":{"code":403,"message":"Request had insufficient authentication scopes","status":"PERMISSION_DENIED"}} during google_ads_offline_store_conversions Job Creation',
                 metadata: generateMetadata(1),
                 statusCode: 403,
               },
@@ -232,11 +232,11 @@ export const v1oauthScenarios = [
           output: {
             authErrorCategory: 'AUTH_STATUS_INACTIVE',
             message:
-              '[Google Ads Offline Conversions]:: Request is missing required authentication credential. Expected OAuth 2 access token, login cookie or other valid authentication credential. See https://developers.google.com/identity/sign-in/web/devconsole-project. during google_ads_offline_store_conversions Job Creation',
+              '[Google Ads Offline Conversions]:: [{"error":{"code":401,"details":[{"@type":"type.googleapis.com/google.ads.googleads.v16.errors.GoogleAdsFailure","errors":[{"errorCode":{"authenticationError":"TWO_STEP_VERIFICATION_NOT_ENROLLED"},"message":"An account administrator changed this account\'s authentication settings. To access this Google Ads account, enable 2-Step Verification in your Google account at https://www.google.com/landing/2step."}],"requestId":"wy4ZYbsjWcgh6uC2Ruc_Zg"}],"message":"Request is missing required authentication credential. Expected OAuth 2 access token, login cookie or other valid authentication credential. See https://developers.google.com/identity/sign-in/web/devconsole-project.","status":"UNAUTHENTICATED"}}] during google_ads_offline_store_conversions Job Creation',
             response: [
               {
                 error:
-                  '[Google Ads Offline Conversions]:: Request is missing required authentication credential. Expected OAuth 2 access token, login cookie or other valid authentication credential. See https://developers.google.com/identity/sign-in/web/devconsole-project. during google_ads_offline_store_conversions Job Creation',
+                  '[Google Ads Offline Conversions]:: [{"error":{"code":401,"details":[{"@type":"type.googleapis.com/google.ads.googleads.v16.errors.GoogleAdsFailure","errors":[{"errorCode":{"authenticationError":"TWO_STEP_VERIFICATION_NOT_ENROLLED"},"message":"An account administrator changed this account\'s authentication settings. To access this Google Ads account, enable 2-Step Verification in your Google account at https://www.google.com/landing/2step."}],"requestId":"wy4ZYbsjWcgh6uC2Ruc_Zg"}],"message":"Request is missing required authentication credential. Expected OAuth 2 access token, login cookie or other valid authentication credential. See https://developers.google.com/identity/sign-in/web/devconsole-project.","status":"UNAUTHENTICATED"}}] during google_ads_offline_store_conversions Job Creation',
                 metadata: {
                   attemptNum: 1,
                   destinationId: 'default-destinationId',

--- a/test/integrations/destinations/google_adwords_offline_conversions/dataDelivery/business.ts
+++ b/test/integrations/destinations/google_adwords_offline_conversions/dataDelivery/business.ts
@@ -250,11 +250,11 @@ export const testScenariosForV1API = [
         body: {
           output: {
             message:
-              '[Google Ads Offline Conversions]:: Request contains an invalid argument. during google_ads_offline_store_conversions Add Conversion',
+              '[Google Ads Offline Conversions]:: {"error":{"code":400,"message":"Request contains an invalid argument.","status":"INVALID_ARGUMENT","details":[{"@type":"type.googleapis.com/google.ads.googleads.v16.errors.GoogleAdsFailure","errors":[{"errorCode":{"offlineUserDataJobError":"INVALID_SHA256_FORMAT"},"message":"The SHA256 encoded value is malformed.","location":{"fieldPathElements":[{"fieldName":"operations","index":0},{"fieldName":"create"},{"fieldName":"user_identifiers","index":0},{"fieldName":"hashed_email"}]}}],"requestId":"68697987"}]}} during google_ads_offline_store_conversions Add Conversion',
             response: [
               {
                 error:
-                  '[Google Ads Offline Conversions]:: Request contains an invalid argument. during google_ads_offline_store_conversions Add Conversion',
+                  '[Google Ads Offline Conversions]:: {"error":{"code":400,"message":"Request contains an invalid argument.","status":"INVALID_ARGUMENT","details":[{"@type":"type.googleapis.com/google.ads.googleads.v16.errors.GoogleAdsFailure","errors":[{"errorCode":{"offlineUserDataJobError":"INVALID_SHA256_FORMAT"},"message":"The SHA256 encoded value is malformed.","location":{"fieldPathElements":[{"fieldName":"operations","index":0},{"fieldName":"create"},{"fieldName":"user_identifiers","index":0},{"fieldName":"hashed_email"}]}}],"requestId":"68697987"}]}} during google_ads_offline_store_conversions Add Conversion',
                 metadata: generateMetadata(1),
                 statusCode: 400,
               },

--- a/test/integrations/destinations/google_adwords_offline_conversions/dataDelivery/oauth.ts
+++ b/test/integrations/destinations/google_adwords_offline_conversions/dataDelivery/oauth.ts
@@ -119,11 +119,11 @@ export const v1oauthScenarios = [
           output: {
             authErrorCategory: 'REFRESH_TOKEN',
             message:
-              '[Google Ads Offline Conversions]:: Request had invalid authentication credentials. Expected OAuth 2 access token, login cookie or other valid authentication credential. See https://developers.google.com/identity/sign-in/web/devconsole-project. during google_ads_offline_store_conversions Job Creation',
+              '[Google Ads Offline Conversions]:: {"error":{"code":401,"message":"Request had invalid authentication credentials. Expected OAuth 2 access token, login cookie or other valid authentication credential. See https://developers.google.com/identity/sign-in/web/devconsole-project.","status":"UNAUTHENTICATED"}} during google_ads_offline_store_conversions Job Creation',
             response: [
               {
                 error:
-                  '[Google Ads Offline Conversions]:: Request had invalid authentication credentials. Expected OAuth 2 access token, login cookie or other valid authentication credential. See https://developers.google.com/identity/sign-in/web/devconsole-project. during google_ads_offline_store_conversions Job Creation',
+                  '[Google Ads Offline Conversions]:: {"error":{"code":401,"message":"Request had invalid authentication credentials. Expected OAuth 2 access token, login cookie or other valid authentication credential. See https://developers.google.com/identity/sign-in/web/devconsole-project.","status":"UNAUTHENTICATED"}} during google_ads_offline_store_conversions Job Creation',
                 metadata: generateMetadata(1),
                 statusCode: 401,
               },
@@ -165,11 +165,11 @@ export const v1oauthScenarios = [
           output: {
             authErrorCategory: 'AUTH_STATUS_INACTIVE',
             message:
-              '[Google Ads Offline Conversions]:: Request had insufficient authentication scopes during google_ads_offline_store_conversions Job Creation',
+              '[Google Ads Offline Conversions]:: {"error":{"code":403,"message":"Request had insufficient authentication scopes","status":"PERMISSION_DENIED"}} during google_ads_offline_store_conversions Job Creation',
             response: [
               {
                 error:
-                  '[Google Ads Offline Conversions]:: Request had insufficient authentication scopes during google_ads_offline_store_conversions Job Creation',
+                  '[Google Ads Offline Conversions]:: {"error":{"code":403,"message":"Request had insufficient authentication scopes","status":"PERMISSION_DENIED"}} during google_ads_offline_store_conversions Job Creation',
                 metadata: generateMetadata(1),
                 statusCode: 403,
               },
@@ -216,11 +216,11 @@ export const v1oauthScenarios = [
           output: {
             authErrorCategory: 'AUTH_STATUS_INACTIVE',
             message:
-              '[Google Ads Offline Conversions]:: Request is missing required authentication credential. Expected OAuth 2 access token, login cookie or other valid authentication credential. See https://developers.google.com/identity/sign-in/web/devconsole-project. during google_ads_offline_store_conversions Job Creation',
+              '[Google Ads Offline Conversions]:: [{"error":{"code":401,"details":[{"@type":"type.googleapis.com/google.ads.googleads.v16.errors.GoogleAdsFailure","errors":[{"errorCode":{"authenticationError":"TWO_STEP_VERIFICATION_NOT_ENROLLED"},"message":"An account administrator changed this account\'s authentication settings. To access this Google Ads account, enable 2-Step Verification in your Google account at https://www.google.com/landing/2step."}],"requestId":"wy4ZYbsjWcgh6uC2Ruc_Zg"}],"message":"Request is missing required authentication credential. Expected OAuth 2 access token, login cookie or other valid authentication credential. See https://developers.google.com/identity/sign-in/web/devconsole-project.","status":"UNAUTHENTICATED"}}] during google_ads_offline_store_conversions Job Creation',
             response: [
               {
                 error:
-                  '[Google Ads Offline Conversions]:: Request is missing required authentication credential. Expected OAuth 2 access token, login cookie or other valid authentication credential. See https://developers.google.com/identity/sign-in/web/devconsole-project. during google_ads_offline_store_conversions Job Creation',
+                  '[Google Ads Offline Conversions]:: [{"error":{"code":401,"details":[{"@type":"type.googleapis.com/google.ads.googleads.v16.errors.GoogleAdsFailure","errors":[{"errorCode":{"authenticationError":"TWO_STEP_VERIFICATION_NOT_ENROLLED"},"message":"An account administrator changed this account\'s authentication settings. To access this Google Ads account, enable 2-Step Verification in your Google account at https://www.google.com/landing/2step."}],"requestId":"wy4ZYbsjWcgh6uC2Ruc_Zg"}],"message":"Request is missing required authentication credential. Expected OAuth 2 access token, login cookie or other valid authentication credential. See https://developers.google.com/identity/sign-in/web/devconsole-project.","status":"UNAUTHENTICATED"}}] during google_ads_offline_store_conversions Job Creation',
                 metadata: {
                   attemptNum: 1,
                   destinationId: 'default-destinationId',


### PR DESCRIPTION
## Summary

- Google Ads delivery errors surface only a generic top-level message (e.g. "Request contains an invalid argument") — the specific error code, field location, and detailed message Google returns are silently dropped
- For some response shapes the error message renders as literal "undefined", giving customers zero debugging context
- Now the full Google error response is included in the error message so customers can see exactly what went wrong

## Test plan

- [x] All 82 GAOC integration tests pass
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
