### PR TITLE
refactor(batch): add record event dispatch to BatchDestination framework

### DIFF
--- a/.claude/skills/batching-framework/SKILL.md
+++ b/.claude/skills/batching-framework/SKILL.md
@@ -91,6 +91,8 @@ class MyIntegration extends BatchDestination<TBody, TConfig, TConnectionConfig> 
 export const Integration = MyIntegration;
 ```
 
+Build the schema with `makeRouterInputSchema({ message, destinationConfig?, connectionConfig? })` — a single message variant plus optional destination/connection config. Hybrid record + event-stream destinations extend `VDMV2ObjectDestination`, which unions two such schemas for you.
+
 ## TransformedEvent Type
 
 ```typescript

--- a/.claude/skills/vdm-v2-object-destination/SKILL.md
+++ b/.claude/skills/vdm-v2-object-destination/SKILL.md
@@ -74,7 +74,9 @@ See `src/v0/destinations/customerio/routerTransform.ts` -- `transformObjectRecor
 
 ### Transform methods are typed from your schemas
 
-Declare two schemas built with `makeRouterInputSchema` -- `recordSchema` and `eventStreamSchema` -- as `readonly` properties, both using the same `destinationConfig` constant. The framework unions them in `getInputSchema()`; you never build the union yourself. `transformObjectRecord(input)` is typed as `z.infer<typeof recordSchema>` and `transformEventStream(input)` as `z.infer<typeof eventStreamSchema>`, so no casting is needed. `RecordInput`/`RecordMessage`/`isRecordInput` remain framework-internal (routing/guard).
+Declare two schemas built with `makeRouterInputSchema` -- `recordSchema` and `eventStreamSchema` -- as `readonly` properties, both using the same `destinationConfig` constant. The framework unions them in `getInputSchema()`; you never build the union yourself. `RecordInput`/`RecordMessage`/`isRecordInput` remain framework-internal (routing/guard).
+
+Type the transform-method parameters inline with `z.infer<typeof recordInputSchema>` (for `transformObjectRecord`) and `z.infer<typeof eventStreamInputSchema>` (for `transformEventStream`), referencing the module-level schema constants. Do **not** introduce a named alias like `type MyRecordInput = z.infer<typeof recordInputSchema>` and annotate with that — the alias reads like a hand-written type that could drift from the schema, whereas `z.infer<typeof ...>` at the use site makes it obvious the type is the schema, single-sourced. No casting is needed. See `src/v0/destinations/customerio/routerTransform.ts`.
 
 ### Connection config constraint
 

--- a/.claude/skills/vdm-v2-object-destination/SKILL.md
+++ b/.claude/skills/vdm-v2-object-destination/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: vdm-v2-object-destination
+description: Create the transformation logic for a new VDM V2 object-based destination. Implements record dispatch by object type and action, with batching and optional event-stream support.
+---
+
+# VDM V2 Object Destination (rudder-transformer)
+
+**Objective:** Build the transformation logic for a new VDM V2 object-based destination -- process warehouse record events into HTTP API requests that create, update, or delete objects (person, event, contact, etc.), with per-object-type dispatch, batching, and optional event-stream support.
+
+## When to use
+
+Use `VDMV2ObjectDestination` when the destination:
+
+- Receives **record events** (insert/update/delete) targeting specific **object types** (person, event, contact, lead, etc.)
+- Object type comes from **connection config** (`connection.config.destination.object`)
+- Different object types may support **different actions** (e.g., person supports delete, event does not)
+- May also support **event-stream events** (identify, track, page, etc.) alongside records
+
+For audience destinations (add/remove users from segments), use the `vdm-next-audience-integration` skill instead.
+
+## Reference
+
+Read these files before implementing:
+
+- **Framework source** -- `src/services/destination/nativeBatching/vdmV2ObjectDestination.ts` -- `VDMV2ObjectDestination` abstract class, `RecordInput`/`RecordMessage` types, `isRecordInput` type guard, dispatch logic
+- **CustomerIO** (`src/v0/destinations/customerio/`) -- canonical implementation with record + event-stream support
+  - `routerTransform.ts` -- `VDMV2ObjectDestination` subclass with handler map, batch strategy, input schema
+  - `routerTransform.test.ts` -- unit tests instantiating the Integration class directly
+  - `types.ts` -- Zod schemas for connection config (with `object` field), destination config, router request type
+  - `v2/recordTransform.ts` -- record payload builder (no action validation)
+  - `v2/types.ts` -- Zod schemas for record and event-stream messages, input schema factory
+- **Batching framework** -- `.claude/skills/batching-framework/SKILL.md`
+
+## File Structure
+
+```
+src/v0/destinations/<dest_name>/
+  routerTransform.ts        # VDMV2ObjectDestination subclass (exported as Integration)
+  routerTransform.test.ts   # Unit tests for the Integration class
+  types.ts                  # Zod schemas, TypeScript types, connection config
+```
+
+Additional files (config, payload builders, utils) depend on the destination's complexity. See the CustomerIO reference for one way to organize them.
+
+## Architecture
+
+```
+RouterTransformationRequestData[]
+    |
+processBatchedDestination()              [framework orchestrator]
+    |
+VDMV2ObjectDestination<TBody, TRecordSchema, TEventStreamSchema>  [your integration class]
+    |--- getInputSchema()                -> [framework] z.union(recordSchema, eventStreamSchema)
+    |--- transformEvent()                -> [inherited] dispatches to:
+    |       |--- isRecordInput()?
+    |       |       |--- transformObjectRecord(input)  -> handler map
+    |       |       |--- framework validates object type + action
+    |       |       |--- calls handler()
+    |       |--- else: transformEventStream(input)
+    |--- getBatchStrategy()              -> batch strategy factory
+    |
+Framework groups by composite key, chunks, wraps
+    |
+RouterTransformationResponse[]
+```
+
+## Key Conventions
+
+### Handler map is the single source of truth
+
+The map returned by `transformObjectRecord(input)` declares which object/action combinations are supported. The framework rejects anything not present. Do not duplicate this validation in payload builders downstream.
+
+See `src/v0/destinations/customerio/routerTransform.ts` -- `transformObjectRecord` method.
+
+### Transform methods are typed from your schemas
+
+Declare two schemas built with `makeRouterInputSchema` -- `recordSchema` and `eventStreamSchema` -- as `readonly` properties, both using the same `destinationConfig` constant. The framework unions them in `getInputSchema()`; you never build the union yourself. `transformObjectRecord(input)` is typed as `z.infer<typeof recordSchema>` and `transformEventStream(input)` as `z.infer<typeof eventStreamSchema>`, so no casting is needed. `RecordInput`/`RecordMessage`/`isRecordInput` remain framework-internal (routing/guard).
+
+### Connection config constraint
+
+`TConnectionConfig` is constrained to `extends { destination: { object: string } }`. The framework reads `this.connection.config.destination.object` to look up the handler map. Define your connection config type with an `object` field (see `src/v0/destinations/customerio/types.ts` -- `CustomerIOConnectionConfigSchema`).
+
+### `ConfigurationError` for framework-level errors
+
+The framework uses `ConfigurationError` (not `InstrumentationError`) for dispatch validation:
+
+| Error | Source |
+|---|---|
+| Missing connection config | Framework |
+| Unsupported object type | Framework (not in handler map) |
+| Unsupported action for object type | Framework (not in handler map) |
+| Event-stream not supported | Framework (default `transformEventStream`) |
+| Bad payload data | Destination code (`InstrumentationError`) |
+
+### Event-stream support is optional
+
+Object destinations declare both `recordSchema` and `eventStreamSchema`. Override `transformEventStream` to return event-stream handlers; if left as the default, event-stream messages are rejected with a `ConfigurationError`. See `src/v0/destinations/customerio/routerTransform.ts`.
+
+## Enabling the Framework
+
+Register in `src/constants/batchedDestinationsMap.ts` and update `src/features.ts` under `defaultFeaturesConfig` with the destination definition name.
+
+## Steps
+
+1. Read the reference files listed above
+2. Create `src/v0/destinations/<dest_name>/types.ts` -- Zod schemas for connection config (with `object` field), record message, and event-stream message; derive TypeScript types
+3. Create `src/v0/destinations/<dest_name>/routerTransform.ts` -- extend `VDMV2ObjectDestination<TBody, typeof recordInputSchema, typeof eventStreamInputSchema>`:
+   - `recordSchema` / `eventStreamSchema` -- `readonly` properties set to the two `makeRouterInputSchema` schemas (shared `destinationConfig` constant)
+   - `transformObjectRecord(input)` -- return handler map with object type -> action -> handler
+   - `getBatchStrategy()` -- return `ChunkBatchStrategy` with `maxPayloadSize`/`maxItems` and `wrapBody`
+   - (Optional) `transformEventStream(input)` -- handle non-record events
+   - Export as `Integration`
+4. Register in `src/constants/batchedDestinationsMap.ts` and `src/features.ts`
+5. Create `src/v0/destinations/<dest_name>/routerTransform.test.ts` -- unit tests
+6. Create `test/integrations/destinations/<dest_name>/router/` -- integration test cases
+7. Verify:
+   ```bash
+   npm run lint
+   npm test -- --testPathPattern="<dest_name>" --no-coverage
+   npm run test:ts -- component --destination=<dest_name>
+   ```

--- a/src/services/destination/nativeBatching/__tests__/batchDestination.test.ts
+++ b/src/services/destination/nativeBatching/__tests__/batchDestination.test.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { InstrumentationError } from '@rudderstack/integrations-lib';
 import {
   BatchDestination,
   TransformedEvent,
@@ -6,9 +7,10 @@ import {
   CustomBatchStrategy,
   parseSizeToBytes,
 } from '../batchDestination';
+import { VDMV2ObjectDestination, type RecordInput } from '../vdmV2ObjectDestination';
 import type { BatchStrategy } from '../batchDestination';
 import type { RouterTransformationRequestData } from '../../../../types/destinationTransformation';
-import type { Destination } from '../../../../types/controlPlaneConfig';
+import type { Destination, Connection } from '../../../../types/controlPlaneConfig';
 import type { Metadata, RudderMessage } from '../../../../types/rudderEvents';
 
 // ---------------------------------------------------------------------------
@@ -79,6 +81,94 @@ class FailingIntegration extends BatchDestination<TestBody> {
   getInputSchema() {
     return z.object({}).passthrough();
   }
+}
+
+type TestConnectionConfig = { destination: { object: string } };
+
+class RecordIntegration extends VDMV2ObjectDestination<TestBody> {
+  protected readonly recordSchema = z.object({}).passthrough();
+
+  protected readonly eventStreamSchema = z.object({}).passthrough();
+
+  private upsertUser(): TransformedEvent<TestBody> {
+    return {
+      body: { value: 'upsert:user' },
+      endpoint: 'https://api.test.com/records',
+      endpointPath: '/records',
+      method: 'POST',
+    };
+  }
+
+  private removeUser(): TransformedEvent<TestBody> {
+    return {
+      body: { value: 'remove:user' },
+      endpoint: 'https://api.test.com/records',
+      endpointPath: '/records',
+      method: 'POST',
+    };
+  }
+
+  private createEvent(): TransformedEvent<TestBody> {
+    return {
+      body: { value: 'create:event' },
+      endpoint: 'https://api.test.com/records',
+      endpointPath: '/records',
+      method: 'POST',
+    };
+  }
+
+  transformObjectRecord(_input: RecordInput) {
+    return {
+      user: {
+        insert: () => this.upsertUser(),
+        update: () => this.upsertUser(),
+        delete: () => this.removeUser(),
+      },
+      event: {
+        insert: () => this.createEvent(),
+        update: () => this.createEvent(),
+        // delete not listed — framework rejects automatically
+      },
+    };
+  }
+
+  getBatchStrategy(): BatchStrategy<TestBody> {
+    return new ChunkBatchStrategy({ maxItems: 10, wrapBody: (bodies) => ({ records: bodies }) });
+  }
+
+  getInputSchema() {
+    return z.object({}).passthrough();
+  }
+}
+
+const mockConnection: Connection<TestConnectionConfig> = {
+  sourceId: 'src-1',
+  destinationId: 'dest-1',
+  enabled: true,
+  config: { destination: { object: 'user' } },
+};
+
+function makeRecordInput(
+  jobId: number,
+  action: string,
+  identifiers: Record<string, string | number>,
+  connection?: Connection<TestConnectionConfig>,
+): RouterTransformationRequestData {
+  return {
+    message: { type: 'record', action, identifiers },
+    metadata: {
+      jobId,
+      workspaceId: 'ws-1',
+      sourceId: 'src-1',
+      sourceType: 'web',
+      sourceCategory: 'cloud',
+      destinationId: 'dest-1',
+      destinationType: 'TEST',
+      messageId: `msg-${jobId}`,
+    },
+    destination: mockDestination,
+    connection: connection ?? mockConnection,
+  } as RouterTransformationRequestData;
 }
 
 function makeInput(
@@ -187,5 +277,86 @@ describe('strategy classes', () => {
     expect(result).toHaveLength(1);
     expect(result[0].body).toEqual({ merged: true });
     expect(result[0].jobIds).toEqual(new Set([1, 2]));
+  });
+});
+
+describe('VDMV2ObjectDestination — record dispatch', () => {
+  it('dispatches record events via handler map', async () => {
+    const integration = new RecordIntegration(mockDestination, mockConnection);
+    const input = makeRecordInput(1, 'insert', { id: 'u1' });
+    const result = await integration.transformEvents([input]);
+    expect(result.successPayloads).toHaveLength(1);
+    expect(result.successPayloads[0].body.value).toBe('upsert:user');
+    expect(result.successPayloads[0].jobId).toBe(1);
+  });
+
+  it('falls through to transformStreamEvent for event-stream events', async () => {
+    const integration = new RecordIntegration(mockDestination, mockConnection);
+    // RecordIntegration doesn't override transformStreamEvent → default throws
+    const eventInput = makeInput(2, 'hello');
+    const result = await integration.transformEvents([eventInput]);
+    expect(result.errorPayloads).toHaveLength(1);
+    expect(result.errorPayloads[0].error).toContain('Event-stream events are not supported');
+  });
+
+  it('rejects unsupported action for object type', async () => {
+    const eventConn: Connection<TestConnectionConfig> = {
+      ...mockConnection,
+      config: { destination: { object: 'event' } },
+    };
+    const integration = new RecordIntegration(mockDestination, eventConn);
+    const input = makeRecordInput(1, 'delete', { id: 'u1' }, eventConn);
+    const result = await integration.transformEvents([input]);
+    expect(result.errorPayloads).toHaveLength(1);
+    expect(result.errorPayloads[0].error).toContain(
+      '"delete" is not supported for object type "event"',
+    );
+  });
+
+  it('rejects unsupported object type', async () => {
+    const badConn: Connection<TestConnectionConfig> = {
+      ...mockConnection,
+      config: { destination: { object: 'unknown_type' } },
+    };
+    const integration = new RecordIntegration(mockDestination, badConn);
+    const input = makeRecordInput(1, 'insert', { id: 'u1' }, badConn);
+    const result = await integration.transformEvents([input]);
+    expect(result.errorPayloads).toHaveLength(1);
+    expect(result.errorPayloads[0].error).toContain('Unsupported object type: "unknown_type"');
+  });
+
+  it('passes standard input to handler', async () => {
+    // Create an integration that echoes message fields into the body for assertion
+    class EchoIntegration extends VDMV2ObjectDestination<Record<string, unknown>> {
+      protected readonly recordSchema = z.object({}).passthrough();
+
+      protected readonly eventStreamSchema = z.object({}).passthrough();
+
+      transformObjectRecord(input: RecordInput) {
+        const handler = () => ({
+          body: { ids: input.message.identifiers, action: input.message.action },
+          endpoint: 'https://api.test.com',
+          endpointPath: '/test',
+          method: 'POST',
+        });
+        return {
+          user: { insert: handler, update: handler, delete: handler },
+        };
+      }
+      getBatchStrategy() {
+        return new ChunkBatchStrategy({ wrapBody: (b) => ({ batch: b }) });
+      }
+      getInputSchema() {
+        return z.object({}).passthrough();
+      }
+    }
+
+    const integration = new EchoIntegration(mockDestination, mockConnection);
+    const input = makeRecordInput(1, 'insert', { email: 'a@b.com', plan: 'pro' });
+    const result = await integration.transformEvents([input]);
+    expect(result.successPayloads[0].body).toEqual({
+      ids: { email: 'a@b.com', plan: 'pro' },
+      action: 'insert',
+    });
   });
 });

--- a/src/services/destination/nativeBatching/__tests__/batchDestination.test.ts
+++ b/src/services/destination/nativeBatching/__tests__/batchDestination.test.ts
@@ -7,10 +7,9 @@ import {
   CustomBatchStrategy,
   parseSizeToBytes,
 } from '../batchDestination';
-import { VDMV2ObjectDestination, type RecordInput } from '../vdmV2ObjectDestination';
 import type { BatchStrategy } from '../batchDestination';
 import type { RouterTransformationRequestData } from '../../../../types/destinationTransformation';
-import type { Destination, Connection } from '../../../../types/controlPlaneConfig';
+import type { Destination } from '../../../../types/controlPlaneConfig';
 import type { Metadata, RudderMessage } from '../../../../types/rudderEvents';
 
 // ---------------------------------------------------------------------------
@@ -81,94 +80,6 @@ class FailingIntegration extends BatchDestination<TestBody> {
   getInputSchema() {
     return z.object({}).passthrough();
   }
-}
-
-type TestConnectionConfig = { destination: { object: string } };
-
-class RecordIntegration extends VDMV2ObjectDestination<TestBody> {
-  protected readonly recordSchema = z.object({}).passthrough();
-
-  protected readonly eventStreamSchema = z.object({}).passthrough();
-
-  private upsertUser(): TransformedEvent<TestBody> {
-    return {
-      body: { value: 'upsert:user' },
-      endpoint: 'https://api.test.com/records',
-      endpointPath: '/records',
-      method: 'POST',
-    };
-  }
-
-  private removeUser(): TransformedEvent<TestBody> {
-    return {
-      body: { value: 'remove:user' },
-      endpoint: 'https://api.test.com/records',
-      endpointPath: '/records',
-      method: 'POST',
-    };
-  }
-
-  private createEvent(): TransformedEvent<TestBody> {
-    return {
-      body: { value: 'create:event' },
-      endpoint: 'https://api.test.com/records',
-      endpointPath: '/records',
-      method: 'POST',
-    };
-  }
-
-  transformObjectRecord(_input: RecordInput) {
-    return {
-      user: {
-        insert: () => this.upsertUser(),
-        update: () => this.upsertUser(),
-        delete: () => this.removeUser(),
-      },
-      event: {
-        insert: () => this.createEvent(),
-        update: () => this.createEvent(),
-        // delete not listed — framework rejects automatically
-      },
-    };
-  }
-
-  getBatchStrategy(): BatchStrategy<TestBody> {
-    return new ChunkBatchStrategy({ maxItems: 10, wrapBody: (bodies) => ({ records: bodies }) });
-  }
-
-  getInputSchema() {
-    return z.object({}).passthrough();
-  }
-}
-
-const mockConnection: Connection<TestConnectionConfig> = {
-  sourceId: 'src-1',
-  destinationId: 'dest-1',
-  enabled: true,
-  config: { destination: { object: 'user' } },
-};
-
-function makeRecordInput(
-  jobId: number,
-  action: string,
-  identifiers: Record<string, string | number>,
-  connection?: Connection<TestConnectionConfig>,
-): RouterTransformationRequestData {
-  return {
-    message: { type: 'record', action, identifiers },
-    metadata: {
-      jobId,
-      workspaceId: 'ws-1',
-      sourceId: 'src-1',
-      sourceType: 'web',
-      sourceCategory: 'cloud',
-      destinationId: 'dest-1',
-      destinationType: 'TEST',
-      messageId: `msg-${jobId}`,
-    },
-    destination: mockDestination,
-    connection: connection ?? mockConnection,
-  } as RouterTransformationRequestData;
 }
 
 function makeInput(
@@ -277,86 +188,5 @@ describe('strategy classes', () => {
     expect(result).toHaveLength(1);
     expect(result[0].body).toEqual({ merged: true });
     expect(result[0].jobIds).toEqual(new Set([1, 2]));
-  });
-});
-
-describe('VDMV2ObjectDestination — record dispatch', () => {
-  it('dispatches record events via handler map', async () => {
-    const integration = new RecordIntegration(mockDestination, mockConnection);
-    const input = makeRecordInput(1, 'insert', { id: 'u1' });
-    const result = await integration.transformEvents([input]);
-    expect(result.successPayloads).toHaveLength(1);
-    expect(result.successPayloads[0].body.value).toBe('upsert:user');
-    expect(result.successPayloads[0].jobId).toBe(1);
-  });
-
-  it('falls through to transformStreamEvent for event-stream events', async () => {
-    const integration = new RecordIntegration(mockDestination, mockConnection);
-    // RecordIntegration doesn't override transformStreamEvent → default throws
-    const eventInput = makeInput(2, 'hello');
-    const result = await integration.transformEvents([eventInput]);
-    expect(result.errorPayloads).toHaveLength(1);
-    expect(result.errorPayloads[0].error).toContain('Event-stream events are not supported');
-  });
-
-  it('rejects unsupported action for object type', async () => {
-    const eventConn: Connection<TestConnectionConfig> = {
-      ...mockConnection,
-      config: { destination: { object: 'event' } },
-    };
-    const integration = new RecordIntegration(mockDestination, eventConn);
-    const input = makeRecordInput(1, 'delete', { id: 'u1' }, eventConn);
-    const result = await integration.transformEvents([input]);
-    expect(result.errorPayloads).toHaveLength(1);
-    expect(result.errorPayloads[0].error).toContain(
-      '"delete" is not supported for object type "event"',
-    );
-  });
-
-  it('rejects unsupported object type', async () => {
-    const badConn: Connection<TestConnectionConfig> = {
-      ...mockConnection,
-      config: { destination: { object: 'unknown_type' } },
-    };
-    const integration = new RecordIntegration(mockDestination, badConn);
-    const input = makeRecordInput(1, 'insert', { id: 'u1' }, badConn);
-    const result = await integration.transformEvents([input]);
-    expect(result.errorPayloads).toHaveLength(1);
-    expect(result.errorPayloads[0].error).toContain('Unsupported object type: "unknown_type"');
-  });
-
-  it('passes standard input to handler', async () => {
-    // Create an integration that echoes message fields into the body for assertion
-    class EchoIntegration extends VDMV2ObjectDestination<Record<string, unknown>> {
-      protected readonly recordSchema = z.object({}).passthrough();
-
-      protected readonly eventStreamSchema = z.object({}).passthrough();
-
-      transformObjectRecord(input: RecordInput) {
-        const handler = () => ({
-          body: { ids: input.message.identifiers, action: input.message.action },
-          endpoint: 'https://api.test.com',
-          endpointPath: '/test',
-          method: 'POST',
-        });
-        return {
-          user: { insert: handler, update: handler, delete: handler },
-        };
-      }
-      getBatchStrategy() {
-        return new ChunkBatchStrategy({ wrapBody: (b) => ({ batch: b }) });
-      }
-      getInputSchema() {
-        return z.object({}).passthrough();
-      }
-    }
-
-    const integration = new EchoIntegration(mockDestination, mockConnection);
-    const input = makeRecordInput(1, 'insert', { email: 'a@b.com', plan: 'pro' });
-    const result = await integration.transformEvents([input]);
-    expect(result.successPayloads[0].body).toEqual({
-      ids: { email: 'a@b.com', plan: 'pro' },
-      action: 'insert',
-    });
   });
 });

--- a/src/services/destination/nativeBatching/__tests__/inputSchema.test.ts
+++ b/src/services/destination/nativeBatching/__tests__/inputSchema.test.ts
@@ -11,22 +11,19 @@ const recordMessage = z
   .object({ type: z.literal('record'), identifiers: z.record(z.unknown()) })
   .passthrough();
 
-const eventStreamMessage = z
-  .object({ type: z.enum(['track', 'identify']), userId: z.string() })
-  .passthrough();
-
 const connectionConfig = z.object({ destination: z.object({ object: z.string() }) }).passthrough();
 
 const validDestination = { Config: { apiKey: 'key-1' } };
 
 // ---------------------------------------------------------------------------
-// Single variant — parity with a non-hybrid destination
+// Single variant — the only supported form
 // ---------------------------------------------------------------------------
 
 describe('makeRouterInputSchema — single variant', () => {
   const schema = makeRouterInputSchema({
+    message: recordMessage,
     destinationConfig,
-    variants: [{ message: recordMessage, connectionConfig }],
+    connectionConfig,
   });
 
   const validCases = [
@@ -87,95 +84,11 @@ describe('makeRouterInputSchema — single variant', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Multiple variants — hybrid destination (record + event-stream)
-// ---------------------------------------------------------------------------
-
-describe('makeRouterInputSchema — multiple variants', () => {
-  const schema = makeRouterInputSchema({
-    destinationConfig,
-    variants: [{ message: recordMessage, connectionConfig }, { message: eventStreamMessage }],
-  });
-
-  const validCases = [
-    {
-      name: 'a record message with a valid connection',
-      input: {
-        message: { type: 'record', identifiers: { id: 'u1' } },
-        destination: validDestination,
-        connection: { config: { destination: { object: 'person' } } },
-      },
-    },
-    {
-      name: 'an event-stream message with no connection',
-      input: {
-        message: { type: 'track', userId: 'u1' },
-        destination: validDestination,
-      },
-    },
-    {
-      // The record connection schema requires `object`; it must not be applied to
-      // event-stream events (the bug #5331 fixed).
-      name: 'an event-stream message whose connection lacks record-only fields',
-      input: {
-        message: { type: 'identify', userId: 'u1' },
-        destination: validDestination,
-        connection: { config: { destination: {} } },
-      },
-    },
-  ];
-
-  const invalidCases = [
-    {
-      name: 'a record message whose connection fails the record schema',
-      input: {
-        message: { type: 'record', identifiers: { id: 'u1' } },
-        destination: validDestination,
-        connection: { config: { destination: {} } },
-      },
-    },
-    {
-      name: 'a message matching neither variant',
-      input: {
-        message: { type: 'group', groupId: 'g1' },
-        destination: validDestination,
-      },
-    },
-  ];
-
-  const pathErrorCases = [
-    {
-      name: 'a bad shared config',
-      input: {
-        message: { type: 'track', userId: 'u1' },
-        destination: { Config: {} },
-      },
-      errorPath: 'destination.Config.apiKey',
-    },
-  ];
-
-  it.each(validCases)('accepts $name', ({ input }) => {
-    expect(schema.safeParse(input).success).toBe(true);
-  });
-
-  it.each(invalidCases)('rejects $name', ({ input }) => {
-    expect(schema.safeParse(input).success).toBe(false);
-  });
-
-  it.each(pathErrorCases)('rejects $name and reports a precise path', ({ input, errorPath }) => {
-    const result = schema.safeParse(input);
-    expect(result.success).toBe(false);
-    expect(!result.success && result.error.issues.some((i) => i.path.join('.') === errorPath)).toBe(
-      true,
-    );
-  });
-});
-
-// ---------------------------------------------------------------------------
 // No destination config (e.g. GAEC)
 // ---------------------------------------------------------------------------
 
 describe('makeRouterInputSchema — no destinationConfig', () => {
-  const schema = makeRouterInputSchema({ variants: [{ message: recordMessage }] });
+  const schema = makeRouterInputSchema({ message: recordMessage });
 
   it('validates only the message and passes destination through', () => {
     const result = schema.safeParse({

--- a/src/services/destination/nativeBatching/__tests__/processBatchedDestination.test.ts
+++ b/src/services/destination/nativeBatching/__tests__/processBatchedDestination.test.ts
@@ -518,4 +518,98 @@ describe('validateInputs', () => {
     expect(valid).toHaveLength(1);
     expect(errors).toHaveLength(0);
   });
+
+  // A hybrid (record + event-stream) union schema, mirroring what the object base builds.
+  const recordVariant = z
+    .object({
+      message: z
+        .object({ type: z.literal('record'), identifiers: z.record(z.unknown()) })
+        .passthrough(),
+      destination: z.object({ Config: z.object({ apiKey: z.string() }) }).passthrough(),
+      connection: z
+        .object({ config: z.object({ destination: z.object({ object: z.string() }) }) })
+        .passthrough()
+        .optional(),
+    })
+    .passthrough();
+  const eventVariant = z
+    .object({
+      message: z.object({ type: z.enum(['track', 'identify']), userId: z.string() }).passthrough(),
+      destination: z.object({ Config: z.object({ apiKey: z.string() }) }).passthrough(),
+    })
+    .passthrough();
+
+  class UnionIntegration extends BatchDestination<TestBody> {
+    transformEvent(): TransformedEvent<TestBody> {
+      return {
+        body: { value: 'x' },
+        endpoint: 'https://api.test.com/events',
+        endpointPath: '/events',
+        method: 'POST',
+      };
+    }
+    getBatchStrategy(): BatchStrategy<TestBody> {
+      return new ChunkBatchStrategy({ maxItems: 3, wrapBody: (bodies) => ({ events: bodies }) });
+    }
+    getInputSchema() {
+      return z.union([recordVariant, eventVariant]);
+    }
+  }
+
+  const unionInput = (jobId: number, message: unknown, config: unknown, connection?: unknown) => ({
+    message,
+    destination: { Config: config },
+    ...(connection ? { connection } : {}),
+    metadata: { jobId },
+  });
+
+  it('accepts a valid event-stream message under a union schema', () => {
+    const integration = new UnionIntegration(mockDestination);
+    const { valid, errors } = validateInputs(
+      [unionInput(1, { type: 'track', userId: 'u1' }, { apiKey: 'k' })] as any,
+      integration,
+    );
+    expect(valid).toHaveLength(1);
+    expect(errors).toHaveLength(0);
+  });
+
+  it('classifies a bad shared Config as CONFIGURATION with a precise path', () => {
+    const integration = new UnionIntegration(mockDestination);
+    const { errors } = validateInputs(
+      [unionInput(2, { type: 'track', userId: 'u1' }, {})] as any,
+      integration,
+    );
+    expect(errors).toHaveLength(1);
+    expect(errors[0].statTags?.errorType).toBe('configuration');
+    expect(errors[0].error).toContain('destination.Config.apiKey');
+  });
+
+  it('classifies a bad connection on a record as CONFIGURATION', () => {
+    const integration = new UnionIntegration(mockDestination);
+    const { errors } = validateInputs(
+      [
+        unionInput(
+          3,
+          { type: 'record', identifiers: { id: 'u1' } },
+          { apiKey: 'k' },
+          {
+            config: { destination: {} },
+          },
+        ),
+      ] as any,
+      integration,
+    );
+    expect(errors).toHaveLength(1);
+    expect(errors[0].statTags?.errorType).toBe('configuration');
+  });
+
+  it('classifies a message matching no variant as INSTRUMENTATION', () => {
+    const integration = new UnionIntegration(mockDestination);
+    const { errors } = validateInputs(
+      [unionInput(4, { type: 'group', groupId: 'g1' }, { apiKey: 'k' })] as any,
+      integration,
+    );
+    expect(errors).toHaveLength(1);
+    expect(errors[0].statTags?.errorType).toBe('instrumentation');
+  });
 });

--- a/src/services/destination/nativeBatching/__tests__/processBatchedDestination.test.ts
+++ b/src/services/destination/nativeBatching/__tests__/processBatchedDestination.test.ts
@@ -556,17 +556,25 @@ describe('validateInputs', () => {
     }
   }
 
-  const unionInput = (jobId: number, message: unknown, config: unknown, connection?: unknown) => ({
-    message,
-    destination: { Config: config },
-    ...(connection ? { connection } : {}),
-    metadata: { jobId },
-  });
+  // Builds deliberately loose/malformed envelopes to exercise schema validation. The cast
+  // is localized here so call sites pass a typed RouterTransformationRequestData[].
+  const unionInput = (
+    jobId: number,
+    message: unknown,
+    config: unknown,
+    connection?: unknown,
+  ): RouterTransformationRequestData =>
+    ({
+      message,
+      destination: { Config: config },
+      ...(connection ? { connection } : {}),
+      metadata: { jobId },
+    }) as unknown as RouterTransformationRequestData;
 
   it('accepts a valid event-stream message under a union schema', () => {
     const integration = new UnionIntegration(mockDestination);
     const { valid, errors } = validateInputs(
-      [unionInput(1, { type: 'track', userId: 'u1' }, { apiKey: 'k' })] as any,
+      [unionInput(1, { type: 'track', userId: 'u1' }, { apiKey: 'k' })],
       integration,
     );
     expect(valid).toHaveLength(1);
@@ -576,7 +584,7 @@ describe('validateInputs', () => {
   it('classifies a bad shared Config as CONFIGURATION with a precise path', () => {
     const integration = new UnionIntegration(mockDestination);
     const { errors } = validateInputs(
-      [unionInput(2, { type: 'track', userId: 'u1' }, {})] as any,
+      [unionInput(2, { type: 'track', userId: 'u1' }, {})],
       integration,
     );
     expect(errors).toHaveLength(1);
@@ -596,7 +604,7 @@ describe('validateInputs', () => {
             config: { destination: {} },
           },
         ),
-      ] as any,
+      ],
       integration,
     );
     expect(errors).toHaveLength(1);
@@ -606,7 +614,7 @@ describe('validateInputs', () => {
   it('classifies a message matching no variant as INSTRUMENTATION', () => {
     const integration = new UnionIntegration(mockDestination);
     const { errors } = validateInputs(
-      [unionInput(4, { type: 'group', groupId: 'g1' }, { apiKey: 'k' })] as any,
+      [unionInput(4, { type: 'group', groupId: 'g1' }, { apiKey: 'k' })],
       integration,
     );
     expect(errors).toHaveLength(1);

--- a/src/services/destination/nativeBatching/__tests__/vdmV2ObjectDestination.test.ts
+++ b/src/services/destination/nativeBatching/__tests__/vdmV2ObjectDestination.test.ts
@@ -1,10 +1,18 @@
 import { z } from 'zod';
-import { VDMV2ObjectDestination, type RecordInput } from '../vdmV2ObjectDestination';
+import { VDMV2ObjectDestination } from '../vdmV2ObjectDestination';
 import { makeRouterInputSchema, TransformedEvent, ChunkBatchStrategy } from '../batchDestination';
 import type { BatchStrategy } from '../types';
 import type { Destination, Connection } from '../../../../types/controlPlaneConfig';
 import type { RouterTransformationRequestData } from '../../../../types/destinationTransformation';
 import type { Metadata, RudderMessage } from '../../../../types/rudderEvents';
+
+// The framework un-exports its internal record envelope type; the test declares its own
+// to annotate transformObjectRecord overrides.
+type RecordInput = RouterTransformationRequestData<{
+  type: 'record';
+  action: 'insert' | 'update' | 'delete';
+  identifiers: Record<string, unknown>;
+}>;
 
 type Body = { value: string };
 

--- a/src/services/destination/nativeBatching/__tests__/vdmV2ObjectDestination.test.ts
+++ b/src/services/destination/nativeBatching/__tests__/vdmV2ObjectDestination.test.ts
@@ -1,0 +1,89 @@
+import { z } from 'zod';
+import { VDMV2ObjectDestination } from '../vdmV2ObjectDestination';
+import { makeRouterInputSchema, TransformedEvent, ChunkBatchStrategy } from '../batchDestination';
+import type { BatchStrategy } from '../types';
+import type { Destination } from '../../../../types/controlPlaneConfig';
+
+type Body = { value: string };
+
+const destConfig = z.object({ apiKey: z.string() });
+const recordInputSchema = makeRouterInputSchema({
+  message: z
+    .object({
+      type: z.literal('record'),
+      action: z.enum(['insert', 'update', 'delete']),
+      identifiers: z.record(z.unknown()),
+    })
+    .passthrough(),
+  destinationConfig: destConfig,
+  connectionConfig: z.object({ destination: z.object({ object: z.string() }) }).passthrough(),
+});
+const eventStreamInputSchema = makeRouterInputSchema({
+  message: z.object({ type: z.enum(['track', 'identify']), userId: z.string() }).passthrough(),
+  destinationConfig: destConfig,
+});
+
+class TestObjectDestination extends VDMV2ObjectDestination<
+  Body,
+  typeof recordInputSchema,
+  typeof eventStreamInputSchema
+> {
+  protected readonly recordSchema = recordInputSchema;
+  protected readonly eventStreamSchema = eventStreamInputSchema;
+  transformObjectRecord() {
+    const handler = () => ({
+      body: { value: 'r' },
+      endpoint: 'x',
+      endpointPath: 'x',
+      method: 'POST',
+    });
+    return { person: { insert: handler, update: handler, delete: handler } };
+  }
+  transformEventStream() {
+    return {
+      track: () => ({ body: { value: 'e' }, endpoint: 'x', endpointPath: 'x', method: 'POST' }),
+    };
+  }
+  getBatchStrategy(): BatchStrategy<Body> {
+    return new ChunkBatchStrategy({ maxItems: 3, wrapBody: (bodies) => ({ events: bodies }) });
+  }
+}
+
+const mockDestination = { Config: { apiKey: 'k' } } as unknown as Destination;
+
+describe('VDMV2ObjectDestination.getInputSchema', () => {
+  const schema = new TestObjectDestination(mockDestination).getInputSchema();
+
+  it('accepts a record input', () => {
+    expect(
+      schema.safeParse({
+        message: { type: 'record', action: 'insert', identifiers: { id: 'u1' } },
+        destination: { Config: { apiKey: 'k' } },
+        connection: { config: { destination: { object: 'person' } } },
+      }).success,
+    ).toBe(true);
+  });
+
+  it('accepts an event-stream input', () => {
+    expect(
+      schema.safeParse({
+        message: { type: 'track', userId: 'u1' },
+        destination: { Config: { apiKey: 'k' } },
+      }).success,
+    ).toBe(true);
+  });
+
+  it('rejects a message matching neither variant', () => {
+    expect(
+      schema.safeParse({
+        message: { type: 'group' },
+        destination: { Config: { apiKey: 'k' } },
+      }).success,
+    ).toBe(false);
+  });
+
+  it('memoizes the schema', () => {
+    const dest = new TestObjectDestination(mockDestination);
+    expect(dest.getInputSchema()).toBe(dest.getInputSchema());
+  });
+});

--- a/src/services/destination/nativeBatching/__tests__/vdmV2ObjectDestination.test.ts
+++ b/src/services/destination/nativeBatching/__tests__/vdmV2ObjectDestination.test.ts
@@ -81,9 +81,4 @@ describe('VDMV2ObjectDestination.getInputSchema', () => {
       }).success,
     ).toBe(false);
   });
-
-  it('memoizes the schema', () => {
-    const dest = new TestObjectDestination(mockDestination);
-    expect(dest.getInputSchema()).toBe(dest.getInputSchema());
-  });
 });

--- a/src/services/destination/nativeBatching/__tests__/vdmV2ObjectDestination.test.ts
+++ b/src/services/destination/nativeBatching/__tests__/vdmV2ObjectDestination.test.ts
@@ -1,10 +1,16 @@
 import { z } from 'zod';
-import { VDMV2ObjectDestination } from '../vdmV2ObjectDestination';
+import { VDMV2ObjectDestination, type RecordInput } from '../vdmV2ObjectDestination';
 import { makeRouterInputSchema, TransformedEvent, ChunkBatchStrategy } from '../batchDestination';
 import type { BatchStrategy } from '../types';
-import type { Destination } from '../../../../types/controlPlaneConfig';
+import type { Destination, Connection } from '../../../../types/controlPlaneConfig';
+import type { RouterTransformationRequestData } from '../../../../types/destinationTransformation';
+import type { Metadata, RudderMessage } from '../../../../types/rudderEvents';
 
 type Body = { value: string };
+
+interface TestMessage extends RudderMessage {
+  data?: string;
+}
 
 const destConfig = z.object({ apiKey: z.string() });
 const recordInputSchema = makeRouterInputSchema({
@@ -49,7 +55,15 @@ class TestObjectDestination extends VDMV2ObjectDestination<
   }
 }
 
-const mockDestination = { Config: { apiKey: 'k' } } as unknown as Destination;
+const mockDestination: Destination = {
+  ID: 'dest-1',
+  Config: { apiKey: 'k' },
+  DestinationDefinition: { ID: 'destDef-1', Name: 'TEST', DisplayName: 'Test', Config: {} },
+  Name: 'test-dest',
+  Enabled: true,
+  WorkspaceID: 'ws-1',
+  Transformations: [],
+};
 
 describe('VDMV2ObjectDestination.getInputSchema', () => {
   const schema = new TestObjectDestination(mockDestination).getInputSchema();
@@ -80,5 +94,189 @@ describe('VDMV2ObjectDestination.getInputSchema', () => {
         destination: { Config: { apiKey: 'k' } },
       }).success,
     ).toBe(false);
+  });
+});
+
+type TestConnectionConfig = { destination: { object: string } };
+
+class RecordIntegration extends VDMV2ObjectDestination<Body> {
+  protected readonly recordSchema = z.object({}).passthrough();
+
+  protected readonly eventStreamSchema = z.object({}).passthrough();
+
+  private upsertUser(): TransformedEvent<Body> {
+    return {
+      body: { value: 'upsert:user' },
+      endpoint: 'https://api.test.com/records',
+      endpointPath: '/records',
+      method: 'POST',
+    };
+  }
+
+  private removeUser(): TransformedEvent<Body> {
+    return {
+      body: { value: 'remove:user' },
+      endpoint: 'https://api.test.com/records',
+      endpointPath: '/records',
+      method: 'POST',
+    };
+  }
+
+  private createEvent(): TransformedEvent<Body> {
+    return {
+      body: { value: 'create:event' },
+      endpoint: 'https://api.test.com/records',
+      endpointPath: '/records',
+      method: 'POST',
+    };
+  }
+
+  transformObjectRecord(_input: RecordInput) {
+    return {
+      user: {
+        insert: () => this.upsertUser(),
+        update: () => this.upsertUser(),
+        delete: () => this.removeUser(),
+      },
+      event: {
+        insert: () => this.createEvent(),
+        update: () => this.createEvent(),
+        // delete not listed — framework rejects automatically
+      },
+    };
+  }
+
+  getBatchStrategy(): BatchStrategy<Body> {
+    return new ChunkBatchStrategy({ maxItems: 10, wrapBody: (bodies) => ({ records: bodies }) });
+  }
+
+  getInputSchema() {
+    return z.object({}).passthrough();
+  }
+}
+
+const mockConnection: Connection<TestConnectionConfig> = {
+  sourceId: 'src-1',
+  destinationId: 'dest-1',
+  enabled: true,
+  config: { destination: { object: 'user' } },
+};
+
+function makeRecordInput(
+  jobId: number,
+  action: string,
+  identifiers: Record<string, string | number>,
+  connection?: Connection<TestConnectionConfig>,
+): RouterTransformationRequestData {
+  return {
+    message: { type: 'record', action, identifiers },
+    metadata: {
+      jobId,
+      workspaceId: 'ws-1',
+      sourceId: 'src-1',
+      sourceType: 'web',
+      sourceCategory: 'cloud',
+      destinationId: 'dest-1',
+      destinationType: 'TEST',
+      messageId: `msg-${jobId}`,
+    },
+    destination: mockDestination,
+    connection: connection ?? mockConnection,
+  } as RouterTransformationRequestData;
+}
+
+function makeInput(jobId: number, data: string): RouterTransformationRequestData {
+  const message: TestMessage = { data, type: 'track' };
+  const metadata: Metadata = {
+    jobId,
+    workspaceId: 'ws-1',
+    sourceId: 'src-1',
+    sourceType: 'web',
+    sourceCategory: 'cloud',
+    destinationId: 'dest-1',
+    destinationType: 'TEST',
+    messageId: `msg-${jobId}`,
+  };
+  return { message, metadata, destination: mockDestination };
+}
+
+describe('VDMV2ObjectDestination — record dispatch', () => {
+  it('dispatches record events via handler map', async () => {
+    const integration = new RecordIntegration(mockDestination, mockConnection);
+    const input = makeRecordInput(1, 'insert', { id: 'u1' });
+    const result = await integration.transformEvents([input]);
+    expect(result.successPayloads).toHaveLength(1);
+    expect(result.successPayloads[0].body.value).toBe('upsert:user');
+    expect(result.successPayloads[0].jobId).toBe(1);
+  });
+
+  it('falls through to transformStreamEvent for event-stream events', async () => {
+    const integration = new RecordIntegration(mockDestination, mockConnection);
+    // RecordIntegration doesn't override transformStreamEvent → default throws
+    const eventInput = makeInput(2, 'hello');
+    const result = await integration.transformEvents([eventInput]);
+    expect(result.errorPayloads).toHaveLength(1);
+    expect(result.errorPayloads[0].error).toContain('Event-stream events are not supported');
+  });
+
+  it('rejects unsupported action for object type', async () => {
+    const eventConn: Connection<TestConnectionConfig> = {
+      ...mockConnection,
+      config: { destination: { object: 'event' } },
+    };
+    const integration = new RecordIntegration(mockDestination, eventConn);
+    const input = makeRecordInput(1, 'delete', { id: 'u1' }, eventConn);
+    const result = await integration.transformEvents([input]);
+    expect(result.errorPayloads).toHaveLength(1);
+    expect(result.errorPayloads[0].error).toContain(
+      '"delete" is not supported for object type "event"',
+    );
+  });
+
+  it('rejects unsupported object type', async () => {
+    const badConn: Connection<TestConnectionConfig> = {
+      ...mockConnection,
+      config: { destination: { object: 'unknown_type' } },
+    };
+    const integration = new RecordIntegration(mockDestination, badConn);
+    const input = makeRecordInput(1, 'insert', { id: 'u1' }, badConn);
+    const result = await integration.transformEvents([input]);
+    expect(result.errorPayloads).toHaveLength(1);
+    expect(result.errorPayloads[0].error).toContain('Unsupported object type: "unknown_type"');
+  });
+
+  it('passes standard input to handler', async () => {
+    // Create an integration that echoes message fields into the body for assertion
+    class EchoIntegration extends VDMV2ObjectDestination<Record<string, unknown>> {
+      protected readonly recordSchema = z.object({}).passthrough();
+
+      protected readonly eventStreamSchema = z.object({}).passthrough();
+
+      transformObjectRecord(input: RecordInput) {
+        const handler = () => ({
+          body: { ids: input.message.identifiers, action: input.message.action },
+          endpoint: 'https://api.test.com',
+          endpointPath: '/test',
+          method: 'POST',
+        });
+        return {
+          user: { insert: handler, update: handler, delete: handler },
+        };
+      }
+      getBatchStrategy() {
+        return new ChunkBatchStrategy({ wrapBody: (b) => ({ batch: b }) });
+      }
+      getInputSchema() {
+        return z.object({}).passthrough();
+      }
+    }
+
+    const integration = new EchoIntegration(mockDestination, mockConnection);
+    const input = makeRecordInput(1, 'insert', { email: 'a@b.com', plan: 'pro' });
+    const result = await integration.transformEvents([input]);
+    expect(result.successPayloads[0].body).toEqual({
+      ids: { email: 'a@b.com', plan: 'pro' },
+      action: 'insert',
+    });
   });
 });

--- a/src/services/destination/nativeBatching/inputSchema.ts
+++ b/src/services/destination/nativeBatching/inputSchema.ts
@@ -1,15 +1,8 @@
 import { z, ZodRawShape, ZodTypeAny } from 'zod';
 
 // ---------------------------------------------------------------------------
-// Router-input schema builder
+// Router-input schema builder (single variant)
 // ---------------------------------------------------------------------------
-
-/**
- * One message shape a destination accepts, with the connection config (if any)
- * that applies to it. Hybrid destinations (e.g. customerio v2) declare several:
- * record messages validate a connection config, event-stream messages don't.
- */
-export type InputVariant = { message: ZodTypeAny; connectionConfig?: ZodTypeAny };
 
 // A declared connection is always optional, mirroring
 // `RouterTransformationRequestData.connection?`. Destinations that require it
@@ -22,86 +15,50 @@ type DestinationField<DC extends ZodTypeAny | undefined> = DC extends ZodTypeAny
   ? { destination: { Config: z.infer<DC> } }
   : unknown;
 
-// Inferred output for a single variant, merged with the shared `destination`.
-type VariantInput<V extends InputVariant, DC extends ZodTypeAny | undefined> = {
-  message: z.infer<V['message']>;
-} & ConnectionField<V['connectionConfig']> &
-  DestinationField<DC>;
-
 /**
- * Output type of a schema built by {@link makeRouterInputSchema}: the union of
- * every variant's inferred shape (each carrying the shared `destination`). Mirrors
- * the relevant parts of the `RouterTransformationRequestData` envelope.
+ * Output type of a schema built by {@link makeRouterInputSchema}: the message plus the
+ * (optional) connection and destination config. Mirrors the relevant parts of the
+ * `RouterTransformationRequestData` envelope.
  */
-export type RouterInput<
-  V extends readonly InputVariant[],
+export type SingleRouterInput<
+  M extends ZodTypeAny,
   DC extends ZodTypeAny | undefined = undefined,
-> = { [K in keyof V]: VariantInput<V[K], DC> }[number];
-
-const connectionObject = (connectionConfig: ZodTypeAny) =>
-  z.object({ config: connectionConfig }).passthrough().optional();
+  CC extends ZodTypeAny | undefined = undefined,
+> = { message: z.infer<M> } & ConnectionField<CC> & DestinationField<DC>;
 
 /**
  * Assemble the Zod schema for a batching destination's router input.
  *
  * The framework owns the invariant `RouterTransformationRequestData` envelope
  * (`.passthrough()` lets `metadata` / `request` / etc. flow through unvalidated).
- * Each destination declares a shared `destinationConfig` (→ `destination.Config`)
- * and one or more message `variants`. A variant's `connectionConfig` (when given)
- * validates `connection.config` for that message shape; connection stays optional.
- *
- * Single-mode destinations pass one variant. Hybrid destinations pass several and
- * the framework applies a `z.union` across them, so e.g. a record variant can
- * validate a connection config while an event-stream variant does not — the record
- * schema is never applied to event-stream events.
- *
- * `destinationConfig` is validated outside the union so a bad Config surfaces a
- * precise `destination.Config.*` path (→ configuration error) instead of the
- * union's generic "Invalid input".
+ * A destination declares the message schema, an optional `destinationConfig`
+ * (→ `destination.Config`) and an optional `connectionConfig` (→ `connection.config`,
+ * kept optional). Hybrid (record + event-stream) destinations build one schema per
+ * variant and let `VDMV2ObjectDestination` union them.
  *
  * Typed via an overload so callers get a precisely-inferred schema without a cast.
  */
 export function makeRouterInputSchema<
-  const V extends readonly InputVariant[],
+  M extends ZodTypeAny,
   DC extends ZodTypeAny | undefined = undefined,
->(spec: { destinationConfig?: DC; variants: V }): z.ZodType<RouterInput<V, DC>>;
+  CC extends ZodTypeAny | undefined = undefined,
+>(spec: {
+  message: M;
+  destinationConfig?: DC;
+  connectionConfig?: CC;
+}): z.ZodType<SingleRouterInput<M, DC, CC>>;
 export function makeRouterInputSchema(spec: {
+  message: ZodTypeAny;
   destinationConfig?: ZodTypeAny;
-  variants: readonly InputVariant[];
+  connectionConfig?: ZodTypeAny;
 }): ZodTypeAny {
-  const { destinationConfig, variants } = spec;
-  // The value at the `destination` envelope key, when a Config schema is declared.
-  const destinationValue = destinationConfig
-    ? z.object({ Config: destinationConfig }).passthrough()
-    : undefined;
-
-  // Single variant: one object, identical to a non-hybrid destination's schema.
-  if (variants.length === 1) {
-    const [variant] = variants;
-    const shape: ZodRawShape = { message: variant.message };
-    if (destinationValue) {
-      shape.destination = destinationValue;
-    }
-    if (variant.connectionConfig) {
-      shape.connection = connectionObject(variant.connectionConfig);
-    }
-    return z.object(shape).passthrough();
+  const { message, destinationConfig, connectionConfig } = spec;
+  const shape: ZodRawShape = { message };
+  if (destinationConfig) {
+    shape.destination = z.object({ Config: destinationConfig }).passthrough();
   }
-
-  // Multiple variants: union the message/connection shapes, validate `destination`
-  // outside the union so its error paths stay precise.
-  const variantSchemas = variants.map((variant) => {
-    const shape: ZodRawShape = { message: variant.message };
-    if (variant.connectionConfig) {
-      shape.connection = connectionObject(variant.connectionConfig);
-    }
-    return z.object(shape).passthrough();
-  });
-
-  // `z.union` requires a tuple of ≥2; this branch only runs with ≥2 variants.
-  const union = z.union(variantSchemas as unknown as [ZodTypeAny, ZodTypeAny, ...ZodTypeAny[]]);
-  if (!destinationValue) {
-    return union;
+  if (connectionConfig) {
+    shape.connection = z.object({ config: connectionConfig }).passthrough().optional();
   }
-  return z.object({ destination: destinationValue }).passthrough().and(union);
+  return z.object(shape).passthrough();
 }

--- a/src/services/destination/nativeBatching/processBatchedDestination.ts
+++ b/src/services/destination/nativeBatching/processBatchedDestination.ts
@@ -1,3 +1,4 @@
+import { ZodError, ZodIssue } from 'zod';
 import stableStringify from 'fast-json-stable-stringify';
 import type { Destination } from '../../../types/controlPlaneConfig';
 import type { Metadata } from '../../../types/rudderEvents';
@@ -16,6 +17,24 @@ import { combineBatchRequestsWithSameJobIds } from '../../../v0/util';
 // Validation
 // ---------------------------------------------------------------------------
 
+const isConfigIssue = (issue: ZodIssue): boolean =>
+  issue.path[0] === 'destination' || issue.path[0] === 'connection';
+
+// A union failure surfaces as a single top-level `invalid_union` issue (empty path)
+// carrying one ZodError per branch. Resolve to the branch that best represents the
+// input: a branch failing ONLY on destination/connection means the message matched
+// that branch and the sole problem is config (→ precise path + CONFIGURATION);
+// otherwise the input matched no branch and we merge all branches' issues.
+function resolveIssues(error: ZodError): ZodIssue[] {
+  const [first] = error.issues;
+  if (error.issues.length === 1 && first.code === 'invalid_union') {
+    const branches = first.unionErrors;
+    const configBranch = branches.find((branch) => resolveIssues(branch).every(isConfigIssue));
+    return configBranch ? resolveIssues(configBranch) : branches.flatMap(resolveIssues);
+  }
+  return error.issues;
+}
+
 export function validateInputs<TBody extends Record<string, unknown>>(
   inputs: RouterTransformationRequestData[],
   integration: BatchDestination<TBody>,
@@ -28,17 +47,16 @@ export function validateInputs<TBody extends Record<string, unknown>>(
   for (const input of inputs) {
     const parseResult = schema.safeParse(input);
     if (!parseResult.success) {
+      const issues = resolveIssues(parseResult.error);
       const errorMessage = [
         ...new Set(
-          parseResult.error.issues.map((issue) => {
+          issues.map((issue) => {
             const path = issue.path.length > 0 ? `${issue.path.join('.')}: ` : '';
             return `${path}${issue.message}`;
           }),
         ),
       ].join('; ');
-      const errorType = parseResult.error.issues.every(
-        (issue) => issue.path[0] === 'destination' || issue.path[0] === 'connection',
-      )
+      const errorType = issues.every(isConfigIssue)
         ? tags.ERROR_TYPES.CONFIGURATION
         : tags.ERROR_TYPES.INSTRUMENTATION;
       errors.push({

--- a/src/services/destination/nativeBatching/vdmV2ObjectDestination.ts
+++ b/src/services/destination/nativeBatching/vdmV2ObjectDestination.ts
@@ -2,20 +2,16 @@ import { z, ZodType } from 'zod';
 import get from 'get-value';
 import { ConfigurationError } from '@rudderstack/integrations-lib';
 import type { RouterTransformationRequestData } from '../../../types/destinationTransformation';
+import type { RudderRecordV2 } from '../../../types/rudderEvents';
 import { MappedToDestinationKey } from '../../../constants';
 import { addExternalIdToTraits, adduserIdFromExternalId } from '../../../v0/util';
 import { BatchDestination } from './batchDestination';
 import type { TransformedEvent } from './types';
 
 // Record message shape known to the framework after schema validation
-export type RecordMessage = {
-  type: 'record';
-  action: 'insert' | 'update' | 'delete';
-  identifiers: Record<string, unknown>;
-  [key: string]: unknown;
-};
+type RecordMessage = Pick<RudderRecordV2, 'type' | 'action' | 'identifiers'>;
 
-export type RecordInput = RouterTransformationRequestData<RecordMessage>;
+type RecordInput = RouterTransformationRequestData<RecordMessage>;
 
 function isRecordInput(input: RouterTransformationRequestData): input is RecordInput {
   return input.message?.type === 'record';

--- a/src/services/destination/nativeBatching/vdmV2ObjectDestination.ts
+++ b/src/services/destination/nativeBatching/vdmV2ObjectDestination.ts
@@ -1,0 +1,135 @@
+import { z, ZodType } from 'zod';
+import get from 'get-value';
+import { ConfigurationError } from '@rudderstack/integrations-lib';
+import type { RouterTransformationRequestData } from '../../../types/destinationTransformation';
+import { MappedToDestinationKey } from '../../../constants';
+import { addExternalIdToTraits, adduserIdFromExternalId } from '../../../v0/util';
+import { BatchDestination } from './batchDestination';
+import type { TransformedEvent } from './types';
+
+// Record message shape known to the framework after schema validation
+export type RecordMessage = {
+  type: 'record';
+  action: 'insert' | 'update' | 'delete';
+  identifiers: Record<string, unknown>;
+  [key: string]: unknown;
+};
+
+export type RecordInput = RouterTransformationRequestData<RecordMessage>;
+
+function isRecordInput(input: RouterTransformationRequestData): input is RecordInput {
+  return input.message?.type === 'record';
+}
+
+// The schema-driven connection type is only as precise as the destination's input
+// schema, so the framework reads the record-dispatch `object` through this shape.
+type ObjectConnectionConfig = { destination: { object: string } };
+
+// The router-input type the framework validates against: the union of the record and
+// event-stream schemas the subclass declares.
+type ObjectRouterInput<
+  TRecordSchema extends ZodType,
+  TEventStreamSchema extends ZodType,
+> = z.ZodType<z.infer<TRecordSchema> | z.infer<TEventStreamSchema>>;
+
+export abstract class VDMV2ObjectDestination<
+  TBody extends Record<string, unknown> = Record<string, unknown>,
+  TRecordSchema extends ZodType = ZodType,
+  TEventStreamSchema extends ZodType = ZodType,
+> extends BatchDestination<TBody, ObjectRouterInput<TRecordSchema, TEventStreamSchema>> {
+  // Subclasses declare the two variant schemas (built via makeRouterInputSchema, each
+  // carrying the shared destinationConfig via a common constant). The framework owns the
+  // union — subclasses do not implement getInputSchema.
+  protected abstract readonly recordSchema: TRecordSchema;
+
+  protected abstract readonly eventStreamSchema: TEventStreamSchema;
+
+  private cachedInputSchema?: ObjectRouterInput<TRecordSchema, TEventStreamSchema>;
+
+  getInputSchema(): ObjectRouterInput<TRecordSchema, TEventStreamSchema> {
+    if (!this.cachedInputSchema) {
+      // destinationConfig lives inside both variants; a bad Config surfaces as an
+      // `invalid_union` error which processBatchedDestination.resolveIssues classifies
+      // as CONFIGURATION.
+      this.cachedInputSchema = z.union([
+        this.recordSchema,
+        this.eventStreamSchema,
+      ]) as unknown as ObjectRouterInput<TRecordSchema, TEventStreamSchema>;
+    }
+    return this.cachedInputSchema;
+  }
+
+  // Returns a map of object type → { action → handler }. Missing object types or actions
+  // are rejected automatically by the framework.
+  abstract transformObjectRecord(
+    input: z.infer<TRecordSchema>,
+  ): Record<
+    string,
+    Partial<
+      Record<
+        'insert' | 'update' | 'delete',
+        () => TransformedEvent<TBody> | TransformedEvent<TBody>[]
+      >
+    >
+  >;
+
+  // Override to return event-stream handlers. Default returns undefined.
+  /* eslint-disable @typescript-eslint/no-unused-vars */
+  transformEventStream(
+    _input: z.infer<TEventStreamSchema>,
+  ):
+    | Partial<Record<string, () => TransformedEvent<TBody> | TransformedEvent<TBody>[]>>
+    | undefined {
+    return undefined;
+  }
+  /* eslint-enable @typescript-eslint/no-unused-vars */
+
+  transformEvent(
+    input: z.infer<ObjectRouterInput<TRecordSchema, TEventStreamSchema>>,
+  ): TransformedEvent<TBody> | TransformedEvent<TBody>[] {
+    // Routing operates on the framework envelope; cast at the boundary since the
+    // schema-inferred union is structurally narrower than RouterTransformationRequestData.
+    const envelope = input as unknown as RouterTransformationRequestData;
+
+    if (isRecordInput(envelope)) {
+      const { action } = envelope.message;
+      if (!this.connection) {
+        throw new ConfigurationError('Missing connection config');
+      }
+      const { object: objectType } = (this.connection.config as ObjectConnectionConfig).destination;
+
+      const objectHandlers = this.transformObjectRecord(input as z.infer<TRecordSchema>);
+      const actionHandlers = objectHandlers[objectType];
+      if (!actionHandlers) {
+        throw new ConfigurationError(`Unsupported object type: "${objectType}"`);
+      }
+      const handler = actionHandlers[action];
+      if (!handler) {
+        throw new ConfigurationError(
+          `"${action}" is not supported for object type "${objectType}"`,
+        );
+      }
+      return handler();
+    }
+
+    const messageType = (envelope.message?.type as string | undefined)?.toLowerCase();
+    if (!messageType) {
+      throw new ConfigurationError('Missing message type');
+    }
+
+    if (get(envelope.message, MappedToDestinationKey)) {
+      addExternalIdToTraits(envelope.message);
+      adduserIdFromExternalId(envelope.message);
+    }
+
+    const eventHandlers = this.transformEventStream(input as z.infer<TEventStreamSchema>);
+    if (!eventHandlers) {
+      throw new ConfigurationError('Event-stream events are not supported by this destination');
+    }
+    const handler = eventHandlers[messageType];
+    if (!handler) {
+      throw new ConfigurationError(`Event type "${messageType}" is not supported`);
+    }
+    return handler();
+  }
+}

--- a/src/services/destination/nativeBatching/vdmV2ObjectDestination.ts
+++ b/src/services/destination/nativeBatching/vdmV2ObjectDestination.ts
@@ -44,19 +44,16 @@ export abstract class VDMV2ObjectDestination<
 
   protected abstract readonly eventStreamSchema: TEventStreamSchema;
 
-  private cachedInputSchema?: ObjectRouterInput<TRecordSchema, TEventStreamSchema>;
-
   getInputSchema(): ObjectRouterInput<TRecordSchema, TEventStreamSchema> {
-    if (!this.cachedInputSchema) {
-      // destinationConfig lives inside both variants; a bad Config surfaces as an
-      // `invalid_union` error which processBatchedDestination.resolveIssues classifies
-      // as CONFIGURATION.
-      this.cachedInputSchema = z.union([
-        this.recordSchema,
-        this.eventStreamSchema,
-      ]) as unknown as ObjectRouterInput<TRecordSchema, TEventStreamSchema>;
-    }
-    return this.cachedInputSchema;
+    // The framework calls this once per instance (processBatchedDestination validates the
+    // whole batch in a single validateInputs pass), so the union is built once — no cache
+    // needed. destinationConfig lives inside both variants; a bad Config surfaces as an
+    // `invalid_union` error which processBatchedDestination.resolveIssues classifies as
+    // CONFIGURATION.
+    return z.union([this.recordSchema, this.eventStreamSchema]) as unknown as ObjectRouterInput<
+      TRecordSchema,
+      TEventStreamSchema
+    >;
   }
 
   // Returns a map of object type → { action → handler }. Missing object types or actions

--- a/src/v0/destinations/custom_audience/routerTransform.ts
+++ b/src/v0/destinations/custom_audience/routerTransform.ts
@@ -23,18 +23,14 @@ import { CustomAudienceDestConfigSchema, CustomAudienceConnectionDestConfigSchem
 
 const customAudienceInputSchema = makeRouterInputSchema({
   destinationConfig: CustomAudienceDestConfigSchema,
-  variants: [
-    {
-      message: z
-        .object({
-          type: z.literal('record'),
-          action: z.nativeEnum(RecordAction),
-          identifiers: z.record(z.unknown()),
-        })
-        .passthrough(),
-      connectionConfig: z.object({ destination: CustomAudienceConnectionDestConfigSchema }),
-    },
-  ],
+  message: z
+    .object({
+      type: z.literal('record'),
+      action: z.nativeEnum(RecordAction),
+      identifiers: z.record(z.unknown()),
+    })
+    .passthrough(),
+  connectionConfig: z.object({ destination: CustomAudienceConnectionDestConfigSchema }),
 });
 
 class CustomAudienceIntegration extends BatchDestination<

--- a/src/v0/destinations/customerio/routerTransform.test.ts
+++ b/src/v0/destinations/customerio/routerTransform.test.ts
@@ -1,9 +1,8 @@
-import { InstrumentationError } from '@rudderstack/integrations-lib';
 import { Integration } from './routerTransform';
-
-type CIOInput = Parameters<InstanceType<typeof Integration>['transformEvent']>[0];
 import type { CustomerIORouterRequest } from './types';
 import type { CustomerIOV2Payload } from './v2/types';
+
+type CIOInput = Parameters<InstanceType<typeof Integration>['transformEvent']>[0];
 
 const siteID = 'test-site-id';
 const apiKey = 'test-api-key';
@@ -25,7 +24,7 @@ const baseConnection = {
   config: { destination: { object: 'person' } },
 } as CustomerIORouterRequest['connection'];
 
-const makeInput = (overrides: Record<string, unknown>): CIOInput =>
+const makeInput = (overrides: Record<string, unknown>, connection = baseConnection): CIOInput =>
   ({
     message: {
       type: 'record' as const,
@@ -35,6 +34,7 @@ const makeInput = (overrides: Record<string, unknown>): CIOInput =>
     },
     metadata: { jobId: 1, userId: 'u1', workspaceId: 'ws-1' },
     destination: baseDestination,
+    connection,
   }) as unknown as CIOInput;
 
 const eventConnection = {
@@ -43,9 +43,11 @@ const eventConnection = {
 } as CustomerIORouterRequest['connection'];
 
 describe('CustomerIOIntegration — record event routing', () => {
-  it('transforms insert record into identify person payload', () => {
+  it('transforms insert record into identify person payload', async () => {
     const integration = new Integration(baseDestination, baseConnection);
-    const result = integration.transformEvent(makeInput({}));
+    const { successPayloads } = await integration.transformEvents([makeInput({})]);
+    expect(successPayloads).toHaveLength(1);
+    const result = successPayloads[0];
     expect(result).toMatchObject({
       body: {
         type: 'person',
@@ -59,9 +61,13 @@ describe('CustomerIOIntegration — record event routing', () => {
     expect(result.endpoint).toMatch(/track\.customer\.io\/api\/v2\/batch/);
   });
 
-  it('transforms delete record into delete person payload without attributes', () => {
+  it('transforms delete record into delete person payload without attributes', async () => {
     const integration = new Integration(baseDestination, baseConnection);
-    const result = integration.transformEvent(makeInput({ action: 'delete' }));
+    const { successPayloads } = await integration.transformEvents([
+      makeInput({ action: 'delete' }),
+    ]);
+    expect(successPayloads).toHaveLength(1);
+    const result = successPayloads[0];
     expect(result.body).toMatchObject({
       type: 'person',
       action: 'delete',
@@ -70,17 +76,20 @@ describe('CustomerIOIntegration — record event routing', () => {
     expect((result.body as CustomerIOV2Payload).attributes).toBeUndefined();
   });
 
-  it('throws InstrumentationError for unsupported action', () => {
+  it('returns error payload for unsupported action', async () => {
     const integration = new Integration(baseDestination, baseConnection);
-    expect(() => integration.transformEvent(makeInput({ action: 'upsert' }))).toThrow(
-      InstrumentationError,
-    );
+    const { successPayloads, errorPayloads } = await integration.transformEvents([
+      makeInput({ action: 'upsert' }),
+    ]);
+    expect(successPayloads).toHaveLength(0);
+    expect(errorPayloads).toHaveLength(1);
+    expect(errorPayloads[0].error).toMatch(/"upsert" is not supported for object type "person"/);
   });
 
-  it('transforms event object record into event person payload', () => {
+  it('transforms event object record into event person payload', async () => {
     const integration = new Integration(baseDestination, eventConnection);
-    const result = integration.transformEvent(
-      makeInput({
+    const input = makeInput(
+      {
         action: 'update',
         identifiers: {
           id: 'user-1',
@@ -88,9 +97,12 @@ describe('CustomerIOIntegration — record event routing', () => {
           plan: 'pro',
           created_at: '2024-06-25T14:00:00.000Z',
         },
-      }),
+      },
+      eventConnection,
     );
-    expect(result.body).toEqual({
+    const { successPayloads } = await integration.transformEvents([input]);
+    expect(successPayloads).toHaveLength(1);
+    expect(successPayloads[0].body).toEqual({
       type: 'person',
       action: 'event',
       identifiers: { id: 'user-1' },
@@ -100,14 +112,13 @@ describe('CustomerIOIntegration — record event routing', () => {
     });
   });
 
-  it('throws InstrumentationError for event object delete records', () => {
+  it('returns error payload for event object delete records', async () => {
     const integration = new Integration(baseDestination, eventConnection);
-    expect(() => integration.transformEvent(makeInput({ action: 'delete' }))).toThrow(
-      InstrumentationError,
-    );
-    expect(() => integration.transformEvent(makeInput({ action: 'delete' }))).toThrow(
-      'Delete action is not supported for CustomerIO event records',
-    );
+    const input = makeInput({ action: 'delete' }, eventConnection);
+    const { successPayloads, errorPayloads } = await integration.transformEvents([input]);
+    expect(successPayloads).toHaveLength(0);
+    expect(errorPayloads).toHaveLength(1);
+    expect(errorPayloads[0].error).toMatch(/"delete" is not supported for object type "event"/);
   });
 
   it.each([

--- a/src/v0/destinations/customerio/routerTransform.ts
+++ b/src/v0/destinations/customerio/routerTransform.ts
@@ -1,3 +1,4 @@
+import { z } from 'zod';
 import get from 'get-value';
 import { InstrumentationError } from '@rudderstack/integrations-lib';
 import {
@@ -7,13 +8,7 @@ import {
 import { VDMV2ObjectDestination } from '../../../services/destination/nativeBatching/vdmV2ObjectDestination';
 import type { BatchStrategy } from '../../../services/destination/nativeBatching/types';
 import { removeUndefinedValues } from '../../util';
-import {
-  recordInputSchema,
-  eventStreamInputSchema,
-  CustomerIOV2Payload,
-  type CustomerIORecordInput,
-  type CustomerIOEventStreamInput,
-} from './v2/types';
+import { recordInputSchema, eventStreamInputSchema, CustomerIOV2Payload } from './v2/types';
 import { MAX_OBJECT_SIZE_BYTES, MAX_BATCH_PAYLOAD } from './v2/config';
 import { buildRecordEvent } from './v2/recordTransform';
 import { validateConfigFields } from './util';
@@ -49,7 +44,7 @@ class CustomerIOIntegration extends VDMV2ObjectDestination<
   }
 
   private buildRecord(
-    input: CustomerIORecordInput,
+    input: z.infer<typeof recordInputSchema>,
     objectType: CustomerIORecordObject,
   ): TransformedEvent<CustomerIOV2Payload> {
     validateConfigFields(this.destination);
@@ -58,7 +53,7 @@ class CustomerIOIntegration extends VDMV2ObjectDestination<
     return { body, ...buildRequestMeta(this.destination) };
   }
 
-  transformObjectRecord(input: CustomerIORecordInput) {
+  transformObjectRecord(input: z.infer<typeof recordInputSchema>) {
     const person = () => this.buildRecord(input, CUSTOMERIO_RECORD_OBJECTS.person);
     const event = () => this.buildRecord(input, CUSTOMERIO_RECORD_OBJECTS.event);
     return {
@@ -73,7 +68,7 @@ class CustomerIOIntegration extends VDMV2ObjectDestination<
     return { body, ...buildRequestMeta(this.destination) };
   }
 
-  transformEventStream(input: CustomerIOEventStreamInput) {
+  transformEventStream(input: z.infer<typeof eventStreamInputSchema>) {
     validateConfigFields(this.destination);
     const { message } = input;
     return {

--- a/src/v0/destinations/customerio/routerTransform.ts
+++ b/src/v0/destinations/customerio/routerTransform.ts
@@ -1,33 +1,44 @@
-import { z } from 'zod';
 import get from 'get-value';
 import { InstrumentationError } from '@rudderstack/integrations-lib';
 import {
-  BatchDestination,
   TransformedEvent,
   ChunkBatchStrategy,
 } from '../../../services/destination/nativeBatching/batchDestination';
-import { addExternalIdToTraits, adduserIdFromExternalId, removeUndefinedValues } from '../../util';
-import { MappedToDestinationKey } from '../../../constants';
+import { VDMV2ObjectDestination } from '../../../services/destination/nativeBatching/vdmV2ObjectDestination';
 import type { BatchStrategy } from '../../../services/destination/nativeBatching/types';
+import { removeUndefinedValues } from '../../util';
 import {
-  customerIOInputSchema,
+  recordInputSchema,
+  eventStreamInputSchema,
   CustomerIOV2Payload,
-  type CustomerIOV2RecordMessage,
-  type CustomerIOConnectionConfig,
+  type CustomerIORecordInput,
+  type CustomerIOEventStreamInput,
 } from './v2/types';
 import { MAX_OBJECT_SIZE_BYTES, MAX_BATCH_PAYLOAD } from './v2/config';
 import { buildRecordEvent } from './v2/recordTransform';
 import { validateConfigFields } from './util';
-import { buildEnvelope, buildRequestMeta } from './v2/util';
+import {
+  buildIdentify,
+  buildTrack,
+  buildPage,
+  buildScreen,
+  buildMerge,
+  buildObject,
+  buildDevice,
+  deviceActionFor,
+  buildRequestMeta,
+} from './v2/util';
+import { CUSTOMERIO_RECORD_OBJECTS, type CustomerIORecordObject } from './types';
 
-function isRecordMessage(msg: { type: string }): msg is CustomerIOV2RecordMessage {
-  return msg.type === 'record';
-}
-
-class CustomerIOIntegration extends BatchDestination<
+class CustomerIOIntegration extends VDMV2ObjectDestination<
   CustomerIOV2Payload,
-  typeof customerIOInputSchema
+  typeof recordInputSchema,
+  typeof eventStreamInputSchema
 > {
+  protected readonly recordSchema = recordInputSchema;
+
+  protected readonly eventStreamSchema = eventStreamInputSchema;
+
   private assertObjectSize(body: unknown): void {
     const size = Buffer.byteLength(JSON.stringify(body), 'utf8');
     if (size > MAX_OBJECT_SIZE_BYTES) {
@@ -37,33 +48,54 @@ class CustomerIOIntegration extends BatchDestination<
     }
   }
 
-  private buildBody(
-    message: z.infer<typeof customerIOInputSchema>['message'],
-  ): CustomerIOV2Payload {
-    if (isRecordMessage(message)) {
-      // The input schema is a union: only the record branch types the connection
-      // config, so narrow to the record connection shape here (record events always
-      // carry a connection — see getInputSchema).
-      const connectionObject = (this.connection!.config.destination as CustomerIOConnectionConfig)
-        .object;
-      return buildRecordEvent(message, connectionObject);
-    }
-    // For RETL/warehouse sources (mappedToDestination), derive userId from
-    // context.externalId and fold externalId into traits, mirroring the v1 path.
-    if (get(message, MappedToDestinationKey)) {
-      addExternalIdToTraits(message);
-      adduserIdFromExternalId(message);
-    }
-    return removeUndefinedValues(buildEnvelope(message, this.destination)) as CustomerIOV2Payload;
-  }
-
-  transformEvent(
-    input: z.infer<typeof customerIOInputSchema>,
+  private buildRecord(
+    input: CustomerIORecordInput,
+    objectType: CustomerIORecordObject,
   ): TransformedEvent<CustomerIOV2Payload> {
     validateConfigFields(this.destination);
-    const body = this.buildBody(input.message);
+    const body = buildRecordEvent(input.message, objectType);
     this.assertObjectSize(body);
     return { body, ...buildRequestMeta(this.destination) };
+  }
+
+  transformObjectRecord(input: CustomerIORecordInput) {
+    const person = () => this.buildRecord(input, CUSTOMERIO_RECORD_OBJECTS.person);
+    const event = () => this.buildRecord(input, CUSTOMERIO_RECORD_OBJECTS.event);
+    return {
+      [CUSTOMERIO_RECORD_OBJECTS.person]: { insert: person, update: person, delete: person },
+      [CUSTOMERIO_RECORD_OBJECTS.event]: { insert: event, update: event },
+    };
+  }
+
+  private wrapEventStreamBody(payload: CustomerIOV2Payload): TransformedEvent<CustomerIOV2Payload> {
+    const body = removeUndefinedValues(payload) as CustomerIOV2Payload;
+    this.assertObjectSize(body);
+    return { body, ...buildRequestMeta(this.destination) };
+  }
+
+  transformEventStream(input: CustomerIOEventStreamInput) {
+    validateConfigFields(this.destination);
+    const { message } = input;
+    return {
+      identify: () => this.wrapEventStreamBody(buildIdentify(message)),
+      track: () => {
+        const evName = get(message, 'event');
+        const deviceAction = deviceActionFor(evName, this.destination);
+        return this.wrapEventStreamBody(
+          deviceAction ? buildDevice(message, deviceAction) : buildTrack(message, evName),
+        );
+      },
+      page: () =>
+        this.wrapEventStreamBody(
+          buildPage(message, 'page', get(message, 'name') || get(message, 'properties.url')),
+        ),
+      screen: () =>
+        this.wrapEventStreamBody(
+          buildScreen(message, 'screen', get(message, 'event') || get(message, 'properties.name')),
+        ),
+      group: () => this.wrapEventStreamBody(buildObject(message)),
+      alias: () => this.wrapEventStreamBody(buildMerge(message)),
+    };
   }
 
   getBatchStrategy(): BatchStrategy<CustomerIOV2Payload> {
@@ -71,10 +103,6 @@ class CustomerIOIntegration extends BatchDestination<
       maxPayloadSize: MAX_BATCH_PAYLOAD,
       wrapBody: (bodies) => ({ batch: bodies }),
     });
-  }
-
-  getInputSchema() {
-    return customerIOInputSchema;
   }
 }
 

--- a/src/v0/destinations/customerio/v2/recordTransform.test.ts
+++ b/src/v0/destinations/customerio/v2/recordTransform.test.ts
@@ -1,4 +1,3 @@
-import { InstrumentationError } from '@rudderstack/integrations-lib';
 import { buildRecordEvent } from './recordTransform';
 
 describe('buildRecordEvent', () => {
@@ -146,27 +145,5 @@ describe('buildRecordEvent', () => {
       name: 'Plan Changed',
       attributes: { plan: 'enterprise' },
     });
-  });
-
-  it('throws InstrumentationError for event record delete action', () => {
-    const message = {
-      type: 'record' as const,
-      action: 'delete' as const,
-      identifiers: { id: 'user-1', event: 'Order Completed' },
-    };
-    expect(() => buildRecordEvent(message, 'event')).toThrow(InstrumentationError);
-    expect(() => buildRecordEvent(message, 'event')).toThrow(
-      'Delete action is not supported for CustomerIO event records',
-    );
-  });
-
-  it('throws InstrumentationError for unsupported action', () => {
-    const message = {
-      type: 'record' as const,
-      action: 'upsert' as any,
-      identifiers: { id: 'user-1' },
-    };
-    expect(() => buildRecordEvent(message, 'person')).toThrow(InstrumentationError);
-    expect(() => buildRecordEvent(message, 'person')).toThrow('Action "upsert" is not supported');
   });
 });

--- a/src/v0/destinations/customerio/v2/recordTransform.ts
+++ b/src/v0/destinations/customerio/v2/recordTransform.ts
@@ -13,7 +13,6 @@ type RecordPayloadContext = {
 
 type RecordPayloadBuilder = {
   getCIOAction: (action: CustomerIOV2RecordMessage['action']) => string;
-  validateAction?: (action: CustomerIOV2RecordMessage['action']) => void;
   getAdditionalFields?: (context: RecordPayloadContext) => Partial<CustomerIOV2Payload>;
   getExcludedAttributeKeys?: () => string[];
 };
@@ -29,13 +28,6 @@ const recordPayloadBuilders: Record<CustomerIORecordObject, RecordPayloadBuilder
   },
   [CUSTOMERIO_RECORD_OBJECTS.event]: {
     getCIOAction: () => 'event',
-    validateAction: (action) => {
-      if (action === EVENT_TYPES.DELETE) {
-        throw new InstrumentationError(
-          'Delete action is not supported for CustomerIO event records',
-        );
-      }
-    },
     getAdditionalFields: ({ rawIdentifiers }) => {
       const name = rawIdentifiers[IDENTIFIERS.NAME];
       if (typeof name !== 'string' || name.length === 0) {
@@ -53,11 +45,7 @@ export const buildRecordEvent = (
 ): CustomerIOV2Payload => {
   const { action, identifiers: rawIdentifiers = {} } = message;
 
-  if (!(action in RECORD_ACTION_MAP)) {
-    throw new InstrumentationError(`Action "${action}" is not supported`);
-  }
   const builder = recordPayloadBuilders[connectionObject];
-  builder.validateAction?.(action);
 
   // Schema guarantees id or email is present; id takes priority over email
   const identifierKey = RECORD_IDENTIFIER_KEYS.find(

--- a/src/v0/destinations/customerio/v2/types.ts
+++ b/src/v0/destinations/customerio/v2/types.ts
@@ -92,17 +92,21 @@ const eventStreamMessageSchema = z
 // Hybrid destination: record events validate connection.config.destination against the
 // record-specific schema (which requires `object`); event-stream events may carry a
 // connection lacking those record-only fields, so their connection is not enforced —
-// validating it against the record schema would wrongly reject them (#5331).
-export const customerIOInputSchema = makeRouterInputSchema({
+// validating it against the record schema would wrongly reject them (#5331). Both
+// variants carry the shared destinationConfig via CustomerIODestinationConfigSchema.
+export const recordInputSchema = makeRouterInputSchema({
+  message: recordMessageSchema,
   destinationConfig: CustomerIODestinationConfigSchema,
-  variants: [
-    {
-      message: recordMessageSchema,
-      connectionConfig: z.object({ destination: CustomerIOConnectionConfigSchema }).passthrough(),
-    },
-    { message: eventStreamMessageSchema },
-  ],
+  connectionConfig: z.object({ destination: CustomerIOConnectionConfigSchema }).passthrough(),
 });
+
+export const eventStreamInputSchema = makeRouterInputSchema({
+  message: eventStreamMessageSchema,
+  destinationConfig: CustomerIODestinationConfigSchema,
+});
+
+export type CustomerIORecordInput = z.infer<typeof recordInputSchema>;
+export type CustomerIOEventStreamInput = z.infer<typeof eventStreamInputSchema>;
 
 export {
   type CustomerIODestination,

--- a/src/v0/destinations/customerio/v2/types.ts
+++ b/src/v0/destinations/customerio/v2/types.ts
@@ -105,9 +105,6 @@ export const eventStreamInputSchema = makeRouterInputSchema({
   destinationConfig: CustomerIODestinationConfigSchema,
 });
 
-export type CustomerIORecordInput = z.infer<typeof recordInputSchema>;
-export type CustomerIOEventStreamInput = z.infer<typeof eventStreamInputSchema>;
-
 export {
   type CustomerIODestination,
   type CustomerIODestinationConfig,

--- a/src/v0/destinations/customerio/v2/util.ts
+++ b/src/v0/destinations/customerio/v2/util.ts
@@ -10,7 +10,7 @@ import {
   validateEventName,
 } from '../../../util';
 import { populateSpecedTraits } from '../util';
-import { EventType, SpecedTraits } from '../../../../constants';
+import { SpecedTraits } from '../../../../constants';
 import {
   getV2Endpoint,
   V2_BATCH_PATH,
@@ -209,7 +209,7 @@ export const buildDevice = (
   return { type: 'person', action, identifiers, device };
 };
 
-const deviceActionFor = (
+export const deviceActionFor = (
   evName: string,
   destination: CustomerIODestination,
 ): 'add_device' | 'delete_device' | null => {
@@ -219,30 +219,6 @@ const deviceActionFor = (
     return null;
   }
   return evName === DEVICE_DELETE_EVENT_NAME ? 'delete_device' : 'add_device';
-};
-
-// Build the unified v2 envelope (type/action/identifiers/...) for a single event.
-export const buildEnvelope = (message, destination: CustomerIODestination): CustomerIOV2Payload => {
-  const messageType = message.type?.toLowerCase();
-  switch (messageType) {
-    case EventType.IDENTIFY:
-      return buildIdentify(message);
-    case EventType.ALIAS:
-      return buildMerge(message);
-    case EventType.GROUP:
-      return buildObject(message);
-    case EventType.PAGE:
-      return buildPage(message, 'page', message.name || message.properties?.url);
-    case EventType.SCREEN:
-      return buildScreen(message, 'screen', message.event || message.properties?.name);
-    case EventType.TRACK: {
-      const evName = message.event;
-      const deviceAction = deviceActionFor(evName, destination);
-      return deviceAction ? buildDevice(message, deviceAction) : buildTrack(message, evName);
-    }
-    default:
-      throw new InstrumentationError(`could not determine type ${messageType}`);
-  }
 };
 
 // Resolve the v2 request metadata (endpoint/method/headers) shared by every

--- a/src/v0/destinations/google_adwords_enhanced_conversions/routerTransform.ts
+++ b/src/v0/destinations/google_adwords_enhanced_conversions/routerTransform.ts
@@ -15,18 +15,14 @@ import { MAX_CONVERSION_ADJUSTMENTS_PER_BATCH } from './config';
 type ConversionAdjustment = Record<string, unknown>;
 
 const gaecInputSchema = makeRouterInputSchema({
-  variants: [
-    {
-      message: z
-        .object({
-          type: z.string().refine((type) => type.toLowerCase() === 'track', {
-            message: 'Message Type is not supported. Only track events are supported.',
-          }),
-          event: z.string().min(1, 'event is required for track calls'),
-        })
-        .passthrough(),
-    },
-  ],
+  message: z
+    .object({
+      type: z.string().refine((type) => type.toLowerCase() === 'track', {
+        message: 'Message Type is not supported. Only track events are supported.',
+      }),
+      event: z.string().min(1, 'event is required for track calls'),
+    })
+    .passthrough(),
 });
 
 class GoogleAdwordsEnhancedConversionsIntegration extends BatchDestination<

--- a/src/v0/destinations/iterable_audience/types.ts
+++ b/src/v0/destinations/iterable_audience/types.ts
@@ -74,12 +74,8 @@ const RecordMessageSchema = z
 
 export const IterableAudienceRouterRequestSchema = makeRouterInputSchema({
   destinationConfig: IterableDestinationConfigSchema,
-  variants: [
-    {
-      message: RecordMessageSchema,
-      connectionConfig: z.object({ destination: IterableConnectionConfigSchema }).passthrough(),
-    },
-  ],
+  message: RecordMessageSchema,
+  connectionConfig: z.object({ destination: IterableConnectionConfigSchema }).passthrough(),
 });
 
 // ---------------------------------------------------------------------------

--- a/src/v0/destinations/posthog/routerTransform.ts
+++ b/src/v0/destinations/posthog/routerTransform.ts
@@ -15,20 +15,16 @@ import { MAX_EVENT_SIZE_BYTES } from './config';
 
 const postHogInputSchema = makeRouterInputSchema({
   destinationConfig: PostHogDestinationConfigSchema,
-  variants: [
-    {
-      message: z
-        .object({
-          userId: z.union([z.string(), z.number()]).nullish(),
-          anonymousId: z.union([z.string(), z.number()]).nullish(),
-          type: z.enum(['track', 'page', 'screen', 'identify', 'alias', 'group']),
-        })
-        .passthrough()
-        .refine((msg) => !!msg.userId || !!msg.anonymousId, {
-          message: 'Either userId or anonymousId must be provided',
-        }),
-    },
-  ],
+  message: z
+    .object({
+      userId: z.union([z.string(), z.number()]).nullish(),
+      anonymousId: z.union([z.string(), z.number()]).nullish(),
+      type: z.enum(['track', 'page', 'screen', 'identify', 'alias', 'group']),
+    })
+    .passthrough()
+    .refine((msg) => !!msg.userId || !!msg.anonymousId, {
+      message: 'Either userId or anonymousId must be provided',
+    }),
 });
 
 class PostHogIntegration extends BatchDestination<PostHogPayload, typeof postHogInputSchema> {

--- a/test/integrations/destinations/customerio/router/dataV2.ts
+++ b/test/integrations/destinations/customerio/router/dataV2.ts
@@ -2228,11 +2228,11 @@ export const dataV2 = [
               metadata: [{ jobId: 106, userId: 'u1', workspaceId: 'ws-cio-v2' }],
               batched: false,
               statusCode: 400,
-              error: 'Delete action is not supported for CustomerIO event records',
+              error: '"delete" is not supported for object type "event"',
               statTags: {
                 destType: 'CUSTOMERIO',
                 errorCategory: 'dataValidation',
-                errorType: 'instrumentation',
+                errorType: 'configuration',
                 feature: 'router',
                 implementation: 'native',
                 module: 'destination',


### PR DESCRIPTION
## Summary

- **`makeRouterInputSchema` is now a single-variant builder.** It takes one `message` schema plus an optional `destinationConfig` (→ `destination.Config`) and optional `connectionConfig` (→ `connection.config`). The previous multi-variant `variants: [...]` API — which built a `z.union` internally and validated `destinationConfig` outside the union — has been removed. All existing batching destinations (posthog, custom_audience, google_adwords_enhanced_conversions, iterable_audience) are migrated to the flat shape.
- **Union responsibility moved to `VDMV2ObjectDestination`.** Hybrid (record + event-stream) destinations declare two schemas — `recordSchema` and `eventStreamSchema`, each built via `makeRouterInputSchema` with the shared `destinationConfig` — and the framework unions them in `getInputSchema()`. Record events validate the connection config (requires `object`); event-stream events don't, so the record schema is never wrongly applied to them.
- **Adds `VDMV2ObjectDestination`, an object-based record-dispatch layer on top of `BatchDestination`:**
  - `transformObjectRecord(input)` returns a handler map of object type → action → handler for record events; `transformEventStream(input)` returns a message type → handler map for event-stream events.
  - The framework validates object types, actions, and message types automatically before invoking handlers, making the handler map the single source of truth (removes redundant validation from `buildRecordEvent`).
  - Constrains `TConnectionConfig` to `{ destination: { object: string } }` so object-type access is type-checked, moves `MappedToDestination` pre-processing into the framework, and uses `ConfigurationError` for framework-level validation.
- **Migrates CustomerIO** to extend `VDMV2ObjectDestination` with record + event-stream support. Transform-method parameters are typed inline with `z.infer<typeof recordInputSchema>` / `z.infer<typeof eventStreamInputSchema>` so the types are unmistakably schema-derived and cannot drift.
- Documents the onboarding flow and conventions in the `vdm-v2-object-destination` skill.

## Test plan

- [ ] Unit tests pass for `makeRouterInputSchema` (single-variant) and the union built by `VDMV2ObjectDestination`
- [ ] Unit tests pass for the BatchDestination / VDMV2ObjectDestination framework
- [ ] Unit tests pass for CustomerIO record + event-stream transforms and `buildRecordEvent`
- [ ] Integration tests pass for CustomerIO
- [ ] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
