### PR TITLE
feat(versioning): carry integration major on Destination + dev-only test_destination

### DIFF
--- a/.claude/skills/code-structure/SKILL.md
+++ b/.claude/skills/code-structure/SKILL.md
@@ -411,3 +411,22 @@ try {
   response.transformed = [{ error: err.message }];
 }
 ```
+
+## Dispatch on the Integration Major (`destination.version`)
+
+A destination definition can ship multiple **integration majors** (its config/API v1 → v2). The data plane carries the major as `destination.version` (a number; `destinationVersion` on the proxy payload). Branch on it **inside the destination's own code** — never route majors through `getDestHandler` (that argument is the unrelated `v0`/`v1`/`v2` architecture directory).
+
+Default to an in-file inline branch on `Number(event.destination.version)` at the top of the entry `process`; keep v1 in place and factor shared logic into `utils.ts`. `0`, `undefined`, and `1` all fall to v1 (`Number(undefined)` is `NaN`).
+
+```ts
+// Good — in-file branch; v1 unchanged; shared logic in utils
+const process = (event) => {
+  const major = Number(event.destination.version);
+  if (major >= 2) return processV2(event);
+  return processV1(event);
+};
+
+// Bad — routing the major through getDestHandler (conflates the architecture-version axis)
+```
+
+Escalate the v2 branch to a sibling module (`transformV2.ts` — the existing repo convention) only on large divergence; prefer that over `./v1` / `./v2` subdirs (none exist today), though subdirs aren't strictly banned for a major large enough to warrant its own tree. Branch `routerTransform` / `deleteUsers` / the proxy `networkHandler` (which reads top-level `destinationVersion`) only when a major actually changes them. Full reference: CONTRIBUTING.md → "Dispatching on the integration major".

--- a/.claude/skills/code-structure/SKILL.md
+++ b/.claude/skills/code-structure/SKILL.md
@@ -416,16 +416,19 @@ try {
 
 A destination definition can ship multiple **integration majors** (its config/API v1 → v2). The data plane carries the major as `destination.version` (a number; `destinationVersion` on the proxy payload). Branch on it **inside the destination's own code** — never route majors through `getDestHandler` (that argument is the unrelated `v0`/`v1`/`v2` architecture directory).
 
-Default to an in-file inline branch on `Number(event.destination.version)` at the top of the entry `process`; keep v1 in place and factor shared logic into `utils.ts`. `0`, `undefined`, and `1` all fall to v1 (`Number(undefined)` is `NaN`).
+Default to an in-file inline branch on `getDestinationVersion(event.destination.version)` (from `src/util/utils`, which normalizes the raw major) at the top of the entry `process`; keep v1 in place and factor shared logic into `utils.ts`. `0`, `undefined`, non-numeric, and `1` all normalize to `1` and fall to v1; fractions are truncated. Branch on the helper, not the bare `Number(...)`, so metrics never see a `destVersion=0`.
 
 ```ts
 // Good — in-file branch; v1 unchanged; shared logic in utils
+import { getDestinationVersion } from '../../../util/utils';
+
 const process = (event) => {
-  const major = Number(event.destination.version);
+  const major = getDestinationVersion(event.destination.version);
   if (major >= 2) return processV2(event);
   return processV1(event);
 };
 
