### PR TITLE
chore(ci): move dev-restart jobs in prepare-for-dev-deploy to self-hosted runner

### DIFF
--- a/.github/workflows/prepare-for-dev-deploy.yml
+++ b/.github/workflows/prepare-for-dev-deploy.yml
@@ -80,7 +80,7 @@ jobs:
 
   restart-k8s-deployment:
     name: Restart K8s Deployment
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, ubuntu-22-amd]
     permissions:
       id-token: write # for AWS OIDC authentication (restart-deployment action uses aws-actions/configure-aws-credentials)
       contents: read # to checkout repository code and local action (actions/checkout)
@@ -106,7 +106,7 @@ jobs:
 
   restart-k8s-deployment-dedicated:
     name: Restart K8s Deployment
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, ubuntu-22-amd]
     permissions:
       id-token: write # for AWS OIDC authentication (restart-deployment action uses aws-actions/configure-aws-credentials)
       contents: read # to checkout repository code and local action (actions/checkout)


### PR DESCRIPTION
## Summary

Move the `restart-k8s-deployment` and `restart-k8s-deployment-dedicated` jobs in `.github/workflows/prepare-for-dev-deploy.yml` from `ubuntu-latest` to `[self-hosted, ubuntu-22-amd]`.

## Why

Standardises these two jobs on the org's shared self-hosted runner pool. No other jobs in the workflow (`generate-tag-names`, the image builds) are touched — they stay on `ubuntu-latest`.

## Compatibility

- OIDC role assumption works identically on self-hosted runners; the existing IAM trust policy is unchanged.
- The `./.github/actions/restart-deployment` composite action uses `azure/setup-kubectl` + `aws-actions/configure-aws-credentials` + `kubectl` — standard tooling that runs on the self-hosted amd64 image.
- The multi-arch image builds elsewhere in this repo are unaffected.

## Test plan

- [x] Merge and confirm the next push to `develop` schedules both restart jobs on a self-hosted runner.
- [ ] Confirm the rollouts complete successfully as before.
