### PR TITLE
refactor(batch): add record event dispatch to BatchDestination framework

### DIFF
--- a/src/services/destination/nativeBatching/__tests__/batchDestination.test.ts
+++ b/src/services/destination/nativeBatching/__tests__/batchDestination.test.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { InstrumentationError } from '@rudderstack/integrations-lib';
 import {
   BatchDestination,
   TransformedEvent,
@@ -6,9 +7,10 @@ import {
   CustomBatchStrategy,
   parseSizeToBytes,
 } from '../batchDestination';
-import type { BatchStrategy } from '../batchDestination';
+import { VDMV2ObjectDestination } from '../vdmV2ObjectDestination';
+import type { BatchStrategy, RecordContext } from '../batchDestination';
 import type { RouterTransformationRequestData } from '../../../../types/destinationTransformation';
-import type { Destination } from '../../../../types/controlPlaneConfig';
+import type { Destination, Connection } from '../../../../types/controlPlaneConfig';
 import type { Metadata, RudderMessage } from '../../../../types/rudderEvents';
 
 // ---------------------------------------------------------------------------
@@ -79,6 +81,94 @@ class FailingIntegration extends BatchDestination<TestBody> {
   getInputSchema() {
     return z.object({}).passthrough();
   }
+}
+
+type TestConnectionConfig = { destination: { object: string } };
+
+class RecordIntegration extends VDMV2ObjectDestination<
+  TestBody,
+  Record<string, unknown>,
+  TestConnectionConfig
+> {
+  private upsertUser(context: RecordContext<TestConnectionConfig>): TransformedEvent<TestBody> {
+    return {
+      body: { value: `upsert:${context.objectType}` },
+      endpoint: 'https://api.test.com/records',
+      endpointPath: '/records',
+      method: 'POST',
+    };
+  }
+
+  private removeUser(context: RecordContext<TestConnectionConfig>): TransformedEvent<TestBody> {
+    return {
+      body: { value: `remove:${context.objectType}` },
+      endpoint: 'https://api.test.com/records',
+      endpointPath: '/records',
+      method: 'POST',
+    };
+  }
+
+  private createEvent(context: RecordContext<TestConnectionConfig>): TransformedEvent<TestBody> {
+    return {
+      body: { value: `create:${context.objectType}` },
+      endpoint: 'https://api.test.com/records',
+      endpointPath: '/records',
+      method: 'POST',
+    };
+  }
+
+  transformObjectRecord() {
+    return {
+      user: {
+        insert: (ctx: RecordContext<TestConnectionConfig>) => this.upsertUser(ctx),
+        update: (ctx: RecordContext<TestConnectionConfig>) => this.upsertUser(ctx),
+        delete: (ctx: RecordContext<TestConnectionConfig>) => this.removeUser(ctx),
+      },
+      event: {
+        insert: (ctx: RecordContext<TestConnectionConfig>) => this.createEvent(ctx),
+        update: (ctx: RecordContext<TestConnectionConfig>) => this.createEvent(ctx),
+        // delete not listed — framework rejects automatically
+      },
+    };
+  }
+
+  getBatchStrategy(): BatchStrategy<TestBody> {
+    return new ChunkBatchStrategy({ maxItems: 10, wrapBody: (bodies) => ({ records: bodies }) });
+  }
+
+  getInputSchema() {
+    return z.object({}).passthrough();
+  }
+}
+
+const mockConnection: Connection<TestConnectionConfig> = {
+  sourceId: 'src-1',
+  destinationId: 'dest-1',
+  enabled: true,
+  config: { destination: { object: 'user' } },
+};
+
+function makeRecordInput(
+  jobId: number,
+  action: string,
+  identifiers: Record<string, string | number>,
+  connection?: Connection<TestConnectionConfig>,
+): RouterTransformationRequestData {
+  return {
+    message: { type: 'record', action, identifiers },
+    metadata: {
+      jobId,
+      workspaceId: 'ws-1',
+      sourceId: 'src-1',
+      sourceType: 'web',
+      sourceCategory: 'cloud',
+      destinationId: 'dest-1',
+      destinationType: 'TEST',
+      messageId: `msg-${jobId}`,
+    },
+    destination: mockDestination,
+    connection: connection ?? mockConnection,
+  } as RouterTransformationRequestData;
 }
 
 function makeInput(
@@ -187,5 +277,99 @@ describe('strategy classes', () => {
     expect(result).toHaveLength(1);
     expect(result[0].body).toEqual({ merged: true });
     expect(result[0].jobIds).toEqual(new Set([1, 2]));
+  });
+});
+
+describe('BatchDestination — record dispatch', () => {
+  it('dispatches record events to transformRecord via handler map', async () => {
+    const integration = new RecordIntegration(mockDestination, mockConnection);
+    const input = makeRecordInput(1, 'insert', { id: 'u1' });
+    const result = await integration.transformEvents([input]);
+    expect(result.successPayloads).toHaveLength(1);
+    expect(result.successPayloads[0].body.value).toBe('upsert:user');
+    expect(result.successPayloads[0].jobId).toBe(1);
+  });
+
+  it('dispatches event-stream events to transformEvent', async () => {
+    const integration = new RecordIntegration(mockDestination, mockConnection);
+    // RecordIntegration doesn't override transformEvent → default throws
+    const eventInput = makeInput(2, 'hello');
+    const result = await integration.transformEvents([eventInput]);
+    expect(result.errorPayloads).toHaveLength(1);
+    expect(result.errorPayloads[0].error).toContain('Event-stream events are not supported');
+  });
+
+  it('handles mixed record and event-stream inputs', async () => {
+    // Use TestIntegration which implements transformEvent but not transformRecord
+    const integration = new TestIntegration(mockDestination);
+    const eventInput = makeInput(1, 'hello');
+    const recordInput = makeRecordInput(2, 'insert', { id: 'u1' });
+    const result = await integration.transformEvents([eventInput, recordInput]);
+    expect(result.successPayloads).toHaveLength(1);
+    expect(result.successPayloads[0].body.value).toBe('hello');
+    expect(result.errorPayloads).toHaveLength(1);
+    expect(result.errorPayloads[0].error).toContain('Record events are not supported');
+  });
+
+  it('rejects unsupported action for object type', async () => {
+    const eventConn: Connection<TestConnectionConfig> = {
+      ...mockConnection,
+      config: { destination: { object: 'event' } },
+    };
+    const integration = new RecordIntegration(mockDestination, eventConn);
+    const input = makeRecordInput(1, 'delete', { id: 'u1' }, eventConn);
+    const result = await integration.transformEvents([input]);
+    expect(result.errorPayloads).toHaveLength(1);
+    expect(result.errorPayloads[0].error).toContain(
+      '"delete" is not supported for object type "event"',
+    );
+  });
+
+  it('rejects unsupported object type', async () => {
+    const badConn: Connection<TestConnectionConfig> = {
+      ...mockConnection,
+      config: { destination: { object: 'unknown_type' } },
+    };
+    const integration = new RecordIntegration(mockDestination, badConn);
+    const input = makeRecordInput(1, 'insert', { id: 'u1' }, badConn);
+    const result = await integration.transformEvents([input]);
+    expect(result.errorPayloads).toHaveLength(1);
+    expect(result.errorPayloads[0].error).toContain('Unsupported object type: "unknown_type"');
+  });
+
+  it('passes identifiers from message into RecordContext', async () => {
+    // Create an integration that echoes identifiers into the body for assertion
+    class EchoIntegration extends VDMV2ObjectDestination<
+      Record<string, unknown>,
+      Record<string, unknown>,
+      TestConnectionConfig
+    > {
+      transformObjectRecord() {
+        const handler = (context: RecordContext<TestConnectionConfig>) => ({
+          body: { ids: context.identifiers, action: context.action, obj: context.objectType },
+          endpoint: 'https://api.test.com',
+          endpointPath: '/test',
+          method: 'POST',
+        });
+        return {
+          user: { insert: handler, update: handler, delete: handler },
+        };
+      }
+      getBatchStrategy() {
+        return new ChunkBatchStrategy({ wrapBody: (b) => ({ batch: b }) });
+      }
+      getInputSchema() {
+        return z.object({}).passthrough();
+      }
+    }
+
+    const integration = new EchoIntegration(mockDestination, mockConnection);
+    const input = makeRecordInput(1, 'insert', { email: 'a@b.com', plan: 'pro' });
+    const result = await integration.transformEvents([input]);
+    expect(result.successPayloads[0].body).toEqual({
+      ids: { email: 'a@b.com', plan: 'pro' },
+      action: 'insert',
+      obj: 'user',
+    });
   });
 });

