### PR TITLE
fix(customerio): fall back to track event for device events missing id/token in v2

### DIFF
--- a/src/v0/destinations/customerio/v2/util.ts
+++ b/src/v0/destinations/customerio/v2/util.ts
@@ -210,6 +210,7 @@ export const buildDevice = (
 };
 
 const deviceActionFor = (
+  message,
   evName: string,
   destination: CustomerIODestination,
 ): 'add_device' | 'delete_device' | null => {
@@ -218,7 +219,19 @@ const deviceActionFor = (
   if (!isDevice) {
     return null;
   }
-  return evName === DEVICE_DELETE_EVENT_NAME ? 'delete_device' : 'add_device';
+  if (evName === DEVICE_DELETE_EVENT_NAME) {
+    return 'delete_device';
+  }
+  // add_device: mirror v0 behaviour — a device-register event with a missing
+  // userId/email or device token degrades to a normal track event rather than
+  // building a device payload.
+  const id =
+    getFieldValueFromMessage(message, 'userIdOnly') || getFieldValueFromMessage(message, 'email');
+  const token = get(message, 'context.device.token');
+  if (!id || !token) {
+    return null;
+  }
+  return 'add_device';
 };
 
 // Build the unified v2 envelope (type/action/identifiers/...) for a single event.
@@ -237,7 +250,7 @@ export const buildEnvelope = (message, destination: CustomerIODestination): Cust
       return buildScreen(message, 'screen', message.event || message.properties?.name);
     case EventType.TRACK: {
       const evName = message.event;
-      const deviceAction = deviceActionFor(evName, destination);
+      const deviceAction = deviceActionFor(message, evName, destination);
       return deviceAction ? buildDevice(message, deviceAction) : buildTrack(message, evName);
     }
     default:

--- a/src/v0/destinations/customerio/v2/util.ts
+++ b/src/v0/destinations/customerio/v2/util.ts
@@ -175,13 +175,18 @@ export const buildObject = (message): CustomerIOV2Payload => {
   };
 };
 
