### PR TITLE
fix: survicate destination keys

### DIFF
--- a/src/v0/destinations/survicate/README.md
+++ b/src/v0/destinations/survicate/README.md
@@ -172,10 +172,10 @@ Create/Update Survicate destination configuration in `rudder-integrations-config
   "website": "https://www.survicate.com",
   "logoUrl": "https://...",
   "config": {
-    "apiKey": {
+    "destinationKey": {
       "type": "string",
-      "displayName": "API Key",
-      "description": "Your Survicate API Key for authentication",
+      "displayName": "Destination Key",
+      "description": "Your Survicate Destination Key for authentication",
       "required": true
     }
   }
@@ -243,7 +243,7 @@ The integration uses Zod schemas for runtime validation:
 ```typescript
 export const SurvicateDestinationConfigSchema = z
   .object({
-    apiKey: z.string().min(1, 'API Key is required'),
+    destinationKey: z.string().min(1, 'Destination Key is required'),
   })
   .passthrough();
 

--- a/src/v0/destinations/survicate/README.md
+++ b/src/v0/destinations/survicate/README.md
@@ -175,7 +175,7 @@ Create/Update Survicate destination configuration in `rudder-integrations-config
     "destinationKey": {
       "type": "string",
       "displayName": "Destination Key",
-      "description": "Your Survicate Destination Key for authentication",
+      "description": "Get your Survicate Destination Key for authentication by selecting RudderStack on the integrations page",
       "required": true
     }
   }

--- a/src/v0/destinations/survicate/transform.test.ts
+++ b/src/v0/destinations/survicate/transform.test.ts
@@ -7,7 +7,7 @@ const dest = {
   ID: 'survicate-dest-id',
   Name: 'Survicate',
   DestinationDefinition: { Config: {} },
-  Config: { apiKey: 'test-key' },
+  Config: { destinationKey: 'test-key' },
   Enabled: true,
   Transformations: [],
 };

--- a/src/v0/destinations/survicate/transform.ts
+++ b/src/v0/destinations/survicate/transform.ts
@@ -26,13 +26,13 @@ import {
 import { ENDPOINT_CONFIG, RESERVED_KEYS } from './config';
 import { RouterTransformationResponse } from '../../../types';
 
-function buildResponse(endpoint: EndpointEntry, apiKey: string, payload: SurvicatePayload) {
+function buildResponse(endpoint: EndpointEntry, destinationKey: string, payload: SurvicatePayload) {
   const response = defaultRequestConfig();
   response.endpoint = endpoint.url;
   response.method = endpoint.method;
   response.headers = {
     'Content-Type': endpoint.contentType,
-    Authorization: `Bearer ${apiKey}`,
+    Authorization: `Bearer ${destinationKey}`,
   };
   response.body.JSON = payload;
   return response;
@@ -89,7 +89,7 @@ function validateSurvicateEvent(event: unknown): SurvicateRouterRequest {
  * @param destinationConfig - The destination configuration
  * @returns Formatted HTTP response
  */
-const processIdentifyEvent = (message: SurvicateIdentifyMessage, apiKey: string) => {
+const processIdentifyEvent = (message: SurvicateIdentifyMessage, destinationKey: string) => {
   // Build the payload - flatten traits and include context properties
   const payload: IdentifyPayload = {
     user_id: message.userId,
@@ -105,7 +105,7 @@ const processIdentifyEvent = (message: SurvicateIdentifyMessage, apiKey: string)
   const ctxIdentify = extractContext(message.context);
   if (ctxIdentify) payload.context = ctxIdentify;
 
-  return buildResponse(ENDPOINT_CONFIG.IDENTIFY, apiKey, payload);
+  return buildResponse(ENDPOINT_CONFIG.IDENTIFY, destinationKey, payload);
 };
 
 /**
@@ -118,7 +118,7 @@ const processIdentifyEvent = (message: SurvicateIdentifyMessage, apiKey: string)
  * @param destinationConfig - The destination configuration
  * @returns Formatted HTTP response
  */
-const processGroupEvent = (message: SurvicateGroupMessage, apiKey: string) => {
+const processGroupEvent = (message: SurvicateGroupMessage, destinationKey: string) => {
   const payload: GroupPayload = {
     user_id: message.userId,
     group_id: message.groupId,
@@ -134,7 +134,7 @@ const processGroupEvent = (message: SurvicateGroupMessage, apiKey: string) => {
   const ctxGroup = extractContext(message.context);
   if (ctxGroup) payload.context = ctxGroup;
 
-  return buildResponse(ENDPOINT_CONFIG.GROUP, apiKey, payload);
+  return buildResponse(ENDPOINT_CONFIG.GROUP, destinationKey, payload);
 };
 
 /**
@@ -147,7 +147,7 @@ const processGroupEvent = (message: SurvicateGroupMessage, apiKey: string) => {
  * @param destinationConfig - The destination configuration
  * @returns Formatted HTTP response
  */
-const processTrackEvent = (message: SurvicateTrackMessage, apiKey: string) => {
+const processTrackEvent = (message: SurvicateTrackMessage, destinationKey: string) => {
   // Build the payload using the utility function
   const payload: TrackPayload = {
     user_id: message.userId,
@@ -165,7 +165,7 @@ const processTrackEvent = (message: SurvicateTrackMessage, apiKey: string) => {
   const ctxTrack = extractContext(message.context);
   if (ctxTrack) payload.context = ctxTrack;
 
-  return buildResponse(ENDPOINT_CONFIG.TRACK, apiKey, payload);
+  return buildResponse(ENDPOINT_CONFIG.TRACK, destinationKey, payload);
 };
 
 /**
@@ -179,17 +179,17 @@ const processTrackEvent = (message: SurvicateTrackMessage, apiKey: string) => {
  */
 const processEvent = (event: SurvicateRouterRequest) => {
   const { message, destination } = event;
-  const { apiKey } = destination.Config;
+  const { destinationKey } = destination.Config;
 
   // Route based on message type. Unsupported types are already rejected by the
   // schema's discriminated union, so `message.type` is exhaustively narrowed here.
   switch (message.type) {
     case 'identify':
-      return processIdentifyEvent(message, apiKey);
+      return processIdentifyEvent(message, destinationKey);
     case 'group':
-      return processGroupEvent(message, apiKey);
+      return processGroupEvent(message, destinationKey);
     case 'track':
-      return processTrackEvent(message, apiKey);
+      return processTrackEvent(message, destinationKey);
     default:
       throw new InstrumentationError('Unsupported Survicate event type.');
   }

--- a/src/v0/destinations/survicate/types.ts
+++ b/src/v0/destinations/survicate/types.ts
@@ -16,7 +16,7 @@ export const SurvicateDestinationSchema = z
   .object({
     Config: z
       .object({
-        apiKey: z.string().min(1, 'API Key is required'),
+        destinationKey: z.string().min(1, 'Destination Key is required'),
       })
       .passthrough(),
   })

--- a/test/integrations/destinations/survicate/router/data.ts
+++ b/test/integrations/destinations/survicate/router/data.ts
@@ -18,7 +18,7 @@ const dest = (key: string) => ({
   ID: 'survicate-dest-id',
   Name: 'Survicate',
   DestinationDefinition: { Config: {} },
-  Config: { apiKey: key },
+  Config: { destinationKey: key },
   Enabled: true,
   Transformations: [],
 });


### PR DESCRIPTION
🔒 Scanned for secrets using gitleaks 8.29.1

## What are the changes introduced in this PR?

Renames the Survicate destination config field `apiKey` → `destinationKey` across schema, db-config, and ui-config, and updates the field label/note to match Survicate's "Destination Key" terminology and setup flow.

## Why
The credential is labeled "Destination Key" in Survicate's RudderStack integration and is copied from the integration's "Connect" tab. Aligning the field name, label, and help text reduces setup confusion.

## Changes
- `schema.json` — `required` and property key `apiKey` → `destinationKey`
- `db-config.json` — `defaultConfig` and `secretKeys` → `destinationKey`
- `ui-config.json` — label "API Key" → "Destination Key", `configKey` → `destinationKey`, `regexErrorMessage` → "Invalid Destination Key", and updated the note with the correct retrieval steps (open the RudderStack integration → "Connect" → copy the Destination Key from the "Connect" tab)