### PR TITLE
feat(braze): add v1 network handler for per-event delivery

### DIFF
--- a/src/adapters/networkHandlerFactory.test.ts
+++ b/src/adapters/networkHandlerFactory.test.ts
@@ -20,10 +20,16 @@ describe('Network Handler Tests', () => {
     expect(networkHandler).toEqual(new cmProxy());
   });
 
-  it('Should return v0 handler if v1 version and handler is present for destination in v0', () => {
+  it('Should return v1 networkhandler braze', () => {
     const { networkHandler } = getNetworkHandler('braze', 'v1');
-    const brazeProxy = require('../v0/destinations/braze/networkHandler').networkHandler;
+    const brazeProxy = require('../v1/destinations/braze/networkHandler').networkHandler;
     expect(networkHandler).toEqual(new brazeProxy());
+  });
+
+  it('Should return v0 handler if v1 version and handler is present for destination in v0', () => {
+    const { networkHandler } = getNetworkHandler('marketo', 'v1');
+    const marketoProxy = require('../v0/destinations/marketo/networkHandler').networkHandler;
+    expect(networkHandler).toEqual(new marketoProxy());
   });
 
   it('Should use exact destination networkhandler for aliases with their own handler', () => {

--- a/src/v0/destinations/braze/types.ts
+++ b/src/v0/destinations/braze/types.ts
@@ -8,6 +8,7 @@ import {
   BatchedRequest,
   MultiBatchRequestOutput,
   ProcessorTransformationOutput,
+  ProxyMetdata,
 } from '../../../types/destinationTransformation';
 
 // Braze User Alias Object
@@ -150,6 +151,7 @@ export interface BrazeResponseHandlerParams {
     };
     status: number;
   };
+  rudderJobMetadata: ProxyMetdata[];
 }
 
 export interface BrazeUser extends BrazeUserAttributes {

--- a/src/v1/destinations/braze/networkHandler.test.ts
+++ b/src/v1/destinations/braze/networkHandler.test.ts
@@ -1,0 +1,183 @@
+jest.mock('../../../util/stats', () => ({
+  increment: jest.fn(),
+  gauge: jest.fn(),
+}));
+
+import stats from '../../../util/stats';
+import { TransformerProxyError } from '../../../v0/util/errorTypes';
+import type { ProxyMetdata } from '../../../types';
+import { responseHandler } from './networkHandler';
+
+const createMetadata = (jobId: number): ProxyMetdata => ({
+  jobId,
+  attemptNum: 0,
+  userId: '',
+  sourceId: 'source-1',
+  destinationId: 'dest-1',
+  workspaceId: 'workspace-1',
+  secret: {},
+  dontBatch: false,
+});
+
+const mockStats = stats as jest.Mocked<typeof stats>;
+
+describe('Braze v1 networkHandler responseHandler', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('happy path — 2xx, message=success, no errors', () => {
+    it('returns per-job entries with the HTTP status code and full response body as error field', () => {
+      const response = { message: 'success', events_processed: 2, purchases_processed: 1 };
+      const destinationResponse = { response, status: 200 };
+      const rudderJobMetadata = [createMetadata(10), createMetadata(20), createMetadata(30)];
+
+      const result = responseHandler({ destinationResponse, rudderJobMetadata });
+
+      expect(result).toEqual({
+        status: 200,
+        message: 'Request for braze Processed Successfully',
+        response: [
+          { statusCode: 200, metadata: createMetadata(10), error: JSON.stringify(response) },
+          { statusCode: 200, metadata: createMetadata(20), error: JSON.stringify(response) },
+          { statusCode: 200, metadata: createMetadata(30), error: JSON.stringify(response) },
+        ],
+      });
+      expect(mockStats.increment).not.toHaveBeenCalled();
+    });
+
+    it('preserves jobId correlation — order and identity match rudderJobMetadata', () => {
+      const response = { message: 'success' };
+      const destinationResponse = { response, status: 201 };
+      const rudderJobMetadata = [createMetadata(10), createMetadata(20), createMetadata(30)];
+
+      const result = responseHandler({ destinationResponse, rudderJobMetadata });
+
+      expect(result.response).toHaveLength(3);
+      expect(result.response[0].metadata.jobId).toBe(10);
+      expect(result.response[1].metadata.jobId).toBe(20);
+      expect(result.response[2].metadata.jobId).toBe(30);
+    });
+  });
+
+  describe('partial failure — 2xx, message=success, errors present', () => {
+    it('increments braze_partial_failure stat and returns statusCode 200 per job', () => {
+      const response = {
+        message: 'success',
+        events_processed: 1,
+        errors: [{ type: "'external_id' is required", input_array: 'events', index: 1 }],
+      };
+      const destinationResponse = { response, status: 200 };
+      const rudderJobMetadata = [createMetadata(10), createMetadata(20)];
+
+      const result = responseHandler({ destinationResponse, rudderJobMetadata });
+
+      expect(result).toEqual({
+        status: 200,
+        message: 'Request for braze Processed Successfully',
+        response: [
+          { statusCode: 200, metadata: createMetadata(10), error: JSON.stringify(response) },
+          { statusCode: 200, metadata: createMetadata(20), error: JSON.stringify(response) },
+        ],
+      });
+      expect(mockStats.increment).toHaveBeenCalledTimes(1);
+      expect(mockStats.increment).toHaveBeenCalledWith('braze_partial_failure');
+    });
+  });
+
+  describe('application-level error — 2xx, message!=success, errors present', () => {
+    it('throws TransformerProxyError with per-job entries at the 2xx HTTP status', () => {
+      const response = {
+        message: "Valid data must be provided in the 'attributes' field.",
+        errors: [{ type: "'external_id' is required", input_array: 'events', index: 0 }],
+      };
+      const destinationResponse = { response, status: 200 };
+      const rudderJobMetadata = [createMetadata(10)];
+
+      expect(() => responseHandler({ destinationResponse, rudderJobMetadata })).toThrow(
+        TransformerProxyError,
+      );
+
+      try {
+        responseHandler({ destinationResponse, rudderJobMetadata });
+      } catch (thrown: unknown) {
+        expect(thrown).toBeInstanceOf(TransformerProxyError);
+        if (thrown instanceof TransformerProxyError) {
+          expect(thrown.message).toContain('Request failed for braze with status: 200');
+          expect(thrown.status).toBe(200);
+          expect(thrown.response).toEqual([
+            { statusCode: 200, metadata: createMetadata(10), error: JSON.stringify(response) },
+          ]);
+        }
+      }
+    });
+  });
+
+  describe('upstream 4xx — aborted error type', () => {
+    it('throws TransformerProxyError with per-job entries and aborted statTag for 401', () => {
+      const response = { message: 'Invalid API Key' };
+      const destinationResponse = { response, status: 401 };
+      const rudderJobMetadata = [createMetadata(10), createMetadata(20)];
+
+      expect(() => responseHandler({ destinationResponse, rudderJobMetadata })).toThrow(
+        TransformerProxyError,
+      );
+
+      try {
+        responseHandler({ destinationResponse, rudderJobMetadata });
+      } catch (thrown: unknown) {
+        expect(thrown).toBeInstanceOf(TransformerProxyError);
+        if (thrown instanceof TransformerProxyError) {
+          expect(thrown.message).toContain('Request failed for braze with status: 401');
+          expect(thrown.status).toBe(401);
+          expect(thrown.statTags).toMatchObject({ errorType: 'aborted' });
+          expect(thrown.response).toEqual([
+            { statusCode: 401, metadata: createMetadata(10), error: JSON.stringify(response) },
+            { statusCode: 401, metadata: createMetadata(20), error: JSON.stringify(response) },
+          ]);
+        }
+      }
+    });
+  });
+
+  describe('upstream 5xx — retryable error type', () => {
+    it('throws TransformerProxyError with per-job entries and retryable statTag for 500', () => {
+      const response = { message: 'Internal Server Error' };
+      const destinationResponse = { response, status: 500 };
+      const rudderJobMetadata = [createMetadata(10)];
+
+      expect(() => responseHandler({ destinationResponse, rudderJobMetadata })).toThrow(
+        TransformerProxyError,
+      );
+
+      try {
+        responseHandler({ destinationResponse, rudderJobMetadata });
+      } catch (thrown: unknown) {
+        expect(thrown).toBeInstanceOf(TransformerProxyError);
+        if (thrown instanceof TransformerProxyError) {
+          expect(thrown.message).toContain('Request failed for braze with status: 500');
+          expect(thrown.status).toBe(500);
+          expect(thrown.statTags).toMatchObject({ errorType: 'retryable' });
+          expect(thrown.response).toEqual([
+            { statusCode: 500, metadata: createMetadata(10), error: JSON.stringify(response) },
+          ]);
+        }
+      }
+    });
+  });
+
+  describe('jobId correlation', () => {
+    it('response array has one entry per metadata and preserves identity', () => {
+      const response = { message: 'success' };
+      const destinationResponse = { response, status: 200 };
+      const rudderJobMetadata = [createMetadata(10), createMetadata(20), createMetadata(30)];
+
+      const result = responseHandler({ destinationResponse, rudderJobMetadata });
+
+      expect(result.response).toHaveLength(3);
+      rudderJobMetadata.forEach((meta, idx) => {
+        expect(result.response[idx].metadata).toEqual(meta);
+      });
+    });
+  });
+});

--- a/src/v1/destinations/braze/networkHandler.ts
+++ b/src/v1/destinations/braze/networkHandler.ts
@@ -1,0 +1,108 @@
+import { prepareProxyRequest, proxyRequest } from '../../../adapters/network';
+import { getDynamicErrorType, processAxiosResponse } from '../../../adapters/utils/networkUtils';
+import { TransformerProxyError } from '../../../v0/util/errorTypes';
+import { TAG_NAMES } from '../../../v0/util/tags';
+import { isHttpStatusSuccess } from '../../../v0/util/index';
+import stats from '../../../util/stats';
+import type { DeliveryJobState, DeliveryV1Response, ProxyMetdata } from '../../../types';
+import { BrazeResponseHandlerParams } from '../../../v0/destinations/braze/types';
+
+const DESTINATION = 'braze';
+
+/**
+ * Typed subset of the Braze REST API response body. The `message` field
+ * signals overall success ('success') or failure. The `errors` array is
+ * present on both partial failures (message='success') and full application-
+ * level errors (message!='success').
+ */
+type BrazeApiResponse = {
+  message?: string;
+  errors?: unknown[];
+};
+
+function isBrazeApiResponse(value: unknown): value is BrazeApiResponse {
+  return typeof value === 'object' && value !== null;
+}
+
+/**
+ * Maps every job in `rudderJobMetadata` to a `DeliveryJobState` using the
+ * same `error` string and the given `statusCode`. The `error` field is the
+ * JSON-serialised Braze response body so downstream consumers can inspect it.
+ * `JSON.stringify(undefined)` returns `undefined` at runtime despite the
+ * TypeScript return type, so the `?? ''` guard ensures we never emit
+ * `error: undefined`.
+ */
+const buildJobStates = (
+  response: unknown,
+  statusCode: number,
+  rudderJobMetadata: ProxyMetdata[],
+): DeliveryJobState[] =>
+  rudderJobMetadata.map((metadata) => ({
+    statusCode,
+    metadata,
+    error: JSON.stringify(response) ?? '',
+  }));
+
+const responseHandler = (params: BrazeResponseHandlerParams): DeliveryV1Response => {
+  const { destinationResponse, rudderJobMetadata } = params;
+  const { response, status } = destinationResponse;
+
+  // Guard 1: non-2xx HTTP status — destination rejected the request entirely
+  if (!isHttpStatusSuccess(status)) {
+    throw new TransformerProxyError(
+      `Request failed for ${DESTINATION} with status: ${status}`,
+      status,
+      { [TAG_NAMES.ERROR_TYPE]: getDynamicErrorType(status) },
+      destinationResponse,
+      '',
+      buildJobStates(response, status, rudderJobMetadata),
+    );
+  }
+
+  const responseBody: BrazeApiResponse | null = isBrazeApiResponse(response) ? response : null;
+  const errors = responseBody?.errors;
+  const hasErrors = Array.isArray(errors) && errors.length > 0;
+  const brazeMessage = responseBody?.message;
+
+  // Guard 2: partial failure — destination accepted the request but some items
+  // within the batch were invalid. Braze signals this with message='success'
+  // and a non-empty errors array. Emit a metric so ops can track frequency;
+  // the batch is still considered delivered (fall through to success).
+  if (brazeMessage === 'success' && hasErrors) {
+    stats.increment('braze_partial_failure');
+  }
+
+  // Guard 3: application-level error — destination returned 2xx but with an
+  // error message (message!='success') and errors, meaning the entire request
+  // was rejected at the application layer despite the transport succeeding.
+  if (brazeMessage !== 'success' && hasErrors) {
+    throw new TransformerProxyError(
+      `Request failed for ${DESTINATION} with status: ${status}`,
+      status,
+      { [TAG_NAMES.ERROR_TYPE]: getDynamicErrorType(status) },
+      destinationResponse,
+      '',
+      buildJobStates(response, status, rudderJobMetadata),
+    );
+  }
+
+  return {
+    status,
+    message: `Request for ${DESTINATION} Processed Successfully`,
+    response: buildJobStates(response, status, rudderJobMetadata),
+  };
+};
+
+function networkHandler(this: {
+  responseHandler: typeof responseHandler;
+  proxy: typeof proxyRequest;
+  prepareProxy: typeof prepareProxyRequest;
+  processAxiosResponse: typeof processAxiosResponse;
+}) {
+  this.responseHandler = responseHandler;
+  this.proxy = proxyRequest;
+  this.prepareProxy = prepareProxyRequest;
+  this.processAxiosResponse = processAxiosResponse;
+}
+
+export { networkHandler, responseHandler };

--- a/src/v1/destinations/braze/networkHandler.ts
+++ b/src/v1/destinations/braze/networkHandler.ts
@@ -10,21 +10,6 @@ import { BrazeResponseHandlerParams } from '../../../v0/destinations/braze/types
 const DESTINATION = 'braze';
 
 /**
- * Typed subset of the Braze REST API response body. The `message` field
- * signals overall success ('success') or failure. The `errors` array is
- * present on both partial failures (message='success') and full application-
- * level errors (message!='success').
- */
-type BrazeApiResponse = {
-  message?: string;
-  errors?: unknown[];
-};
-
-function isBrazeApiResponse(value: unknown): value is BrazeApiResponse {
-  return typeof value === 'object' && value !== null;
-}
-
-/**
  * Maps every job in `rudderJobMetadata` to a `DeliveryJobState` using the
  * same `error` string and the given `statusCode`. The `error` field is the
  * JSON-serialised Braze response body so downstream consumers can inspect it.
@@ -59,10 +44,9 @@ const responseHandler = (params: BrazeResponseHandlerParams): DeliveryV1Response
     );
   }
 
-  const responseBody: BrazeApiResponse | null = isBrazeApiResponse(response) ? response : null;
-  const errors = responseBody?.errors;
+  const errors = response?.errors;
   const hasErrors = Array.isArray(errors) && errors.length > 0;
-  const brazeMessage = responseBody?.message;
+  const brazeMessage = response?.message;
 
   // Guard 2: partial failure — destination accepted the request but some items
   // within the batch were invalid. Braze signals this with message='success'


### PR DESCRIPTION
## What are the changes introduced in this PR?

Migrates Braze's delivery network handler from **v0** to **v1**.

- **New `src/v1/destinations/braze/networkHandler.ts`** exporting `prepareProxy`, `proxy`, `processAxiosResponse`, `responseHandler`. Where v0 returns a single status for the entire proxy batch, the v1 `responseHandler` returns one `DeliveryJobState` per event in `DeliveryV1Response.response[]`, correlated by `metadata.jobId`.
- The handler is a **like-for-like port of v0's decision logic**:
  - non-2xx upstream → throw `TransformerProxyError` with one per-job entry at the upstream status code
  - 2xx + `message === 'success'` → per-job `statusCode: 200`
  - 2xx + `message === 'success'` + non-empty `errors[]` → increment the `braze_partial_failure` stat, still treated as delivered
  - 2xx + `message !== 'success'` + non-empty `errors[]` → throw (application-level error)
- **`BrazeResponseHandlerParams`** (in `src/v0/destinations/braze/types.ts`) gains `rudderJobMetadata: ProxyMetdata[]` so the handler can map each job to its result.
- Braze `proxy_v1` requests now route to this handler automatically via the network-handler factory's auto-discovery — no registry edit needed. The v0 handler is left untouched.

**Tests**
- New unit tests (`networkHandler.test.ts`) cover the four response shapes plus `metadata.jobId` correlation.
- `networkHandlerFactory.test.ts`: the existing "v1 request falls back to v0" test used Braze as its example (valid only while Braze had no v1 handler) — repointed to `marketo`, and added a case asserting Braze now resolves to its v1 handler.

## What is the related Linear task?

Resolves INT-6633

## Please explain the objectives of your changes below

A like-for-like migration to the v1 networkHandler. v0 reports a single outcome for a whole Braze proxy batch; v1 reports one outcome per event keyed by `metadata.jobId`, which is the prerequisite for per-event delivery response handling. Delivery semantics are unchanged.

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

No change to delivery behaviour. Braze `proxy_v1` requests previously fell back to the v0 handler (wrapped by the v0→v1 adapter in `nativeIntegration.ts`); they now execute the native v1 handler. Per-job verdicts are functionally identical — confirmed by the existing Braze `dataDelivery` component fixtures, which route through the new handler and pass unchanged. The `BrazeResponseHandlerParams` change is additive.

### Any new dependencies introduced with this change?

N/A

### Any new generic utility introduced or modified. Please explain the changes.

N/A

### Any technical or performance related pointers to consider with the change?

The factory auto-discovers v1 handlers, so adding the file activates the v1 path for Braze on deploy. Should a rollback be needed, the built-in v1→v0 fallback restores prior behaviour once the handler is removed.

@coderabbitai review

<hr>

### Developer checklist

- [x] My code follows the style guidelines of this project

- [x] **No breaking changes are being introduced.**

- [ ] All related docs linked with the PR?

- [ ] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [x] Is the PR limited to 10 file changes?

- [x] Is the PR limited to one linear task?

- [x] Are relevant unit and component test-cases added in **new readability format**?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.