+// Bad — bare Number(event.destination.version) (skips normalization; destVersion=0 leaks to metrics)
 // Bad — routing the major through getDestHandler (conflates the architecture-version axis)
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -954,14 +954,18 @@ A destination can ship multiple **integration majors** (e.g. v1 → v2 of its co
 > - **transformer architecture version** — the `src/v0` / `v1` / `v2` directory (`getDestHandler`'s `version` argument, the `version: 'v0'` field in component tests). Unrelated.
 > - **REST request-config version** — `version: '1'` inside `defaultRequestConfig()` / the proxy request shape. Unrelated.
 
-**The idiom — an in-file inline branch, by default.** At the top of your entry `process`, branch on `Number(event.destination.version)`. Keep the existing v1 logic in place and factor shared logic into `utils.ts`:
+**The idiom — an in-file inline branch, by default.** At the top of your entry `process`, branch on `getDestinationVersion(event.destination.version)`. Keep the existing v1 logic in place and factor shared logic into `utils.ts`:
 
 ```ts
+import { getDestinationVersion } from '../../../util/utils';
+
 const V2_MAJOR = 2;
 
 const process = (event) => {
-  // 0 / undefined / 1 all resolve to Number(...) < 2 and run the existing v1 path (defensive).
-  const major = Number(event.destination.version);
+  // getDestinationVersion normalizes the raw major (0 / undefined / non-numeric -> 1, fractions
+  // truncated), so 0 / undefined / 1 all run the existing v1 path (defensive) and metrics never
+  // see a bogus destVersion=0.
+  const major = getDestinationVersion(event.destination.version);
   if (major >= V2_MAJOR) {
     return processV2(event); // new major
   }
@@ -969,7 +973,7 @@ const process = (event) => {
 };
 ```
 
-- **Read `destination.version`, never `Config.apiVersion`.** It is a number and may be absent on routes that don't carry it — `Number(undefined)` is `NaN`, which falls to v1. So `0`, `undefined`, and `1` all behave identically (v1).
+- **Normalize with `getDestinationVersion(...)` (`src/util/utils.js`); read `destination.version`, never `Config.apiVersion`.** The raw major is a number that may be absent on routes that don't carry it. `getDestinationVersion` maps `0` / `undefined` / non-numeric to `1` and truncates fractions to a whole integer, so `0`, `undefined`, and `1` all behave identically (v1) and dashboards never see `destVersion=0`. Branching on the bare `Number(event.destination.version)` skips this normalization — always go through the helper.
 - **Shared logic lives in `utils.ts`**; v1 stays where it is. Until a destination ships a new major, every destination is v1 and runs exactly as today.
 - **Escalate to a sibling module only on large divergence.** If the v2 branch grows large, move it to a sibling module following the existing repo convention (`transformV2.ts` / `<dest>Transform-v2.ts`, as Klaviyo/HubSpot/TikTok/Snapchat do). **Prefer a sibling module over `./v1` / `./v2` subdirectories** — no destination uses subdirs today, so they fragment the layout — but they aren't strictly off-limits if a major is large enough to warrant its own tree. The entry `transform` stays the dispatcher either way.
 - **Branch `routerTransform`, `deleteUsers`, and the proxy/delivery handler only when a major actually changes them.** Most majors only touch `transform`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -980,7 +980,7 @@ const process = (event) => {
 - **The proxy / dataDelivery route has no destination object** — the major arrives as a top-level **`destinationVersion`** on the proxy request payload. Read it there (e.g. in `networkHandler`'s `proxy`/`responseHandler`), not `destination.version`.
 - **Never route integration majors through `getDestHandler`.** That argument is the architecture version; routing majors there would explode the directory matrix.
 
-See `src/v0/destinations/test_destination` for a worked, dev-only example exercising this idiom across `process`, `processRouterDest`, and `networkHandler`.
+See `src/v0/destinations/test_destination` for a worked, dev-only example exercising this idiom across `process` and `networkHandler`. Its router runs through the native batching framework (`routerTransform.ts`), which reuses `process`, so the major dispatch lives in one place rather than a separate `processRouterDest`.
 
 ### 3. Test your destination integration
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -945,6 +945,39 @@ And here's an example of the mapping configuration files:
 ]
 ```
 
+#### Dispatching on the integration major (`destination.version`)
+
+A destination can ship multiple **integration majors** (e.g. v1 → v2 of its config + API). The control plane stamps the major on the destination and the data plane **carries** it to the transformer — there is no up-conversion (stored shape = delivered shape = processed shape). Your job is to read that major and branch on it **inside your own destination's code**.
+
+> **Terminology trap.** Three unrelated "versions" exist — do not conflate them:
+> - **integration major** — `destination.version` (a number; `destinationVersion` on the proxy payload). **This is the axis you branch on.**
+> - **transformer architecture version** — the `src/v0` / `v1` / `v2` directory (`getDestHandler`'s `version` argument, the `version: 'v0'` field in component tests). Unrelated.
+> - **REST request-config version** — `version: '1'` inside `defaultRequestConfig()` / the proxy request shape. Unrelated.
+
+**The idiom — an in-file inline branch, by default.** At the top of your entry `process`, branch on `Number(event.destination.version)`. Keep the existing v1 logic in place and factor shared logic into `utils.ts`:
+
+```ts
+const V2_MAJOR = 2;
+
+const process = (event) => {
+  // 0 / undefined / 1 all resolve to Number(...) < 2 and run the existing v1 path (defensive).
+  const major = Number(event.destination.version);
+  if (major >= V2_MAJOR) {
+    return processV2(event); // new major
+  }
+  return processV1(event); // existing v1 logic, unchanged
+};
+```
+
+- **Read `destination.version`, never `Config.apiVersion`.** It is a number and may be absent on routes that don't carry it — `Number(undefined)` is `NaN`, which falls to v1. So `0`, `undefined`, and `1` all behave identically (v1).
+- **Shared logic lives in `utils.ts`**; v1 stays where it is. Until a destination ships a new major, every destination is v1 and runs exactly as today.
+- **Escalate to a sibling module only on large divergence.** If the v2 branch grows large, move it to a sibling module following the existing repo convention (`transformV2.ts` / `<dest>Transform-v2.ts`, as Klaviyo/HubSpot/TikTok/Snapchat do). **Prefer a sibling module over `./v1` / `./v2` subdirectories** — no destination uses subdirs today, so they fragment the layout — but they aren't strictly off-limits if a major is large enough to warrant its own tree. The entry `transform` stays the dispatcher either way.
+- **Branch `routerTransform`, `deleteUsers`, and the proxy/delivery handler only when a major actually changes them.** Most majors only touch `transform`.
+- **The proxy / dataDelivery route has no destination object** — the major arrives as a top-level **`destinationVersion`** on the proxy request payload. Read it there (e.g. in `networkHandler`'s `proxy`/`responseHandler`), not `destination.version`.
+- **Never route integration majors through `getDestHandler`.** That argument is the architecture version; routing majors there would explode the directory matrix.
+
+See `src/v0/destinations/test_destination` for a worked, dev-only example exercising this idiom across `process`, `processRouterDest`, and `networkHandler`.
+
 ### 3. Test your destination integration
 
 

--- a/src/constants/batchedDestinationsMap.ts
+++ b/src/constants/batchedDestinationsMap.ts
@@ -4,6 +4,7 @@ export const batchedDestinationsMap: Record<string, true> = {
   POSTHOG: true,
   CUSTOM_AUDIENCE: true,
   ITERABLE_AUDIENCE: true,
+  TEST_DESTINATION: true, // dev-only fixture (INT-6492); only ever reached in dev — gated out of prod at features.ts
 };
 
 // Per-destination env var: {DEST}_BATCHING_FRAMEWORK_ENABLED_WORKSPACE_IDS

--- a/src/constants/batchedDestinationsMap.ts
+++ b/src/constants/batchedDestinationsMap.ts
@@ -4,7 +4,7 @@ export const batchedDestinationsMap: Record<string, true> = {
   POSTHOG: true,
   CUSTOM_AUDIENCE: true,
   ITERABLE_AUDIENCE: true,
-  TEST_DESTINATION: true, // dev-only fixture (INT-6492); only ever reached in dev — gated out of prod at features.ts
+  TEST_DESTINATION: true, // dev-only fixture — see src/v0/destinations/test_destination/config.ts
 };
 
 // Per-destination env var: {DEST}_BATCHING_FRAMEWORK_ENABLED_WORKSPACE_IDS

--- a/src/features.ts
+++ b/src/features.ts
@@ -103,6 +103,7 @@ const defaultFeaturesConfig: FeaturesConfig = {
     CUSTOM_AUDIENCE: true,
     ITERABLE_AUDIENCE: true,
     SURVICATE: true,
+    TEST_DESTINATION: true, // dev-only test fixture for definition-versioning (INT-6492); gated out of staging/prod at the control plane
   },
   regulations: [
     'BRAZE',

--- a/src/features.ts
+++ b/src/features.ts
@@ -103,9 +103,9 @@ const defaultFeaturesConfig: FeaturesConfig = {
     CUSTOM_AUDIENCE: true,
     ITERABLE_AUDIENCE: true,
     SURVICATE: true,
-    // dev-only test fixture for definition-versioning (INT-6492); kept out of the prod /features
-    // payload here (NODE_ENV==='production'), so exposure no longer rests solely on control-plane gating.
-    ...(process.env.NODE_ENV !== 'production' && { TEST_DESTINATION: true }),
+    // dev-only fixture — see src/v0/destinations/test_destination/config.ts. The /features payload is
+    // informational; whether a destination is processed is governed by control-plane workspace config.
+    TEST_DESTINATION: true,
   },
   regulations: [
     'BRAZE',

--- a/src/features.ts
+++ b/src/features.ts
@@ -103,7 +103,9 @@ const defaultFeaturesConfig: FeaturesConfig = {
     CUSTOM_AUDIENCE: true,
     ITERABLE_AUDIENCE: true,
     SURVICATE: true,
-    TEST_DESTINATION: true, // dev-only test fixture for definition-versioning (INT-6492); gated out of staging/prod at the control plane
+    // dev-only test fixture for definition-versioning (INT-6492); kept out of the prod /features
+    // payload here (NODE_ENV==='production'), so exposure no longer rests solely on control-plane gating.
+    ...(process.env.NODE_ENV !== 'production' && { TEST_DESTINATION: true }),
   },
   regulations: [
     'BRAZE',

--- a/src/types/controlPlaneConfig.ts
+++ b/src/types/controlPlaneConfig.ts
@@ -45,6 +45,7 @@ export type Destination<
   deliveryAccount?: DeliveryAccountT;
   deleteAccount?: DeleteAccountT;
   hasDynamicConfig?: boolean; // Flag indicating whether the destination config contains dynamic config patterns
+  version?: number; // integration major (mirrors Go DestinationT.Version). May be undefined; 0/undefined/1 all dispatch as v1.
 };
 
 export type DestinationConnectionConfig<T> = {

--- a/src/types/destinationTransformation.ts
+++ b/src/types/destinationTransformation.ts
@@ -183,6 +183,7 @@ export type ProxyV0Request = {
   files?: Record<string, unknown>;
   metadata: ProxyMetdata;
   destinationConfig: Record<string, unknown>;
+  destinationVersion?: number; // integration major; the proxy payload carries no destination object, so the major arrives as this sibling field
 };
 
 /**

--- a/src/types/zodTypes.ts
+++ b/src/types/zodTypes.ts
@@ -141,6 +141,7 @@ export const ProxyV0RequestSchema = z.object({
   files: z.record(z.unknown()).optional(),
   metadata: ProxyMetadataSchema,
   destinationConfig: z.record(z.unknown()),
+  destinationVersion: z.number().optional(),
 });
 
 export const ProxyV1RequestSchema = z.object({
@@ -162,6 +163,7 @@ export const ProxyV1RequestSchema = z.object({
   files: z.record(z.unknown()).optional(),
   metadata: z.array(ProxyMetadataSchema),
   destinationConfig: z.record(z.unknown()),
+  destinationVersion: z.number().optional(),
 });
 
 const validateStatTags = (data: any) => {

--- a/src/util/utils.js
+++ b/src/util/utils.js
@@ -286,6 +286,22 @@ const responseStatusHandler = (status, entity, id, url) => {
 };
 
 const getIntegrationVersion = () => 'v0';
+
+/**
+ * Resolves the integration major (the destination definition version) to dispatch on, normalized
+ * for both branching and metrics. The control plane carries the major as `destination.version` on
+ * the transform/router routes and as a top-level `destinationVersion` on the proxy route; it sends
+ * `0` when the workspace config has no version stamped, and the field is absent on payloads that
+ * don't carry it. `0`, `undefined`, and any non-numeric value all normalize to `1` (the implicit
+ * first major) — the result is never `0`, so dashboards never see a bogus `destVersion=0`.
+ * @param {number} [version] raw destination.version / destinationVersion off the payload
+ * @returns {number} the integration major, always >= 1
+ */
+const getDestinationVersion = (version) => {
+  const major = Number(version);
+  return major >= 1 ? major : 1;
+};
+
 const sendViolationMetrics = (validationErrors, dropped, metaTags) => {
   const vTags = {
     'Unplanned-Event': 0,
@@ -400,6 +416,7 @@ module.exports = {
   RetryRequestError,
   responseStatusHandler,
   getIntegrationVersion,
+  getDestinationVersion,
   constructValidationErrors,
   sendViolationMetrics,
   logProcessInfo,

--- a/src/util/utils.js
+++ b/src/util/utils.js
@@ -293,12 +293,13 @@ const getIntegrationVersion = () => 'v0';
  * the transform/router routes and as a top-level `destinationVersion` on the proxy route; it sends
  * `0` when the workspace config has no version stamped, and the field is absent on payloads that
  * don't carry it. `0`, `undefined`, and any non-numeric value all normalize to `1` (the implicit
- * first major) — the result is never `0`, so dashboards never see a bogus `destVersion=0`.
+ * first major), and a fractional value is truncated toward zero to a whole major — the result is
+ * always an integer `>= 1`, so dashboards never see a bogus `destVersion=0` or a non-integer major.
  * @param {number} [version] raw destination.version / destinationVersion off the payload
- * @returns {number} the integration major, always >= 1
+ * @returns {number} the integration major, an integer always >= 1
  */
 const getDestinationVersion = (version) => {
-  const major = Number(version);
+  const major = Math.trunc(Number(version));
   return major >= 1 ? major : 1;
 };
 

--- a/src/util/utils.test.js
+++ b/src/util/utils.test.js
@@ -24,6 +24,7 @@ const {
   fetchWithDnsWrapper,
   isBlockedIP,
   ssrfSafeAgentFactory,
+  getDestinationVersion,
 } = require('./utils');
 
 describe('asyncHooks behaviour', () => {
@@ -333,5 +334,22 @@ describe('ssrfSafeAgentFactory', () => {
     const a = ssrfSafeAgentFactory(url('https://a.example.com'));
     const b = ssrfSafeAgentFactory(url('https://b.example.com'));
     expect(a).toBe(b);
+  });
+});
+
+describe('getDestinationVersion', () => {
+  // 0 (workspace config carries no version), undefined/absent, and non-numeric all mean "first
+  // major" — they must normalize to 1 so dispatch falls to v1 and metrics never see destVersion=0.
+  it.each([
+    [undefined, 1],
+    [0, 1],
+    [1, 1],
+    [2, 2],
+    [3, 3],
+    [NaN, 1],
+    ['2', 2], // defensive: stringified majors coerce
+    ['not-a-number', 1],
+  ])('normalizes %p to %p', (input, expected) => {
+    expect(getDestinationVersion(input)).toBe(expected);
   });
 });

--- a/src/util/utils.test.js
+++ b/src/util/utils.test.js
@@ -340,6 +340,7 @@ describe('ssrfSafeAgentFactory', () => {
 describe('getDestinationVersion', () => {
   // 0 (workspace config carries no version), undefined/absent, and non-numeric all mean "first
   // major" — they must normalize to 1 so dispatch falls to v1 and metrics never see destVersion=0.
+  // Fractional majors are truncated toward zero so the result is always a whole integer.
   it.each([
     [undefined, 1],
     [0, 1],
@@ -347,6 +348,8 @@ describe('getDestinationVersion', () => {
     [2, 2],
     [3, 3],
     [NaN, 1],
+    [1.9, 1], // fractional major truncates down (stays v1)
+    [2.5, 2], // fractional major truncates down (still routes to v2)
     ['2', 2], // defensive: stringified majors coerce
     ['not-a-number', 1],
   ])('normalizes %p to %p', (input, expected) => {

--- a/src/v0/destinations/test_destination/config.ts
+++ b/src/v0/destinations/test_destination/config.ts
@@ -1,0 +1,11 @@
+// ⚠️ DEV-ONLY TEST FIXTURE — NOT A REAL DESTINATION (INT-6492).
+// `test_destination` exists solely to validate integration definition-versioning dispatch
+// end-to-end (control plane + data plane). It must never be shipped or enabled for customers.
+// v1 config shape: { restApiKey (secret), dataCenter }. v2 renames these (apiKey, region) and adds
+// a required accountId; only v1 is implemented in the transformer today.
+
+// The `.invalid` TLD is reserved (RFC 2606) and never resolves — a deliberate signal that this
+// endpoint is fake. The env override keeps it pointable in dev/tests.
+export const getV1Endpoint = (dataCenter = 'us'): string =>
+  process.env.TEST_DESTINATION_API_ENDPOINT ||
+  `https://${dataCenter}.test-destination.invalid/v1/events`;

--- a/src/v0/destinations/test_destination/config.ts
+++ b/src/v0/destinations/test_destination/config.ts
@@ -4,6 +4,10 @@
 // v1 config shape: { restApiKey (secret), dataCenter }. v2 renames these (apiKey, region) and adds
 // a required accountId; only v1 is implemented in the transformer today.
 
+// Integration major at which the v2 config/API shape (apiKey/region/accountId) kicks in (INT-6492).
+// Single source shared by transform.ts (process dispatch) and networkHandler.ts (proxy dispatch).
+export const V2_MAJOR = 2;
+
 // The `.invalid` TLD is reserved (RFC 2606) and never resolves — a deliberate signal that this
 // endpoint is fake. The env override keeps it pointable in dev/tests.
 export const getV1Endpoint = (dataCenter = 'us'): string =>

--- a/src/v0/destinations/test_destination/networkHandler.ts
+++ b/src/v0/destinations/test_destination/networkHandler.ts
@@ -3,6 +3,7 @@ import { ConfigurationError, NetworkError } from '@rudderstack/integrations-lib'
 import { isHttpStatusSuccess } from '../../util/index';
 import { proxyRequest, prepareProxyRequest } from '../../../adapters/network';
 import { getDynamicErrorType, processAxiosResponse } from '../../../adapters/utils/networkUtils';
+import { getDestinationVersion } from '../../../util/utils';
 import tags from '../../util/tags';
 import { ProxyRequest } from '../../../types';
 import { TestDestinationResponseParams } from './type';
@@ -15,7 +16,7 @@ const V2_MAJOR = 2;
 // Proxy/dataDelivery carries no destination object — the major arrives as the top-level
 // `destinationVersion` on the proxy payload. Dispatch on it: 0/undefined/1 deliver via the v1 path.
 const proxy = async (deliveryRequest: ProxyRequest, destType: string) => {
-  const major = Number(deliveryRequest.destinationVersion);
+  const major = getDestinationVersion(deliveryRequest.destinationVersion);
   if (major >= V2_MAJOR) {
     throw new ConfigurationError(`${DEST} v2 delivery is not yet implemented`);
   }

--- a/src/v0/destinations/test_destination/networkHandler.ts
+++ b/src/v0/destinations/test_destination/networkHandler.ts
@@ -1,17 +1,12 @@
 // ⚠️ DEV-ONLY TEST FIXTURE — NOT A REAL DESTINATION (INT-6492). See config.ts.
-import { ConfigurationError, NetworkError } from '@rudderstack/integrations-lib';
-import { isHttpStatusSuccess } from '../../util/index';
-import { proxyRequest, prepareProxyRequest } from '../../../adapters/network';
-import { getDynamicErrorType, processAxiosResponse } from '../../../adapters/utils/networkUtils';
+import { ConfigurationError } from '@rudderstack/integrations-lib';
+import { proxyRequest } from '../../../adapters/network';
+import { networkHandler as genericNetworkHandler } from '../../../adapters/networkhandler/genericNetworkHandler';
 import { getDestinationVersion } from '../../../util/utils';
-import tags from '../../util/tags';
 import { ProxyRequest } from '../../../types';
-import { TestDestinationResponseParams } from './type';
+import { V2_MAJOR } from './config';
 
 const DEST = 'test_destination';
-
-// Integration major at which the v2 delivery shape kicks in (INT-6492). Only v1 ships today.
-const V2_MAJOR = 2;
 
 // Proxy/dataDelivery carries no destination object — the major arrives as the top-level
 // `destinationVersion` on the proxy payload. Dispatch on it: 0/undefined/1 deliver via the v1 path.
@@ -23,34 +18,12 @@ const proxy = async (deliveryRequest: ProxyRequest, destType: string) => {
   return proxyRequest(deliveryRequest, destType);
 };
 
-const responseHandler = (responseParams: TestDestinationResponseParams) => {
-  const { destinationResponse } = responseParams;
-  const { status } = destinationResponse;
-  if (!isHttpStatusSuccess(status)) {
-    throw new NetworkError(
-      `[${DEST}] delivery failed with status: ${status}`,
-      status,
-      { [tags.TAG_NAMES.ERROR_TYPE]: getDynamicErrorType(status) },
-      destinationResponse,
-    );
-  }
-  return {
-    status,
-    message: `[${DEST}] delivery processed successfully`,
-    destinationResponse,
-  };
-};
-
-function networkHandler(this: {
-  responseHandler: typeof responseHandler;
-  proxy: typeof proxy;
-  prepareProxy: typeof prepareProxyRequest;
-  processAxiosResponse: typeof processAxiosResponse;
-}) {
-  this.responseHandler = responseHandler;
+// Inherit the generic responseHandler / processAxiosResponse / prepareProxy contract and override
+// only the proxy with integration-major dispatch, so future changes to the shared network contract
+// reach this destination instead of silently bypassing a re-declared copy.
+function networkHandler(this: Record<string, unknown>) {
+  genericNetworkHandler.call(this);
   this.proxy = proxy;
-  this.prepareProxy = prepareProxyRequest;
-  this.processAxiosResponse = processAxiosResponse;
 }
 
 export { networkHandler };

--- a/src/v0/destinations/test_destination/networkHandler.ts
+++ b/src/v0/destinations/test_destination/networkHandler.ts
@@ -1,0 +1,55 @@
+// ⚠️ DEV-ONLY TEST FIXTURE — NOT A REAL DESTINATION (INT-6492). See config.ts.
+import { ConfigurationError, NetworkError } from '@rudderstack/integrations-lib';
+import { isHttpStatusSuccess } from '../../util/index';
+import { proxyRequest, prepareProxyRequest } from '../../../adapters/network';
+import { getDynamicErrorType, processAxiosResponse } from '../../../adapters/utils/networkUtils';
+import tags from '../../util/tags';
+import { ProxyRequest } from '../../../types';
+import { TestDestinationResponseParams } from './type';
+
+const DEST = 'test_destination';
+
+// Integration major at which the v2 delivery shape kicks in (INT-6492). Only v1 ships today.
+const V2_MAJOR = 2;
+
+// Proxy/dataDelivery carries no destination object — the major arrives as the top-level
+// `destinationVersion` on the proxy payload. Dispatch on it: 0/undefined/1 deliver via the v1 path.
+const proxy = async (deliveryRequest: ProxyRequest, destType: string) => {
+  const major = Number(deliveryRequest.destinationVersion);
+  if (major >= V2_MAJOR) {
+    throw new ConfigurationError(`${DEST} v2 delivery is not yet implemented`);
+  }
+  return proxyRequest(deliveryRequest, destType);
+};
+
+const responseHandler = (responseParams: TestDestinationResponseParams) => {
+  const { destinationResponse } = responseParams;
+  const { status } = destinationResponse;
+  if (!isHttpStatusSuccess(status)) {
+    throw new NetworkError(
+      `[${DEST}] delivery failed with status: ${status}`,
+      status,
+      { [tags.TAG_NAMES.ERROR_TYPE]: getDynamicErrorType(status) },
+      destinationResponse,
+    );
+  }
+  return {
+    status,
+    message: `[${DEST}] delivery processed successfully`,
+    destinationResponse,
+  };
+};
+
+function networkHandler(this: {
+  responseHandler: typeof responseHandler;
+  proxy: typeof proxy;
+  prepareProxy: typeof prepareProxyRequest;
+  processAxiosResponse: typeof processAxiosResponse;
+}) {
+  this.responseHandler = responseHandler;
+  this.proxy = proxy;
+  this.prepareProxy = prepareProxyRequest;
+  this.processAxiosResponse = processAxiosResponse;
+}
+
+export { networkHandler };

--- a/src/v0/destinations/test_destination/routerTransform.test.ts
+++ b/src/v0/destinations/test_destination/routerTransform.test.ts
@@ -1,0 +1,88 @@
+import { Integration } from './routerTransform';
+import { ChunkBatchStrategy } from '../../../services/destination/nativeBatching/batchDestination';
+import { processBatchedDestination } from '../../../services/destination/nativeBatching/processBatchedDestination';
+import { TestDestination, TestDestinationRouterRequest } from './type';
+
+const destinationDefinition = {
+  ID: 'test-destination-def-id',
+  Name: 'TEST_DESTINATION',
+  DisplayName: 'Test Destination (dev-only fixture)',
+  Config: {},
+};
+
+const destinationV1 = {
+  ID: 'test-destination-v1',
+  Name: 'TEST_DESTINATION',
+  DestinationDefinition: destinationDefinition,
+  Config: { restApiKey: 'v1-secret-key', dataCenter: 'eu' },
+  Enabled: true,
+  WorkspaceID: 'ws-1',
+  Transformations: [],
+  version: 1,
+} as unknown as TestDestination;
+
+const destinationNoVersion = { ...destinationV1, version: undefined } as TestDestination;
+const destinationV2 = {
+  ...destinationV1,
+  Config: { apiKey: 'v2-secret-key', region: 'eu', accountId: 'acct-123' },
+  version: 2,
+} as unknown as TestDestination;
+
+const message = {
+  type: 'track',
+  event: 'Test Event',
+  userId: 'user-1',
+  properties: { plan: 'pro' },
+};
+
+const v1Endpoint = 'https://eu.test-destination.invalid/v1/events';
+const v1Headers = { 'Content-Type': 'application/json', 'X-Api-Key': 'v1-secret-key' };
+
+const buildInput = (jobId: number, destination: TestDestination): TestDestinationRouterRequest =>
+  ({
+    message,
+    metadata: { jobId, workspaceId: 'ws-1' },
+    destination,
+  }) as unknown as TestDestinationRouterRequest;
+
+describe('test_destination batching framework Integration', () => {
+  it('transformEvent reshapes a v1 event into the framework payload', () => {
+    const integration = new Integration(destinationV1);
+    expect(integration.transformEvent(buildInput(1, destinationV1))).toEqual({
+      body: message,
+      endpoint: v1Endpoint,
+      endpointPath: '/v1/events',
+      method: 'POST',
+      headers: v1Headers,
+    });
+  });
+
+  it('getBatchStrategy returns a ChunkBatchStrategy', () => {
+    expect(new Integration(destinationV1).getBatchStrategy()).toBeInstanceOf(ChunkBatchStrategy);
+  });
+
+  it('batches v1 + no-version events (same endpoint/headers) into one request', async () => {
+    const results = await processBatchedDestination(
+      [buildInput(1, destinationV1), buildInput(2, destinationNoVersion)],
+      Integration,
+      {},
+    );
+    expect(results).toHaveLength(1);
+    expect(results[0].batched).toBe(true);
+    expect(results[0].statusCode).toBe(200);
+    expect(results[0].metadata).toHaveLength(2);
+    expect((results[0].batchedRequest as any).body.JSON).toEqual({ batch: [message, message] });
+  });
+
+  it('rejects a v2 event with a 400 — only v1 is implemented', async () => {
+    const results = await processBatchedDestination(
+      [buildInput(3, destinationV2)],
+      Integration,
+      {},
+    );
+    expect(results).toHaveLength(1);
+    expect(results[0].batched).toBe(false);
+    expect(results[0].statusCode).toBe(400);
+    expect(results[0].error).toContain('v2 transformation is not yet implemented');
+  });
+});

--- a/src/v0/destinations/test_destination/routerTransform.ts
+++ b/src/v0/destinations/test_destination/routerTransform.ts
@@ -1,0 +1,47 @@
+// ⚠️ DEV-ONLY TEST FIXTURE — NOT A REAL DESTINATION (INT-6492). See config.ts.
+// Batching is not required for this dummy destination — it is wired through the native batching
+// framework purely as a worked reference for the recommended router-transform pattern.
+import { z, ZodType } from 'zod';
+import {
+  BatchDestination,
+  TransformedEvent,
+  ChunkBatchStrategy,
+} from '../../../services/destination/nativeBatching/batchDestination';
+import type { BatchStrategy } from '../../../services/destination/nativeBatching/types';
+import { process as transformEvent } from './transform';
+import type {
+  TestDestinationProcessorRequest,
+  TestDestinationRouterRequest,
+  TestDestinationV1Payload,
+} from './type';
+
+class TestDestinationIntegration extends BatchDestination<TestDestinationV1Payload> {
+  transformEvent(input: TestDestinationRouterRequest): TransformedEvent<TestDestinationV1Payload> {
+    // Reuse the version-dispatching per-event transform (throws ConfigurationError on v2); the
+    // framework wraps that throw into a per-event error response.
+    const result = transformEvent({
+      message: input.message,
+      destination: input.destination,
+    } as TestDestinationProcessorRequest);
+    return {
+      body: result.body.JSON as TestDestinationV1Payload,
+      endpoint: result.endpoint,
+      endpointPath: '/v1/events',
+      method: result.method,
+      headers: result.headers,
+    };
+  }
+
+  getBatchStrategy(): BatchStrategy<TestDestinationV1Payload> {
+    // No size/count limits — events that share endpoint + headers collapse into one request.
+    return new ChunkBatchStrategy<TestDestinationV1Payload>({
+      wrapBody: (bodies) => ({ batch: bodies }),
+    });
+  }
+
+  getInputSchema(): ZodType {
+    return z.object({ message: z.object({}).passthrough() }).passthrough();
+  }
+}
+
+export const Integration = TestDestinationIntegration;

--- a/src/v0/destinations/test_destination/transform.test.ts
+++ b/src/v0/destinations/test_destination/transform.test.ts
@@ -27,7 +27,8 @@ const v1Response = {
 };
 
 describe('test_destination process — integration-major dispatch', () => {
-  // major 0 / undefined / 1 all resolve to Number(...) < 2 and run the v1 path
+  // getDestinationVersion normalizes the major (0 / undefined / non-numeric -> 1), so 0 / undefined / 1
+  // all run the v1 path (< V2_MAJOR)
   const v1Cases: { name: string; version: number | undefined }[] = [
     { name: 'version 1', version: 1 },
     { name: 'version 0', version: 0 },

--- a/src/v0/destinations/test_destination/transform.test.ts
+++ b/src/v0/destinations/test_destination/transform.test.ts
@@ -1,0 +1,44 @@
+import { ConfigurationError } from '@rudderstack/integrations-lib';
+import { process } from './transform';
+import { TestDestinationProcessorRequest } from './type';
+
+const message = {
+  type: 'track',
+  event: 'Test Event',
+  userId: 'user-1',
+  properties: { plan: 'pro' },
+} as unknown as TestDestinationProcessorRequest['message'];
+
+const buildEvent = (version: number | undefined): TestDestinationProcessorRequest =>
+  ({
+    message,
+    destination: { version, Config: { restApiKey: 'v1-secret-key', dataCenter: 'eu' } },
+  }) as unknown as TestDestinationProcessorRequest;
+
+const v1Response = {
+  version: '1',
+  type: 'REST',
+  method: 'POST',
+  endpoint: 'https://eu.test-destination.invalid/v1/events',
+  headers: { 'Content-Type': 'application/json', 'X-Api-Key': 'v1-secret-key' },
+  params: {},
+  body: { JSON: message, JSON_ARRAY: {}, XML: {}, FORM: {} },
+  files: {},
+};
+
+describe('test_destination process — integration-major dispatch', () => {
+  // major 0 / undefined / 1 all resolve to Number(...) < 2 and run the v1 path
+  const v1Cases: { name: string; version: number | undefined }[] = [
+    { name: 'version 1', version: 1 },
+    { name: 'version 0', version: 0 },
+    { name: 'version undefined', version: undefined },
+  ];
+  it.each(v1Cases)('routes $name to the v1 branch', ({ version }) => {
+    expect(process(buildEvent(version))).toEqual(v1Response);
+  });
+
+  it('throws on v2 since only v1 is implemented', () => {
+    expect(() => process(buildEvent(2))).toThrow(ConfigurationError);
+    expect(() => process(buildEvent(2))).toThrow('v2 transformation is not yet implemented');
+  });
+});

--- a/src/v0/destinations/test_destination/transform.ts
+++ b/src/v0/destinations/test_destination/transform.ts
@@ -2,15 +2,14 @@
 import { ConfigurationError } from '@rudderstack/integrations-lib';
 import { simpleProcessRouterDest } from '../../util';
 import { getDestinationVersion } from '../../../util/utils';
+import { V2_MAJOR } from './config';
 import { processV1 } from './utils';
 import { TestDestinationProcessorRequest, TestDestinationRouterRequest } from './type';
 
-// Integration major at which the v2 config shape (apiKey/region/accountId) kicks in (INT-6492).
-const V2_MAJOR = 2;
-
 // In-file dispatch on the integration major (destination.version). Defaults to v1: a major of
-// 0, undefined ("1" not yet stamped) or 1 all normalize to 1 (< 2) and run the v1 path.
-const process = (event: TestDestinationProcessorRequest) => {
+// 0, undefined ("1" not yet stamped) or 1 all normalize to 1 (< V2_MAJOR) and run the v1 path.
+// Named transformEvent (not `process`) to avoid shadowing the Node.js global `process`; exported as `process`.
+const transformEvent = (event: TestDestinationProcessorRequest) => {
   const major = getDestinationVersion(event.destination.version);
   if (major >= V2_MAJOR) {
     throw new ConfigurationError('test_destination v2 transformation is not yet implemented');
@@ -21,6 +20,6 @@ const process = (event: TestDestinationProcessorRequest) => {
 const processRouterDest = async (
   inputs: TestDestinationRouterRequest[],
   reqMetadata: Record<string, unknown>,
-) => simpleProcessRouterDest(inputs, process, reqMetadata, {});
+) => simpleProcessRouterDest(inputs, transformEvent, reqMetadata, {});
 
-export { process, processRouterDest };
+export { transformEvent as process, processRouterDest };

--- a/src/v0/destinations/test_destination/transform.ts
+++ b/src/v0/destinations/test_destination/transform.ts
@@ -1,6 +1,7 @@
 // ⚠️ DEV-ONLY TEST FIXTURE — NOT A REAL DESTINATION (INT-6492). See config.ts.
 import { ConfigurationError } from '@rudderstack/integrations-lib';
 import { simpleProcessRouterDest } from '../../util';
+import { getDestinationVersion } from '../../../util/utils';
 import { processV1 } from './utils';
 import { TestDestinationProcessorRequest, TestDestinationRouterRequest } from './type';
 
@@ -8,9 +9,9 @@ import { TestDestinationProcessorRequest, TestDestinationRouterRequest } from '.
 const V2_MAJOR = 2;
 
 // In-file dispatch on the integration major (destination.version). Defaults to v1: a major of
-// 0, undefined ("1" not yet stamped) or 1 all yield Number(...) < 2 and run the v1 path.
+// 0, undefined ("1" not yet stamped) or 1 all normalize to 1 (< 2) and run the v1 path.
 const process = (event: TestDestinationProcessorRequest) => {
-  const major = Number(event.destination.version);
+  const major = getDestinationVersion(event.destination.version);
   if (major >= V2_MAJOR) {
     throw new ConfigurationError('test_destination v2 transformation is not yet implemented');
   }

--- a/src/v0/destinations/test_destination/transform.ts
+++ b/src/v0/destinations/test_destination/transform.ts
@@ -1,14 +1,15 @@
 // ⚠️ DEV-ONLY TEST FIXTURE — NOT A REAL DESTINATION (INT-6492). See config.ts.
 import { ConfigurationError } from '@rudderstack/integrations-lib';
-import { simpleProcessRouterDest } from '../../util';
 import { getDestinationVersion } from '../../../util/utils';
 import { V2_MAJOR } from './config';
 import { processV1 } from './utils';
-import { TestDestinationProcessorRequest, TestDestinationRouterRequest } from './type';
+import { TestDestinationProcessorRequest } from './type';
 
-// In-file dispatch on the integration major (destination.version). Defaults to v1: a major of
-// 0, undefined ("1" not yet stamped) or 1 all normalize to 1 (< V2_MAJOR) and run the v1 path.
+// In-file dispatch on the integration major (destination.version). getDestinationVersion normalizes
+// the raw major (0 / undefined / non-numeric -> 1), so a major below V2_MAJOR runs the v1 path.
 // Named transformEvent (not `process`) to avoid shadowing the Node.js global `process`; exported as `process`.
+// The router path runs through the native batching framework (routerTransform.ts), so there is no
+// processRouterDest here — test_destination is batching-GA, so the legacy router path is never reached.
 const transformEvent = (event: TestDestinationProcessorRequest) => {
   const major = getDestinationVersion(event.destination.version);
   if (major >= V2_MAJOR) {
@@ -17,9 +18,4 @@ const transformEvent = (event: TestDestinationProcessorRequest) => {
   return processV1(event);
 };
 
-const processRouterDest = async (
-  inputs: TestDestinationRouterRequest[],
-  reqMetadata: Record<string, unknown>,
-) => simpleProcessRouterDest(inputs, transformEvent, reqMetadata, {});
-
-export { transformEvent as process, processRouterDest };
+export { transformEvent as process };

--- a/src/v0/destinations/test_destination/transform.ts
+++ b/src/v0/destinations/test_destination/transform.ts
@@ -1,0 +1,25 @@
+// ⚠️ DEV-ONLY TEST FIXTURE — NOT A REAL DESTINATION (INT-6492). See config.ts.
+import { ConfigurationError } from '@rudderstack/integrations-lib';
+import { simpleProcessRouterDest } from '../../util';
+import { processV1 } from './utils';
+import { TestDestinationProcessorRequest, TestDestinationRouterRequest } from './type';
+
+// Integration major at which the v2 config shape (apiKey/region/accountId) kicks in (INT-6492).
+const V2_MAJOR = 2;
+
+// In-file dispatch on the integration major (destination.version). Defaults to v1: a major of
+// 0, undefined ("1" not yet stamped) or 1 all yield Number(...) < 2 and run the v1 path.
+const process = (event: TestDestinationProcessorRequest) => {
+  const major = Number(event.destination.version);
+  if (major >= V2_MAJOR) {
+    throw new ConfigurationError('test_destination v2 transformation is not yet implemented');
+  }
+  return processV1(event);
+};
+
+const processRouterDest = async (
+  inputs: TestDestinationRouterRequest[],
+  reqMetadata: Record<string, unknown>,
+) => simpleProcessRouterDest(inputs, process, reqMetadata, {});
+
+export { process, processRouterDest };

--- a/src/v0/destinations/test_destination/type.ts
+++ b/src/v0/destinations/test_destination/type.ts
@@ -9,10 +9,12 @@ import {
 
 // v1 config. v2 renames restApiKey -> apiKey, dataCenter -> region and adds a required accountId
 // (INT-6492). Only v1 is modelled here — the v2 branch is not implemented yet.
-export interface TestDestinationV1Config {
+// A type alias (not an interface) so it carries an implicit index signature and stays assignable to
+// Record<string, unknown> — required for the batching framework's RouterTransformationRequestData.
+export type TestDestinationV1Config = {
   restApiKey?: string;
   dataCenter?: string;
-}
+};
 
 export type TestDestination = Destination<TestDestinationV1Config>;
 
@@ -28,3 +30,6 @@ export type TestDestinationRouterRequest = RouterTransformationRequestData<
   undefined, // no connection needed for this fixture
   Metadata
 >;
+
+// Per-event batch payload — the v1 transform echoes the whole message, so the payload is the message.
+export type TestDestinationV1Payload = Record<string, unknown>;

--- a/src/v0/destinations/test_destination/type.ts
+++ b/src/v0/destinations/test_destination/type.ts
@@ -3,7 +3,6 @@ import {
   Destination,
   Metadata,
   ProcessorTransformationRequest,
-  ProxyRequest,
   RouterTransformationRequestData,
   RudderMessage,
 } from '../../../types';
@@ -29,10 +28,3 @@ export type TestDestinationRouterRequest = RouterTransformationRequestData<
   undefined, // no connection needed for this fixture
   Metadata
 >;
-
-// Minimal shape consumed by the proxy responseHandler; destinationRequest carries the major.
-export interface TestDestinationResponseParams {
-  destinationResponse: { status: number; response?: unknown };
-  destType: string;
-  destinationRequest: ProxyRequest;
-}

--- a/src/v0/destinations/test_destination/type.ts
+++ b/src/v0/destinations/test_destination/type.ts
@@ -1,0 +1,38 @@
+// ⚠️ DEV-ONLY TEST FIXTURE — NOT A REAL DESTINATION (INT-6492). See config.ts.
+import {
+  Destination,
+  Metadata,
+  ProcessorTransformationRequest,
+  ProxyRequest,
+  RouterTransformationRequestData,
+  RudderMessage,
+} from '../../../types';
+
+// v1 config. v2 renames restApiKey -> apiKey, dataCenter -> region and adds a required accountId
+// (INT-6492). Only v1 is modelled here — the v2 branch is not implemented yet.
+export interface TestDestinationV1Config {
+  restApiKey?: string;
+  dataCenter?: string;
+}
+
+export type TestDestination = Destination<TestDestinationV1Config>;
+
+export type TestDestinationProcessorRequest = ProcessorTransformationRequest<
+  RudderMessage,
+  Metadata,
+  TestDestination
+>;
+
+export type TestDestinationRouterRequest = RouterTransformationRequestData<
+  RudderMessage,
+  TestDestination,
+  undefined, // no connection needed for this fixture
+  Metadata
+>;
+
+// Minimal shape consumed by the proxy responseHandler; destinationRequest carries the major.
+export interface TestDestinationResponseParams {
+  destinationResponse: { status: number; response?: unknown };
+  destType: string;
+  destinationRequest: ProxyRequest;
+}

--- a/src/v0/destinations/test_destination/utils.ts
+++ b/src/v0/destinations/test_destination/utils.ts
@@ -1,0 +1,22 @@
+// ⚠️ DEV-ONLY TEST FIXTURE — NOT A REAL DESTINATION (INT-6492). See config.ts.
+import { defaultRequestConfig } from '../../util';
+import { JSON_MIME_TYPE } from '../../util/constant';
+import { getV1Endpoint } from './config';
+import { TestDestinationProcessorRequest } from './type';
+
+// v1 transform — intentionally minimal (dev-only fixture, no real business logic). Echoes the
+// message to the dataCenter-scoped endpoint, authenticating with the v1 restApiKey secret.
+export const processV1 = (event: TestDestinationProcessorRequest) => {
+  const { message, destination } = event;
+  const { restApiKey, dataCenter } = destination.Config;
+
+  const response = defaultRequestConfig();
+  response.method = 'POST';
+  response.endpoint = getV1Endpoint(dataCenter);
+  response.headers = {
+    'Content-Type': JSON_MIME_TYPE,
+    ...(restApiKey && { 'X-Api-Key': restApiKey }),
+  };
+  response.body.JSON = message as Record<string, unknown>;
+  return response;
+};

--- a/test/integrations/destinations/test_destination/common.ts
+++ b/test/integrations/destinations/test_destination/common.ts
@@ -1,0 +1,54 @@
+// ⚠️ DEV-ONLY TEST FIXTURE — NOT A REAL DESTINATION (INT-6492).
+// Fixtures for the dev-only `test_destination` that validates definition-versioning dispatch.
+import { Destination } from '../../../../src/types';
+
+export const destType = 'test_destination';
+export const destTypeInUpperCase = 'TEST_DESTINATION';
+export const displayName = 'Test Destination (dev-only fixture)';
+
+const destinationDefinition = {
+  DisplayName: displayName,
+  ID: 'test-destination-def-id',
+  Name: destTypeInUpperCase,
+  Config: {},
+};
+
+// v1 destination (integration major 1): config { restApiKey (secret), dataCenter }.
+export const destinationV1: Destination = {
+  ID: 'test-destination-v1',
+  Name: destTypeInUpperCase,
+  DestinationDefinition: destinationDefinition,
+  Config: { restApiKey: 'v1-secret-key', dataCenter: 'eu' },
+  Enabled: true,
+  WorkspaceID: 'test-workspace-id',
+  Transformations: [],
+  version: 1,
+};
+
+// No version stamped — must dispatch identically to v1 (Number(undefined) => NaN < 2).
+export const destinationNoVersion: Destination = {
+  ...destinationV1,
+  ID: 'test-destination-no-version',
+  version: undefined,
+};
+
+// v2 destination — only v1 is implemented, so dispatch must reject this until v2 ships.
+export const destinationV2: Destination = {
+  ...destinationV1,
+  ID: 'test-destination-v2',
+  Config: { apiKey: 'v2-secret-key', region: 'eu', accountId: 'acct-123' },
+  version: 2,
+};
+
+export const baseMessage = {
+  type: 'track' as const,
+  event: 'Test Event',
+  userId: 'user-1',
+  properties: { plan: 'pro' },
+  originalTimestamp: '2023-01-01T00:00:00.000Z',
+  sentAt: '2023-01-01T00:00:00.000Z',
+  timestamp: '2023-01-01T00:00:00.000Z',
+  messageId: 'msg-1',
+};
+
+export const v1Endpoint = 'https://eu.test-destination.invalid/v1/events';

--- a/test/integrations/destinations/test_destination/common.ts
+++ b/test/integrations/destinations/test_destination/common.ts
@@ -54,7 +54,7 @@ export const baseMessage = {
 export const v1Endpoint = 'https://eu.test-destination.invalid/v1/events';
 
 // Shared v1 REST request shape produced by processV1 — dataCenter-scoped endpoint + restApiKey
-// header. Single source for the processor/router fixtures so the wire shape lives in one place.
+// header. Used by the processor fixture (the router fixture asserts the batched-request shape).
 export const v1RequestShape = {
   version: '1',
   type: 'REST',

--- a/test/integrations/destinations/test_destination/common.ts
+++ b/test/integrations/destinations/test_destination/common.ts
@@ -52,3 +52,28 @@ export const baseMessage = {
 };
 
 export const v1Endpoint = 'https://eu.test-destination.invalid/v1/events';
+
+// Shared v1 REST request shape produced by processV1 — dataCenter-scoped endpoint + restApiKey
+// header. Single source for the processor/router fixtures so the wire shape lives in one place.
+export const v1RequestShape = {
+  version: '1',
+  type: 'REST',
+  method: 'POST',
+  endpoint: v1Endpoint,
+  headers: { 'Content-Type': 'application/json', 'X-Api-Key': 'v1-secret-key' },
+  params: {},
+  body: { JSON: baseMessage, JSON_ARRAY: {}, XML: {}, FORM: {} },
+  files: {},
+};
+
+// statTags emitted when a v2 event hits the not-yet-implemented ConfigurationError, by feature.
+export const v2StatTags = (feature: string) => ({
+  destType: destTypeInUpperCase,
+  destinationId: 'default-destinationId',
+  errorCategory: 'dataValidation',
+  errorType: 'configuration',
+  feature,
+  implementation: 'native',
+  module: 'destination',
+  workspaceId: 'default-workspaceId',
+});

--- a/test/integrations/destinations/test_destination/common.ts
+++ b/test/integrations/destinations/test_destination/common.ts
@@ -25,7 +25,7 @@ export const destinationV1: Destination = {
   version: 1,
 };
 
-// No version stamped — must dispatch identically to v1 (Number(undefined) => NaN < 2).
+// No version stamped — must dispatch identically to v1 (getDestinationVersion normalizes undefined to major 1).
 export const destinationNoVersion: Destination = {
   ...destinationV1,
   ID: 'test-destination-no-version',

--- a/test/integrations/destinations/test_destination/dataDelivery/data.ts
+++ b/test/integrations/destinations/test_destination/dataDelivery/data.ts
@@ -1,7 +1,7 @@
 // ⚠️ DEV-ONLY TEST FIXTURE — NOT A REAL DESTINATION (INT-6492).
 import { generateMetadata, generateProxyV1Payload } from '../../../testUtils';
 import { ProxyV1TestData } from '../../../testTypes';
-import { v1Endpoint } from '../common';
+import { v1Endpoint, v2StatTags } from '../common';
 
 const v1Headers = { 'Content-Type': 'application/json', 'X-Api-Key': 'v1-secret-key' };
 const deliveryBody = { event: 'Test Event', userId: 'user-1' };
@@ -33,7 +33,8 @@ export const data: ProxyV1TestData[] = [
         body: {
           output: {
             status: 200,
-            message: '[test_destination] delivery processed successfully',
+            message:
+              '[Generic Response Handler] Request for destination: test_destination Processed Successfully',
             response: [
               {
                 error: JSON.stringify({ success: true }),
@@ -71,16 +72,7 @@ export const data: ProxyV1TestData[] = [
                 metadata: generateMetadata(1),
               },
             ],
-            statTags: {
-              destType: 'TEST_DESTINATION',
-              destinationId: 'default-destinationId',
-              errorCategory: 'dataValidation',
-              errorType: 'configuration',
-              feature: 'dataDelivery',
-              implementation: 'native',
-              module: 'destination',
-              workspaceId: 'default-workspaceId',
-            },
+            statTags: v2StatTags('dataDelivery'),
           },
         },
       },

--- a/test/integrations/destinations/test_destination/dataDelivery/data.ts
+++ b/test/integrations/destinations/test_destination/dataDelivery/data.ts
@@ -1,0 +1,89 @@
+// ⚠️ DEV-ONLY TEST FIXTURE — NOT A REAL DESTINATION (INT-6492).
+import { generateMetadata, generateProxyV1Payload } from '../../../testUtils';
+import { ProxyV1TestData } from '../../../testTypes';
+import { v1Endpoint } from '../common';
+
+const v1Headers = { 'Content-Type': 'application/json', 'X-Api-Key': 'v1-secret-key' };
+const deliveryBody = { event: 'Test Event', userId: 'user-1' };
+
+// The proxy payload carries the integration major as the top-level `destinationVersion` (the proxy
+// route has no destination object). Dispatch reads it: 1 -> v1 delivery, 2 -> not implemented.
+const v1ProxyPayload = (destinationVersion?: number) => ({
+  ...generateProxyV1Payload(
+    { endpoint: v1Endpoint, method: 'POST', headers: v1Headers, JSON: deliveryBody },
+    [generateMetadata(1)],
+  ),
+  destinationVersion,
+});
+
+export const data: ProxyV1TestData[] = [
+  {
+    id: 'test_destination-delivery-v1',
+    name: 'test_destination',
+    description: 'v1 delivery (destinationVersion: 1) is sent via the v1 proxy path',
+    successCriteria: 'Should return 200 with a successful delivery response',
+    scenario: 'Integration-major dispatch — delivery',
+    feature: 'dataDelivery',
+    module: 'destination',
+    version: 'v1',
+    input: { request: { body: v1ProxyPayload(1), method: 'POST' } },
+    output: {
+      response: {
+        status: 200,
+        body: {
+          output: {
+            status: 200,
+            message: '[test_destination] delivery processed successfully',
+            response: [
+              {
+                error: JSON.stringify({ success: true }),
+                statusCode: 200,
+                metadata: generateMetadata(1),
+              },
+            ],
+          },
+        },
+      },
+    },
+  },
+  {
+    id: 'test_destination-delivery-v2-unimplemented',
+    name: 'test_destination',
+    description:
+      'v2 delivery (destinationVersion: 2) is rejected before any request — only v1 ships',
+    successCriteria: 'Should return an error indicating v2 delivery is not yet implemented',
+    scenario: 'Integration-major dispatch — delivery v2 not implemented',
+    feature: 'dataDelivery',
+    module: 'destination',
+    version: 'v1',
+    input: { request: { body: v1ProxyPayload(2), method: 'POST' } },
+    output: {
+      response: {
+        status: 200,
+        body: {
+          output: {
+            status: 400,
+            message: 'test_destination v2 delivery is not yet implemented',
+            response: [
+              {
+                error: 'test_destination v2 delivery is not yet implemented',
+                statusCode: 400,
+                metadata: generateMetadata(1),
+              },
+            ],
+            statTags: {
+              destType: 'TEST_DESTINATION',
+              destinationId: 'default-destinationId',
+              errorCategory: 'dataValidation',
+              errorType: 'configuration',
+              feature: 'dataDelivery',
+              implementation: 'native',
+              module: 'destination',
+              workspaceId: 'default-workspaceId',
+            },
+          },
+        },
+      },
+    },
+  },
+];

--- a/test/integrations/destinations/test_destination/network.ts
+++ b/test/integrations/destinations/test_destination/network.ts
@@ -1,0 +1,14 @@
+// ⚠️ DEV-ONLY TEST FIXTURE — NOT A REAL DESTINATION (INT-6492).
+// Mocked delivery responses for the `.invalid` (non-resolving) test endpoint.
+export const networkCallsData = [
+  {
+    description: 'test_destination v1 delivery — destination accepts the echoed event',
+    httpReq: {
+      method: 'POST',
+      url: 'https://eu.test-destination.invalid/v1/events',
+      headers: { 'Content-Type': 'application/json', 'X-Api-Key': 'v1-secret-key' },
+      data: { event: 'Test Event', userId: 'user-1' },
+    },
+    httpRes: { data: { success: true }, status: 200 },
+  },
+];

--- a/test/integrations/destinations/test_destination/processor/data.ts
+++ b/test/integrations/destinations/test_destination/processor/data.ts
@@ -1,0 +1,113 @@
+import { ProcessorTestData } from '../../../testTypes';
+import { generateMetadata } from '../../../testUtils';
+import {
+  destinationNoVersion,
+  destinationV1,
+  destinationV2,
+  baseMessage,
+  v1Endpoint,
+} from '../common';
+
+const v1Output = {
+  version: '1',
+  type: 'REST',
+  method: 'POST',
+  endpoint: v1Endpoint,
+  headers: { 'Content-Type': 'application/json', 'X-Api-Key': 'v1-secret-key' },
+  params: {},
+  body: { JSON: baseMessage, JSON_ARRAY: {}, XML: {}, FORM: {} },
+  files: {},
+  userId: '',
+};
+
+export const data: ProcessorTestData[] = [
+  {
+    id: 'test_destination-processor-v1',
+    name: 'test_destination',
+    description: 'v1 destination (version: 1) routes through the v1 branch',
+    scenario: 'Integration-major dispatch',
+    successCriteria:
+      'Should return 200 with the v1 request shape (dataCenter endpoint, restApiKey header)',
+    feature: 'processor',
+    module: 'destination',
+    version: 'v0',
+    input: {
+      request: {
+        method: 'POST',
+        body: [{ message: baseMessage, metadata: generateMetadata(1), destination: destinationV1 }],
+      },
+    },
+    output: {
+      response: {
+        status: 200,
+        body: [{ output: v1Output, statusCode: 200, metadata: generateMetadata(1) }],
+      },
+    },
+  },
+  {
+    id: 'test_destination-processor-no-version',
+    name: 'test_destination',
+    description: 'Destination without a stamped version falls to the v1 branch (defensive)',
+    scenario: 'Integration-major dispatch — undefined version',
+    successCriteria: 'Should behave identically to v1 when version is undefined',
+    feature: 'processor',
+    module: 'destination',
+    version: 'v0',
+    input: {
+      request: {
+        method: 'POST',
+        body: [
+          {
+            message: baseMessage,
+            metadata: generateMetadata(2),
+            destination: destinationNoVersion,
+          },
+        ],
+      },
+    },
+    output: {
+      response: {
+        status: 200,
+        body: [{ output: v1Output, statusCode: 200, metadata: generateMetadata(2) }],
+      },
+    },
+  },
+  {
+    id: 'test_destination-processor-v2-unimplemented',
+    name: 'test_destination',
+    description: 'v2 destination (version: 2) is rejected — only v1 is implemented',
+    scenario: 'Integration-major dispatch — v2 not implemented',
+    successCriteria: 'Should return an error indicating v2 is not yet implemented',
+    feature: 'processor',
+    module: 'destination',
+    version: 'v0',
+    input: {
+      request: {
+        method: 'POST',
+        body: [{ message: baseMessage, metadata: generateMetadata(3), destination: destinationV2 }],
+      },
+    },
+    output: {
+      response: {
+        status: 200,
+        body: [
+          {
+            statusCode: 400,
+            error: 'test_destination v2 transformation is not yet implemented',
+            metadata: generateMetadata(3),
+            statTags: {
+              destType: 'TEST_DESTINATION',
+              destinationId: 'default-destinationId',
+              errorCategory: 'dataValidation',
+              errorType: 'configuration',
+              feature: 'processor',
+              implementation: 'native',
+              module: 'destination',
+              workspaceId: 'default-workspaceId',
+            },
+          },
+        ],
+      },
+    },
+  },
+];

--- a/test/integrations/destinations/test_destination/processor/data.ts
+++ b/test/integrations/destinations/test_destination/processor/data.ts
@@ -5,20 +5,11 @@ import {
   destinationV1,
   destinationV2,
   baseMessage,
-  v1Endpoint,
+  v1RequestShape,
+  v2StatTags,
 } from '../common';
 
-const v1Output = {
-  version: '1',
-  type: 'REST',
-  method: 'POST',
-  endpoint: v1Endpoint,
-  headers: { 'Content-Type': 'application/json', 'X-Api-Key': 'v1-secret-key' },
-  params: {},
-  body: { JSON: baseMessage, JSON_ARRAY: {}, XML: {}, FORM: {} },
-  files: {},
-  userId: '',
-};
+const v1Output = { ...v1RequestShape, userId: '' };
 
 export const data: ProcessorTestData[] = [
   {
@@ -95,16 +86,7 @@ export const data: ProcessorTestData[] = [
             statusCode: 400,
             error: 'test_destination v2 transformation is not yet implemented',
             metadata: generateMetadata(3),
-            statTags: {
-              destType: 'TEST_DESTINATION',
-              destinationId: 'default-destinationId',
-              errorCategory: 'dataValidation',
-              errorType: 'configuration',
-              feature: 'processor',
-              implementation: 'native',
-              module: 'destination',
-              workspaceId: 'default-workspaceId',
-            },
+            statTags: v2StatTags('processor'),
           },
         ],
       },

--- a/test/integrations/destinations/test_destination/router/data.ts
+++ b/test/integrations/destinations/test_destination/router/data.ts
@@ -5,19 +5,11 @@ import {
   destinationV1,
   destinationV2,
   baseMessage,
-  v1Endpoint,
+  v1RequestShape,
+  v2StatTags,
 } from '../common';
 
-const v1BatchedRequest = {
-  version: '1',
-  type: 'REST',
-  method: 'POST',
-  endpoint: v1Endpoint,
-  headers: { 'Content-Type': 'application/json', 'X-Api-Key': 'v1-secret-key' },
-  params: {},
-  body: { JSON: baseMessage, JSON_ARRAY: {}, XML: {}, FORM: {} },
-  files: {},
-};
+const v1BatchedRequest = v1RequestShape;
 
 export const data: RouterTestData[] = [
   {
@@ -100,16 +92,7 @@ export const data: RouterTestData[] = [
               statusCode: 400,
               error: 'test_destination v2 transformation is not yet implemented',
               destination: destinationV2,
-              statTags: {
-                destType: 'TEST_DESTINATION',
-                destinationId: 'default-destinationId',
-                errorCategory: 'dataValidation',
-                errorType: 'configuration',
-                feature: 'router',
-                implementation: 'native',
-                module: 'destination',
-                workspaceId: 'default-workspaceId',
-              },
+              statTags: v2StatTags('router'),
             },
           ],
         },

--- a/test/integrations/destinations/test_destination/router/data.ts
+++ b/test/integrations/destinations/test_destination/router/data.ts
@@ -1,0 +1,119 @@
+import { RouterTestData } from '../../../testTypes';
+import { generateMetadata } from '../../../testUtils';
+import {
+  destinationNoVersion,
+  destinationV1,
+  destinationV2,
+  baseMessage,
+  v1Endpoint,
+} from '../common';
+
+const v1BatchedRequest = {
+  version: '1',
+  type: 'REST',
+  method: 'POST',
+  endpoint: v1Endpoint,
+  headers: { 'Content-Type': 'application/json', 'X-Api-Key': 'v1-secret-key' },
+  params: {},
+  body: { JSON: baseMessage, JSON_ARRAY: {}, XML: {}, FORM: {} },
+  files: {},
+};
+
+export const data: RouterTestData[] = [
+  {
+    id: 'test_destination-router-v1',
+    name: 'test_destination',
+    description: 'v1 + no-version destinations both route through the v1 branch',
+    scenario: 'Integration-major dispatch',
+    successCriteria: 'Both events return the v1 request shape',
+    feature: 'router',
+    module: 'destination',
+    version: 'v0',
+    input: {
+      request: {
+        method: 'POST',
+        body: {
+          input: [
+            { message: baseMessage, metadata: generateMetadata(1), destination: destinationV1 },
+            {
+              message: baseMessage,
+              metadata: generateMetadata(2),
+              destination: destinationNoVersion,
+            },
+          ],
+          destType: 'test_destination',
+        },
+      },
+    },
+    output: {
+      response: {
+        status: 200,
+        body: {
+          output: [
+            {
+              batchedRequest: v1BatchedRequest,
+              metadata: [generateMetadata(1)],
+              batched: false,
+              statusCode: 200,
+              destination: destinationV1,
+            },
+            {
+              batchedRequest: v1BatchedRequest,
+              metadata: [generateMetadata(2)],
+              batched: false,
+              statusCode: 200,
+              destination: destinationNoVersion,
+            },
+          ],
+        },
+      },
+    },
+  },
+  {
+    id: 'test_destination-router-v2-unimplemented',
+    name: 'test_destination',
+    description: 'v2 destination is rejected per-event — only v1 is implemented',
+    scenario: 'Integration-major dispatch — v2 not implemented',
+    successCriteria: 'Should return an error indicating v2 is not yet implemented',
+    feature: 'router',
+    module: 'destination',
+    version: 'v0',
+    input: {
+      request: {
+        method: 'POST',
+        body: {
+          input: [
+            { message: baseMessage, metadata: generateMetadata(3), destination: destinationV2 },
+          ],
+          destType: 'test_destination',
+        },
+      },
+    },
+    output: {
+      response: {
+        status: 200,
+        body: {
+          output: [
+            {
+              metadata: [generateMetadata(3)],
+              batched: false,
+              statusCode: 400,
+              error: 'test_destination v2 transformation is not yet implemented',
+              destination: destinationV2,
+              statTags: {
+                destType: 'TEST_DESTINATION',
+                destinationId: 'default-destinationId',
+                errorCategory: 'dataValidation',
+                errorType: 'configuration',
+                feature: 'router',
+                implementation: 'native',
+                module: 'destination',
+                workspaceId: 'default-workspaceId',
+              },
+            },
+          ],
+        },
+      },
+    },
+  },
+];

--- a/test/integrations/destinations/test_destination/router/data.ts
+++ b/test/integrations/destinations/test_destination/router/data.ts
@@ -1,23 +1,29 @@
 import { RouterTestData } from '../../../testTypes';
 import { generateMetadata } from '../../../testUtils';
-import {
-  destinationNoVersion,
-  destinationV1,
-  destinationV2,
-  baseMessage,
-  v1RequestShape,
-  v2StatTags,
-} from '../common';
+import { destinationV1, destinationV2, baseMessage, v1Endpoint, v2StatTags } from '../common';
 
-const v1BatchedRequest = v1RequestShape;
+// Routed through the native batching framework: events sharing endpoint + headers collapse into a
+// single request whose body wraps the per-event payloads under `batch`.
+const v1BatchedRequest = {
+  version: '1',
+  type: 'REST',
+  method: 'POST',
+  endpoint: v1Endpoint,
+  endpointPath: '/v1/events',
+  headers: { 'Content-Type': 'application/json', 'X-Api-Key': 'v1-secret-key' },
+  params: {},
+  body: { JSON: { batch: [baseMessage, baseMessage] }, JSON_ARRAY: {}, XML: {}, FORM: {} },
+  files: {},
+};
 
 export const data: RouterTestData[] = [
   {
     id: 'test_destination-router-v1',
     name: 'test_destination',
-    description: 'v1 + no-version destinations both route through the v1 branch',
-    scenario: 'Integration-major dispatch',
-    successCriteria: 'Both events return the v1 request shape',
+    description:
+      'Multiple v1 events on the same destination batch into a single request via the framework',
+    scenario: 'Integration-major dispatch + native batching',
+    successCriteria: 'Both events collapse into one batched v1 request',
     feature: 'router',
     module: 'destination',
     version: 'v0',
@@ -27,11 +33,7 @@ export const data: RouterTestData[] = [
         body: {
           input: [
             { message: baseMessage, metadata: generateMetadata(1), destination: destinationV1 },
-            {
-              message: baseMessage,
-              metadata: generateMetadata(2),
-              destination: destinationNoVersion,
-            },
+            { message: baseMessage, metadata: generateMetadata(2), destination: destinationV1 },
           ],
           destType: 'test_destination',
         },
@@ -44,17 +46,10 @@ export const data: RouterTestData[] = [
           output: [
             {
               batchedRequest: v1BatchedRequest,
-              metadata: [generateMetadata(1)],
-              batched: false,
+              metadata: [generateMetadata(1), generateMetadata(2)],
+              batched: true,
               statusCode: 200,
               destination: destinationV1,
-            },
-            {
-              batchedRequest: v1BatchedRequest,
-              metadata: [generateMetadata(2)],
-              batched: false,
-              statusCode: 200,
-              destination: destinationNoVersion,
             },
           ],
         },


### PR DESCRIPTION
## What

The data-plane half of integration definition-versioning in the transformer — carry the **integration major** on the destination and dispatch on it, plus a dev-only destination that exercises it end-to-end. No production destination grows a real per-major branch here.

### INT-6495 — version on the `Destination` type + dispatch idiom
- `version?: number` on the `Destination` type (mirrors Go `DestinationT.Version`). Optional because it can be undefined — `0` / `undefined` / `1` all dispatch as v1 (`Number(undefined)` is `NaN`), so existing destinations behave identically.
- `destinationVersion?: number` received on the proxy/dataDelivery payload (`ProxyV0/V1Request` + zod schemas) — the proxy route carries no destination object, so the major arrives as a sibling field.
- Dispatch idiom documented in `CONTRIBUTING.md` and the `code-structure` Claude skill (in-file branch by default; sibling-module escalation; never route majors through `getDestHandler`).

### INT-6492 — dev-only `test_destination` (v1 only)
- `src/v0/destinations/test_destination/` dispatches on `Number(destination.version)` in `transform`/`processRouterDest` and on `destinationVersion` in `networkHandler`; `major >= 2` throws not-implemented (only v1 is built).
- Processor / router / dataDelivery integration fixtures (v1, no-version, v2-rejection) + a co-located unit test.
- Router capability registered in `features.ts`. Clearly labelled **"DEV-ONLY — NOT A REAL DESTINATION"**; uses the reserved `.invalid` endpoint. Control-plane exposure is gated to dev only (other repos).

## Out of scope
- No real per-major branch for any production destination (rollout milestone).
- `test_destination` v2 path — stubbed to throw; only v1 implemented.

## Testing
- `test_destination` unit 4/4 · component (processor/router/dataDelivery) 7/7
- `webhook` smoke 23/23 · `misc` (getFeatures) 2/2 — no regression
- Full pre-commit suite (`test:ts` + `test:js` + lint) green.

## References
- Linear: [INT-6495](https://linear.app/rudderstack/issue/INT-6495) (version on the `Destination` type + dispatch idiom) · [INT-6492](https://linear.app/rudderstack/issue/INT-6492) (dev-only `test_destination`)
- Paired (data plane sender): rudderlabs/rudder-server#7125 — carries `version` on `DestinationT`; sends `destination.version` (transform/router) + top-level `destinationVersion` (proxy).
- Stacked follow-up: #5319 — [INT-6576](https://linear.app/rudderstack/issue/INT-6576) `destVersion` metric label.
