### PR TITLE
chore(release): pull main into develop post release v1.138.0

### DIFF
--- a/.claude/skills/batching-framework/SKILL.md
+++ b/.claude/skills/batching-framework/SKILL.md
@@ -43,6 +43,22 @@ src/v0/destinations/<dest_name>/
 └── routerTransform.test.ts   # Unit tests
 ```
 
+## Migrating a legacy (v0 JS) destination
+
+When adding batching to a destination that already has a `transform.js` with a working per-event
+transform, **reuse it — do not reimplement the payload logic in `routerTransform.ts`**:
+
+- Have `transformEvent` call the existing per-event function (`process`/`processEvent`) and reshape
+  its delivery request into a `TransformedEvent` — pull the single per-event payload out of
+  `body.JSON`, and pass `endpoint`/`method`/`headers`/`params` straight through. `posthog` is the
+  canonical example (it reuses `processEvent` from its transform). `wrapBody` then re-assembles the
+  array wrapper the API expects.
+- Legacy transforms are often declared `async` but do no real I/O. Since `transformEvent` must be
+  synchronous, drop the cosmetic `async`/`await` from the reused chain so it returns directly.
+  Callers that `await` a now-plain value are unaffected.
+- **Keep the legacy `processRouterDest` exported.** During pre-GA env-var rollout the destination
+  falls back to it for workspaces not yet enabled, so it must stay functional.
+
 ## BatchDestination Abstract Class
 
 ```typescript
@@ -61,6 +77,9 @@ class MyIntegration extends BatchDestination<TBody, TConfig, TConnectionConfig> 
   ): TransformedEvent<TBody> | TransformedEvent<TBody>[];
   // Transform a single input event into one or more intermediate payloads.
   // Throw InstrumentationError for bad input — framework wraps it into error response.
+  // MUST be synchronous — the framework calls transformEvent WITHOUT awaiting it
+  // (see transformEvents in batchDestination.ts). Never make it async / return a Promise;
+  // an async transformEvent would push a Promise as the payload and silently corrupt the batch.
 
   getBatchStrategy(endpoint: string): BatchStrategy<TBody>;
   // Return a batch strategy instance that defines how events are chunked and wrapped.