--- a/src/services/destination/nativeBatching/batchDestination.ts
+++ b/src/services/destination/nativeBatching/batchDestination.ts
@@ -1,8 +1,9 @@
 import { ZodType } from 'zod';
+import { InstrumentationError } from '@rudderstack/integrations-lib';
 import type { Connection, Destination } from '../../../types/controlPlaneConfig';
 import type { RouterTransformationRequestData } from '../../../types/destinationTransformation';
 import { generateErrorObject } from '../../../v0/util';
-import type { BatchStrategy, TransformedEvent, TransformResult } from './types';
+import type { BatchStrategy, TransformedEvent, TransformResult, RecordContext } from './types';
 
 export type {
   TransformedEvent,
@@ -10,6 +11,7 @@ export type {
   TransformResult,
   BatchGroup,
   BatchStrategy,
+  RecordContext,
 } from './types';
 export { BodyFormat, parseSizeToBytes } from './types';
 export { ChunkBatchStrategy } from './chunkBatchStrategy';
@@ -48,16 +50,32 @@ export abstract class BatchDestination<
 
   // --- MUST implement ---
 
-  abstract transformEvent(
-    input: RouterTransformationRequestData,
-    reqMetadata?: NonNullable<unknown>,
-  ): TransformedEvent<TBody> | TransformedEvent<TBody>[];
-
   abstract getBatchStrategy(endpoint: string): BatchStrategy<TBody>;
 
   abstract getInputSchema(): ZodType;
 
   // --- MAY override ---
+
+  // --- Event-stream events (identify, track, page, screen, alias, group) ---
+  // Override in subclasses that handle event-stream events.
+  /* eslint-disable @typescript-eslint/no-unused-vars */
+  transformEvent(
+    input: RouterTransformationRequestData,
+    reqMetadata?: NonNullable<unknown>,
+  ): TransformedEvent<TBody> | TransformedEvent<TBody>[] {
+    throw new InstrumentationError('Event-stream events are not supported by this destination');
+  }
+  /* eslint-enable @typescript-eslint/no-unused-vars */
+
+  // --- Record events (insert, update, delete) ---
+  // Override in subclasses that handle record events.
+  /* eslint-disable @typescript-eslint/no-unused-vars */
+  transformRecord(
+    context: RecordContext<TConnectionConfig>,
+  ): TransformedEvent<TBody> | TransformedEvent<TBody>[] {
+    throw new InstrumentationError('Record events are not supported by this destination');
+  }
+  /* eslint-enable @typescript-eslint/no-unused-vars */
 
   async transformEvents(
     inputs: RouterTransformationRequestData[],
@@ -69,7 +87,26 @@ export abstract class BatchDestination<
     for (const input of inputs) {
       const jobId = input.metadata?.jobId;
       try {
-        const transformedPayload = this.transformEvent(input, reqMetadata);
+        let transformedPayload: TransformedEvent<TBody> | TransformedEvent<TBody>[];
+
+        if (input.message?.type === 'record') {
+          const msg = input.message as unknown as {
+            action: string;
+            identifiers?: Record<string, string | number>;
+          };
+          const context: RecordContext<TConnectionConfig> = {
+            action: msg.action as RecordContext['action'],
+            objectType:
+              (input.connection?.config as Record<string, Record<string, string>>)?.destination
+                ?.object ?? '',
+            identifiers: msg.identifiers ?? {},
+            connection: input.connection as Connection<TConnectionConfig>,
+          };
+          transformedPayload = this.transformRecord(context);
+        } else {
+          transformedPayload = this.transformEvent(input, reqMetadata);
+        }
+
         const results = Array.isArray(transformedPayload)
           ? transformedPayload
           : [transformedPayload];

--- a/src/services/destination/nativeBatching/types.ts
+++ b/src/services/destination/nativeBatching/types.ts
@@ -2,6 +2,8 @@
 // Shared types and utilities for the native batching framework
 // ---------------------------------------------------------------------------
 
+import type { Connection } from '../../../types/controlPlaneConfig';
+
 export type TransformedEvent<TBody extends Record<string, unknown> = Record<string, unknown>> = {
   body: TBody;
   endpoint: string;
@@ -43,6 +45,17 @@ export interface BatchStrategy<TBody extends Record<string, unknown> = Record<st
   bodyFormat: BodyFormat;
   batch(payloads: (TransformedEvent<TBody> & { jobId: number })[]): Promise<BatchGroup[]>;
 }
+
+// ---------------------------------------------------------------------------
+// Record event dispatch types
+// ---------------------------------------------------------------------------
+
+export type RecordContext<TConnectionConfig = Record<string, unknown>> = {
+  action: 'insert' | 'update' | 'delete';
+  objectType: string;
+  identifiers: Record<string, string | number>;
+  connection: Connection<TConnectionConfig>;
+};
 
 const SIZE_UNITS: Record<string, number> = {
   B: 1,

--- a/src/services/destination/nativeBatching/vdmV2ObjectDestination.ts
+++ b/src/services/destination/nativeBatching/vdmV2ObjectDestination.ts
@@ -1,0 +1,44 @@
+import { InstrumentationError } from '@rudderstack/integrations-lib';
+import { BatchDestination } from './batchDestination';
+import type { RecordContext, TransformedEvent } from './types';
+
+// ---------------------------------------------------------------------------
+// VDMV2ObjectDestination — object-based record dispatch
+// ---------------------------------------------------------------------------
+
+export abstract class VDMV2ObjectDestination<
+  TBody extends Record<string, unknown> = Record<string, unknown>,
+  TConfig = Record<string, unknown>,
+  TConnectionConfig = Record<string, unknown>,
+> extends BatchDestination<TBody, TConfig, TConnectionConfig> {
+  // Returns a map of object type → { action → handler }.
+  // Missing object types or actions are rejected automatically by transformRecord.
+  abstract transformObjectRecord(): Record<
+    string,
+    Partial<
+      Record<
+        'insert' | 'update' | 'delete',
+        (
+          context: RecordContext<TConnectionConfig>,
+        ) => TransformedEvent<TBody> | TransformedEvent<TBody>[]
+      >
+    >
+  >;
+
+  transformRecord(
+    context: RecordContext<TConnectionConfig>,
+  ): TransformedEvent<TBody> | TransformedEvent<TBody>[] {
+    const objectHandlers = this.transformObjectRecord();
+    const actionHandlers = objectHandlers[context.objectType];
+    if (!actionHandlers) {
+      throw new InstrumentationError(`Unsupported object type: "${context.objectType}"`);
+    }
+    const handler = actionHandlers[context.action];
+    if (!handler) {
+      throw new InstrumentationError(
+        `"${context.action}" is not supported for object type "${context.objectType}"`,
+      );
+    }
+    return handler(context);
+  }
+}

--- a/src/v0/destinations/custom_audience/routerTransform.ts
+++ b/src/v0/destinations/custom_audience/routerTransform.ts
@@ -5,7 +5,10 @@ import {
   CustomBatchStrategy,
   TransformedEvent,
 } from '../../../services/destination/nativeBatching/batchDestination';
-import type { BatchStrategy } from '../../../services/destination/nativeBatching/types';
+import type {
+  BatchStrategy,
+  RecordContext,
+} from '../../../services/destination/nativeBatching/types';
 import { chunkPayloads } from '../../../services/destination/nativeBatching/chunkPayloads';
 import type { Connection, Destination } from '../../../types/controlPlaneConfig';
 import { EVENT_TYPES } from '../../util/recordUtils';
@@ -18,12 +21,7 @@ import {
   resolveEndpoint,
   validateRequiredFields,
 } from './utils';
-import type {
-  Action,
-  CustomAudienceConnectionDestConfig,
-  CustomAudienceDestConfig,
-  CustomAudienceRouterRequest,
-} from './types';
+import type { Action, CustomAudienceConnectionDestConfig, CustomAudienceDestConfig } from './types';
 
 class CustomAudienceIntegration extends BatchDestination<
   Record<string, unknown>,
@@ -65,15 +63,21 @@ class CustomAudienceIntegration extends BatchDestination<
     ) as Partial<Record<Action, string>>;
   }
 
-  transformEvent(input: CustomAudienceRouterRequest): TransformedEvent<Record<string, unknown>> {
-    const { message } = input;
+  transformRecord(
+    context: RecordContext<{ destination: CustomAudienceConnectionDestConfig }>,
+  ): TransformedEvent<Record<string, unknown>> {
+    const { action: messageAction, identifiers } = context;
     const { action: resolvedAction, config: actionConfig } = lookupActionConfig(
-      message.action,
+      messageAction,
       this.destination.Config.actions,
     );
-    validateRequiredFields(message.action, message.identifiers!, actionConfig.fields);
+    validateRequiredFields(
+      messageAction,
+      identifiers as Record<string, unknown>,
+      actionConfig.fields,
+    );
     const fieldsWithCustomMappings = injectCustomMappings(
-      message.identifiers!,
+      identifiers as Record<string, unknown>,
       this.connectionConfig.customMappings,
     );
     const record = processFields(
@@ -89,7 +93,7 @@ class CustomAudienceIntegration extends BatchDestination<
 
     return {
       body: record,
-      endpoint: this.endpointByAction[message.action]!,
+      endpoint: this.endpointByAction[messageAction]!,
       // Use the action name rather than the full URL to keep metric cardinality low —
       // each destination instance has a unique endpoint, but actions are a fixed set.
       endpointPath: `/${resolvedAction}`,

--- a/src/v0/destinations/customerio/routerTransform.test.ts
+++ b/src/v0/destinations/customerio/routerTransform.test.ts
@@ -1,4 +1,3 @@
-import { InstrumentationError } from '@rudderstack/integrations-lib';
 import { Integration } from './routerTransform';
 import type { CustomerIORouterRequest } from './types';
 import type { CustomerIOV2Payload } from './v2/types';
@@ -33,6 +32,7 @@ const makeInput = (overrides: Record<string, unknown>): CustomerIORouterRequest 
     },
     metadata: { jobId: 1, userId: 'u1', workspaceId: 'ws-1' },
     destination: baseDestination,
+    connection: baseConnection,
   }) as unknown as CustomerIORouterRequest;
 
 const eventConnection = {
@@ -41,9 +41,11 @@ const eventConnection = {
 } as CustomerIORouterRequest['connection'];
 
 describe('CustomerIOIntegration — record event routing', () => {
-  it('transforms insert record into identify person payload', () => {
+  it('transforms insert record into identify person payload', async () => {
     const integration = new Integration(baseDestination, baseConnection);
-    const result = integration.transformEvent(makeInput({}));
+    const { successPayloads } = await integration.transformEvents([makeInput({})]);
+    expect(successPayloads).toHaveLength(1);
+    const result = successPayloads[0];
     expect(result).toMatchObject({
       body: {
         type: 'person',
@@ -57,9 +59,13 @@ describe('CustomerIOIntegration — record event routing', () => {
     expect(result.endpoint).toMatch(/track\.customer\.io\/api\/v2\/batch/);
   });
 
-  it('transforms delete record into delete person payload without attributes', () => {
+  it('transforms delete record into delete person payload without attributes', async () => {
     const integration = new Integration(baseDestination, baseConnection);
-    const result = integration.transformEvent(makeInput({ action: 'delete' }));
+    const { successPayloads } = await integration.transformEvents([
+      makeInput({ action: 'delete' }),
+    ]);
+    expect(successPayloads).toHaveLength(1);
+    const result = successPayloads[0];
     expect(result.body).toMatchObject({
       type: 'person',
       action: 'delete',
@@ -68,27 +74,32 @@ describe('CustomerIOIntegration — record event routing', () => {
     expect((result.body as CustomerIOV2Payload).attributes).toBeUndefined();
   });
 
-  it('throws InstrumentationError for unsupported action', () => {
+  it('returns error payload for unsupported action', async () => {
     const integration = new Integration(baseDestination, baseConnection);
-    expect(() => integration.transformEvent(makeInput({ action: 'upsert' }))).toThrow(
-      InstrumentationError,
-    );
+    const { successPayloads, errorPayloads } = await integration.transformEvents([
+      makeInput({ action: 'upsert' }),
+    ]);
+    expect(successPayloads).toHaveLength(0);
+    expect(errorPayloads).toHaveLength(1);
+    expect(errorPayloads[0].error).toMatch(/"upsert" is not supported for object type "person"/);
   });
 
-  it('transforms event object record into event person payload', () => {
+  it('transforms event object record into event person payload', async () => {
     const integration = new Integration(baseDestination, eventConnection);
-    const result = integration.transformEvent(
-      makeInput({
-        action: 'update',
-        identifiers: {
-          id: 'user-1',
-          name: 'Order Completed',
-          plan: 'pro',
-          created_at: '2024-06-25T14:00:00.000Z',
-        },
-      }),
-    );
-    expect(result.body).toEqual({
+    const input = makeInput({
+      action: 'update',
+      identifiers: {
+        id: 'user-1',
+        name: 'Order Completed',
+        plan: 'pro',
+        created_at: '2024-06-25T14:00:00.000Z',
+      },
+    });
+    // makeInput uses baseConnection; override connection for event object
+    (input as any).connection = eventConnection;
+    const { successPayloads } = await integration.transformEvents([input]);
+    expect(successPayloads).toHaveLength(1);
+    expect(successPayloads[0].body).toEqual({
       type: 'person',
       action: 'event',
       identifiers: { id: 'user-1' },
@@ -98,14 +109,14 @@ describe('CustomerIOIntegration — record event routing', () => {
     });
   });
 
-  it('throws InstrumentationError for event object delete records', () => {
+  it('returns error payload for event object delete records', async () => {
     const integration = new Integration(baseDestination, eventConnection);
-    expect(() => integration.transformEvent(makeInput({ action: 'delete' }))).toThrow(
-      InstrumentationError,
-    );
-    expect(() => integration.transformEvent(makeInput({ action: 'delete' }))).toThrow(
-      'Delete action is not supported for CustomerIO event records',
-    );
+    const input = makeInput({ action: 'delete' });
+    (input as any).connection = eventConnection;
+    const { successPayloads, errorPayloads } = await integration.transformEvents([input]);
+    expect(successPayloads).toHaveLength(0);
+    expect(errorPayloads).toHaveLength(1);
+    expect(errorPayloads[0].error).toMatch(/"delete" is not supported for object type "event"/);
   });
 
   it('batches multiple record events into one { batch: [...] } body', async () => {

--- a/src/v0/destinations/customerio/routerTransform.ts
+++ b/src/v0/destinations/customerio/routerTransform.ts
@@ -2,30 +2,29 @@ import { ZodType } from 'zod';
 import get from 'get-value';
 import { InstrumentationError } from '@rudderstack/integrations-lib';
 import {
-  BatchDestination,
   TransformedEvent,
   ChunkBatchStrategy,
 } from '../../../services/destination/nativeBatching/batchDestination';
+import { VDMV2ObjectDestination } from '../../../services/destination/nativeBatching/vdmV2ObjectDestination';
+import type {
+  RecordContext,
+  BatchStrategy,
+} from '../../../services/destination/nativeBatching/types';
 import { addExternalIdToTraits, adduserIdFromExternalId, removeUndefinedValues } from '../../util';
 import { MappedToDestinationKey } from '../../../constants';
-import type { BatchStrategy } from '../../../services/destination/nativeBatching/types';
-import {
-  getV2InputSchema,
-  CustomerIOV2Payload,
-  CustomerIODestinationConfig,
-  type CustomerIOV2RecordMessage,
-} from './v2/types';
+import { getV2InputSchema, CustomerIOV2Payload, CustomerIODestinationConfig } from './v2/types';
 import { MAX_OBJECT_SIZE_BYTES, MAX_BATCH_PAYLOAD } from './v2/config';
 import { buildRecordEvent } from './v2/recordTransform';
 import { validateConfigFields } from './util';
 import { buildEnvelope, buildRequestMeta } from './v2/util';
-import { CustomerIORouterRequest, CustomerIOConnection } from './types';
+import {
+  CustomerIORouterRequest,
+  CustomerIOConnection,
+  CUSTOMERIO_RECORD_OBJECTS,
+  type CustomerIORecordObject,
+} from './types';
 
-function isRecordMessage(msg: { type: string }): msg is CustomerIOV2RecordMessage {
-  return msg.type === 'record';
-}
-
-class CustomerIOIntegration extends BatchDestination<
+class CustomerIOIntegration extends VDMV2ObjectDestination<
   CustomerIOV2Payload,
   CustomerIODestinationConfig,
   CustomerIOConnection['config']
@@ -39,23 +38,37 @@ class CustomerIOIntegration extends BatchDestination<
     }
   }
 
-  private buildBody(message: CustomerIORouterRequest['message']): CustomerIOV2Payload {
-    if (isRecordMessage(message)) {
-      const connectionObject = this.connection!.config.destination.object;
-      return buildRecordEvent(message, connectionObject);
-    }
-    // For RETL/warehouse sources (mappedToDestination), derive userId from
-    // context.externalId and fold externalId into traits, mirroring the v1 path.
-    if (get(message, MappedToDestinationKey)) {
-      addExternalIdToTraits(message);
-      adduserIdFromExternalId(message);
-    }
-    return removeUndefinedValues(buildEnvelope(message, this.destination)) as CustomerIOV2Payload;
+  private buildRecord(
+    context: RecordContext<CustomerIOConnection['config']>,
+    objectType: CustomerIORecordObject,
+  ): TransformedEvent<CustomerIOV2Payload> {
+    validateConfigFields(this.destination);
+    const body = buildRecordEvent(context, objectType);
+    this.assertObjectSize(body);
+    return { body, ...buildRequestMeta(this.destination) };
+  }
+
+  transformObjectRecord() {
+    const person = (ctx: RecordContext<CustomerIOConnection['config']>) =>
+      this.buildRecord(ctx, CUSTOMERIO_RECORD_OBJECTS.person);
+    const event = (ctx: RecordContext<CustomerIOConnection['config']>) =>
+      this.buildRecord(ctx, CUSTOMERIO_RECORD_OBJECTS.event);
+    return {
+      [CUSTOMERIO_RECORD_OBJECTS.person]: { insert: person, update: person, delete: person },
+      [CUSTOMERIO_RECORD_OBJECTS.event]: { insert: event, update: event },
+    };
   }
 
   transformEvent(input: CustomerIORouterRequest): TransformedEvent<CustomerIOV2Payload> {
     validateConfigFields(this.destination);
-    const body = this.buildBody(input.message);
+    const { message } = input;
+    if (get(message, MappedToDestinationKey)) {
+      addExternalIdToTraits(message);
+      adduserIdFromExternalId(message);
+    }
+    const body = removeUndefinedValues(
+      buildEnvelope(message, this.destination),
+    ) as CustomerIOV2Payload;
     this.assertObjectSize(body);
     return { body, ...buildRequestMeta(this.destination) };
   }

--- a/src/v0/destinations/customerio/v2/recordTransform.test.ts
+++ b/src/v0/destinations/customerio/v2/recordTransform.test.ts
@@ -1,30 +1,31 @@
 import { InstrumentationError } from '@rudderstack/integrations-lib';
+import type { RecordContext } from '../../../../services/destination/nativeBatching/types';
+import type { CustomerIOConnection } from '../types';
 import { buildRecordEvent } from './recordTransform';
 
-describe('buildRecordEvent', () => {
-  const eventCases = [
-    {
-      action: 'insert' as const,
-      expectedAttributes: { plan: 'pro' },
-    },
-    {
-      action: 'update' as const,
-      expectedAttributes: { plan: 'pro' },
-    },
-  ];
+type TestContext = RecordContext<CustomerIOConnection['config']>;
 
+const makeContext = (
+  action: 'insert' | 'update' | 'delete',
+  identifiers: Record<string, string | number>,
+): TestContext => ({
+  action,
+  identifiers,
+  objectType: 'person',
+  connection: {} as any,
+});
+
+describe('buildRecordEvent', () => {
   it('maps insert action to identify with attributes from identifiers', () => {
-    const message = {
-      type: 'record' as const,
-      action: 'insert' as const,
-      identifiers: {
+    const result = buildRecordEvent(
+      makeContext('insert', {
         id: 'user-1',
         name: 'Alice',
         plan: 'pro',
         created_at: '2024-06-25T14:00:00.000Z',
-      },
-    };
-    const result = buildRecordEvent(message, 'person');
+      }),
+      'person',
+    );
     expect(result).toEqual({
       type: 'person',
       action: 'identify',
@@ -35,12 +36,10 @@ describe('buildRecordEvent', () => {
   });
 
   it('maps update action to identify with attributes from identifiers', () => {
-    const message = {
-      type: 'record' as const,
-      action: 'update' as const,
-      identifiers: { email: 'alice@example.com', plan: 'enterprise' },
-    };
-    const result = buildRecordEvent(message, 'person');
+    const result = buildRecordEvent(
+      makeContext('update', { email: 'alice@example.com', plan: 'enterprise' }),
+      'person',
+    );
     expect(result).toEqual({
       type: 'person',
       action: 'identify',
@@ -50,12 +49,10 @@ describe('buildRecordEvent', () => {
   });
 
   it('maps delete action to delete without attributes', () => {
-    const message = {
-      type: 'record' as const,
-      action: 'delete' as const,
-      identifiers: { id: 'user-1', name: 'Alice' },
-    };
-    const result = buildRecordEvent(message, 'person');
+    const result = buildRecordEvent(
+      makeContext('delete', { id: 'user-1', name: 'Alice' }),
+      'person',
+    );
     expect(result).toEqual({
       type: 'person',
       action: 'delete',
@@ -65,80 +62,74 @@ describe('buildRecordEvent', () => {
   });
 
   it('omits attributes when identifiers has only id', () => {
-    const message = {
-      type: 'record' as const,
-      action: 'insert' as const,
-      identifiers: { id: 'user-1' },
-    };
-    const result = buildRecordEvent(message, 'person');
+    const result = buildRecordEvent(makeContext('insert', { id: 'user-1' }), 'person');
     expect(result.attributes).toBeUndefined();
   });
 
   it('prefers cio_id over id and email when all are present', () => {
-    const message = {
-      type: 'record' as const,
-      action: 'insert' as const,
-      identifiers: { cio_id: 'cio-abc', id: 'user-1', email: 'alice@example.com', plan: 'pro' },
-    };
-    const result = buildRecordEvent(message, 'person');
+    const result = buildRecordEvent(
+      makeContext('insert', {
+        cio_id: 'cio-abc',
+        id: 'user-1',
+        email: 'alice@example.com',
+        plan: 'pro',
+      }),
+      'person',
+    );
     expect(result.identifiers).toEqual({ cio_id: 'cio-abc' });
     expect(result.attributes).toEqual({ id: 'user-1', email: 'alice@example.com', plan: 'pro' });
   });
 
   it('prefers id over email when cio_id is absent', () => {
-    const message = {
-      type: 'record' as const,
-      action: 'insert' as const,
-      identifiers: { id: 'user-1', email: 'alice@example.com', plan: 'pro' },
-    };
-    const result = buildRecordEvent(message, 'person');
+    const result = buildRecordEvent(
+      makeContext('insert', { id: 'user-1', email: 'alice@example.com', plan: 'pro' }),
+      'person',
+    );
     expect(result.identifiers).toEqual({ id: 'user-1' });
     expect(result.attributes).toEqual({ email: 'alice@example.com', plan: 'pro' });
   });
 
   it('uses email identifier when id is absent', () => {
-    const message = {
-      type: 'record' as const,
-      action: 'insert' as const,
-      identifiers: { email: 'alice@example.com', plan: 'pro' },
-    };
-    const result = buildRecordEvent(message, 'person');
+    const result = buildRecordEvent(
+      makeContext('insert', { email: 'alice@example.com', plan: 'pro' }),
+      'person',
+    );
     expect(result.identifiers).toEqual({ email: 'alice@example.com' });
     expect(result.attributes).toEqual({ plan: 'pro' });
   });
 
-  it.each(eventCases)(
+  it.each([{ action: 'insert' as const }, { action: 'update' as const }])(
     'maps event record $action action to event payload',
-    ({ action, expectedAttributes }) => {
-      const message = {
-        type: 'record' as const,
-        action,
-        identifiers: {
+    ({ action }) => {
+      const result = buildRecordEvent(
+        makeContext(action, {
           id: 'user-1',
           name: 'Order Completed',
           plan: 'pro',
           created_at: '2024-06-25T14:00:00.000Z',
-        },
-      };
-      const result = buildRecordEvent(message, 'event');
+        }),
+        'event',
+      );
       expect(result).toEqual({
         type: 'person',
         action: 'event',
         identifiers: { id: 'user-1' },
         name: 'Order Completed',
         timestamp: 1719324000,
-        attributes: expectedAttributes,
+        attributes: { plan: 'pro' },
       });
     },
   );
 
   it('maps event record update action using connection object marker', () => {
-    const message = {
-      type: 'record' as const,
-      action: 'update' as const,
-      identifiers: { email: 'alice@example.com', name: 'Plan Changed', plan: 'enterprise' },
-    };
-    const result = buildRecordEvent(message, 'event');
+    const result = buildRecordEvent(
+      makeContext('update', {
+        email: 'alice@example.com',
+        name: 'Plan Changed',
+        plan: 'enterprise',
+      }),
+      'event',
+    );
     expect(result).toEqual({
       type: 'person',
       action: 'event',
@@ -149,24 +140,11 @@ describe('buildRecordEvent', () => {
   });
 
   it('throws InstrumentationError for event record delete action', () => {
-    const message = {
-      type: 'record' as const,
-      action: 'delete' as const,
-      identifiers: { id: 'user-1', event: 'Order Completed' },
-    };
-    expect(() => buildRecordEvent(message, 'event')).toThrow(InstrumentationError);
-    expect(() => buildRecordEvent(message, 'event')).toThrow(
-      'Delete action is not supported for CustomerIO event records',
-    );
-  });
-
-  it('throws InstrumentationError for unsupported action', () => {
-    const message = {
-      type: 'record' as const,
-      action: 'upsert' as any,
-      identifiers: { id: 'user-1' },
-    };
-    expect(() => buildRecordEvent(message, 'person')).toThrow(InstrumentationError);
-    expect(() => buildRecordEvent(message, 'person')).toThrow('Action "upsert" is not supported');
+    expect(() =>
+      buildRecordEvent(makeContext('delete', { id: 'user-1', event: 'Order Completed' }), 'event'),
+    ).toThrow(InstrumentationError);
+    expect(() =>
+      buildRecordEvent(makeContext('delete', { id: 'user-1', event: 'Order Completed' }), 'event'),
+    ).toThrow('Delete action is not supported for CustomerIO event records');
   });
 });

--- a/src/v0/destinations/customerio/v2/recordTransform.ts
+++ b/src/v0/destinations/customerio/v2/recordTransform.ts
@@ -1,19 +1,24 @@
 import { InstrumentationError } from '@rudderstack/integrations-lib';
+import type { RecordContext } from '../../../../services/destination/nativeBatching/types';
 import { RECORD_ACTION_MAP, RECORD_IDENTIFIER_KEYS } from './config';
-import { CustomerIOV2Payload, type CustomerIOV2RecordMessage } from './types';
+import { CustomerIOV2Payload } from './types';
 import { toUnixSeconds } from './util';
-import { CUSTOMERIO_RECORD_OBJECTS, type CustomerIORecordObject } from '../types';
+import {
+  CUSTOMERIO_RECORD_OBJECTS,
+  type CustomerIORecordObject,
+  type CustomerIOConnection,
+} from '../types';
 import { EVENT_TYPES } from '../../../util/recordUtils';
 
 type RecordPayloadContext = {
-  rawIdentifiers: CustomerIOV2RecordMessage['identifiers'];
+  rawIdentifiers: Record<string, string | number>;
   identifierKey: string;
-  action: CustomerIOV2RecordMessage['action'];
+  action: 'insert' | 'update' | 'delete';
 };
 
 type RecordPayloadBuilder = {
-  getCIOAction: (action: CustomerIOV2RecordMessage['action']) => string;
-  validateAction?: (action: CustomerIOV2RecordMessage['action']) => void;
+  getCIOAction: (action: 'insert' | 'update' | 'delete') => string;
+  validateAction?: (action: 'insert' | 'update' | 'delete') => void;
   getAdditionalFields?: (context: RecordPayloadContext) => Partial<CustomerIOV2Payload>;
   getExcludedAttributeKeys?: () => string[];
 };
@@ -48,10 +53,10 @@ const recordPayloadBuilders: Record<CustomerIORecordObject, RecordPayloadBuilder
 };
 
 export const buildRecordEvent = (
-  message: CustomerIOV2RecordMessage,
+  context: RecordContext<CustomerIOConnection['config']>,
   connectionObject: CustomerIORecordObject,
 ): CustomerIOV2Payload => {
-  const { action, identifiers: rawIdentifiers = {} } = message;
+  const { action, identifiers: rawIdentifiers = {} } = context;
 
   if (!(action in RECORD_ACTION_MAP)) {
     throw new InstrumentationError(`Action "${action}" is not supported`);
@@ -64,10 +69,9 @@ export const buildRecordEvent = (
     (key) => typeof rawIdentifiers[key] === 'string' && (rawIdentifiers[key] as string).length > 0,
   ) as string;
 
-  const cioAction = builder.getCIOAction(action);
   const payload: CustomerIOV2Payload = {
     type: CUSTOMERIO_RECORD_OBJECTS.person,
-    action: cioAction,
+    action: builder.getCIOAction(action),
     identifiers: {
       [identifierKey]: rawIdentifiers[identifierKey] as string,
     },

--- a/src/v0/destinations/iterable_audience/routerTransform.ts
+++ b/src/v0/destinations/iterable_audience/routerTransform.ts
@@ -4,13 +4,12 @@ import {
   BatchDestination,
   ChunkBatchStrategy,
   type TransformedEvent,
+  type RecordContext,
 } from '../../../services/destination/nativeBatching/batchDestination';
 import type { BatchStrategy } from '../../../services/destination/nativeBatching/types';
 import type { Connection, Destination } from '../../../types/controlPlaneConfig';
-import type { RouterTransformationRequestData } from '../../../types/destinationTransformation';
 import { processAudienceRecord } from '../../util/audienceUtils';
 import {
-  ACTION_RECORD_MAP,
   DESTINATION_TYPE,
   MAX_BATCH_SIZE,
   getSubscribeEndpoint,
@@ -63,34 +62,25 @@ class IterableAudienceIntegration extends BatchDestination<
     return this.connection!.config.destination;
   }
 
-  transformEvent(
-    input: RouterTransformationRequestData,
+  private static readonly ACTION_MAP: Record<string, 'subscribe' | 'unsubscribe'> = {
+    insert: 'subscribe',
+    update: 'subscribe',
+    delete: 'unsubscribe',
+  };
+
+  transformRecord(
+    context: RecordContext<{ destination: IterableConnectionConfig }>,
   ): TransformedEvent<IterableAudiencePayload> {
-    const { message, metadata } = input;
-    const messageAction = (message as { action?: string }).action;
-    if (!messageAction) {
-      throw new InstrumentationError('record event is missing action');
-    }
-    const action = ACTION_RECORD_MAP[messageAction];
+    const { identifiers, action: rawAction } = context;
+    const action = IterableAudienceIntegration.ACTION_MAP[rawAction];
     if (!action) {
-      throw new InstrumentationError(`Unsupported record action: ${messageAction}`);
+      throw new InstrumentationError(`Unsupported record action: ${rawAction}`);
     }
 
-    const identifiers = (message as { identifiers?: Record<string, unknown> }).identifiers ?? {};
-
-    // `message.identifiers` already arrives keyed by the Iterable field
-    // (`email` / `userId`) — rudder-sources resolves the mapping upstream — so
-    // it is passed straight through. `processAudienceRecord` normalises +
-    // validates the `email`/`userId` fields per `IDENTIFIER_FIELD_CONFIG` and
-    // drops null/empty values; any other key passes through untouched and is
-    // then ignored by `selectIdentifierForRow`, which only reads email/userId.
-    // `config: { isHashRequired: false }` is required by the destructure even
-    // though no identifier field is hashable.
     const processed = processAudienceRecord(identifiers, {
       fieldConfigs: IDENTIFIER_FIELD_CONFIG,
       destination: {
-        workspaceId:
-          (metadata as { workspaceId?: string }).workspaceId ?? this.destination.WorkspaceID,
+        workspaceId: this.destination.WorkspaceID,
         id: this.destination.ID,
         type: DESTINATION_TYPE,
         config: { isHashRequired: false },

--- a/test/integrations/destinations/customerio/router/dataV2.ts
+++ b/test/integrations/destinations/customerio/router/dataV2.ts
@@ -2228,7 +2228,7 @@ export const dataV2 = [
               metadata: [{ jobId: 106, userId: 'u1', workspaceId: 'ws-cio-v2' }],
               batched: false,
               statusCode: 400,
-              error: 'Delete action is not supported for CustomerIO event records',
+              error: '"delete" is not supported for object type "event"',
               statTags: {
                 destType: 'CUSTOMERIO',
                 errorCategory: 'dataValidation',


### PR DESCRIPTION
## Summary

- Adds `RecordContext` type and record event dispatch in `BatchDestination.transformEvents` — record events (`message.type === 'record'`) now route to `transformRecord` with a typed context (action, objectType, identifiers, connection) instead of being mixed into `transformEvent`
- Introduces `VDMV2ObjectDestination` subclass for object-based destinations — provides `transformObjectRecord()` handler map with automatic per-object-type + per-action dispatch and validation
- Migrates CustomerIO (extends `VDMV2ObjectDestination`), IterableAudience and CustomAudience (extend `BatchDestination`, override `transformRecord` directly)

## Test plan

- [ ] Unit tests pass for BatchDestination framework (33 tests including new dispatch tests)
- [ ] Unit tests pass for CustomerIO (17 tests — record + event-stream)
- [ ] Unit tests pass for IterableAudience (40 tests)
- [ ] Unit tests pass for CustomAudience (147 tests)
- [ ] Integration tests pass for all three migrated destinations
- [ ] PostHog and GAEC tests pass (event-stream only, unaffected)
- [ ] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)