+// Resolve the person id (userId/email) and device token used to decide and build
+// device payloads. Shared by deviceActionFor (gating) and buildDevice (construction).
+const getDeviceCredentials = (message): { id: unknown; token: unknown } => ({
+  id: getFieldValueFromMessage(message, 'userIdOnly') || getFieldValueFromMessage(message, 'email'),
+  token: get(message, 'context.device.token'),
+});
+
 export const buildDevice = (
   message,
   action: 'add_device' | 'delete_device',
 ): CustomerIOV2Payload => {
-  const id =
-    getFieldValueFromMessage(message, 'userIdOnly') || getFieldValueFromMessage(message, 'email');
-  const token = get(message, 'context.device.token');
+  const { id, token } = getDeviceCredentials(message);
   if (!id || !token) {
     throw new InstrumentationError('userId/email or device_token not present');
   }
@@ -225,9 +230,7 @@ const deviceActionFor = (
   // add_device: mirror v0 behaviour — a device-register event with a missing
   // userId/email or device token degrades to a normal track event rather than
   // building a device payload.
-  const id =
-    getFieldValueFromMessage(message, 'userIdOnly') || getFieldValueFromMessage(message, 'email');
-  const token = get(message, 'context.device.token');
+  const { id, token } = getDeviceCredentials(message);
   if (!id || !token) {
     return null;
   }

--- a/test/integrations/destinations/customerio/router/dataV2.ts
+++ b/test/integrations/destinations/customerio/router/dataV2.ts
@@ -1420,6 +1420,123 @@ export const dataV2 = [
   },
   {
     name: 'customerio',
+    description:
+      'v2: Application Installed with missing userId/email or device token falls back to a track event',
+    feature: 'router',
+    module: 'destination',
+    version: 'v0',
+    envOverrides: {
+      CUSTOMERIO_BATCHING_FRAMEWORK_ENABLED_WORKSPACE_IDS: 'ALL',
+    },
+    input: {
+      request: {
+        body: {
+          input: [
+            {
+              // no userId/email — falls back to a track event identified by anonymous_id
+              message: {
+                anonymousId: '7e32188a4dab669f',
+                channel: 'mobile',
+                context: {
+                  device: {
+                    id: '7e32188a4dab669f',
+                    type: 'android',
+                    token: 'abcxyz',
+                  },
+                },
+                event: 'Application Installed',
+                originalTimestamp: '2020-01-09T10:01:53.558Z',
+                type: 'track',
+                properties: { review_id: 'r1', product_id: 'p1', rating: 2 },
+                sentAt: '2020-01-09T10:02:03.257Z',
+              },
+              metadata: { jobId: 39, userId: 'u1', workspaceId: 'ws-cio-v2' },
+              destination: { Config: { datacenter: 'US', siteID: secret1, apiKey: secret2 } },
+            },
+            {
+              // no device token — falls back to a track event identified by id
+              message: {
+                anonymousId: '7e32188a4dab669f',
+                channel: 'mobile',
+                context: {
+                  device: {
+                    id: '7e32188a4dab669f',
+                    type: 'android',
+                    // no token present
+                  },
+                },
+                event: 'Application Installed',
+                userId: '12345',
+                originalTimestamp: '2020-01-09T10:01:53.558Z',
+                type: 'track',
+                properties: { review_id: 'r1', product_id: 'p1', rating: 2 },
+                sentAt: '2020-01-09T10:02:03.257Z',
+              },
+              metadata: { jobId: 40, userId: 'u1', workspaceId: 'ws-cio-v2' },
+              destination: { Config: { datacenter: 'US', siteID: secret1, apiKey: secret2 } },
+            },
+          ],
+          destType: 'customerio',
+        },
+        method: 'POST',
+      },
+    },
+    output: {
+      response: {
+        status: 200,
+        body: {
+          output: [
+            {
+              batchedRequest: {
+                version: '1',
+                type: 'REST',
+                method: 'POST',
+                endpoint: 'https://track.customer.io/api/v2/batch',
+                endpointPath: 'v2/batch',
+                headers: { Authorization: authHeader1, 'Content-Type': 'application/json' },
+                params: {},
+                body: {
+                  JSON: {
+                    batch: [
+                      {
+                        type: 'person',
+                        action: 'event',
+                        identifiers: { anonymous_id: '7e32188a4dab669f' },
+                        name: 'Application Installed',
+                        attributes: { review_id: 'r1', product_id: 'p1', rating: 2 },
+                        timestamp: 1578564113,
+                      },
+                      {
+                        type: 'person',
+                        action: 'event',
+                        identifiers: { id: '12345' },
+                        name: 'Application Installed',
+                        attributes: { review_id: 'r1', product_id: 'p1', rating: 2 },
+                        timestamp: 1578564113,
+                      },
+                    ],
+                  },
+                  JSON_ARRAY: {},
+                  XML: {},
+                  FORM: {},
+                },
+                files: {},
+              },
+              metadata: [
+                { jobId: 39, userId: 'u1', workspaceId: 'ws-cio-v2' },
+                { jobId: 40, userId: 'u1', workspaceId: 'ws-cio-v2' },
+              ],
+              destination: { Config: { datacenter: 'US', siteID: secret1, apiKey: secret2 } },
+              batched: true,
+              statusCode: 200,
+            },
+          ],
+        },
+      },
+    },
+  },
+  {
+    name: 'customerio',
     description: 'v2: screen event with anonymousId maps to anonymous_id identifier',
     feature: 'router',
     module: 'destination',


### PR DESCRIPTION
## What are the changes introduced in this PR?

Align v2 device-event handling with v0: an Application Installed / deviceTokenEventName event that is missing userId/email or the device token now degrades to a normal track event instead of throwing. The guard moves into deviceActionFor, which returns null so the envelope routes through buildTrack. delete_device still throws, matching v0.

Adds a combined router test covering both fallback paths (anonymous_id and id identifiers) in a single batched request.
## What is the related Linear task?

[Resolves INT-6710](https://linear.app/rudderstack/issue/INT-6710/customerio-fix-device-event-payload-creation-for-v2-implementation)

## Please explain the objectives of your changes below

Put down any required details on the broader aspect of your changes. If there are any dependent changes, **mandatorily** mention them here

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

N/A

### Any new dependencies introduced with this change?

N/A

### Any new generic utility introduced or modified. Please explain the changes.

N/A

### Any technical or performance related pointers to consider with the change?

N/A

@coderabbitai review

<hr>

### Developer checklist

- [ ] My code follows the style guidelines of this project

- [ ] **No breaking changes are being introduced.**

- [ ] All related docs linked with the PR?

- [ ] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [ ] Is the PR limited to 10 file changes?

- [ ] Is the PR limited to one linear task?

- [ ] Are relevant unit and component test-cases added in **new readability format**?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.