@@ -86,6 +105,8 @@ type TransformedEvent<TBody> = {
 ```
 
 The framework groups all `TransformedEvent` objects by a composite key of `(endpoint, method, headers, params, internalGroupKey)`. Events in the same group are batched together.
+
+> **Put batch-invariant fields in `headers`/`params`.** Anything that must be identical across a batch (auth token, account/customer IDs, target action, API resource being addressed) belongs in `headers` or `params` so the composite key naturally keeps incompatible events apart. You usually don't need `internalGroupKey` if these already carry the distinguishing values.
 
 ### The `internalGroupKey` Pattern
 
@@ -185,6 +206,26 @@ When enabled, the platform routes events through `processBatchedDestination()` i
 
 For gradual rollout before GA, use the env var pattern:
 `{DEST_NAME_UPPER}_BATCHING_FRAMEWORK_ENABLED_WORKSPACE_IDS` (comma-separated workspace IDs or `ALL`).
+
+## Proxy / networkHandler destinations
+
+Some destinations deliver through a custom `networkHandler` that builds the actual HTTP request
+(URL, SDK call) at delivery time rather than from the transformed payload. When that's the case,
+`transformEvent`'s `endpoint` is typically left empty/placeholder and unused — the handler derives
+the real URL from `params` (and sometimes details unknown at transform time, e.g. the API version).
+If instead the handler reads the endpoint from the payload, set it normally. Two things to watch
+when the handler owns delivery:
+
+- **Audit the network handler for single-item assumptions.** Pre-batching it received one item per
+  request and often hard-codes index `0` (e.g. `set(body.JSON, 'items[0].field', ...)`). Once
+  batched, `items` is an array of N — change it to iterate the whole array. The single-item case
+  collapses to an array of one, so legacy traffic is unaffected (a safe, ungated change).
+- The proxy layer runs in a later service call than the transform and **does not see the workspace
+  batching flag**, so don't try to gate network-handler changes on it; make them
+  unconditionally-correct for both 1 and N items instead.
+
+Cover this with a focused unit test that mocks the delivery SDK/client and asserts the per-item
+field is set on **every** item (cheaper and more direct than a full dataDelivery mock).
 
 ## Testing
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [1.138.0](https://github.com/rudderlabs/rudder-transformer/compare/v1.137.0...v1.138.0) (2026-06-16)
+
+
+### Features
+
+* **gaec:** batch conversion adjustments with per-event partial failure handling ([#5288](https://github.com/rudderlabs/rudder-transformer/issues/5288)) ([496c5fe](https://github.com/rudderlabs/rudder-transformer/commit/496c5fec1a6509684141d376c58a3b4d07e5f8bc))
+
+
+### Bug Fixes
+
+* **gaoc:** google ads delivery errors show generic messages, hiding the actual error detail ([#5294](https://github.com/rudderlabs/rudder-transformer/issues/5294)) ([a288791](https://github.com/rudderlabs/rudder-transformer/commit/a288791843f0227d1e17ef7eda0ff6d1aedeb00f))
+
 ## [1.137.0](https://github.com/rudderlabs/rudder-transformer/compare/v1.136.0...v1.137.0) (2026-06-10)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rudder-transformer",
-  "version": "1.137.0",
+  "version": "1.138.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rudder-transformer",
-      "version": "1.137.0",
+      "version": "1.138.0",
       "license": "ISC",
       "dependencies": {
         "@amplitude/ua-parser-js": "0.7.24",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rudder-transformer",
-  "version": "1.137.0",
+  "version": "1.138.0",
   "description": "",
   "homepage": "https://github.com/rudderlabs/rudder-transformer#readme",
   "bugs": {

--- a/src/services/destination/nativeBatching/__tests__/batchDestination.test.ts
+++ b/src/services/destination/nativeBatching/__tests__/batchDestination.test.ts
@@ -41,6 +41,7 @@ class TestIntegration extends BatchDestination<TestBody> {
     return {
       body: { value: input.message.data ?? '' },
       endpoint: 'https://api.test.com/events',
+      endpointPath: '/events',
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
     };
@@ -66,6 +67,7 @@ class FailingIntegration extends BatchDestination<TestBody> {
     return {
       body: { value: 'ok' },
       endpoint: 'https://api.test.com/events',
+      endpointPath: '/events',
       method: 'POST',
     };
   }
@@ -166,8 +168,20 @@ describe('strategy classes', () => {
       { body: { merged: true }, jobIds: new Set(payloads.map((p) => p.jobId)) },
     ]);
     const payloads = [
-      { body: { value: 'a' }, endpoint: '/test', method: 'POST' as const, jobId: 1 },
-      { body: { value: 'b' }, endpoint: '/test', method: 'POST' as const, jobId: 2 },
+      {
+        body: { value: 'a' },
+        endpoint: '/test',
+        endpointPath: '/test',
+        method: 'POST' as const,
+        jobId: 1,
+      },
+      {
+        body: { value: 'b' },
+        endpoint: '/test',
+        endpointPath: '/test',
+        method: 'POST' as const,
+        jobId: 2,
+      },
     ];
     const result = await strategy.batch(payloads);
     expect(result).toHaveLength(1);

--- a/src/services/destination/nativeBatching/__tests__/processBatchedDestination.test.ts
+++ b/src/services/destination/nativeBatching/__tests__/processBatchedDestination.test.ts
@@ -52,6 +52,7 @@ class SimpleIntegration extends BatchDestination<TestBody> {
     return {
       body: { value: message.data ?? '' },
       endpoint: 'https://api.test.com/events',
+      endpointPath: '/events',
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
     };
@@ -76,6 +77,7 @@ class MultiEndpointIntegration extends BatchDestination<TestBody> {
       body: { value: message.data ?? '' },
       endpoint:
         message.type === 'track' ? 'https://api.test.com/track' : 'https://api.test.com/identify',
+      endpointPath: message.type === 'track' ? '/track' : '/identify',
       method: 'POST',
     };
   }
@@ -101,6 +103,7 @@ class PartialFailIntegration extends BatchDestination<TestBody> {
     return {
       body: { value: 'ok' },
       endpoint: 'https://api.test.com/events',
+      endpointPath: '/events',
       method: 'POST',
     };
   }
@@ -120,6 +123,7 @@ class CustomBatchIntegration extends BatchDestination<TestBody> {
     return {
       body: { value: message.data ?? '' },
       endpoint: 'https://api.test.com/merge',
+      endpointPath: '/merge',
       method: 'POST',
     };
   }
@@ -150,6 +154,7 @@ class TypedErrorIntegration extends BatchDestination<TestBody> {
     return {
       body: { value: 'ok' },
       endpoint: 'https://api.test.com/events',
+      endpointPath: '/events',
       method: 'POST',
     };
   }
@@ -453,6 +458,7 @@ describe('groupPayloadsByCompositeKey', () => {
       {
         body: { value: 'a' },
         endpoint: 'https://a.com',
+        endpointPath: '/a',
         method: 'POST',
         headers: { h: '1' },
         jobId: 1,
@@ -460,6 +466,7 @@ describe('groupPayloadsByCompositeKey', () => {
       {
         body: { value: 'b' },
         endpoint: 'https://a.com',
+        endpointPath: '/a',
         method: 'POST',
         headers: { h: '1' },
         jobId: 2,
@@ -467,6 +474,7 @@ describe('groupPayloadsByCompositeKey', () => {
       {
         body: { value: 'c' },
         endpoint: 'https://b.com',
+        endpointPath: '/b',
         method: 'POST',
         headers: { h: '1' },
         jobId: 3,
@@ -483,6 +491,7 @@ describe('groupPayloadsByCompositeKey', () => {
       {
         body: { value: 'a' },
         endpoint: 'https://a.com',
+        endpointPath: '/a',
         method: 'POST',
         headers: { h: '1' },
         jobId: 1,
@@ -490,6 +499,7 @@ describe('groupPayloadsByCompositeKey', () => {
       {
         body: { value: 'b' },
         endpoint: 'https://a.com',
+        endpointPath: '/a',
         method: 'POST',
         headers: { h: '2' },
         jobId: 2,

--- a/src/services/destination/nativeBatching/processBatchedDestination.ts
+++ b/src/services/destination/nativeBatching/processBatchedDestination.ts
@@ -100,6 +100,8 @@ type RequestGroup<TBody extends Record<string, unknown>> = {
   headers: Record<string, unknown> | undefined;
   params: Record<string, unknown> | undefined;
   payloads: TransformResult<TBody>['successPayloads'];
+  // Observability-only — not part of the grouping key
+  endpointPath: string;
 };
 
 export function groupPayloadsByCompositeKey<
@@ -120,6 +122,7 @@ export function groupPayloadsByCompositeKey<
     if (!group) {
       group = {
         endpoint: payload.endpoint,
+        endpointPath: payload.endpointPath,
         method: payload.method,
         headers: payload.headers,
         params: payload.params,
@@ -140,6 +143,7 @@ export function groupPayloadsByCompositeKey<
 function mapSuccessPayloadToServerFormat(
   batchResult: { body: Record<string, unknown>; jobIds: Set<number> },
   endpoint: string,
+  endpointPath: string,
   method: string,
   headers: Record<string, unknown> | undefined,
   params: Record<string, unknown> | undefined,
@@ -153,6 +157,7 @@ function mapSuccessPayloadToServerFormat(
       type: 'REST',
       method,
       endpoint,
+      endpointPath,
       headers: headers ?? {},
       params: params ?? {},
       body: {
@@ -292,6 +297,7 @@ export async function processBatchedDestination<
         mapSuccessPayloadToServerFormat(
           batchResult,
           group.endpoint,
+          group.endpointPath,
           group.method,
           group.headers,
           group.params,

--- a/src/services/destination/nativeBatching/types.ts
+++ b/src/services/destination/nativeBatching/types.ts
@@ -5,6 +5,7 @@
 export type TransformedEvent<TBody extends Record<string, unknown> = Record<string, unknown>> = {
   body: TBody;
   endpoint: string;
+  endpointPath: string;
   method: string;
   headers?: Record<string, unknown>;
   params?: Record<string, unknown>;

--- a/src/v0/destinations/custom_audience/routerTransform.ts
+++ b/src/v0/destinations/custom_audience/routerTransform.ts
@@ -90,6 +90,9 @@ class CustomAudienceIntegration extends BatchDestination<
     return {
       body: record,
       endpoint: this.endpointByAction[message.action]!,
+      // Use the action name rather than the full URL to keep metric cardinality low —
+      // each destination instance has a unique endpoint, but actions are a fixed set.
+      endpointPath: `/${resolvedAction}`,
       method: actionConfig.method,
       headers: this.headers,
       // Force the framework's composite-key grouping to keep different actions

--- a/src/v0/destinations/google_adwords_enhanced_conversions/config.js
+++ b/src/v0/destinations/google_adwords_enhanced_conversions/config.js
@@ -10,9 +10,15 @@ const CONVERSION_ACTION_ID_CACHE_TTL = process.env.CONVERSION_ACTION_ID_CACHE_TT
 const hashAttributes = ['email', 'phone', 'firstName', 'lastName', 'streetAddress'];
 const MAPPING_CONFIG = getMappingConfig(CONFIG_CATEGORIES, __dirname);
 
+// Google Ads API caps UploadConversionAdjustments at 2000 conversion adjustments per
+// request; exceeding it is rejected with TOO_MANY_ADJUSTMENTS_IN_REQUEST.
+// Ref - https://developers.google.com/google-ads/api/docs/best-practices/quotas
+const MAX_CONVERSION_ADJUSTMENTS_PER_BATCH = 2000;
+
 module.exports = {
   trackMapping: MAPPING_CONFIG[CONFIG_CATEGORIES.TRACK_CONFIG.name],
   hashAttributes,
   CONVERSION_ACTION_ID_CACHE_TTL,
+  MAX_CONVERSION_ADJUSTMENTS_PER_BATCH,
   destType: 'google_adwords_enhanced_conversions',
 };

--- a/src/v0/destinations/google_adwords_enhanced_conversions/networkHandler.js
+++ b/src/v0/destinations/google_adwords_enhanced_conversions/networkHandler.js
@@ -108,7 +108,12 @@ const gaecProxyRequest = async (request) => {
     googleAds,
   });
 
-  set(body.JSON, 'conversionAdjustments[0].conversionAction', `${conversionActionId}`);
+  // A request may carry multiple conversion adjustments when events are batched. They all
+  // share the same conversion name (grouping key), so the single resolved conversionActionId
+  // applies to every adjustment. For the non-batched path this is an array of one.
+  body.JSON.conversionAdjustments.forEach((_, index) => {
+    set(body.JSON, `conversionAdjustments[${index}].conversionAction`, `${conversionActionId}`);
+  });
 
   const response = await googleAds.addConversionAdjustMent(body.JSON);
 
@@ -172,4 +177,4 @@ class networkHandler {
   }
 }
 
-module.exports = { networkHandler };
+module.exports = { networkHandler, gaecProxyRequest, gaecProcessAxiosResponse };

--- a/src/v0/destinations/google_adwords_enhanced_conversions/networkHandler.test.js
+++ b/src/v0/destinations/google_adwords_enhanced_conversions/networkHandler.test.js
@@ -1,5 +1,65 @@
 const { NetworkError } = require('@rudderstack/integrations-lib');
+
+const mockGetConversionActionId = jest.fn();
+const mockAddConversionAdjustMent = jest.fn();
+
+jest.mock('@rudderstack/integrations-lib', () => ({
+  ...jest.requireActual('@rudderstack/integrations-lib'),
+  GoogleAdsSDK: {
+    GoogleAds: jest.fn().mockImplementation(() => ({
+      getConversionActionId: mockGetConversionActionId,
+      addConversionAdjustMent: mockAddConversionAdjustMent,
+    })),
+  },
+}));
+
+jest.mock('../../util/googleUtils', () => ({
+  ...jest.requireActual('../../util/googleUtils'),
+  getDeveloperToken: () => 'dummy-developer-token',
+}));
+
 const { networkHandler } = require('./networkHandler');
+
+describe('google adwords enhanced conversions - proxy', () => {
+  const { proxy } = new networkHandler();
+
+  beforeEach(() => {
+    mockGetConversionActionId.mockReset().mockResolvedValue('999');
+    mockAddConversionAdjustMent
+      .mockReset()
+      .mockResolvedValue({ statusCode: 200, responseBody: {} });
+  });
+
+  it('sets the resolved conversionAction on every adjustment in a batched request', async () => {
+    const request = {
+      body: {
+        JSON: {
+          partialFailure: true,
+          conversionAdjustments: [
+            { adjustmentType: 'ENHANCEMENT', orderId: '1' },
+            { adjustmentType: 'ENHANCEMENT', orderId: '2' },
+            { adjustmentType: 'ENHANCEMENT', orderId: '3' },
+          ],
+        },
+      },
+      params: {
+        event: 'Page View',
+        customerId: '1234567890',
+        accessToken: 'dummy-access-token',
+        loginCustomerId: '11',
+        subAccount: true,
+      },
+    };
+
+    await proxy(request);
+
+    const sentBody = mockAddConversionAdjustMent.mock.calls[0][0];
+    expect(sentBody.conversionAdjustments).toHaveLength(3);
+    sentBody.conversionAdjustments.forEach((adjustment) => {
+      expect(adjustment.conversionAction).toBe('999');
+    });
+  });
+});
 
 describe('google adwords enhanced conversions - responseHandler', () => {
   const { responseHandler } = new networkHandler();

--- a/src/v0/destinations/google_adwords_enhanced_conversions/routerTransform.test.ts
+++ b/src/v0/destinations/google_adwords_enhanced_conversions/routerTransform.test.ts
@@ -1,0 +1,211 @@
+import { Integration } from './routerTransform';
+import { ChunkBatchStrategy } from '../../../services/destination/nativeBatching/batchDestination';
+import { processBatchedDestination } from '../../../services/destination/nativeBatching/processBatchedDestination';
+import type { Destination } from '../../../types/controlPlaneConfig';
+import type {
+  ProcessorTransformationOutput,
+  RouterTransformationRequestData,
+  RouterTransformationResponse,
+} from '../../../types/destinationTransformation';
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+const destination: Destination = {
+  ID: 'gaec-dest-1',
+  Config: {
+    customerId: '1234567890',
+    subAccount: true,
+    loginCustomerId: '11',
+    listOfConversions: [{ conversions: 'Page View' }, { conversions: 'Product Added' }],
+    authStatus: 'active',
+  },
+  DestinationDefinition: {
+    ID: 'destDef-1',
+    Name: 'GOOGLE_ADWORDS_ENHANCED_CONVERSIONS',
+    DisplayName: 'Google Enhanced Conversions',
+    Config: {},
+  },
+  Name: 'google_adwords_enhanced_conversions',
+  Enabled: true,
+  WorkspaceID: 'ws-1',
+  Transformations: [],
+};
+
+type EventOverrides = { event?: string; type?: string; traits?: Record<string, unknown> };
+
+function makeInput(jobId: number, overrides?: EventOverrides): RouterTransformationRequestData {
+  const message = {
+    type: overrides?.type ?? 'track',
+    event: overrides?.event ?? 'Page View',
+    userId: '12345',
+    context: {
+      traits: overrides?.traits ?? { email: 'user@testmail.com' },
+    },
+    properties: {
+      gclid: 'gclid1234',
+      conversionDateTime: '2022-01-01 12:32:45-08:00',
+      order_id: 10000,
+      total: 1000,
+    },
+  };
+  const metadata = {
+    jobId,
+    userId: 'u1',
+    workspaceId: 'ws-1',
+    destinationId: 'gaec-dest-1',
+    destinationType: 'GOOGLE_ADWORDS_ENHANCED_CONVERSIONS',
+    secret: {
+      access_token: 'dummy-access-token',
+      refresh_token: 'dummy-refresh-token',
+      developer_token: 'dummy-developer-token',
+    },
+  };
+  return { message, metadata, destination } as unknown as RouterTransformationRequestData;
+}
+
+// The framework returns batchedRequest as a single output, an array, or undefined. For this
+// destination it is always a single output; narrow to it (and its JSON body) for assertions.
+const singleBatch = (resp: RouterTransformationResponse): ProcessorTransformationOutput => {
+  const { batchedRequest } = resp;
+  if (!batchedRequest || Array.isArray(batchedRequest)) {
+    throw new Error('expected a single batchedRequest');
+  }
+  return batchedRequest;
+};
+
+type EnhancedConversionsBody = { conversionAdjustments: unknown[]; partialFailure: boolean };
+
+const batchBody = (resp: RouterTransformationResponse): EnhancedConversionsBody =>
+  singleBatch(resp).body?.JSON as EnhancedConversionsBody;
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('GoogleAdwordsEnhancedConversions Integration', () => {
+  const integration = new Integration(destination);
+
+  describe('transformEvent', () => {
+    it('reshapes a single track event into a TransformedEvent carrying one adjustment', () => {
+      const result = integration.transformEvent(makeInput(1));
+
+      expect(result.endpoint).toBe('');
+      expect(result.method).toBe('POST');
+      expect(result.headers).toMatchObject({
+        Authorization: 'Bearer dummy-access-token',
+        'Content-Type': 'application/json',
+        'login-customer-id': '11',
+      });
+      expect(result.params).toMatchObject({
+        event: 'Page View',
+        customerId: '1234567890',
+        loginCustomerId: '11',
+        subAccount: true,
+      });
+      // body is the single conversion adjustment; the conversionAdjustments wrapper and
+      // partialFailure flag are re-added by wrapBody at batch time.
+      expect(result.body).toHaveProperty('adjustmentType', 'ENHANCEMENT');
+      expect(result.body).toHaveProperty('userIdentifiers');
+      expect(result.body).not.toHaveProperty('conversionAdjustments');
+    });
+  });
+
+  describe('getBatchStrategy', () => {
+    it('returns a ChunkBatchStrategy', () => {
+      expect(integration.getBatchStrategy()).toBeInstanceOf(ChunkBatchStrategy);
+    });
+
+    it('wraps adjustments into conversionAdjustments with partialFailure', async () => {
+      const strategy = integration.getBatchStrategy();
+      const adjustments = [
+        { adjustmentType: 'ENHANCEMENT', orderId: '1' },
+        { adjustmentType: 'ENHANCEMENT', orderId: '2' },
+      ];
+
+      const [result] = await strategy.batch(
+        adjustments.map((body, i) => ({
+          body,
+          endpoint: '',
+          endpointPath: '/uploadConversionAdjustments',
+          method: 'POST',
+          jobId: i + 1,
+        })),
+      );
+
+      expect(result.body).toEqual({
+        conversionAdjustments: adjustments,
+        partialFailure: true,
+      });
+      expect(result.jobIds).toEqual(new Set([1, 2]));
+    });
+  });
+
+  describe('getInputSchema', () => {
+    const schema = integration.getInputSchema();
+    const parse = (input: RouterTransformationRequestData) => schema.safeParse(input).success;
+
+    it('accepts a valid track event', () => {
+      expect(parse(makeInput(1))).toBe(true);
+    });
+
+    it('rejects non-track events', () => {
+      expect(parse(makeInput(1, { type: 'identify' }))).toBe(false);
+    });
+
+    it('rejects track events without an event name', () => {
+      expect(parse(makeInput(1, { event: '' }))).toBe(false);
+    });
+  });
+
+  describe('processBatchedDestination', () => {
+    it('batches events with the same conversion name + customer into one request', async () => {
+      const inputs = [makeInput(1), makeInput(2), makeInput(3)];
+      const results = await processBatchedDestination(inputs, Integration, {});
+
+      expect(results).toHaveLength(1);
+      const [batch] = results;
+      expect(batch.batched).toBe(true);
+      expect(batch.statusCode).toBe(200);
+      const body = batchBody(batch);
+      expect(body.conversionAdjustments).toHaveLength(3);
+      expect(body.partialFailure).toBe(true);
+      expect(singleBatch(batch).params).toMatchObject({ event: 'Page View' });
+      expect(batch.metadata.map((m) => m.jobId)).toEqual([1, 2, 3]);
+    });
+
+    it('splits events with different conversion names into separate batches', async () => {
+      const inputs = [
+        makeInput(1, { event: 'Page View' }),
+        makeInput(2, { event: 'Product Added' }),
+        makeInput(3, { event: 'Page View' }),
+      ];
+      const results = await processBatchedDestination(inputs, Integration, {});
+
+      expect(results).toHaveLength(2);
+      const byEvent: Record<string, RouterTransformationResponse> = Object.fromEntries(
+        results.map((r) => [singleBatch(r).params?.event as string, r]),
+      );
+      expect(batchBody(byEvent['Page View']).conversionAdjustments).toHaveLength(2);
+      expect(batchBody(byEvent['Product Added']).conversionAdjustments).toHaveLength(1);
+    });
+
+    it('returns per-event errors for invalid events without poisoning the batch', async () => {
+      const inputs = [
+        makeInput(1),
+        makeInput(2, { type: 'identify' }), // schema rejects → 400
+        makeInput(3, { traits: {} }), // no user identifiers → transform throws → 400
+      ];
+      const results = await processBatchedDestination(inputs, Integration, {});
+
+      const success = results.filter((r) => r.statusCode === 200);
+      const errors = results.filter((r) => r.statusCode === 400);
+
+      expect(success).toHaveLength(1);
+      expect(batchBody(success[0]).conversionAdjustments).toHaveLength(1);
+      expect(success[0].metadata.map((m) => m.jobId)).toEqual([1]);
+      expect(errors.map((e) => e.metadata[0].jobId).sort()).toEqual([2, 3]);
+    });
+  });
+});

--- a/src/v0/destinations/google_adwords_enhanced_conversions/routerTransform.ts
+++ b/src/v0/destinations/google_adwords_enhanced_conversions/routerTransform.ts
@@ -1,0 +1,62 @@
+import { z, ZodType } from 'zod';
+import {
+  BatchDestination,
+  TransformedEvent,
+  ChunkBatchStrategy,
+} from '../../../services/destination/nativeBatching/batchDestination';
+import type { BatchStrategy } from '../../../services/destination/nativeBatching/types';
+import type { RouterTransformationRequestData } from '../../../types/destinationTransformation';
+// `process` (from transform.js) builds the single-event delivery request synchronously and is
+// reused here so no transform logic is duplicated.
+import { process as transformSingleEvent } from './transform';
+import { MAX_CONVERSION_ADJUSTMENTS_PER_BATCH } from './config';
+
+// Each batched item is a single Google Ads conversion adjustment.
+type ConversionAdjustment = Record<string, unknown>;
+
+class GoogleAdwordsEnhancedConversionsIntegration extends BatchDestination<ConversionAdjustment> {
+  transformEvent(input: RouterTransformationRequestData): TransformedEvent<ConversionAdjustment> {
+    // Reuse the existing per-event transform untouched. It returns a delivery request whose
+    // body.JSON is `{ conversionAdjustments: [<single adjustment>], partialFailure: true }`.
+    const result = transformSingleEvent(input);
+
+    return {
+      body: result.body.JSON.conversionAdjustments[0],
+      endpoint: result.endpoint, // '' — delivery is handled by the networkHandler/proxy
+      endpointPath: '/uploadConversionAdjustments',
+      method: result.method,
+      headers: result.headers,
+      // params carries event (conversion name), customerId, loginCustomerId, subAccount and
+      // accessToken — all part of the framework's grouping key, so events only batch together
+      // when they target the same conversion action + customer, as the Google Ads API requires.
+      params: result.params,
+    };
+  }
+
+  getBatchStrategy(): BatchStrategy<ConversionAdjustment> {
+    return new ChunkBatchStrategy<ConversionAdjustment>({
+      maxItems: MAX_CONVERSION_ADJUSTMENTS_PER_BATCH,
+      wrapBody: (bodies) => ({
+        conversionAdjustments: bodies,
+        partialFailure: true,
+      }),
+    });
+  }
+
+  getInputSchema(): ZodType {
+    return z
+      .object({
+        message: z
+          .object({
+            type: z.string().refine((type) => type.toLowerCase() === 'track', {
+              message: 'Message Type is not supported. Only track events are supported.',
+            }),
+            event: z.string().min(1, 'event is required for track calls'),
+          })
+          .passthrough(),
+      })
+      .passthrough();
+  }
+}
+
+export const Integration = GoogleAdwordsEnhancedConversionsIntegration;

--- a/src/v0/destinations/google_adwords_enhanced_conversions/transform.js
+++ b/src/v0/destinations/google_adwords_enhanced_conversions/transform.js
@@ -33,7 +33,7 @@ const updateMappingJson = (mapping) => {
   return newMapping;
 };
 
-const responseBuilder = async (metadata, message, { Config }, payload) => {
+const responseBuilder = (metadata, message, { Config }, payload) => {
   const deliveryRequest = defaultRequestConfig();
   const { event } = message;
   const { subAccount } = Config;
@@ -77,7 +77,7 @@ const responseBuilder = async (metadata, message, { Config }, payload) => {
   return deliveryRequest;
 };
 
-const processTrackEvent = async (metadata, message, destination) => {
+const processTrackEvent = (metadata, message, destination) => {
   let flag = false;
   const { Config } = destination;
   const { event } = message;
@@ -122,7 +122,7 @@ const processTrackEvent = async (metadata, message, destination) => {
   return responseBuilder(metadata, message, destination, payload);
 };
 
-const processEvent = async (metadata, message, destination) => {
+const processEvent = (metadata, message, destination) => {
   const { type } = message;
   if (!type) {
     throw new InstrumentationError('Invalid payload. Message Type is not present');
@@ -134,7 +134,7 @@ const processEvent = async (metadata, message, destination) => {
   }
 };
 
-const process = async (event) => processEvent(event.metadata, event.message, event.destination);
+const process = (event) => processEvent(event.metadata, event.message, event.destination);
 
 const processRouterDest = async (inputs, reqMetadata) => {
   const respList = await simpleProcessRouterDest(inputs, process, reqMetadata);

--- a/src/v0/destinations/iterable_audience/config.ts
+++ b/src/v0/destinations/iterable_audience/config.ts
@@ -27,11 +27,19 @@ export const UNSUBSCRIBE_CATEGORY = {
   endpoint: 'lists/unsubscribe',
 } as const;
 
-export const getSubscribeEndpoint = (dataCenter: DataCenter): string =>
-  constructEndpoint(DATA_CENTER_TO_BASE_KEY[dataCenter], SUBSCRIBE_CATEGORY);
+export const getSubscribeEndpoint = (
+  dataCenter: DataCenter,
+): { endpoint: string; endpointPath: string } => ({
+  endpoint: constructEndpoint(DATA_CENTER_TO_BASE_KEY[dataCenter], SUBSCRIBE_CATEGORY),
+  endpointPath: `/${SUBSCRIBE_CATEGORY.endpoint}`,
+});
 
-export const getUnsubscribeEndpoint = (dataCenter: DataCenter): string =>
-  constructEndpoint(DATA_CENTER_TO_BASE_KEY[dataCenter], UNSUBSCRIBE_CATEGORY);
+export const getUnsubscribeEndpoint = (
+  dataCenter: DataCenter,
+): { endpoint: string; endpointPath: string } => ({
+  endpoint: constructEndpoint(DATA_CENTER_TO_BASE_KEY[dataCenter], UNSUBSCRIBE_CATEGORY),
+  endpointPath: `/${UNSUBSCRIBE_CATEGORY.endpoint}`,
+});
 
 // Iterable's documented per-request maximum for list subscribe/unsubscribe.
 // See doc/loom/knowledge/concerns.md — unverified against the live API.

--- a/src/v0/destinations/iterable_audience/routerTransform.ts
+++ b/src/v0/destinations/iterable_audience/routerTransform.ts
@@ -103,7 +103,7 @@ class IterableAudienceIntegration extends BatchDestination<
 
     const subscriber = selectIdentifierForRow(processed, this.accountConfig.projectType);
 
-    const endpoint =
+    const { endpoint, endpointPath } =
       action === 'subscribe'
         ? getSubscribeEndpoint(this.accountConfig.dataCenter)
         : getUnsubscribeEndpoint(this.accountConfig.dataCenter);
@@ -111,6 +111,7 @@ class IterableAudienceIntegration extends BatchDestination<
     return {
       body: { action, subscriber },
       endpoint,
+      endpointPath,
       method: 'POST',
       headers: this.headers,
     };

--- a/src/v0/destinations/posthog/routerTransform.test.ts
+++ b/src/v0/destinations/posthog/routerTransform.test.ts
@@ -72,6 +72,7 @@ describe('Integration', () => {
 
       expect(result).toEqual({
         endpoint: 'https://app.posthog.com/batch',
+        endpointPath: '/batch',
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: expect.objectContaining({ type: expect.any(String) }),
@@ -120,7 +121,13 @@ describe('Integration', () => {
       ];
 
       const [result] = await strategy.batch(
-        testBodies.map((body, i) => ({ body, endpoint: '', method: 'POST', jobId: i + 1 })),
+        testBodies.map((body, i) => ({
+          body,
+          endpoint: '',
+          endpointPath: '/batch',
+          method: 'POST',
+          jobId: i + 1,
+        })),
       );
 
       expect(result.body).toEqual({

--- a/src/v0/destinations/posthog/routerTransform.ts
+++ b/src/v0/destinations/posthog/routerTransform.ts
@@ -27,6 +27,7 @@ class PostHogIntegration extends BatchDestination<PostHogPayload> {
     return {
       body: eventBody,
       endpoint: result.endpoint,
+      endpointPath: '/batch',
       method: result.method,
       headers: result.headers,
     };

--- a/src/v1/destinations/google_adwords_enhanced_conversions/networkHandler.test.ts
+++ b/src/v1/destinations/google_adwords_enhanced_conversions/networkHandler.test.ts
@@ -1,0 +1,183 @@
+import { NetworkError } from '@rudderstack/integrations-lib';
+import { ProxyMetdata, ResponseProxyObject } from '../../../types';
+import { gaecResponseHandler } from './networkHandler';
+
+const makeMetadata = (jobId: number): ProxyMetdata => ({
+  jobId,
+  attemptNum: 1,
+  userId: 'user-1',
+  sourceId: 'source-1',
+  destinationId: 'dest-1',
+  workspaceId: 'ws-1',
+  secret: {},
+  dontBatch: false,
+});
+
+const partialFailureDetails = [
+  {
+    '@type': 'type.googleapis.com/google.ads.googleads.v15.errors.GoogleAdsFailure',
+    errors: [
+      {
+        errorCode: { conversionAdjustmentUploadError: 'CONVERSION_ALREADY_ENHANCED' },
+        message: 'Conversion already enhanced',
+      },
+    ],
+  },
+];
+
+describe('google adwords enhanced conversions v1 - gaecResponseHandler', () => {
+  const successCases = [
+    {
+      name: 'returns all events as success when no partial failure',
+      input: {
+        destinationResponse: {
+          status: 200,
+          response: [{ results: [{ adjustmentType: 'ENHANCEMENT' }] }],
+        },
+        rudderJobMetadata: [makeMetadata(1), makeMetadata(2)],
+      },
+      expected: {
+        status: 200,
+        message: 'Request Processed Successfully',
+        response: [
+          { statusCode: 200, metadata: makeMetadata(1), error: 'success' },
+          { statusCode: 200, metadata: makeMetadata(2), error: 'success' },
+        ],
+      },
+    },
+    {
+      name: 'returns success when partialFailureError has code 0',
+      input: {
+        destinationResponse: {
+          status: 200,
+          response: { partialFailureError: { code: 0 }, results: [{}, {}] },
+        },
+        rudderJobMetadata: [makeMetadata(1)],
+      },
+      expected: {
+        status: 200,
+        message: 'Request Processed Successfully',
+        response: [{ statusCode: 200, metadata: makeMetadata(1), error: 'success' }],
+      },
+    },
+    {
+      name: 'handles undefined response body as success',
+      input: {
+        destinationResponse: { status: 200, response: undefined },
+        rudderJobMetadata: [makeMetadata(1)],
+      },
+      expected: {
+        status: 200,
+        message: 'Request Processed Successfully',
+        response: [{ statusCode: 200, metadata: makeMetadata(1), error: 'success' }],
+      },
+    },
+  ];
+
+  it.each(successCases)('$name', ({ input, expected }) => {
+    const result = gaecResponseHandler(input);
+    expect(result).toEqual(expect.objectContaining(expected));
+  });
+
+  const partialFailureCases = [
+    {
+      name: 'maps per-event success/failure with mixed results',
+      input: {
+        destinationResponse: {
+          status: 200,
+          response: {
+            partialFailureError: {
+              code: 3,
+              message: 'event at index 1 failed, at conversion_adjustments[1]',
+              details: partialFailureDetails,
+            },
+            results: [{ adjustmentType: 'ENHANCEMENT', orderId: '100' }, {}],
+          },
+        },
+        rudderJobMetadata: [makeMetadata(1), makeMetadata(2)],
+      },
+      expected: {
+        status: 400,
+        response: [
+          { statusCode: 200, metadata: makeMetadata(1), error: 'success' },
+          {
+            statusCode: 400,
+            metadata: makeMetadata(2),
+            error: 'event at index 1 failed, at conversion_adjustments[1]',
+          },
+        ],
+      },
+    },
+    {
+      name: 'marks all events as failed when no results array',
+      input: {
+        destinationResponse: {
+          status: 200,
+          response: {
+            partialFailureError: { code: 3, message: 'all events failed' },
+          },
+        },
+        rudderJobMetadata: [makeMetadata(1), makeMetadata(2)],
+      },
+      expected: {
+        status: 400,
+        response: [
+          { statusCode: 400, metadata: makeMetadata(1), error: 'all events failed' },
+          { statusCode: 400, metadata: makeMetadata(2), error: 'all events failed' },
+        ],
+      },
+    },
+    {
+      name: 'uses "unknown error format" when partialFailureError has no message',
+      input: {
+        destinationResponse: {
+          status: 200,
+          response: { partialFailureError: { code: 3 }, results: [{}] },
+        },
+        rudderJobMetadata: [makeMetadata(1)],
+      },
+      expected: {
+        status: 400,
+        response: [{ statusCode: 400, metadata: makeMetadata(1), error: 'unknown error format' }],
+      },
+    },
+  ];
+
+  it.each(partialFailureCases)('$name', ({ input, expected }) => {
+    const result = gaecResponseHandler(input);
+    expect(result).toEqual(expect.objectContaining(expected));
+  });
+
+  it('returns correct statTags on partial failure', () => {
+    const result = gaecResponseHandler({
+      destinationResponse: {
+        status: 200,
+        response: { partialFailureError: { code: 3, message: 'some error' }, results: [{}] },
+      },
+      rudderJobMetadata: [makeMetadata(1)],
+    }) as ResponseProxyObject;
+
+    expect(result.statTags).toEqual({
+      errorCategory: 'network',
+      errorType: 'aborted',
+      destType: 'GOOGLE_ADWORDS_ENHANCED_CONVERSIONS',
+      module: 'destination',
+      implementation: 'native',
+      feature: 'dataDelivery',
+      destinationId: 'dest-1',
+      workspaceId: 'ws-1',
+    });
+  });
+
+  it('throws NetworkError for non-2xx status', () => {
+    expect(() =>
+      gaecResponseHandler({
+        destinationResponse: {
+          status: 401,
+          response: { error: { message: 'Invalid credentials' } },
+        },
+        rudderJobMetadata: [makeMetadata(1)],
+      }),
+    ).toThrow(NetworkError);
+  });
+});

--- a/src/v1/destinations/google_adwords_enhanced_conversions/networkHandler.ts
+++ b/src/v1/destinations/google_adwords_enhanced_conversions/networkHandler.ts
@@ -1,0 +1,122 @@
+/**
+ * V1 network handler for Google Ads Enhanced Conversions.
+ *
+ * Reuses the v0 proxy and processAxiosResponse. The response handler returns per-event
+ * success/failure statuses on partial failure instead of throwing a single error for the
+ * whole batch.
+ *
+ * This file lives under v1/ so the networkHandlerFactory registers it with
+ * handlerVersion='v1', which bypasses the v0→v1 adaptation layer in nativeIntegration.ts.
+ */
+import { NetworkError } from '@rudderstack/integrations-lib';
+import { prepareProxyRequest } from '../../../adapters/network';
+import { getDynamicErrorType } from '../../../adapters/utils/networkUtils';
+import {
+  DeliveryJobState,
+  ProxyMetdata,
+  ResponseHandlerParams,
+  ResponseProxyObject,
+} from '../../../types';
+import { isHttpStatusSuccess, isEmptyObject } from '../../../v0/util';
+import { getAuthErrCategory } from '../../../v0/util/googleUtils';
+import tags from '../../../v0/util/tags';
+import { CommonUtils } from '../../../util/common';
+import {
+  gaecProxyRequest,
+  gaecProcessAxiosResponse,
+} from '../../../v0/destinations/google_adwords_enhanced_conversions/networkHandler';
+
+const DEST_TYPE = 'GOOGLE_ADWORDS_ENHANCED_CONVERSIONS';
+
+/**
+ * Per-event response handler for batched Google Ads Enhanced Conversions requests.
+ *
+ * When the API returns a partialFailureError alongside a results array, each event
+ * is individually mapped to success or failure based on whether its positional entry
+ * in results is populated or empty.
+ *
+ * Ref: https://developers.google.com/google-ads/api/reference/rpc/v17/UploadConversionAdjustmentsResponse
+ */
+const gaecResponseHandler = (responseParams: ResponseHandlerParams): ResponseProxyObject => {
+  const { destinationResponse, rudderJobMetadata } = responseParams;
+  const message = 'Request Processed Successfully';
+  const { status } = destinationResponse;
+  const metaDataArray: ProxyMetdata[] = CommonUtils.toArray(rudderJobMetadata);
+
+  if (isHttpStatusSuccess(status)) {
+    const { partialFailureError, results } = destinationResponse?.response || {};
+
+    // Fully successful — no partial failure or code 0 means all events succeeded
+    if (!partialFailureError || partialFailureError.code === 0) {
+      return {
+        status,
+        message,
+        response: metaDataArray.map(
+          (metadata): DeliveryJobState => ({
+            statusCode: status,
+            metadata,
+            error: 'success',
+          }),
+        ),
+      };
+    }
+
+    // Partial failure: map each event to its result. Empty result = failed event.
+    // Ref: https://github.com/googleapis/googleapis/blob/master/google/rpc/code.proto
+    const errorMessage: string = partialFailureError.message || 'unknown error format';
+    const responseWithIndividualEvents: DeliveryJobState[] = metaDataArray.map(
+      (metadata, i): DeliveryJobState => {
+        // The API returns results positionally: a populated object means the event
+        // succeeded, an empty object (or missing entry) means it failed.
+        // Failed events are always non-retryable data issues (duplicate enhancement,
+        // invalid gclid, etc.) so 400 is the appropriate status.
+        const eventResponse = results?.[i] ?? {};
+        const isEventFailed = isEmptyObject(eventResponse);
+        return {
+          statusCode: isEventFailed ? 400 : 200,
+          metadata,
+          error: isEventFailed ? errorMessage : 'success',
+        };
+      },
+    );
+
+    return {
+      status: 400,
+      message: `[Google Ads Enhanced Conversions]:: ${errorMessage}`,
+      destinationResponse,
+      statTags: {
+        errorCategory: 'network',
+        errorType: 'aborted',
+        destType: DEST_TYPE,
+        module: 'destination',
+        implementation: 'native',
+        feature: 'dataDelivery',
+        destinationId: metaDataArray[0]?.destinationId || '',
+        workspaceId: metaDataArray[0]?.workspaceId || '',
+      },
+      response: responseWithIndividualEvents,
+    };
+  }
+
+  // Non-2xx status — complete failure for all events
+  const { response } = destinationResponse;
+  const errMessage = response?.error?.message || '';
+  throw new NetworkError(
+    `${errMessage} during Google_adwords_enhanced_conversions response transformation`,
+    status,
+    {
+      [tags.TAG_NAMES.ERROR_TYPE]: getDynamicErrorType(status),
+    },
+    response,
+    getAuthErrCategory({ response, status }),
+  );
+};
+
+function networkHandler(this: any) {
+  this.proxy = gaecProxyRequest;
+  this.responseHandler = gaecResponseHandler;
+  this.processAxiosResponse = gaecProcessAxiosResponse;
+  this.prepareProxy = prepareProxyRequest;
+}
+
+export { networkHandler, gaecResponseHandler };

--- a/src/v1/destinations/google_adwords_offline_conversions/networkHandler.js
+++ b/src/v1/destinations/google_adwords_offline_conversions/networkHandler.js
@@ -36,6 +36,18 @@ const conversionCustomVariableCache = new Cache(
   CONVERSION_CUSTOM_VARIABLE_CACHE_TTL,
 );
 
+/**
+ * Extracts the full error detail from a Google Ads API error response.
+ */
+const getGoogleAdsError = (response) => {
+  if (typeof response === 'string') return response;
+  try {
+    return JSON.stringify(response);
+  } catch {
+    return String(response);
+  }
+};
+
 const createJob = async ({ endpoint, headers, payload, metadata }) => {
   const endPoint = `${endpoint}:create`;
   let createJobResponse = await httpPOST(
@@ -55,7 +67,7 @@ const createJob = async ({ endpoint, headers, payload, metadata }) => {
   const { response, status } = createJobResponse;
   if (!isHttpStatusSuccess(status)) {
     throw new AbortedError(
-      `[Google Ads Offline Conversions]:: ${response?.error?.message || response?.[0]?.error?.message} during google_ads_offline_store_conversions Job Creation`,
+      `[Google Ads Offline Conversions]:: ${getGoogleAdsError(response)} during google_ads_offline_store_conversions Job Creation`,
       status,
       response,
       getAuthErrCategory(createJobResponse),
@@ -83,7 +95,7 @@ const addConversionToJob = async ({ endpoint, headers, jobId, payload, metadata 
   const { response, status } = addConversionToJobResponse;
   if (!isHttpStatusSuccess(status)) {
     throw new AbortedError(
-      `[Google Ads Offline Conversions]:: ${response?.error?.message} during google_ads_offline_store_conversions Add Conversion`,
+      `[Google Ads Offline Conversions]:: ${getGoogleAdsError(response)} during google_ads_offline_store_conversions Add Conversion`,
       status,
       response,
       getAuthErrCategory(addConversionToJobResponse),
@@ -141,7 +153,7 @@ const getConversionCustomVariable = async ({ headers, params, metadata }) => {
     const { response, status } = searchStreamResponse;
     if (!isHttpStatusSuccess(status)) {
       throw new NetworkError(
-        `[Google Ads Offline Conversions]:: ${response?.[0]?.error?.message} during google_ads_offline_conversions response transformation`,
+        `[Google Ads Offline Conversions]:: ${getGoogleAdsError(response)} during google_ads_offline_conversions response transformation`,
         status,
         {
           [tags.TAG_NAMES.ERROR_TYPE]: getDynamicErrorType(status),
@@ -367,7 +379,7 @@ const responseHandler = (responseParams) => {
   // return status, original destination response, message
   const { response } = destinationResponse;
   throw new AbortedError(
-    `[Google Ads Offline Conversions]:: ${response?.error?.message} during google_ads_offline_conversions response transformation`,
+    `[Google Ads Offline Conversions]:: ${getGoogleAdsError(response)} during google_ads_offline_conversions response transformation`,
     status,
     response,
     getAuthErrCategory(destinationResponse),

--- a/test/integrations/destinations/custom_audience/router/data.ts
+++ b/test/integrations/destinations/custom_audience/router/data.ts
@@ -96,6 +96,7 @@ export const data: RouterTestData[] = [
                 type: 'REST',
                 method: 'POST',
                 endpoint: insertEndpoint,
+                endpointPath: '/insert',
                 headers,
                 params: {},
                 body: {
@@ -120,6 +121,7 @@ export const data: RouterTestData[] = [
                 type: 'REST',
                 method: 'POST',
                 endpoint: insertEndpoint,
+                endpointPath: '/update',
                 headers,
                 params: {},
                 body: {
@@ -144,6 +146,7 @@ export const data: RouterTestData[] = [
                 type: 'REST',
                 method: 'DELETE',
                 endpoint: deleteEndpoint,
+                endpointPath: '/delete',
                 headers,
                 params: {},
                 body: {
@@ -228,6 +231,7 @@ export const data: RouterTestData[] = [
                 type: 'REST',
                 method: 'POST',
                 endpoint: insertEndpoint,
+                endpointPath: '/insert',
                 headers,
                 params: {},
                 body: {
@@ -317,6 +321,7 @@ export const data: RouterTestData[] = [
                 type: 'REST',
                 method: 'POST',
                 endpoint: insertEndpoint,
+                endpointPath: '/insert',
                 headers,
                 params: {},
                 body: {
@@ -394,6 +399,7 @@ export const data: RouterTestData[] = [
                 type: 'REST',
                 method: 'POST',
                 endpoint: insertEndpoint,
+                endpointPath: '/insert',
                 headers,
                 params: {},
                 body: {
@@ -469,6 +475,7 @@ export const data: RouterTestData[] = [
                 type: 'REST',
                 method: 'POST',
                 endpoint: insertEndpoint,
+                endpointPath: '/insert',
                 headers,
                 params: {},
                 body: {
@@ -542,6 +549,7 @@ export const data: RouterTestData[] = [
                 type: 'REST',
                 method: 'POST',
                 endpoint: insertEndpoint,
+                endpointPath: '/insert',
                 headers,
                 params: {},
                 body: {
@@ -606,6 +614,7 @@ export const data: RouterTestData[] = [
                 type: 'REST',
                 method: 'POST',
                 endpoint: insertEndpoint,
+                endpointPath: '/insert',
                 headers,
                 params: {},
                 body: {
@@ -773,6 +782,7 @@ export const data: RouterTestData[] = [
                 type: 'REST',
                 method: 'POST',
                 endpoint: insertEndpoint,
+                endpointPath: '/insert',
                 headers,
                 params: {},
                 body: {

--- a/test/integrations/destinations/google_adwords_enhanced_conversions/dataDelivery/business.ts
+++ b/test/integrations/destinations/google_adwords_enhanced_conversions/dataDelivery/business.ts
@@ -1,4 +1,4 @@
-import { authHeader1 } from '../maskedSecrets';
+import { authHeader1, secret1 } from '../maskedSecrets';
 import {
   generateMetadata,
   generateProxyV0Payload,
@@ -215,7 +215,7 @@ export const testScenariosForV1API: ProxyV1TestData[] = [
     name: 'google_adwords_enhanced_conversions',
     description:
       '[Proxy v1 API] :: Test for a valid request with a successful 200 response from the destination',
-    successCriteria: 'Should return 200 with destination response',
+    successCriteria: 'Should return 200 with per-event success',
     scenario: 'Business',
     feature: 'dataDelivery',
     module: 'destination',
@@ -240,22 +240,7 @@ export const testScenariosForV1API: ProxyV1TestData[] = [
             message: 'Request Processed Successfully',
             response: [
               {
-                error: JSON.stringify([
-                  {
-                    results: [
-                      {
-                        adjustmentType: 'ENHANCEMENT',
-                        conversionAction: 'customers/7693729833/conversionActions/874224905',
-                        adjustmentDateTime: '2021-01-01 12:32:45-08:00',
-                        gclidDateTimePair: {
-                          gclid: '1234',
-                          conversionDateTime: '2021-01-01 12:32:45-08:00',
-                        },
-                        orderId: '12345',
-                      },
-                    ],
-                  },
-                ]),
+                error: 'success',
                 metadata: generateMetadata(1),
                 statusCode: 200,
               },
@@ -271,7 +256,7 @@ export const testScenariosForV1API: ProxyV1TestData[] = [
     name: 'google_adwords_enhanced_conversions',
     description:
       '[Proxy v1 API] :: Test for a partial failure request with a 200 response from the destination',
-    successCriteria: 'Should return 400 with partial failure error',
+    successCriteria: 'Should return per-event error for the failed event',
     scenario: 'Business',
     feature: 'dataDelivery',
     module: 'destination',
@@ -301,29 +286,11 @@ export const testScenariosForV1API: ProxyV1TestData[] = [
         status: 200,
         body: {
           output: {
-            message: JSON.stringify({
-              code: 3,
-              message:
-                'Conversion already has enhancements with the same Order ID and conversion action. Make sure your data is correctly configured and try again., at conversion_adjustments[0]',
-              details: [
-                {
-                  '@type': 'type.googleapis.com/google.ads.googleads.v15.errors.GoogleAdsFailure',
-                  errors: [
-                    {
-                      errorCode: { conversionAdjustmentUploadError: 'CONVERSION_ALREADY_ENHANCED' },
-                      message:
-                        'Conversion already has enhancements with the same Order ID and conversion action. Make sure your data is correctly configured and try again.',
-                      location: {
-                        fieldPathElements: [{ fieldName: 'conversion_adjustments', index: 0 }],
-                      },
-                    },
-                  ],
-                },
-              ],
-            }),
-            response: [
-              {
-                error: JSON.stringify({
+            message:
+              '[Google Ads Enhanced Conversions]:: Conversion already has enhancements with the same Order ID and conversion action. Make sure your data is correctly configured and try again., at conversion_adjustments[0]',
+            destinationResponse: {
+              response: {
+                partialFailureError: {
                   code: 3,
                   message:
                     'Conversion already has enhancements with the same Order ID and conversion action. Make sure your data is correctly configured and try again., at conversion_adjustments[0]',
@@ -345,7 +312,14 @@ export const testScenariosForV1API: ProxyV1TestData[] = [
                       ],
                     },
                   ],
-                }),
+                },
+              },
+              status: 200,
+            },
+            response: [
+              {
+                error:
+                  'Conversion already has enhancements with the same Order ID and conversion action. Make sure your data is correctly configured and try again., at conversion_adjustments[0]',
                 metadata: generateMetadata(1),
                 statusCode: 400,
               },
@@ -458,11 +432,11 @@ export const testScenariosForV1API: ProxyV1TestData[] = [
           output: {
             authErrorCategory: 'REFRESH_TOKEN',
             message:
-              'Request had invalid authentication credentials. Expected OAuth 2 access token, login cookie or other valid authentication credential. See https://developers.google.com/identity/sign-in/web/devconsole-project." during Google_adwords_enhanced_conversions response transformation',
+              'Request had invalid authentication credentials. Expected OAuth 2 access token, login cookie or other valid authentication credential. See https://developers.google.com/identity/sign-in/web/devconsole-project. during Google_adwords_enhanced_conversions response transformation',
             response: [
               {
                 error:
-                  'Request had invalid authentication credentials. Expected OAuth 2 access token, login cookie or other valid authentication credential. See https://developers.google.com/identity/sign-in/web/devconsole-project." during Google_adwords_enhanced_conversions response transformation',
+                  'Request had invalid authentication credentials. Expected OAuth 2 access token, login cookie or other valid authentication credential. See https://developers.google.com/identity/sign-in/web/devconsole-project. during Google_adwords_enhanced_conversions response transformation',
                 metadata: {
                   attemptNum: 1,
                   destinationId: 'default-destinationId',
@@ -480,6 +454,157 @@ export const testScenariosForV1API: ProxyV1TestData[] = [
             ],
             statTags: expectedStatTags,
             status: 401,
+          },
+        },
+      },
+    },
+  },
+  {
+    id: 'gaec_v1_scenario_5',
+    name: 'google_adwords_enhanced_conversions',
+    description:
+      '[Proxy v1 API] :: Test for a multi-event batch with partial failure — first event succeeds, second fails',
+    successCriteria:
+      'Should return per-event statuses: 200 for the first event, 400 for the second',
+    scenario: 'Business',
+    feature: 'dataDelivery',
+    module: 'destination',
+    version: 'v1',
+    input: {
+      request: {
+        body: generateProxyV1Payload(
+          {
+            headers,
+            params: {
+              event: 'Product Added',
+              customerId: '1234567777',
+              destination: 'google_adwords_enhanced_conversions',
+              accessToken: secret1,
+              subAccount: false,
+            },
+            JSON: {
+              partialFailure: true,
+              conversionAdjustments: [
+                {
+                  gclidDateTimePair: {
+                    gclid: 'gclid1234',
+                    conversionDateTime: '2022-01-01 12:32:45-08:00',
+                  },
+                  restatementValue: { adjustedValue: 10, currency: 'INR' },
+                  order_id: '10000',
+                  adjustmentDateTime: '2022-01-01 12:32:45-08:00',
+                  userAgent:
+                    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36',
+                  userIdentifiers: [
+                    {
+                      addressInfo: {
+                        hashedFirstName:
+                          'a8cfcd74832004951b4408cdb0a5dbcd8c7e52d43f7fe244bf720582e05241da',
+                        hashedLastName:
+                          '1c574b17eefa532b6d61c963550a82d2d3dfca4a7fb69e183374cfafd5328ee4',
+                        state: 'UK',
+                        city: 'London',
+                        hashedStreetAddress:
+                          '9a4d2e50828448f137f119a3ebdbbbab8d6731234a67595fdbfeb2a2315dd550',
+                      },
+                    },
+                  ],
+                  adjustmentType: 'ENHANCEMENT',
+                },
+                {
+                  gclidDateTimePair: {
+                    gclid: 'gclid5678',
+                    conversionDateTime: '2022-01-01 12:32:45-08:00',
+                  },
+                  restatementValue: { adjustedValue: 20, currency: 'INR' },
+                  order_id: '10001',
+                  adjustmentDateTime: '2022-01-01 12:32:45-08:00',
+                  userAgent:
+                    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36',
+                  userIdentifiers: [
+                    {
+                      addressInfo: {
+                        hashedFirstName:
+                          'a8cfcd74832004951b4408cdb0a5dbcd8c7e52d43f7fe244bf720582e05241da',
+                        hashedLastName:
+                          '1c574b17eefa532b6d61c963550a82d2d3dfca4a7fb69e183374cfafd5328ee4',
+                        state: 'UK',
+                        city: 'London',
+                        hashedStreetAddress:
+                          '9a4d2e50828448f137f119a3ebdbbbab8d6731234a67595fdbfeb2a2315dd550',
+                      },
+                    },
+                  ],
+                  adjustmentType: 'ENHANCEMENT',
+                },
+              ],
+            },
+            endpoint: '',
+          },
+          [generateMetadata(1), generateMetadata(2)],
+        ),
+        method: 'POST',
+      },
+    },
+    output: {
+      response: {
+        status: 200,
+        body: {
+          output: {
+            message:
+              '[Google Ads Enhanced Conversions]:: Conversion already has enhancements with the same Order ID and conversion action. Make sure your data is correctly configured and try again., at conversion_adjustments[1]',
+            destinationResponse: {
+              response: {
+                partialFailureError: {
+                  code: 3,
+                  message:
+                    'Conversion already has enhancements with the same Order ID and conversion action. Make sure your data is correctly configured and try again., at conversion_adjustments[1]',
+                  details: [
+                    {
+                      '@type':
+                        'type.googleapis.com/google.ads.googleads.v15.errors.GoogleAdsFailure',
+                      errors: [
+                        {
+                          errorCode: {
+                            conversionAdjustmentUploadError: 'CONVERSION_ALREADY_ENHANCED',
+                          },
+                          message:
+                            'Conversion already has enhancements with the same Order ID and conversion action. Make sure your data is correctly configured and try again.',
+                          location: {
+                            fieldPathElements: [{ fieldName: 'conversion_adjustments', index: 1 }],
+                          },
+                        },
+                      ],
+                    },
+                  ],
+                },
+                results: [
+                  {
+                    adjustmentType: 'ENHANCEMENT',
+                    conversionAction: 'customers/1234567777/conversionActions/123434350',
+                    adjustmentDateTime: '2022-01-01 12:32:45-08:00',
+                    orderId: '10000',
+                  },
+                  {},
+                ],
+              },
+              status: 200,
+            },
+            response: [
+              {
+                error: 'success',
+                metadata: generateMetadata(1),
+                statusCode: 200,
+              },
+              {
+                error:
+                  'Conversion already has enhancements with the same Order ID and conversion action. Make sure your data is correctly configured and try again., at conversion_adjustments[1]',
+                metadata: generateMetadata(2),
+                statusCode: 400,
+              },
+            ],
+            statTags: expectedStatTags,
+            status: 400,
           },
         },
       },

--- a/test/integrations/destinations/google_adwords_enhanced_conversions/network.ts
+++ b/test/integrations/destinations/google_adwords_enhanced_conversions/network.ts
@@ -525,6 +525,150 @@ const v19NetworkCallsData = [
       },
     },
   },
+  // Multi-event batch: searchStream to resolve conversionActionId for customerId 1234567777
+  {
+    httpReq: {
+      url: `https://googleads.googleapis.com/v22/customers/1234567777/googleAds:searchStream`,
+      data: {
+        query: `SELECT conversion_action.id FROM conversion_action WHERE conversion_action.name = 'Product Added'`,
+      },
+      params: { destination: 'google_adwords_enhanced_conversion' },
+      headers: {
+        Authorization: authHeader1,
+        'Content-Type': 'application/json',
+        'developer-token': 'test-developer-token-12345',
+      },
+      method: 'POST',
+    },
+    httpRes: {
+      data: [
+        {
+          results: [
+            {
+              conversionAction: {
+                id: 123434350,
+                resourceName: 'customers/1234567777/conversionActions/123434350',
+              },
+            },
+          ],
+        },
+      ],
+      status: 200,
+    },
+  },
+  // Multi-event batch: uploadConversionAdjustments with 2 events → partial failure (event 0 ok, event 1 failed)
+  {
+    httpReq: {
+      url: `https://googleads.googleapis.com/v22/customers/1234567777:uploadConversionAdjustments`,
+      data: {
+        conversionAdjustments: [
+          {
+            adjustmentDateTime: '2022-01-01 12:32:45-08:00',
+            adjustmentType: 'ENHANCEMENT',
+            conversionAction: 'customers/1234567777/conversionActions/123434350',
+            gclidDateTimePair: {
+              conversionDateTime: '2022-01-01 12:32:45-08:00',
+              gclid: 'gclid1234',
+            },
+            order_id: '10000',
+            restatementValue: { adjustedValue: 10, currency: 'INR' },
+            userAgent:
+              'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36',
+            userIdentifiers: [
+              {
+                addressInfo: {
+                  hashedFirstName:
+                    'a8cfcd74832004951b4408cdb0a5dbcd8c7e52d43f7fe244bf720582e05241da',
+                  hashedLastName:
+                    '1c574b17eefa532b6d61c963550a82d2d3dfca4a7fb69e183374cfafd5328ee4',
+                  state: 'UK',
+                  city: 'London',
+                  hashedStreetAddress:
+                    '9a4d2e50828448f137f119a3ebdbbbab8d6731234a67595fdbfeb2a2315dd550',
+                },
+              },
+            ],
+          },
+          {
+            adjustmentDateTime: '2022-01-01 12:32:45-08:00',
+            adjustmentType: 'ENHANCEMENT',
+            conversionAction: 'customers/1234567777/conversionActions/123434350',
+            gclidDateTimePair: {
+              conversionDateTime: '2022-01-01 12:32:45-08:00',
+              gclid: 'gclid5678',
+            },
+            order_id: '10001',
+            restatementValue: { adjustedValue: 20, currency: 'INR' },
+            userAgent:
+              'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36',
+            userIdentifiers: [
+              {
+                addressInfo: {
+                  hashedFirstName:
+                    'a8cfcd74832004951b4408cdb0a5dbcd8c7e52d43f7fe244bf720582e05241da',
+                  hashedLastName:
+                    '1c574b17eefa532b6d61c963550a82d2d3dfca4a7fb69e183374cfafd5328ee4',
+                  state: 'UK',
+                  city: 'London',
+                  hashedStreetAddress:
+                    '9a4d2e50828448f137f119a3ebdbbbab8d6731234a67595fdbfeb2a2315dd550',
+                },
+              },
+            ],
+          },
+        ],
+        partialFailure: true,
+      },
+      params: { destination: 'google_adwords_enhanced_conversion' },
+      headers: {
+        Authorization: authHeader1,
+        'Content-Type': 'application/json',
+        'developer-token': 'test-developer-token-12345',
+      },
+      method: 'POST',
+    },
+    httpRes: {
+      status: 200,
+      data: {
+        partialFailureError: {
+          code: 3,
+          message:
+            'Conversion already has enhancements with the same Order ID and conversion action. Make sure your data is correctly configured and try again., at conversion_adjustments[1]',
+          details: [
+            {
+              '@type': 'type.googleapis.com/google.ads.googleads.v15.errors.GoogleAdsFailure',
+              errors: [
+                {
+                  errorCode: {
+                    conversionAdjustmentUploadError: 'CONVERSION_ALREADY_ENHANCED',
+                  },
+                  message:
+                    'Conversion already has enhancements with the same Order ID and conversion action. Make sure your data is correctly configured and try again.',
+                  location: {
+                    fieldPathElements: [
+                      {
+                        fieldName: 'conversion_adjustments',
+                        index: 1,
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          ],
+        },
+        results: [
+          {
+            adjustmentType: 'ENHANCEMENT',
+            conversionAction: 'customers/1234567777/conversionActions/123434350',
+            adjustmentDateTime: '2022-01-01 12:32:45-08:00',
+            orderId: '10000',
+          },
+          {},
+        ],
+      },
+    },
+  },
 ];
 
 export const networkCallsData = [

--- a/test/integrations/destinations/google_adwords_enhanced_conversions/network.ts
+++ b/test/integrations/destinations/google_adwords_enhanced_conversions/network.ts
@@ -528,7 +528,7 @@ const v19NetworkCallsData = [
   // Multi-event batch: searchStream to resolve conversionActionId for customerId 1234567777
   {
     httpReq: {
-      url: `https://googleads.googleapis.com/v22/customers/1234567777/googleAds:searchStream`,
+      url: `https://googleads.googleapis.com/v23/customers/1234567777/googleAds:searchStream`,
       data: {
         query: `SELECT conversion_action.id FROM conversion_action WHERE conversion_action.name = 'Product Added'`,
       },
@@ -559,7 +559,7 @@ const v19NetworkCallsData = [
   // Multi-event batch: uploadConversionAdjustments with 2 events → partial failure (event 0 ok, event 1 failed)
   {
     httpReq: {
-      url: `https://googleads.googleapis.com/v22/customers/1234567777:uploadConversionAdjustments`,
+      url: `https://googleads.googleapis.com/v23/customers/1234567777:uploadConversionAdjustments`,
       data: {
         conversionAdjustments: [
           {

--- a/test/integrations/destinations/google_adwords_enhanced_conversions/router/batching-data.ts
+++ b/test/integrations/destinations/google_adwords_enhanced_conversions/router/batching-data.ts
@@ -1,0 +1,278 @@
+/**
+ * Google Enhanced Conversions - Router Tests with the native batching framework
+ *
+ * These tests exercise the batching path, enabled per-workspace via the env var
+ * GOOGLE_ADWORDS_ENHANCED_CONVERSIONS_BATCHING_FRAMEWORK_ENABLED_WORKSPACE_IDS (set to 'ALL'
+ * here through envOverrides). The default (env var unset) path is covered by data.ts.
+ *
+ * When batching is enabled, events that share a conversion name + customer (and therefore the
+ * same grouping key) are combined into a single request with multiple conversionAdjustments.
+ */
+
+import { authHeader1, secret1 } from '../maskedSecrets';
+
+const sharedConfig = {
+  rudderAccountId: '25u5whFH7gVTnCiAjn4ykoCLGoC',
+  customerId: '1234567890',
+  subAccount: true,
+  loginCustomerId: '11',
+  listOfConversions: [{ conversions: 'Page View' }, { conversions: 'Product Added' }],
+  authStatus: 'active',
+};
+
+const trackMessage = (event: string) => ({
+  channel: 'web',
+  context: {
+    traits: {
+      phone: '912382193',
+      firstName: 'John',
+      lastName: 'Gomes',
+      city: 'London',
+      state: 'UK',
+      streetAddress: '71 Cherry Court SOUTHAMPTON SO53 5PD UK',
+    },
+    userAgent:
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36',
+  },
+  event,
+  type: 'track',
+  messageId: '5e10d13a-bf9a-44bf-b884-43a9e591ea71',
+  anonymousId: '00000000000000000000000000',
+  userId: '12345',
+  properties: {
+    gclid: 'gclid1234',
+    conversionDateTime: '2022-01-01 12:32:45-08:00',
+    adjustedValue: '10',
+    currency: 'INR',
+    adjustmentDateTime: '2022-01-01 12:32:45-08:00',
+    order_id: 10000,
+    total: 1000,
+  },
+});
+
+const secret = {
+  access_token: secret1,
+  refresh_token: 'efgh5678',
+  developer_token: 'ijkl91011',
+};
+
+const enhancementAdjustment = {
+  adjustmentDateTime: '2022-01-01 12:32:45-08:00',
+  adjustmentType: 'ENHANCEMENT',
+  gclidDateTimePair: {
+    conversionDateTime: '2022-01-01 12:32:45-08:00',
+    gclid: 'gclid1234',
+  },
+  orderId: '10000',
+  restatementValue: {
+    adjustedValue: 10,
+    currencyCode: 'INR',
+  },
+  userAgent:
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36',
+  userIdentifiers: [
+    {
+      hashedPhoneNumber: '04387707e6cbed8c4538c81cc570ed9252d579469f36c273839b26d784e4bdbe',
+    },
+    {
+      addressInfo: {
+        city: 'London',
+        hashedFirstName: 'a8cfcd74832004951b4408cdb0a5dbcd8c7e52d43f7fe244bf720582e05241da',
+        hashedLastName: '1c574b17eefa532b6d61c963550a82d2d3dfca4a7fb69e183374cfafd5328ee4',
+        hashedStreetAddress: '9a4d2e50828448f137f119a3ebdbbbab8d6731234a67595fdbfeb2a2315dd550',
+        state: 'UK',
+      },
+    },
+  ],
+};
+
+const envOverrides = {
+  GOOGLE_ADWORDS_ENHANCED_CONVERSIONS_BATCHING_FRAMEWORK_ENABLED_WORKSPACE_IDS: 'ALL',
+};
+
+export const newData = [
+  {
+    name: 'google_adwords_enhanced_conversions',
+    description:
+      'Batching Framework: two track events with the same conversion + customer are combined into one request',
+    feature: 'router',
+    module: 'destination',
+    version: 'v0',
+    input: {
+      request: {
+        body: {
+          input: [
+            {
+              metadata: { secret, jobId: 1, userId: 'u1', workspaceId: 'ws-1' },
+              destination: { hasDynamicConfig: false, Config: sharedConfig },
+              message: trackMessage('Page View'),
+            },
+            {
+              metadata: { secret, jobId: 2, userId: 'u1', workspaceId: 'ws-1' },
+              destination: { hasDynamicConfig: false, Config: sharedConfig },
+              message: trackMessage('Page View'),
+            },
+          ],
+          destType: 'google_adwords_enhanced_conversions',
+        },
+        method: 'POST',
+      },
+    },
+    output: {
+      response: {
+        status: 200,
+        body: {
+          output: [
+            {
+              batchedRequest: {
+                version: '1',
+                type: 'REST',
+                method: 'POST',
+                endpoint: '',
+                endpointPath: '/uploadConversionAdjustments',
+                headers: {
+                  Authorization: authHeader1,
+                  'Content-Type': 'application/json',
+                  'login-customer-id': '11',
+                },
+                params: {
+                  accessToken: 'google_adwords_enhanced_conversions1',
+                  customerId: '1234567890',
+                  event: 'Page View',
+                  loginCustomerId: '11',
+                  subAccount: true,
+                },
+                body: {
+                  JSON: {
+                    conversionAdjustments: [enhancementAdjustment, enhancementAdjustment],
+                    partialFailure: true,
+                  },
+                  JSON_ARRAY: {},
+                  XML: {},
+                  FORM: {},
+                },
+                files: {},
+              },
+              metadata: [
+                { secret, jobId: 1, userId: 'u1', workspaceId: 'ws-1' },
+                { secret, jobId: 2, userId: 'u1', workspaceId: 'ws-1' },
+              ],
+              destination: { hasDynamicConfig: false, Config: sharedConfig },
+              batched: true,
+              statusCode: 200,
+            },
+          ],
+        },
+      },
+    },
+    envOverrides,
+  },
+  {
+    name: 'google_adwords_enhanced_conversions',
+    description:
+      'Batching Framework: events with different conversion names are split into separate batches',
+    feature: 'router',
+    module: 'destination',
+    version: 'v0',
+    input: {
+      request: {
+        body: {
+          input: [
+            {
+              metadata: { secret, jobId: 1, userId: 'u1', workspaceId: 'ws-1' },
+              destination: { hasDynamicConfig: false, Config: sharedConfig },
+              message: trackMessage('Page View'),
+            },
+            {
+              metadata: { secret, jobId: 2, userId: 'u1', workspaceId: 'ws-1' },
+              destination: { hasDynamicConfig: false, Config: sharedConfig },
+              message: trackMessage('Product Added'),
+            },
+          ],
+          destType: 'google_adwords_enhanced_conversions',
+        },
+        method: 'POST',
+      },
+    },
+    output: {
+      response: {
+        status: 200,
+        body: {
+          output: [
+            {
+              batchedRequest: {
+                version: '1',
+                type: 'REST',
+                method: 'POST',
+                endpoint: '',
+                endpointPath: '/uploadConversionAdjustments',
+                headers: {
+                  Authorization: authHeader1,
+                  'Content-Type': 'application/json',
+                  'login-customer-id': '11',
+                },
+                params: {
+                  accessToken: 'google_adwords_enhanced_conversions1',
+                  customerId: '1234567890',
+                  event: 'Page View',
+                  loginCustomerId: '11',
+                  subAccount: true,
+                },
+                body: {
+                  JSON: {
+                    conversionAdjustments: [enhancementAdjustment],
+                    partialFailure: true,
+                  },
+                  JSON_ARRAY: {},
+                  XML: {},
+                  FORM: {},
+                },
+                files: {},
+              },
+              metadata: [{ secret, jobId: 1, userId: 'u1', workspaceId: 'ws-1' }],
+              destination: { hasDynamicConfig: false, Config: sharedConfig },
+              batched: true,
+              statusCode: 200,
+            },
+            {
+              batchedRequest: {
+                version: '1',
+                type: 'REST',
+                method: 'POST',
+                endpoint: '',
+                endpointPath: '/uploadConversionAdjustments',
+                headers: {
+                  Authorization: authHeader1,
+                  'Content-Type': 'application/json',
+                  'login-customer-id': '11',
+                },
+                params: {
+                  accessToken: 'google_adwords_enhanced_conversions1',
+                  customerId: '1234567890',
+                  event: 'Product Added',
+                  loginCustomerId: '11',
+                  subAccount: true,
+                },
+                body: {
+                  JSON: {
+                    conversionAdjustments: [enhancementAdjustment],
+                    partialFailure: true,
+                  },
+                  JSON_ARRAY: {},
+                  XML: {},
+                  FORM: {},
+                },
+                files: {},
+              },
+              metadata: [{ secret, jobId: 2, userId: 'u1', workspaceId: 'ws-1' }],
+              destination: { hasDynamicConfig: false, Config: sharedConfig },
+              batched: true,
+              statusCode: 200,
+            },
+          ],
+        },
+      },
+    },
+    envOverrides,
+  },
+];

--- a/test/integrations/destinations/google_adwords_enhanced_conversions/router/data.ts
+++ b/test/integrations/destinations/google_adwords_enhanced_conversions/router/data.ts
@@ -1,4 +1,5 @@
 import { authHeader1, secret1 } from '../maskedSecrets';
+import { newData as batchingData } from './batching-data';
 
 const events = [
   {
@@ -1063,4 +1064,5 @@ export const data = [
     },
   },
   ...invalidRtTfCases,
+  ...batchingData,
 ];

--- a/test/integrations/destinations/google_adwords_offline_conversions/dataDelivery/batchFetching/business.ts
+++ b/test/integrations/destinations/google_adwords_offline_conversions/dataDelivery/batchFetching/business.ts
@@ -279,11 +279,11 @@ export const testScenariosForV1API = [
         body: {
           output: {
             message:
-              '[Google Ads Offline Conversions]:: Request contains an invalid argument. during google_ads_offline_store_conversions Add Conversion',
+              '[Google Ads Offline Conversions]:: {"error":{"code":400,"message":"Request contains an invalid argument.","status":"INVALID_ARGUMENT","details":[{"@type":"type.googleapis.com/google.ads.googleads.v16.errors.GoogleAdsFailure","errors":[{"errorCode":{"offlineUserDataJobError":"INVALID_SHA256_FORMAT"},"message":"The SHA256 encoded value is malformed.","location":{"fieldPathElements":[{"fieldName":"operations","index":0},{"fieldName":"create"},{"fieldName":"user_identifiers","index":0},{"fieldName":"hashed_email"}]}}],"requestId":"68697987"}]}} during google_ads_offline_store_conversions Add Conversion',
             response: [
               {
                 error:
-                  '[Google Ads Offline Conversions]:: Request contains an invalid argument. during google_ads_offline_store_conversions Add Conversion',
+                  '[Google Ads Offline Conversions]:: {"error":{"code":400,"message":"Request contains an invalid argument.","status":"INVALID_ARGUMENT","details":[{"@type":"type.googleapis.com/google.ads.googleads.v16.errors.GoogleAdsFailure","errors":[{"errorCode":{"offlineUserDataJobError":"INVALID_SHA256_FORMAT"},"message":"The SHA256 encoded value is malformed.","location":{"fieldPathElements":[{"fieldName":"operations","index":0},{"fieldName":"create"},{"fieldName":"user_identifiers","index":0},{"fieldName":"hashed_email"}]}}],"requestId":"68697987"}]}} during google_ads_offline_store_conversions Add Conversion',
                 metadata: generateMetadata(1),
                 statusCode: 400,
               },

--- a/test/integrations/destinations/google_adwords_offline_conversions/dataDelivery/batchFetching/oauth.ts
+++ b/test/integrations/destinations/google_adwords_offline_conversions/dataDelivery/batchFetching/oauth.ts
@@ -129,11 +129,11 @@ export const v1oauthScenarios = [
           output: {
             authErrorCategory: 'REFRESH_TOKEN',
             message:
-              '[Google Ads Offline Conversions]:: Request had invalid authentication credentials. Expected OAuth 2 access token, login cookie or other valid authentication credential. See https://developers.google.com/identity/sign-in/web/devconsole-project. during google_ads_offline_store_conversions Job Creation',
+              '[Google Ads Offline Conversions]:: {"error":{"code":401,"message":"Request had invalid authentication credentials. Expected OAuth 2 access token, login cookie or other valid authentication credential. See https://developers.google.com/identity/sign-in/web/devconsole-project.","status":"UNAUTHENTICATED"}} during google_ads_offline_store_conversions Job Creation',
             response: [
               {
                 error:
-                  '[Google Ads Offline Conversions]:: Request had invalid authentication credentials. Expected OAuth 2 access token, login cookie or other valid authentication credential. See https://developers.google.com/identity/sign-in/web/devconsole-project. during google_ads_offline_store_conversions Job Creation',
+                  '[Google Ads Offline Conversions]:: {"error":{"code":401,"message":"Request had invalid authentication credentials. Expected OAuth 2 access token, login cookie or other valid authentication credential. See https://developers.google.com/identity/sign-in/web/devconsole-project.","status":"UNAUTHENTICATED"}} during google_ads_offline_store_conversions Job Creation',
                 metadata: generateMetadata(1),
                 statusCode: 401,
               },
@@ -178,11 +178,11 @@ export const v1oauthScenarios = [
           output: {
             authErrorCategory: 'AUTH_STATUS_INACTIVE',
             message:
-              '[Google Ads Offline Conversions]:: Request had insufficient authentication scopes during google_ads_offline_store_conversions Job Creation',
+              '[Google Ads Offline Conversions]:: {"error":{"code":403,"message":"Request had insufficient authentication scopes","status":"PERMISSION_DENIED"}} during google_ads_offline_store_conversions Job Creation',
             response: [
               {
                 error:
-                  '[Google Ads Offline Conversions]:: Request had insufficient authentication scopes during google_ads_offline_store_conversions Job Creation',
+                  '[Google Ads Offline Conversions]:: {"error":{"code":403,"message":"Request had insufficient authentication scopes","status":"PERMISSION_DENIED"}} during google_ads_offline_store_conversions Job Creation',
                 metadata: generateMetadata(1),
                 statusCode: 403,
               },
@@ -232,11 +232,11 @@ export const v1oauthScenarios = [
           output: {
             authErrorCategory: 'AUTH_STATUS_INACTIVE',
             message:
-              '[Google Ads Offline Conversions]:: Request is missing required authentication credential. Expected OAuth 2 access token, login cookie or other valid authentication credential. See https://developers.google.com/identity/sign-in/web/devconsole-project. during google_ads_offline_store_conversions Job Creation',
+              '[Google Ads Offline Conversions]:: [{"error":{"code":401,"details":[{"@type":"type.googleapis.com/google.ads.googleads.v16.errors.GoogleAdsFailure","errors":[{"errorCode":{"authenticationError":"TWO_STEP_VERIFICATION_NOT_ENROLLED"},"message":"An account administrator changed this account\'s authentication settings. To access this Google Ads account, enable 2-Step Verification in your Google account at https://www.google.com/landing/2step."}],"requestId":"wy4ZYbsjWcgh6uC2Ruc_Zg"}],"message":"Request is missing required authentication credential. Expected OAuth 2 access token, login cookie or other valid authentication credential. See https://developers.google.com/identity/sign-in/web/devconsole-project.","status":"UNAUTHENTICATED"}}] during google_ads_offline_store_conversions Job Creation',
             response: [
               {
                 error:
-                  '[Google Ads Offline Conversions]:: Request is missing required authentication credential. Expected OAuth 2 access token, login cookie or other valid authentication credential. See https://developers.google.com/identity/sign-in/web/devconsole-project. during google_ads_offline_store_conversions Job Creation',
+                  '[Google Ads Offline Conversions]:: [{"error":{"code":401,"details":[{"@type":"type.googleapis.com/google.ads.googleads.v16.errors.GoogleAdsFailure","errors":[{"errorCode":{"authenticationError":"TWO_STEP_VERIFICATION_NOT_ENROLLED"},"message":"An account administrator changed this account\'s authentication settings. To access this Google Ads account, enable 2-Step Verification in your Google account at https://www.google.com/landing/2step."}],"requestId":"wy4ZYbsjWcgh6uC2Ruc_Zg"}],"message":"Request is missing required authentication credential. Expected OAuth 2 access token, login cookie or other valid authentication credential. See https://developers.google.com/identity/sign-in/web/devconsole-project.","status":"UNAUTHENTICATED"}}] during google_ads_offline_store_conversions Job Creation',
                 metadata: {
                   attemptNum: 1,
                   destinationId: 'default-destinationId',

--- a/test/integrations/destinations/google_adwords_offline_conversions/dataDelivery/business.ts
+++ b/test/integrations/destinations/google_adwords_offline_conversions/dataDelivery/business.ts
@@ -250,11 +250,11 @@ export const testScenariosForV1API = [
         body: {
           output: {
             message:
-              '[Google Ads Offline Conversions]:: Request contains an invalid argument. during google_ads_offline_store_conversions Add Conversion',
+              '[Google Ads Offline Conversions]:: {"error":{"code":400,"message":"Request contains an invalid argument.","status":"INVALID_ARGUMENT","details":[{"@type":"type.googleapis.com/google.ads.googleads.v16.errors.GoogleAdsFailure","errors":[{"errorCode":{"offlineUserDataJobError":"INVALID_SHA256_FORMAT"},"message":"The SHA256 encoded value is malformed.","location":{"fieldPathElements":[{"fieldName":"operations","index":0},{"fieldName":"create"},{"fieldName":"user_identifiers","index":0},{"fieldName":"hashed_email"}]}}],"requestId":"68697987"}]}} during google_ads_offline_store_conversions Add Conversion',
             response: [
               {
                 error:
-                  '[Google Ads Offline Conversions]:: Request contains an invalid argument. during google_ads_offline_store_conversions Add Conversion',
+                  '[Google Ads Offline Conversions]:: {"error":{"code":400,"message":"Request contains an invalid argument.","status":"INVALID_ARGUMENT","details":[{"@type":"type.googleapis.com/google.ads.googleads.v16.errors.GoogleAdsFailure","errors":[{"errorCode":{"offlineUserDataJobError":"INVALID_SHA256_FORMAT"},"message":"The SHA256 encoded value is malformed.","location":{"fieldPathElements":[{"fieldName":"operations","index":0},{"fieldName":"create"},{"fieldName":"user_identifiers","index":0},{"fieldName":"hashed_email"}]}}],"requestId":"68697987"}]}} during google_ads_offline_store_conversions Add Conversion',
                 metadata: generateMetadata(1),
                 statusCode: 400,
               },

--- a/test/integrations/destinations/google_adwords_offline_conversions/dataDelivery/oauth.ts
+++ b/test/integrations/destinations/google_adwords_offline_conversions/dataDelivery/oauth.ts
@@ -119,11 +119,11 @@ export const v1oauthScenarios = [
           output: {
             authErrorCategory: 'REFRESH_TOKEN',
             message:
-              '[Google Ads Offline Conversions]:: Request had invalid authentication credentials. Expected OAuth 2 access token, login cookie or other valid authentication credential. See https://developers.google.com/identity/sign-in/web/devconsole-project. during google_ads_offline_store_conversions Job Creation',
+              '[Google Ads Offline Conversions]:: {"error":{"code":401,"message":"Request had invalid authentication credentials. Expected OAuth 2 access token, login cookie or other valid authentication credential. See https://developers.google.com/identity/sign-in/web/devconsole-project.","status":"UNAUTHENTICATED"}} during google_ads_offline_store_conversions Job Creation',
             response: [
               {
                 error:
-                  '[Google Ads Offline Conversions]:: Request had invalid authentication credentials. Expected OAuth 2 access token, login cookie or other valid authentication credential. See https://developers.google.com/identity/sign-in/web/devconsole-project. during google_ads_offline_store_conversions Job Creation',
+                  '[Google Ads Offline Conversions]:: {"error":{"code":401,"message":"Request had invalid authentication credentials. Expected OAuth 2 access token, login cookie or other valid authentication credential. See https://developers.google.com/identity/sign-in/web/devconsole-project.","status":"UNAUTHENTICATED"}} during google_ads_offline_store_conversions Job Creation',
                 metadata: generateMetadata(1),
                 statusCode: 401,
               },
@@ -165,11 +165,11 @@ export const v1oauthScenarios = [
           output: {
             authErrorCategory: 'AUTH_STATUS_INACTIVE',
             message:
-              '[Google Ads Offline Conversions]:: Request had insufficient authentication scopes during google_ads_offline_store_conversions Job Creation',
+              '[Google Ads Offline Conversions]:: {"error":{"code":403,"message":"Request had insufficient authentication scopes","status":"PERMISSION_DENIED"}} during google_ads_offline_store_conversions Job Creation',
             response: [
               {
                 error:
-                  '[Google Ads Offline Conversions]:: Request had insufficient authentication scopes during google_ads_offline_store_conversions Job Creation',
+                  '[Google Ads Offline Conversions]:: {"error":{"code":403,"message":"Request had insufficient authentication scopes","status":"PERMISSION_DENIED"}} during google_ads_offline_store_conversions Job Creation',
                 metadata: generateMetadata(1),
                 statusCode: 403,
               },
@@ -216,11 +216,11 @@ export const v1oauthScenarios = [
           output: {
             authErrorCategory: 'AUTH_STATUS_INACTIVE',
             message:
-              '[Google Ads Offline Conversions]:: Request is missing required authentication credential. Expected OAuth 2 access token, login cookie or other valid authentication credential. See https://developers.google.com/identity/sign-in/web/devconsole-project. during google_ads_offline_store_conversions Job Creation',
+              '[Google Ads Offline Conversions]:: [{"error":{"code":401,"details":[{"@type":"type.googleapis.com/google.ads.googleads.v16.errors.GoogleAdsFailure","errors":[{"errorCode":{"authenticationError":"TWO_STEP_VERIFICATION_NOT_ENROLLED"},"message":"An account administrator changed this account\'s authentication settings. To access this Google Ads account, enable 2-Step Verification in your Google account at https://www.google.com/landing/2step."}],"requestId":"wy4ZYbsjWcgh6uC2Ruc_Zg"}],"message":"Request is missing required authentication credential. Expected OAuth 2 access token, login cookie or other valid authentication credential. See https://developers.google.com/identity/sign-in/web/devconsole-project.","status":"UNAUTHENTICATED"}}] during google_ads_offline_store_conversions Job Creation',
             response: [
               {
                 error:
-                  '[Google Ads Offline Conversions]:: Request is missing required authentication credential. Expected OAuth 2 access token, login cookie or other valid authentication credential. See https://developers.google.com/identity/sign-in/web/devconsole-project. during google_ads_offline_store_conversions Job Creation',
+                  '[Google Ads Offline Conversions]:: [{"error":{"code":401,"details":[{"@type":"type.googleapis.com/google.ads.googleads.v16.errors.GoogleAdsFailure","errors":[{"errorCode":{"authenticationError":"TWO_STEP_VERIFICATION_NOT_ENROLLED"},"message":"An account administrator changed this account\'s authentication settings. To access this Google Ads account, enable 2-Step Verification in your Google account at https://www.google.com/landing/2step."}],"requestId":"wy4ZYbsjWcgh6uC2Ruc_Zg"}],"message":"Request is missing required authentication credential. Expected OAuth 2 access token, login cookie or other valid authentication credential. See https://developers.google.com/identity/sign-in/web/devconsole-project.","status":"UNAUTHENTICATED"}}] during google_ads_offline_store_conversions Job Creation',
                 metadata: {
                   attemptNum: 1,
                   destinationId: 'default-destinationId',

--- a/test/integrations/destinations/iterable_audience/router/data.ts
+++ b/test/integrations/destinations/iterable_audience/router/data.ts
@@ -124,6 +124,7 @@ export const data: RouterTestData[] = [
                 type: 'REST',
                 method: 'POST',
                 endpoint: subscribeEndpoint,
+                endpointPath: '/lists/subscribe',
                 headers,
                 params: {},
                 body: {
@@ -159,6 +160,7 @@ export const data: RouterTestData[] = [
                 type: 'REST',
                 method: 'POST',
                 endpoint: unsubscribeEndpoint,
+                endpointPath: '/lists/unsubscribe',
                 headers,
                 params: {},
                 body: {
@@ -247,6 +249,7 @@ export const data: RouterTestData[] = [
                 type: 'REST',
                 method: 'POST',
                 endpoint: subscribeEndpoint,
+                endpointPath: '/lists/subscribe',
                 headers,
                 params: {},
                 body: {
@@ -271,6 +274,7 @@ export const data: RouterTestData[] = [
                 type: 'REST',
                 method: 'POST',
                 endpoint: unsubscribeEndpoint,
+                endpointPath: '/lists/unsubscribe',
                 headers,
                 params: {},
                 body: {
@@ -353,6 +357,7 @@ export const data: RouterTestData[] = [
                 type: 'REST',
                 method: 'POST',
                 endpoint: subscribeEndpoint,
+                endpointPath: '/lists/subscribe',
                 headers,
                 params: {},
                 body: {
@@ -432,6 +437,7 @@ export const data: RouterTestData[] = [
                 type: 'REST',
                 method: 'POST',
                 endpoint: euSubscribeEndpoint,
+                endpointPath: '/lists/subscribe',
                 headers,
                 params: {},
                 body: {
@@ -456,6 +462,7 @@ export const data: RouterTestData[] = [
                 type: 'REST',
                 method: 'POST',
                 endpoint: euUnsubscribeEndpoint,
+                endpointPath: '/lists/unsubscribe',
                 headers,
                 params: {},
                 body: {
@@ -546,6 +553,7 @@ export const data: RouterTestData[] = [
                 type: 'REST',
                 method: 'POST',
                 endpoint: subscribeEndpoint,
+                endpointPath: '/lists/subscribe',
                 headers,
                 params: {},
                 body: {

--- a/test/integrations/destinations/posthog/router/data.ts
+++ b/test/integrations/destinations/posthog/router/data.ts
@@ -74,6 +74,7 @@ export const data = [
                 type: 'REST',
                 method: 'POST',
                 endpoint: 'https://app.posthog.com/batch',
+                endpointPath: '/batch',
                 headers: { 'Content-Type': 'application/json' },
                 params: {},
                 body: {
@@ -223,6 +224,7 @@ export const data = [
                 type: 'REST',
                 method: 'POST',
                 endpoint: 'https://app.posthog.com/batch',
+                endpointPath: '/batch',
                 headers: { 'Content-Type': 'application/json' },
                 params: {},
                 body: {
@@ -453,6 +455,7 @@ export const data = [
                 type: 'REST',
                 method: 'POST',
                 endpoint: 'https://app.posthog.com/batch',
+                endpointPath: '/batch',
                 headers: { 'Content-Type': 'application/json' },
                 params: {},
                 body: {
@@ -604,6 +607,7 @@ export const data = [
                 type: 'REST',
                 method: 'POST',
                 endpoint: 'https://app.posthog.com/batch',
+                endpointPath: '/batch',
                 headers: { 'Content-Type': 'application/json' },
                 params: {},
                 body: {


### PR DESCRIPTION
Pulls `main` into `develop` after release v1.138.0, with a fix to a Google Ads Enhanced Conversions delivery test that breaks on the merge.

### Why the plain merge failed
The hotfix release added a multi-event batch delivery test (customer `1234567777`) whose mocks were pinned to Google Ads API `v22`. Meanwhile `develop` had bumped `@rudderstack/integrations-lib` to `0.2.71`, which issues requests against `v23`. After merging `main` into `develop`, the new mocks no longer matched the request URL, so the delivery test failed with `Could not find mock for ... /v23/customers/1234567777/googleAds:searchStream`.

### Fix
Aligned the two new mock URLs with `v23` to match the bumped library. All Google Ads Enhanced Conversions integration tests pass.

Supersedes #5296.

🤖 Generated with [Claude Code](https://claude.com/claude-code)