### PR TITLE
fix(customerio): event stream events rejected by record-only connection schema

### DIFF
--- a/src/v0/destinations/customerio/routerTransform.test.ts
+++ b/src/v0/destinations/customerio/routerTransform.test.ts
@@ -108,6 +108,48 @@ describe('CustomerIOIntegration — record event routing', () => {
     );
   });
 
+  it.each([
+    {
+      name: 'no destination object (VDM v1)',
+      connection: {
+        sourceId: 'src-1',
+        destinationId: 'dest-1',
+        enabled: true,
+        config: {},
+      },
+    },
+    {
+      name: 'connection with nil config',
+      connection: {
+        sourceId: 'src-1',
+        destinationId: 'dest-1',
+        enabled: true,
+        config: null,
+      },
+    },
+    {
+      name: 'no connection at all',
+      connection: undefined,
+    },
+  ])('input schema accepts non VDM v2 messages — $name', ({ connection }) => {
+    const integration = new Integration(baseDestination);
+    const schema = integration.getInputSchema();
+
+    const input = {
+      message: {
+        type: 'identify',
+        userId: 'user-1',
+        traits: { email: 'test@example.com' },
+      },
+      metadata: { jobId: 1, userId: 'u1', workspaceId: 'ws-1' },
+      destination: baseDestination,
+      ...(connection !== undefined && { connection }),
+    };
+
+    const result = schema.safeParse(input);
+    expect(result.success).toBe(true);
+  });
+
   it('batches multiple record events into one { batch: [...] } body', async () => {
     const integration = new Integration(baseDestination, baseConnection);
     const inputs = [

--- a/src/v0/destinations/customerio/v2/types.ts
+++ b/src/v0/destinations/customerio/v2/types.ts
@@ -89,21 +89,30 @@ const eventStreamMessageSchema = z
   );
 
 export const getV2InputSchema = (): ZodType =>
-  z
-    .object({
-      message: z.union([recordMessageSchema, eventStreamMessageSchema]),
-      connection: z
-        .object({
-          config: z
-            .object({
-              destination: CustomerIOConnectionConfigSchema,
-            })
-            .passthrough(),
-        })
-        .passthrough()
-        .optional(),
-    })
-    .passthrough();
+  z.union([
+    // Record messages: validate connection.config.destination against the record-specific schema
+    z
+      .object({
+        message: recordMessageSchema,
+        connection: z
+          .object({
+            config: z
+              .object({
+                destination: CustomerIOConnectionConfigSchema,
+              })
+              .passthrough(),
+          })
+          .passthrough()
+          .optional(),
+      })
+      .passthrough(),
+    // Event stream messages: no connection schema enforcement
+    z
+      .object({
+        message: eventStreamMessageSchema,
+      })
+      .passthrough(),
+  ]);
 
 export {
   type CustomerIODestination,


### PR DESCRIPTION
## Summary
- The `getV2InputSchema()` Zod schema applied `CustomerIOConnectionConfigSchema` (which requires `object: 'person'|'event'`) to **all** events, not just record messages. Event stream messages (identify, track, page, etc.) arriving with a connection object were rejected because their connection config lacks the record-specific `object` field.
- Split the input schema into a `z.union` of two variants: record messages validate connection config against the record-specific schema; event stream messages skip connection validation entirely.
- Added table-driven tests covering event stream messages with no destination object (VDM v1), nil config, and no connection.

## Test plan
- [x] Unit test proves the bug: event stream message with `config: {}` connection was rejected before the fix
- [x] All 9 unit tests pass (`routerTransform.test.ts`)
- [x] All 62 Customer.io unit tests pass
- [x] All 121 Customer.io integration tests pass (processor + router + dataDelivery)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
