### PR TITLE
fix: types for survicate

### DIFF
--- a/src/v0/destinations/survicate/README.md
+++ b/src/v0/destinations/survicate/README.md
@@ -172,10 +172,10 @@ Create/Update Survicate destination configuration in `rudder-integrations-config
   "website": "https://www.survicate.com",
   "logoUrl": "https://...",
   "config": {
-    "destinationKey": {
+    "apiKey": {
       "type": "string",
-      "displayName": "Destination Key",
-      "description": "Your Survicate Destination Key for authentication",
+      "displayName": "API Key",
+      "description": "Your Survicate API Key for authentication",
       "required": true
     }
   }
@@ -243,7 +243,7 @@ The integration uses Zod schemas for runtime validation:
 ```typescript
 export const SurvicateDestinationConfigSchema = z
   .object({
-    destinationKey: z.string().min(1, 'Destination Key is required'),
+    apiKey: z.string().min(1, 'API Key is required'),
   })
   .passthrough();
 

--- a/src/v0/destinations/survicate/transform.test.ts
+++ b/src/v0/destinations/survicate/transform.test.ts
@@ -7,7 +7,7 @@ const dest = {
   ID: 'survicate-dest-id',
   Name: 'Survicate',
   DestinationDefinition: { Config: {} },
-  Config: { destinationKey: 'test-key' },
+  Config: { apiKey: 'test-key' },
   Enabled: true,
   Transformations: [],
 };

--- a/src/v0/destinations/survicate/transform.ts
+++ b/src/v0/destinations/survicate/transform.ts
@@ -89,7 +89,7 @@ function validateSurvicateEvent(event: unknown): SurvicateRouterRequest {
  * @param destinationConfig - The destination configuration
  * @returns Formatted HTTP response
  */
-const processIdentifyEvent = (message: SurvicateIdentifyMessage, destinationKey: string) => {
+const processIdentifyEvent = (message: SurvicateIdentifyMessage, apiKey: string) => {
   // Build the payload - flatten traits and include context properties
   const payload: IdentifyPayload = {
     user_id: message.userId,
@@ -105,7 +105,7 @@ const processIdentifyEvent = (message: SurvicateIdentifyMessage, destinationKey:
   const ctxIdentify = extractContext(message.context);
   if (ctxIdentify) payload.context = ctxIdentify;
 
-  return buildResponse(ENDPOINT_CONFIG.IDENTIFY, destinationKey, payload);
+  return buildResponse(ENDPOINT_CONFIG.IDENTIFY, apiKey, payload);
 };
 
 /**
@@ -118,7 +118,7 @@ const processIdentifyEvent = (message: SurvicateIdentifyMessage, destinationKey:
  * @param destinationConfig - The destination configuration
  * @returns Formatted HTTP response
  */
-const processGroupEvent = (message: SurvicateGroupMessage, destinationKey: string) => {
+const processGroupEvent = (message: SurvicateGroupMessage, apiKey: string) => {
   const payload: GroupPayload = {
     user_id: message.userId,
     group_id: message.groupId,
@@ -134,7 +134,7 @@ const processGroupEvent = (message: SurvicateGroupMessage, destinationKey: strin
   const ctxGroup = extractContext(message.context);
   if (ctxGroup) payload.context = ctxGroup;
 
-  return buildResponse(ENDPOINT_CONFIG.GROUP, destinationKey, payload);
+  return buildResponse(ENDPOINT_CONFIG.GROUP, apiKey, payload);
 };
 
 /**
@@ -147,7 +147,7 @@ const processGroupEvent = (message: SurvicateGroupMessage, destinationKey: strin
  * @param destinationConfig - The destination configuration
  * @returns Formatted HTTP response
  */
-const processTrackEvent = (message: SurvicateTrackMessage, destinationKey: string) => {
+const processTrackEvent = (message: SurvicateTrackMessage, apiKey: string) => {
   // Build the payload using the utility function
   const payload: TrackPayload = {
     user_id: message.userId,
@@ -165,7 +165,7 @@ const processTrackEvent = (message: SurvicateTrackMessage, destinationKey: strin
   const ctxTrack = extractContext(message.context);
   if (ctxTrack) payload.context = ctxTrack;
 
-  return buildResponse(ENDPOINT_CONFIG.TRACK, destinationKey, payload);
+  return buildResponse(ENDPOINT_CONFIG.TRACK, apiKey, payload);
 };
 
 /**
@@ -179,17 +179,17 @@ const processTrackEvent = (message: SurvicateTrackMessage, destinationKey: strin
  */
 const processEvent = (event: SurvicateRouterRequest) => {
   const { message, destination } = event;
-  const { destinationKey } = destination.Config;
+  const { apiKey } = destination.Config;
 
   // Route based on message type. Unsupported types are already rejected by the
   // schema's discriminated union, so `message.type` is exhaustively narrowed here.
   switch (message.type) {
     case 'identify':
-      return processIdentifyEvent(message, destinationKey);
+      return processIdentifyEvent(message, apiKey);
     case 'group':
-      return processGroupEvent(message, destinationKey);
+      return processGroupEvent(message, apiKey);
     case 'track':
-      return processTrackEvent(message, destinationKey);
+      return processTrackEvent(message, apiKey);
     default:
       throw new InstrumentationError('Unsupported Survicate event type.');
   }

--- a/src/v0/destinations/survicate/types.ts
+++ b/src/v0/destinations/survicate/types.ts
@@ -9,7 +9,6 @@ import {
   ERR_MISSING_GROUP_ID,
   ERR_MISSING_EVENT,
 } from './config';
-import { MetadataSchema } from '../../../types/rudderEvents';
 
 export type EndpointEntry = (typeof ENDPOINT_CONFIG)[keyof typeof ENDPOINT_CONFIG];
 
@@ -17,7 +16,7 @@ export const SurvicateDestinationSchema = z
   .object({
     Config: z
       .object({
-        destinationKey: z.string().min(1, 'Destination Key is required'),
+        apiKey: z.string().min(1, 'API Key is required'),
       })
       .passthrough(),
   })
@@ -100,7 +99,7 @@ export type SurvicateTrackMessage = Extract<SurvicateMessage, { type: 'track' }>
 export const SurvicateRouterRequestSchema = z.object({
   message: SurvicateMessageSchema,
   destination: SurvicateDestinationSchema,
-  metadata: MetadataSchema,
+  metadata: z.unknown(),
 });
 
 export type SurvicateRouterRequest = z.infer<typeof SurvicateRouterRequestSchema>;

--- a/test/integrations/destinations/survicate/router/data.ts
+++ b/test/integrations/destinations/survicate/router/data.ts
@@ -18,7 +18,7 @@ const dest = (key: string) => ({
   ID: 'survicate-dest-id',
   Name: 'Survicate',
   DestinationDefinition: { Config: {} },
-  Config: { destinationKey: key },
+  Config: { apiKey: key },
   Enabled: true,
   Transformations: [],
 });


### PR DESCRIPTION
## What are the changes introduced in this PR?

## Description

Renames the Survicate destination config field destinationKey → apiKey to align with the destination's actual authentication terminology. The value is used as a Bearer token in the Authorisation header; only the field name changes, not the auth behaviour.

Also drops the unused MetadataSchema import in types.ts, replacing the router request metadata field with z.unknown().

## What is the related Linear task?

Resolves INT-6537