### PR TITLE
fix: google enhanced conversion hashing

### DIFF
--- a/src/v0/destinations/google_adwords_enhanced_conversions/data/trackConfig.json
+++ b/src/v0/destinations/google_adwords_enhanced_conversions/data/trackConfig.json
@@ -55,7 +55,7 @@
     "sourceFromGenericMap": true,
     "required": false,
     "metadata": {
-      "type": ["trim", "hashToSha256"]
+      "type": "trim"
     }
   },
   {
@@ -64,7 +64,7 @@
     "sourceFromGenericMap": true,
     "required": false,
     "metadata": {
-      "type": ["trim", "hashToSha256"]
+      "type": "trim"
     }
   },
   {
@@ -73,7 +73,7 @@
     "sourceFromGenericMap": true,
     "required": false,
     "metadata": {
-      "type": ["trim", "hashToSha256"]
+      "type": "trim"
     }
   },
   {
@@ -82,7 +82,7 @@
     "sourceFromGenericMap": true,
     "required": false,
     "metadata": {
-      "type": ["trim", "hashToSha256"]
+      "type": "trim"
     }
   },
   {
@@ -127,7 +127,7 @@
     "sourceKeys": ["context.traits.streetAddress", "context.traits.address"],
     "required": false,
     "metadata": {
-      "type": ["trim", "hashToSha256"]
+      "type": "trim"
     }
   }
 ]

--- a/src/v0/destinations/google_adwords_enhanced_conversions/transform.ts
+++ b/src/v0/destinations/google_adwords_enhanced_conversions/transform.ts
@@ -1,5 +1,4 @@
-import get from 'get-value';
-import { cloneDeep, isNumber } from 'lodash';
+import { isNumber } from 'lodash';
 import { InstrumentationError, ConfigurationError } from '@rudderstack/integrations-lib';
 import isString from 'lodash/isString';
 import type {
@@ -12,6 +11,7 @@ import type {
   ConversionAdjustment,
 } from './types';
 import { trackMapping } from './config';
+import { processUserIdentifiers } from './utils';
 import type { Metadata } from '../../../types';
 import type { RouterTransformationResponse } from '../../../types/destinationTransformation';
 import {
@@ -27,43 +27,13 @@ import { isFeatureEnabled } from '../../../util/featureFlags';
 const ADJUSTMENT_TYPE_ENHANCEMENT = 'ENHANCEMENT';
 const ADJUSTMENT_TYPE_RESTATEMENT = 'RESTATEMENT';
 
-/** Shape of a single element in the mapping JSON (trackConfig.json). */
-interface MappingElement {
-  metadata?: {
-    type?: string | string[];
-  };
-  [key: string]: unknown;
-}
-
-const isMappingElement = (value: unknown): value is MappingElement =>
-  typeof value === 'object' && value !== null;
-
-/**
- * This function is helping to update the mappingJson.
- * It is removing the metadata field with type "hashToSha256"
- * @param mapping -> it is the configMapping.json
- * @returns
- */
-const updateMappingJson = (mapping: unknown[]): unknown[] => {
-  const newMapping: unknown[] = [];
-  mapping.forEach((element) => {
-    if (
-      isMappingElement(element) &&
-      get(element, 'metadata.type') &&
-      element.metadata?.type?.includes('hashToSha256')
-    ) {
-      // eslint-disable-next-line no-param-reassign -- intentional in-place mutation: this function's purpose is to rewrite metadata.type
-      element.metadata.type = 'toString';
-    }
-    newMapping.push(element);
-  });
-  return newMapping;
-};
+const MISSING_IDENTIFIERS_ERROR =
+  'Any of email, phone, firstName, lastName, city, street, countryCode, postalCode or streetAddress is required in traits.';
 
 const responseBuilder = (
   metadata: Metadata,
   message: GaecInputMessage,
-  destination: { Config: GaecConfig },
+  destination: { Config: GaecConfig; [key: string]: unknown },
   payload: GaecPayload,
 ): GaecDeliveryRequest => {
   // typed at construction: the builder starts from empty slots and is mutated in place
@@ -114,11 +84,11 @@ const responseBuilder = (
 const processTrackEvent = (
   metadata: Metadata,
   message: GaecInputMessage,
-  destination: { Config: GaecConfig },
+  destination: { Config: GaecConfig; [key: string]: unknown },
 ): GaecDeliveryRequest => {
-  const { Config } = destination;
+  const { Config, ID } = destination;
   const { event } = message;
-  const { listOfConversions, adjustmentType } = Config;
+  const { listOfConversions, adjustmentType, requireHash } = Config;
   const isConfiguredConversion =
     Array.isArray(listOfConversions) && listOfConversions.some((i) => i.conversions === event);
   if (event === undefined || event === '' || !isConfiguredConversion) {
@@ -126,25 +96,18 @@ const processTrackEvent = (
       `Conversion named "${String(event)}" was not specified in the RudderStack destination configuration`,
     );
   }
-  const { requireHash } = Config;
-  let updatedMapping = cloneDeep(trackMapping);
 
-  if (requireHash === false) {
-    updatedMapping = updateMappingJson(updatedMapping);
-  }
-
-  // `!` mirrors the original JS's implicit non-null trust in `constructPayload`'s return
-  // (migration guide #6) — a null surfaces as a TypeError on the next access, exactly
-  // like the original JS.
-  const payload: GaecPayload = constructPayload(message, updatedMapping)!;
+  // `!` mirrors the original JS's implicit non-null trust in `constructPayload`'s return —
+  // a null surfaces as a TypeError on the next access, exactly like the original JS.
+  // hashToSha256 has been removed from trackConfig.json; the mapping now extracts raw values
+  // only (trim). processUserIdentifiers handles normalization, consistency-check, and hashing.
+  const payload: GaecPayload = constructPayload(message, trackMapping)!;
 
   payload.partialFailure = true;
   // `?.` on [0] is a genuine runtime guard: the array may be empty, and the intended
   // failure is this InstrumentationError, not a TypeError
   if (!payload.conversionAdjustments![0]?.userIdentifiers) {
-    throw new InstrumentationError(
-      `Any of email, phone, firstName, lastName, city, street, countryCode, postalCode or streetAddress is required in traits.`,
-    );
+    throw new InstrumentationError(MISSING_IDENTIFIERS_ERROR);
   }
   const firstAdjustment: ConversionAdjustment = payload.conversionAdjustments![0];
   firstAdjustment.adjustmentType = ADJUSTMENT_TYPE_ENHANCEMENT;
@@ -154,15 +117,36 @@ const processTrackEvent = (
   const arr = firstAdjustment.userIdentifiers;
   firstAdjustment.userIdentifiers = arr!.filter((item) => !!item);
 
-  if (
+  const isRestatement =
     isFeatureEnabled('DEST_GAEC_ADJUSTMENT_TYPE_SUPPORTED_WORKSPACE_IDS', metadata.workspaceId) &&
     adjustmentType &&
-    adjustmentType === ADJUSTMENT_TYPE_RESTATEMENT
-  ) {
+    adjustmentType === ADJUSTMENT_TYPE_RESTATEMENT;
+
+  if (isRestatement) {
     firstAdjustment.adjustmentType = ADJUSTMENT_TYPE_RESTATEMENT;
     delete firstAdjustment.userIdentifiers;
     delete firstAdjustment.userAgent;
+  } else {
+    // Run processUserIdentifiers ONLY when identifiers will actually be sent.
+    // Restatement events delete userIdentifiers — running the hash pipeline on them
+    // would throw spurious hash-inconsistency errors.
+    // `destinationId` for metric labels: v0 destination objects carry uppercase `ID`
+    // (same field GARL reads); it comes through the index signature as unknown, so a
+    // string guard + '' fallback is needed
+    const destinationId = typeof ID === 'string' ? ID : '';
+    processUserIdentifiers(payload, {
+      requireHash,
+      workspaceId: metadata.workspaceId,
+      destinationId,
+    });
+
+    // After pruning, re-check: processUserIdentifiers may have dropped all identifiers
+    // (e.g. all were invalid), leaving userIdentifiers empty.
+    if (!firstAdjustment.userIdentifiers || firstAdjustment.userIdentifiers.length === 0) {
+      throw new InstrumentationError(MISSING_IDENTIFIERS_ERROR);
+    }
   }
+
   return responseBuilder(metadata, message, destination, payload);
 };
 

--- a/src/v0/destinations/google_adwords_enhanced_conversions/transform.ts
+++ b/src/v0/destinations/google_adwords_enhanced_conversions/transform.ts
@@ -2,7 +2,7 @@ import { isNumber } from 'lodash';
 import { InstrumentationError, ConfigurationError } from '@rudderstack/integrations-lib';
 import isString from 'lodash/isString';
 import type {
-  GaecConfig,
+  GaecDestination,
   GaecPayload,
   GaecDeliveryRequest,
   GaecInputMessage,
@@ -33,7 +33,7 @@ const MISSING_IDENTIFIERS_ERROR =
 const responseBuilder = (
   metadata: Metadata,
   message: GaecInputMessage,
-  destination: { Config: GaecConfig; [key: string]: unknown },
+  destination: GaecDestination,
   payload: GaecPayload,
 ): GaecDeliveryRequest => {
   // typed at construction: the builder starts from empty slots and is mutated in place
@@ -84,7 +84,7 @@ const responseBuilder = (
 const processTrackEvent = (
   metadata: Metadata,
   message: GaecInputMessage,
-  destination: { Config: GaecConfig; [key: string]: unknown },
+  destination: GaecDestination,
 ): GaecDeliveryRequest => {
   const { Config, ID } = destination;
   const { event } = message;
@@ -130,21 +130,22 @@ const processTrackEvent = (
     // Run processUserIdentifiers ONLY when identifiers will actually be sent.
     // Restatement events delete userIdentifiers — running the hash pipeline on them
     // would throw spurious hash-inconsistency errors.
-    // `destinationId` for metric labels: v0 destination objects carry uppercase `ID`
-    // (same field GARL reads); it comes through the index signature as unknown, so a
-    // string guard + '' fallback is needed
+    // `destinationId` for metric labels: `ID` is typed string on GaecDestination, but the
+    // router envelope isn't runtime-validated (the Zod schema passes `destination` through
+    // unchecked, and fixtures omit `ID`) — the guard + '' fallback covers that gap.
     const destinationId = typeof ID === 'string' ? ID : '';
-    processUserIdentifiers(payload, {
+    const survivingIdentifiers = processUserIdentifiers(payload, {
       requireHash,
       workspaceId: metadata.workspaceId,
       destinationId,
     });
 
-    // After pruning, re-check: processUserIdentifiers may have dropped all identifiers
-    // (e.g. all were invalid), leaving userIdentifiers empty.
-    if (!firstAdjustment.userIdentifiers || firstAdjustment.userIdentifiers.length === 0) {
+    // The pipeline may drop every identifier (all invalid/empty after normalization) —
+    // same error as the pre-transform guard above.
+    if (survivingIdentifiers.length === 0) {
       throw new InstrumentationError(MISSING_IDENTIFIERS_ERROR);
     }
+    firstAdjustment.userIdentifiers = survivingIdentifiers;
   }
 
   return responseBuilder(metadata, message, destination, payload);
@@ -153,7 +154,7 @@ const processTrackEvent = (
 const processEvent = (
   metadata: Metadata,
   message: GaecInputMessage,
-  destination: { Config: GaecConfig },
+  destination: GaecDestination,
 ): GaecDeliveryRequest => {
   const { type } = message;
   if (!type) {

--- a/src/v0/destinations/google_adwords_enhanced_conversions/types.ts
+++ b/src/v0/destinations/google_adwords_enhanced_conversions/types.ts
@@ -50,7 +50,7 @@ export interface GaecInputMessage {
 export interface GaecProcessInput {
   metadata?: Metadata;
   message: GaecInputMessage;
-  destination?: { Config: GaecConfig };
+  destination?: GaecDestination;
 }
 
 /** Address component nested inside a UserIdentifier. */

--- a/src/v0/destinations/google_adwords_enhanced_conversions/types.ts
+++ b/src/v0/destinations/google_adwords_enhanced_conversions/types.ts
@@ -10,7 +10,8 @@ import type { RouterTransformationRequestData } from '../../../types/destination
  * control-plane serialises some numeric IDs as numbers.
  */
 export interface GaecConfig {
-  requireHash: boolean;
+  // Omitted by most control-plane configs; missing means "hash" (only explicit false disables it)
+  requireHash?: boolean;
   customerId: string | number;
   loginCustomerId?: string | number;
   subAccount?: boolean;

--- a/src/v0/destinations/google_adwords_enhanced_conversions/utils.test.ts
+++ b/src/v0/destinations/google_adwords_enhanced_conversions/utils.test.ts
@@ -71,39 +71,40 @@ const makePayload = (overrides: {
 };
 
 describe('processUserIdentifiers', () => {
-  describe('normalize + hash write-back (requireHash: true)', () => {
+  describe('normalize + hash (requireHash: true)', () => {
     it('normalizes and hashes a raw email', () => {
       const payload = makePayload({ hashedEmail: 'TEST@EXAMPLE.COM' });
-      processUserIdentifiers(payload, makeDestCtx(true));
-      const entry = payload.conversionAdjustments?.[0]?.userIdentifiers?.[0];
-      expect(entry).toEqual({ hashedEmail: sha256('test@example.com') });
+      const identifiers = processUserIdentifiers(payload, makeDestCtx(true));
+      expect(identifiers).toEqual([{ hashedEmail: sha256('test@example.com') }]);
+      // the input payload is left untouched — the function returns instead of mutating
+      expect(payload.conversionAdjustments?.[0]?.userIdentifiers?.[0]).toEqual({
+        hashedEmail: 'TEST@EXAMPLE.COM',
+      });
     });
 
     it('normalizes gmail email: strips dots and +suffix, then hashes', () => {
       const payload = makePayload({ hashedEmail: 'j.o.h.n+alias@gmail.com' });
-      processUserIdentifiers(payload, makeDestCtx(true));
-      const entry = payload.conversionAdjustments?.[0]?.userIdentifiers?.[0];
-      expect(entry).toEqual({ hashedEmail: sha256('john@gmail.com') });
+      const identifiers = processUserIdentifiers(payload, makeDestCtx(true));
+      expect(identifiers).toEqual([{ hashedEmail: sha256('john@gmail.com') }]);
     });
 
     it('normalizes and hashes a raw phone number (prepends +)', () => {
       const payload = makePayload({ hashedPhoneNumber: '912382193' });
-      processUserIdentifiers(payload, makeDestCtx(true));
-      const entry = payload.conversionAdjustments?.[0]?.userIdentifiers?.[0];
-      expect(entry).toEqual({ hashedPhoneNumber: sha256('+912382193') });
+      const identifiers = processUserIdentifiers(payload, makeDestCtx(true));
+      expect(identifiers).toEqual([{ hashedPhoneNumber: sha256('+912382193') }]);
     });
 
     it('normalizes (trim+lowercase) and hashes first/last names', () => {
       const payload = makePayload({ hashedFirstName: ' John ', hashedLastName: 'GOMES' });
-      processUserIdentifiers(payload, makeDestCtx(true));
-      const firstAdj = payload.conversionAdjustments?.[0];
-      const addressEntry = firstAdj?.userIdentifiers?.[0];
-      expect(addressEntry).toEqual({
-        addressInfo: {
-          hashedFirstName: sha256('john'),
-          hashedLastName: sha256('gomes'),
+      const identifiers = processUserIdentifiers(payload, makeDestCtx(true));
+      expect(identifiers).toEqual([
+        {
+          addressInfo: {
+            hashedFirstName: sha256('john'),
+            hashedLastName: sha256('gomes'),
+          },
         },
-      });
+      ]);
     });
 
     it('normalizes (trim+lowercase) and hashes street address', () => {
@@ -111,23 +112,22 @@ describe('processUserIdentifiers', () => {
         hashedStreetAddress: '71 Cherry Court SOUTHAMPTON SO53 5PD UK',
         city: 'London',
       });
-      processUserIdentifiers(payload, makeDestCtx(true));
-      const firstAdj = payload.conversionAdjustments?.[0];
-      const addressEntry = firstAdj?.userIdentifiers?.[0];
-      expect(addressEntry).toEqual({
-        addressInfo: {
-          hashedStreetAddress: sha256('71 cherry court southampton so53 5pd uk'),
-          city: 'London',
+      const identifiers = processUserIdentifiers(payload, makeDestCtx(true));
+      expect(identifiers).toEqual([
+        {
+          addressInfo: {
+            hashedStreetAddress: sha256('71 cherry court southampton so53 5pd uk'),
+            city: 'London',
+          },
         },
-      });
+      ]);
     });
 
     it('passes pre-hashed values through when requireHash: false', () => {
       const preHashedEmail = sha256('test@example.com');
       const payload = makePayload({ hashedEmail: preHashedEmail });
-      processUserIdentifiers(payload, makeDestCtx(false));
-      const entry = payload.conversionAdjustments?.[0]?.userIdentifiers?.[0];
-      expect(entry).toEqual({ hashedEmail: preHashedEmail });
+      const identifiers = processUserIdentifiers(payload, makeDestCtx(false));
+      expect(identifiers).toEqual([{ hashedEmail: preHashedEmail }]);
     });
   });
 
@@ -158,23 +158,20 @@ describe('processUserIdentifiers', () => {
   describe('invalid / empty field drops', () => {
     it('drops invalid email (not a valid email after normalization)', () => {
       const payload = makePayload({ hashedEmail: 'not-an-email' });
-      processUserIdentifiers(payload, makeDestCtx(true));
-      const identifiers = payload.conversionAdjustments?.[0]?.userIdentifiers;
-      // email entry should be pruned since hashedEmail was dropped
+      const identifiers = processUserIdentifiers(payload, makeDestCtx(true));
+      // email entry does not survive since hashedEmail was dropped
       expect(identifiers).toEqual([]);
     });
 
     it('drops invalid phone number (non-numeric after normalization)', () => {
       const payload = makePayload({ hashedPhoneNumber: 'not-a-phone' });
-      processUserIdentifiers(payload, makeDestCtx(true));
-      const identifiers = payload.conversionAdjustments?.[0]?.userIdentifiers;
+      const identifiers = processUserIdentifiers(payload, makeDestCtx(true));
       expect(identifiers).toEqual([]);
     });
 
     it('drops empty/whitespace-only email', () => {
       const payload = makePayload({ hashedEmail: '   ' });
-      processUserIdentifiers(payload, makeDestCtx(true));
-      const identifiers = payload.conversionAdjustments?.[0]?.userIdentifiers;
+      const identifiers = processUserIdentifiers(payload, makeDestCtx(true));
       expect(identifiers).toEqual([]);
     });
   });
@@ -187,8 +184,8 @@ describe('processUserIdentifiers', () => {
         city: 'London',
         hashedStreetAddress: { streetAddress: '71 Cherry Court', city: 'London' },
       });
-      processUserIdentifiers(payload, makeDestCtx(true));
-      expect(payload.conversionAdjustments?.[0]?.userIdentifiers).toEqual([
+      const identifiers = processUserIdentifiers(payload, makeDestCtx(true));
+      expect(identifiers).toEqual([
         { addressInfo: { hashedFirstName: sha256('john'), city: 'London' } },
       ]);
     });
@@ -199,78 +196,69 @@ describe('processUserIdentifiers', () => {
         hashedFirstName: preHashedFirstName,
         hashedStreetAddress: { streetAddress: '71 Cherry Court' },
       });
-      processUserIdentifiers(payload, makeDestCtx(false));
-      expect(payload.conversionAdjustments?.[0]?.userIdentifiers).toEqual([
-        { addressInfo: { hashedFirstName: preHashedFirstName } },
-      ]);
+      const identifiers = processUserIdentifiers(payload, makeDestCtx(false));
+      expect(identifiers).toEqual([{ addressInfo: { hashedFirstName: preHashedFirstName } }]);
     });
 
     it('accepts a numeric phone value and hashes its string form', () => {
       const payload = makePayload({ hashedPhoneNumber: 912382193 });
-      processUserIdentifiers(payload, makeDestCtx(true));
-      expect(payload.conversionAdjustments?.[0]?.userIdentifiers).toEqual([
-        { hashedPhoneNumber: sha256('+912382193') },
-      ]);
+      const identifiers = processUserIdentifiers(payload, makeDestCtx(true));
+      expect(identifiers).toEqual([{ hashedPhoneNumber: sha256('+912382193') }]);
     });
   });
 
   describe('requireHash default semantics', () => {
     it('hashes when requireHash is undefined (missing from config)', () => {
       const payload = makePayload({ hashedEmail: 'TEST@EXAMPLE.COM' });
-      processUserIdentifiers(payload, makeDestCtx(undefined));
-      expect(payload.conversionAdjustments?.[0]?.userIdentifiers).toEqual([
-        { hashedEmail: sha256('test@example.com') },
-      ]);
+      const identifiers = processUserIdentifiers(payload, makeDestCtx(undefined));
+      expect(identifiers).toEqual([{ hashedEmail: sha256('test@example.com') }]);
     });
   });
 
-  describe('pruning behavior', () => {
-    it('prunes the email entry when hashedEmail is dropped', () => {
+  describe('surviving-entry rebuilding', () => {
+    it('excludes the email entry when hashedEmail is dropped', () => {
       const payload = makePayload({ hashedEmail: 'invalid' });
-      processUserIdentifiers(payload, makeDestCtx(true));
-      const identifiers = payload.conversionAdjustments?.[0]?.userIdentifiers;
-      // No entry with {} should remain
-      expect(identifiers?.some((e) => e && Object.keys(e).length === 0)).toBe(false);
-    });
-
-    it('prunes addressInfo when all hashable fields are dropped but preserves non-hashable fields', () => {
-      // Invalid first/last name but valid city — city should be preserved; address entry kept
-      const payload = makePayload({
-        hashedFirstName: '', // empty → drops
-        hashedLastName: '', // empty → drops
-        city: 'London',
-      });
-      processUserIdentifiers(payload, makeDestCtx(true));
-      const identifiers = payload.conversionAdjustments?.[0]?.userIdentifiers;
-      expect(identifiers).toEqual([{ addressInfo: { city: 'London' } }]);
-    });
-
-    it('prunes the entire address entry when all hashable AND non-hashable address fields are absent', () => {
-      // Only firstName provided, it's invalid
-      const payload = makePayload({ hashedFirstName: '' });
-      processUserIdentifiers(payload, makeDestCtx(true));
-      const identifiers = payload.conversionAdjustments?.[0]?.userIdentifiers;
+      const identifiers = processUserIdentifiers(payload, makeDestCtx(true));
       expect(identifiers).toEqual([]);
     });
 
-    it('preserves a valid email entry while pruning an invalid phone entry', () => {
+    it('keeps addressInfo without hashable fields when non-hashable fields are present', () => {
+      // Whitespace-only names normalize to '' and are dropped by the pipeline;
+      // the valid city is preserved and the address entry kept
+      const payload = makePayload({
+        hashedFirstName: '   ', // whitespace → normalized to '' → dropped
+        hashedLastName: '   ', // whitespace → normalized to '' → dropped
+        city: 'London',
+      });
+      const identifiers = processUserIdentifiers(payload, makeDestCtx(true));
+      expect(identifiers).toEqual([{ addressInfo: { city: 'London' } }]);
+    });
+
+    it('excludes the address entry when all hashable AND non-hashable address fields are absent', () => {
+      // Only firstName provided; whitespace normalizes to '' and is dropped
+      const payload = makePayload({ hashedFirstName: '   ' });
+      const identifiers = processUserIdentifiers(payload, makeDestCtx(true));
+      expect(identifiers).toEqual([]);
+    });
+
+    it('keeps a valid email entry while excluding an invalid phone entry', () => {
       const payload = makePayload({
         hashedEmail: 'test@example.com',
         hashedPhoneNumber: 'not-a-phone',
       });
-      processUserIdentifiers(payload, makeDestCtx(true));
-      const identifiers = payload.conversionAdjustments?.[0]?.userIdentifiers;
+      const identifiers = processUserIdentifiers(payload, makeDestCtx(true));
       expect(identifiers).toEqual([{ hashedEmail: sha256('test@example.com') }]);
     });
   });
 
   describe('no-op cases', () => {
-    it('returns without mutating when userIdentifiers is absent', () => {
+    it('returns an empty array when userIdentifiers is absent', () => {
       const payload: GaecPayload = {
         conversionAdjustments: [{ adjustmentType: 'RESTATEMENT', orderId: '12345' }],
       };
       // Should not throw
-      processUserIdentifiers(payload, makeDestCtx(true));
+      const identifiers = processUserIdentifiers(payload, makeDestCtx(true));
+      expect(identifiers).toEqual([]);
       expect(payload.conversionAdjustments?.[0]?.userIdentifiers).toBeUndefined();
     });
   });

--- a/src/v0/destinations/google_adwords_enhanced_conversions/utils.test.ts
+++ b/src/v0/destinations/google_adwords_enhanced_conversions/utils.test.ts
@@ -1,0 +1,291 @@
+import sha256 from 'sha256';
+import { processUserIdentifiers, GAEC_FIELD_CONFIG } from './utils';
+import type { GaecPayload } from './types';
+
+// Shared destination context for tests (undefined requireHash models configs that omit it)
+const makeDestCtx = (
+  requireHash: boolean | undefined,
+  workspaceId = 'ws1',
+  destinationId = 'dest1',
+) => ({
+  requireHash,
+  workspaceId,
+  destinationId,
+});
+
+// Helper to build a minimal valid GaecPayload with userIdentifiers.
+// hashedPhoneNumber/hashedStreetAddress accept unknown: the mapping output is unvalidated,
+// so tests model non-string shapes (numeric phone, the traits.address object fallback).
+const makePayload = (overrides: {
+  hashedEmail?: string;
+  hashedPhoneNumber?: unknown;
+  hashedFirstName?: string;
+  hashedLastName?: string;
+  hashedStreetAddress?: unknown;
+  city?: string;
+  state?: string;
+  countryCode?: string;
+  postalCode?: string;
+}): GaecPayload => {
+  const {
+    hashedEmail,
+    hashedPhoneNumber,
+    hashedFirstName,
+    hashedLastName,
+    hashedStreetAddress,
+    city,
+    state,
+    countryCode,
+    postalCode,
+  } = overrides;
+
+  const userIdentifiers: Array<Record<string, unknown> | null> = [null, null, null];
+
+  if (hashedEmail) {
+    userIdentifiers[0] = { hashedEmail };
+  }
+  if (hashedPhoneNumber) {
+    userIdentifiers[1] = { hashedPhoneNumber };
+  }
+  const addressInfo: Record<string, unknown> = {};
+  if (hashedFirstName) addressInfo.hashedFirstName = hashedFirstName;
+  if (hashedLastName) addressInfo.hashedLastName = hashedLastName;
+  if (hashedStreetAddress) addressInfo.hashedStreetAddress = hashedStreetAddress;
+  if (city) addressInfo.city = city;
+  if (state) addressInfo.state = state;
+  if (countryCode) addressInfo.countryCode = countryCode;
+  if (postalCode) addressInfo.postalCode = postalCode;
+  if (Object.keys(addressInfo).length > 0) {
+    userIdentifiers[2] = { addressInfo };
+  }
+
+  return {
+    conversionAdjustments: [
+      {
+        adjustmentType: 'ENHANCEMENT',
+        orderId: '12345',
+        userIdentifiers,
+      },
+    ],
+  };
+};
+
+describe('processUserIdentifiers', () => {
+  describe('normalize + hash write-back (requireHash: true)', () => {
+    it('normalizes and hashes a raw email', () => {
+      const payload = makePayload({ hashedEmail: 'TEST@EXAMPLE.COM' });
+      processUserIdentifiers(payload, makeDestCtx(true));
+      const entry = payload.conversionAdjustments?.[0]?.userIdentifiers?.[0];
+      expect(entry).toEqual({ hashedEmail: sha256('test@example.com') });
+    });
+
+    it('normalizes gmail email: strips dots and +suffix, then hashes', () => {
+      const payload = makePayload({ hashedEmail: 'j.o.h.n+alias@gmail.com' });
+      processUserIdentifiers(payload, makeDestCtx(true));
+      const entry = payload.conversionAdjustments?.[0]?.userIdentifiers?.[0];
+      expect(entry).toEqual({ hashedEmail: sha256('john@gmail.com') });
+    });
+
+    it('normalizes and hashes a raw phone number (prepends +)', () => {
+      const payload = makePayload({ hashedPhoneNumber: '912382193' });
+      processUserIdentifiers(payload, makeDestCtx(true));
+      const entry = payload.conversionAdjustments?.[0]?.userIdentifiers?.[0];
+      expect(entry).toEqual({ hashedPhoneNumber: sha256('+912382193') });
+    });
+
+    it('normalizes (trim+lowercase) and hashes first/last names', () => {
+      const payload = makePayload({ hashedFirstName: ' John ', hashedLastName: 'GOMES' });
+      processUserIdentifiers(payload, makeDestCtx(true));
+      const firstAdj = payload.conversionAdjustments?.[0];
+      const addressEntry = firstAdj?.userIdentifiers?.[0];
+      expect(addressEntry).toEqual({
+        addressInfo: {
+          hashedFirstName: sha256('john'),
+          hashedLastName: sha256('gomes'),
+        },
+      });
+    });
+
+    it('normalizes (trim+lowercase) and hashes street address', () => {
+      const payload = makePayload({
+        hashedStreetAddress: '71 Cherry Court SOUTHAMPTON SO53 5PD UK',
+        city: 'London',
+      });
+      processUserIdentifiers(payload, makeDestCtx(true));
+      const firstAdj = payload.conversionAdjustments?.[0];
+      const addressEntry = firstAdj?.userIdentifiers?.[0];
+      expect(addressEntry).toEqual({
+        addressInfo: {
+          hashedStreetAddress: sha256('71 cherry court southampton so53 5pd uk'),
+          city: 'London',
+        },
+      });
+    });
+
+    it('passes pre-hashed values through when requireHash: false', () => {
+      const preHashedEmail = sha256('test@example.com');
+      const payload = makePayload({ hashedEmail: preHashedEmail });
+      processUserIdentifiers(payload, makeDestCtx(false));
+      const entry = payload.conversionAdjustments?.[0]?.userIdentifiers?.[0];
+      expect(entry).toEqual({ hashedEmail: preHashedEmail });
+    });
+  });
+
+  describe('mismatch throws (strict path)', () => {
+    it('throws when requireHash:true and value appears pre-hashed', () => {
+      const preHashedEmail = sha256('test@example.com');
+      const payload = makePayload({ hashedEmail: preHashedEmail });
+      expect(() => processUserIdentifiers(payload, makeDestCtx(true))).toThrow(
+        /Hashing is enabled but the value for field hashedEmail appears to already be hashed/,
+      );
+    });
+
+    it('throws when requireHash:false and value appears raw (unhashed email)', () => {
+      const payload = makePayload({ hashedEmail: 'test@example.com' });
+      expect(() => processUserIdentifiers(payload, makeDestCtx(false))).toThrow(
+        /Hashing is disabled but the value for field hashedEmail appears to be unhashed/,
+      );
+    });
+
+    it('throws when requireHash:false and phone appears raw', () => {
+      const payload = makePayload({ hashedPhoneNumber: '912382193' });
+      expect(() => processUserIdentifiers(payload, makeDestCtx(false))).toThrow(
+        /Hashing is disabled but the value for field hashedPhoneNumber appears to be unhashed/,
+      );
+    });
+  });
+
+  describe('invalid / empty field drops', () => {
+    it('drops invalid email (not a valid email after normalization)', () => {
+      const payload = makePayload({ hashedEmail: 'not-an-email' });
+      processUserIdentifiers(payload, makeDestCtx(true));
+      const identifiers = payload.conversionAdjustments?.[0]?.userIdentifiers;
+      // email entry should be pruned since hashedEmail was dropped
+      expect(identifiers).toEqual([]);
+    });
+
+    it('drops invalid phone number (non-numeric after normalization)', () => {
+      const payload = makePayload({ hashedPhoneNumber: 'not-a-phone' });
+      processUserIdentifiers(payload, makeDestCtx(true));
+      const identifiers = payload.conversionAdjustments?.[0]?.userIdentifiers;
+      expect(identifiers).toEqual([]);
+    });
+
+    it('drops empty/whitespace-only email', () => {
+      const payload = makePayload({ hashedEmail: '   ' });
+      processUserIdentifiers(payload, makeDestCtx(true));
+      const identifiers = payload.conversionAdjustments?.[0]?.userIdentifiers;
+      expect(identifiers).toEqual([]);
+    });
+  });
+
+  describe('non-scalar field drops', () => {
+    it('drops an object-valued street address instead of hashing String(object)', () => {
+      // Models the trackConfig fallback resolving the whole context.traits.address object
+      const payload = makePayload({
+        hashedFirstName: 'John',
+        city: 'London',
+        hashedStreetAddress: { streetAddress: '71 Cherry Court', city: 'London' },
+      });
+      processUserIdentifiers(payload, makeDestCtx(true));
+      expect(payload.conversionAdjustments?.[0]?.userIdentifiers).toEqual([
+        { addressInfo: { hashedFirstName: sha256('john'), city: 'London' } },
+      ]);
+    });
+
+    it('drops an object-valued street address without a consistency throw when requireHash:false', () => {
+      const preHashedFirstName = sha256('john');
+      const payload = makePayload({
+        hashedFirstName: preHashedFirstName,
+        hashedStreetAddress: { streetAddress: '71 Cherry Court' },
+      });
+      processUserIdentifiers(payload, makeDestCtx(false));
+      expect(payload.conversionAdjustments?.[0]?.userIdentifiers).toEqual([
+        { addressInfo: { hashedFirstName: preHashedFirstName } },
+      ]);
+    });
+
+    it('accepts a numeric phone value and hashes its string form', () => {
+      const payload = makePayload({ hashedPhoneNumber: 912382193 });
+      processUserIdentifiers(payload, makeDestCtx(true));
+      expect(payload.conversionAdjustments?.[0]?.userIdentifiers).toEqual([
+        { hashedPhoneNumber: sha256('+912382193') },
+      ]);
+    });
+  });
+
+  describe('requireHash default semantics', () => {
+    it('hashes when requireHash is undefined (missing from config)', () => {
+      const payload = makePayload({ hashedEmail: 'TEST@EXAMPLE.COM' });
+      processUserIdentifiers(payload, makeDestCtx(undefined));
+      expect(payload.conversionAdjustments?.[0]?.userIdentifiers).toEqual([
+        { hashedEmail: sha256('test@example.com') },
+      ]);
+    });
+  });
+
+  describe('pruning behavior', () => {
+    it('prunes the email entry when hashedEmail is dropped', () => {
+      const payload = makePayload({ hashedEmail: 'invalid' });
+      processUserIdentifiers(payload, makeDestCtx(true));
+      const identifiers = payload.conversionAdjustments?.[0]?.userIdentifiers;
+      // No entry with {} should remain
+      expect(identifiers?.some((e) => e && Object.keys(e).length === 0)).toBe(false);
+    });
+
+    it('prunes addressInfo when all hashable fields are dropped but preserves non-hashable fields', () => {
+      // Invalid first/last name but valid city — city should be preserved; address entry kept
+      const payload = makePayload({
+        hashedFirstName: '', // empty → drops
+        hashedLastName: '', // empty → drops
+        city: 'London',
+      });
+      processUserIdentifiers(payload, makeDestCtx(true));
+      const identifiers = payload.conversionAdjustments?.[0]?.userIdentifiers;
+      expect(identifiers).toEqual([{ addressInfo: { city: 'London' } }]);
+    });
+
+    it('prunes the entire address entry when all hashable AND non-hashable address fields are absent', () => {
+      // Only firstName provided, it's invalid
+      const payload = makePayload({ hashedFirstName: '' });
+      processUserIdentifiers(payload, makeDestCtx(true));
+      const identifiers = payload.conversionAdjustments?.[0]?.userIdentifiers;
+      expect(identifiers).toEqual([]);
+    });
+
+    it('preserves a valid email entry while pruning an invalid phone entry', () => {
+      const payload = makePayload({
+        hashedEmail: 'test@example.com',
+        hashedPhoneNumber: 'not-a-phone',
+      });
+      processUserIdentifiers(payload, makeDestCtx(true));
+      const identifiers = payload.conversionAdjustments?.[0]?.userIdentifiers;
+      expect(identifiers).toEqual([{ hashedEmail: sha256('test@example.com') }]);
+    });
+  });
+
+  describe('no-op cases', () => {
+    it('returns without mutating when userIdentifiers is absent', () => {
+      const payload: GaecPayload = {
+        conversionAdjustments: [{ adjustmentType: 'RESTATEMENT', orderId: '12345' }],
+      };
+      // Should not throw
+      processUserIdentifiers(payload, makeDestCtx(true));
+      expect(payload.conversionAdjustments?.[0]?.userIdentifiers).toBeUndefined();
+    });
+  });
+});
+
+describe('GAEC_FIELD_CONFIG', () => {
+  it('exports config for all five PII fields', () => {
+    expect(Object.keys(GAEC_FIELD_CONFIG).sort()).toEqual(
+      [
+        'hashedEmail',
+        'hashedFirstName',
+        'hashedLastName',
+        'hashedPhoneNumber',
+        'hashedStreetAddress',
+      ].sort(),
+    );
+  });
+});

--- a/src/v0/destinations/google_adwords_enhanced_conversions/utils.ts
+++ b/src/v0/destinations/google_adwords_enhanced_conversions/utils.ts
@@ -64,6 +64,10 @@ export const GAEC_FIELD_CONFIG: Record<string, AudienceField> = Object.fromEntri
   ]),
 );
 
+// The hashed address sub-fields, listed once — used both to collect raw values and to
+// rebuild the surviving addressInfo, so adding/removing one is a single edit.
+const ADDRESS_HASH_KEYS = ['hashedFirstName', 'hashedLastName', 'hashedStreetAddress'] as const;
+
 interface ProcessUserIdentifiersContext {
   // The control plane omits requireHash from most configs, so undefined is a real
   // runtime state — it means "hash" (see the isHashRequired mapping below).
@@ -132,9 +136,7 @@ export const processUserIdentifiers = (
   const hashableTargets = [
     { key: 'hashedEmail', container: emailEntry },
     { key: 'hashedPhoneNumber', container: phoneEntry },
-    { key: 'hashedFirstName', container: addressInfo },
-    { key: 'hashedLastName', container: addressInfo },
-    { key: 'hashedStreetAddress', container: addressInfo },
+    ...ADDRESS_HASH_KEYS.map((key) => ({ key, container: addressInfo })),
   ];
 
   // Collect every present hashable field into ONE record — processAudienceRecord treats each
@@ -178,24 +180,17 @@ export const processUserIdentifiers = (
   }
   if (addressInfo) {
     // Non-hashable address fields (city, state, countryCode, postalCode) carry through
-    // untouched; hashed fields appear only when they survived the pipeline. Dropping the
-    // rebuilt object when empty replaces the old in-place addressInfo prune.
+    // untouched; each hashed sub-field is replaced by its surviving value or dropped.
+    // Dropping the rebuilt object when empty replaces the old in-place addressInfo prune.
     const rebuiltAddressInfo: AddressInfo = { ...addressInfo };
-    delete rebuiltAddressInfo.hashedFirstName;
-    delete rebuiltAddressInfo.hashedLastName;
-    delete rebuiltAddressInfo.hashedStreetAddress;
-    const hashedFirstName = survivingValue('hashedFirstName');
-    if (hashedFirstName) {
-      rebuiltAddressInfo.hashedFirstName = hashedFirstName;
-    }
-    const hashedLastName = survivingValue('hashedLastName');
-    if (hashedLastName) {
-      rebuiltAddressInfo.hashedLastName = hashedLastName;
-    }
-    const hashedStreetAddress = survivingValue('hashedStreetAddress');
-    if (hashedStreetAddress) {
-      rebuiltAddressInfo.hashedStreetAddress = hashedStreetAddress;
-    }
+    ADDRESS_HASH_KEYS.forEach((key) => {
+      const value = survivingValue(key);
+      if (value) {
+        rebuiltAddressInfo[key] = value;
+      } else {
+        delete rebuiltAddressInfo[key];
+      }
+    });
     if (Object.keys(rebuiltAddressInfo).length > 0) {
       survivors.push({ addressInfo: rebuiltAddressInfo });
     }

--- a/src/v0/destinations/google_adwords_enhanced_conversions/utils.ts
+++ b/src/v0/destinations/google_adwords_enhanced_conversions/utils.ts
@@ -1,0 +1,215 @@
+import validator from 'validator';
+import { processAudienceRecord, isValidPhoneNumber, HashingType } from '../../util/audienceUtils';
+import type { AudienceField } from '../../util/audienceUtils';
+import {
+  normalizeEmail,
+  normalizePhone,
+  normalizeName,
+} from '../../util/googleUtils/userDataNormalization';
+import type { GaecPayload, UserIdentifierEntry, AddressInfo } from './types';
+import { destType } from './config';
+
+/**
+ * Per-field normalization and validation rules for GAEC user identifiers.
+ * Normalization follows Google Enhanced Conversions requirements:
+ * https://developers.google.com/google-ads/api/docs/conversions/enhance-conversions-leads
+ *
+ * The destKey names in trackConfig.json use the "hashed" prefix per Google's API naming
+ * convention. With hashToSha256 removed from the mapping, these fields carry raw values
+ * post-constructPayload; this config governs the normalize→validate→hash pipeline.
+ */
+
+// String-typed config for compile-time exhaustiveness; bridged to AudienceField below.
+const GAEC_STRING_FIELD_CONFIG = {
+  hashedEmail: {
+    normalize: normalizeEmail,
+    validate: validator.isEmail,
+    hashingType: HashingType.SHA256,
+  },
+  hashedPhoneNumber: {
+    normalize: normalizePhone,
+    validate: isValidPhoneNumber,
+    hashingType: HashingType.SHA256,
+  },
+  hashedFirstName: {
+    normalize: normalizeName,
+    validate: (v: string) => v.length > 0,
+    hashingType: HashingType.SHA256,
+  },
+  hashedLastName: {
+    normalize: normalizeName,
+    validate: (v: string) => v.length > 0,
+    hashingType: HashingType.SHA256,
+  },
+  // Google's OfflineUserAddressInfo proto: SHA-256 after normalization (lower case only).
+  // Street address is only accepted by ConversionAdjustmentUploadService, so GARL has no
+  // equivalent field.
+  hashedStreetAddress: {
+    normalize: (v: string) => v.trim().toLowerCase(),
+    validate: (v: string) => v.length > 0,
+    hashingType: HashingType.SHA256,
+  },
+} as const;
+
+// Bridge string-typed config to the unknown-typed AudienceField interface expected by
+// processAudienceRecord — mirrors the same pattern used in GARL's util.ts.
+export const GAEC_FIELD_CONFIG: Record<string, AudienceField> = Object.fromEntries(
+  Object.entries(GAEC_STRING_FIELD_CONFIG).map(([key, { normalize, validate, ...rest }]) => [
+    key,
+    {
+      ...rest,
+      normalize: (v: unknown) => normalize(String(v)),
+      validate: (v: unknown) => typeof v === 'string' && validate(v),
+    },
+  ]),
+);
+
+interface ProcessUserIdentifiersContext {
+  // The control plane omits requireHash from most configs, so undefined is a real
+  // runtime state — it means "hash" (see the isHashRequired mapping below).
+  requireHash: boolean | undefined;
+  workspaceId: string;
+  destinationId: string;
+}
+
+/**
+ * Runs the normalize → consistency-check → validate → hash pipeline on the five PII fields
+ * in the payload's first conversionAdjustment, then prunes identifier entries that end up
+ * empty after field drops.
+ *
+ * The pipeline is fed through processAudienceRecord (audienceUtils.ts) which handles:
+ *   1. Hashing-consistency check: throws InstrumentationError when data contradicts requireHash
+ *   2. Normalization via the per-field normalize function
+ *   3. Validation + field rejection (emits <destType>_invalid_field metric on failure)
+ *   4. SHA-256 hashing when isHashRequired=true
+ *
+ * This function mutates the payload in place, matching the pattern of constructPayload itself.
+ *
+ * The caller must invoke this AFTER the RESTATEMENT branch, since RESTATEMENT deletes
+ * userIdentifiers — calling this on a restatement event would throw spurious hash errors.
+ */
+export const processUserIdentifiers = (
+  payload: GaecPayload,
+  { requireHash, workspaceId, destinationId }: ProcessUserIdentifiersContext,
+): void => {
+  const firstAdjustment = payload.conversionAdjustments?.[0];
+  const userIdentifiers = firstAdjustment?.userIdentifiers;
+  if (!userIdentifiers) {
+    return;
+  }
+
+  const audienceDest = {
+    workspaceId,
+    id: destinationId,
+    type: destType,
+    // Legacy semantics: missing/undefined requireHash meant "hash" (only explicit `false` disabled it).
+    config: { isHashRequired: requireHash !== false },
+  };
+
+  // The trackConfig.json mapping produces { hashedEmail } / { hashedPhoneNumber } /
+  // { addressInfo: {...} } at fixed indices, but the caller (transform.ts) filters out the
+  // null slots of absent fields before this runs, so positions shift (e.g. a missing email
+  // moves the phone entry to index 0). Entries are therefore located by content key.
+  // (truthiness guards, never `!== undefined` — src/util/lodash-es-core.js shadows global
+  // `undefined` project-wide)
+  // UserIdentifierEntry has an index signature, so these accesses are type-safe without cast.
+  const findEntry = (key: string): UserIdentifierEntry | null =>
+    userIdentifiers.find((entry) => entry && entry[key]) ?? null;
+  const emailEntry = findEntry('hashedEmail');
+  const phoneEntry = findEntry('hashedPhoneNumber');
+  const addressEntry = findEntry('addressInfo');
+
+  // Narrow addressInfo once; after the object guard, the index signature on AddressInfo
+  // ([key: string]: unknown) makes the assignment structurally valid without a cast.
+  let addressInfo: AddressInfo | null = null;
+  if (addressEntry) {
+    const rawAddressInfo = addressEntry.addressInfo;
+    if (rawAddressInfo && typeof rawAddressInfo === 'object' && !Array.isArray(rawAddressInfo)) {
+      addressInfo = rawAddressInfo;
+    }
+  }
+
+  // Collect every present hashable field into ONE record — processAudienceRecord treats each
+  // field independently, so a single call is equivalent to per-entry calls and matches how the
+  // other integrations (GARL, fb_custom_audience, tiktok_audience) consume it.
+  // Only string/number values are usable PII: the mapping can resolve a whole object (e.g.
+  // hashedStreetAddress falling back to context.traits.address), and hashing String(object)
+  // would ship a useless sha256("[object Object]") identifier. Non-scalar values are deleted
+  // from the payload so they can't leak through unprocessed.
+  const rawFields: Record<string, unknown> = {};
+  const collectHashableField = (entry: Record<string, unknown> | null, key: string): void => {
+    if (!entry) {
+      return;
+    }
+    const value = entry[key];
+    if (!value) {
+      return;
+    }
+    if (typeof value === 'string' || typeof value === 'number') {
+      rawFields[key] = value;
+    } else {
+      // eslint-disable-next-line no-param-reassign -- intentional in-place delete of an unusable non-scalar field
+      delete entry[key];
+    }
+  };
+  collectHashableField(emailEntry, 'hashedEmail');
+  collectHashableField(phoneEntry, 'hashedPhoneNumber');
+  collectHashableField(addressInfo, 'hashedFirstName');
+  collectHashableField(addressInfo, 'hashedLastName');
+  collectHashableField(addressInfo, 'hashedStreetAddress');
+
+  if (Object.keys(rawFields).length > 0) {
+    const processed = processAudienceRecord(rawFields, {
+      fieldConfigs: GAEC_FIELD_CONFIG,
+      destination: audienceDest,
+    });
+
+    // Write each processed field back to the entry it came from, or delete it when the
+    // pipeline dropped it (invalid or empty after normalization).
+    const writeBack = (target: Record<string, unknown>, key: string): void => {
+      if (!rawFields[key]) {
+        return;
+      }
+      const processedValue = processed[key];
+      if (processedValue && typeof processedValue === 'string') {
+        // eslint-disable-next-line no-param-reassign -- intentional in-place write-back into the payload entry
+        target[key] = processedValue;
+      } else {
+        // eslint-disable-next-line no-param-reassign -- intentional in-place delete of a field the pipeline dropped
+        delete target[key];
+      }
+    };
+    if (emailEntry) {
+      writeBack(emailEntry, 'hashedEmail');
+    }
+    if (phoneEntry) {
+      writeBack(phoneEntry, 'hashedPhoneNumber');
+    }
+    if (addressInfo) {
+      writeBack(addressInfo, 'hashedFirstName');
+      writeBack(addressInfo, 'hashedLastName');
+      writeBack(addressInfo, 'hashedStreetAddress');
+    }
+  }
+
+  // Prune addressInfo if all hashable fields were dropped AND there are no non-hashable
+  // address fields (city, state, countryCode, postalCode) to preserve.
+  if (addressEntry && addressInfo) {
+    const hasHashableField =
+      addressInfo.hashedFirstName || addressInfo.hashedLastName || addressInfo.hashedStreetAddress;
+    const hasNonHashableField =
+      addressInfo.city || addressInfo.state || addressInfo.countryCode || addressInfo.postalCode;
+
+    if (!hasHashableField && !hasNonHashableField) {
+      delete addressEntry.addressInfo;
+    }
+  }
+
+  // Prune identifier entries that are now empty objects (all fields dropped)
+  firstAdjustment.userIdentifiers = userIdentifiers.filter(
+    (entry): entry is UserIdentifierEntry => {
+      if (!entry) return false;
+      return Object.keys(entry).length > 0;
+    },
+  );
+};

--- a/src/v0/destinations/google_adwords_enhanced_conversions/utils.ts
+++ b/src/v0/destinations/google_adwords_enhanced_conversions/utils.ts
@@ -74,8 +74,9 @@ interface ProcessUserIdentifiersContext {
 
 /**
  * Runs the normalize → consistency-check → validate → hash pipeline on the five PII fields
- * in the payload's first conversionAdjustment, then prunes identifier entries that end up
- * empty after field drops.
+ * in the payload's first conversionAdjustment and returns the surviving identifier entries
+ * in mapping order (email, phone, addressInfo). The payload itself is NOT mutated — the
+ * caller owns the result (assign it, count it, throw when empty).
  *
  * The pipeline is fed through processAudienceRecord (audienceUtils.ts) which handles:
  *   1. Hashing-consistency check: throws InstrumentationError when data contradicts requireHash
@@ -83,19 +84,16 @@ interface ProcessUserIdentifiersContext {
  *   3. Validation + field rejection (emits <destType>_invalid_field metric on failure)
  *   4. SHA-256 hashing when isHashRequired=true
  *
- * This function mutates the payload in place, matching the pattern of constructPayload itself.
- *
  * The caller must invoke this AFTER the RESTATEMENT branch, since RESTATEMENT deletes
  * userIdentifiers — calling this on a restatement event would throw spurious hash errors.
  */
 export const processUserIdentifiers = (
   payload: GaecPayload,
   { requireHash, workspaceId, destinationId }: ProcessUserIdentifiersContext,
-): void => {
-  const firstAdjustment = payload.conversionAdjustments?.[0];
-  const userIdentifiers = firstAdjustment?.userIdentifiers;
+): UserIdentifierEntry[] => {
+  const userIdentifiers = payload.conversionAdjustments?.[0]?.userIdentifiers;
   if (!userIdentifiers) {
-    return;
+    return [];
   }
 
   const audienceDest = {
@@ -129,87 +127,83 @@ export const processUserIdentifiers = (
     }
   }
 
+  // The field→container binding, declared once — collection and survivor rebuilding below
+  // both derive from it, so adding or removing a PII field is a one-line change here.
+  const hashableTargets = [
+    { key: 'hashedEmail', container: emailEntry },
+    { key: 'hashedPhoneNumber', container: phoneEntry },
+    { key: 'hashedFirstName', container: addressInfo },
+    { key: 'hashedLastName', container: addressInfo },
+    { key: 'hashedStreetAddress', container: addressInfo },
+  ];
+
   // Collect every present hashable field into ONE record — processAudienceRecord treats each
   // field independently, so a single call is equivalent to per-entry calls and matches how the
   // other integrations (GARL, fb_custom_audience, tiktok_audience) consume it.
   // Only string/number values are usable PII: the mapping can resolve a whole object (e.g.
   // hashedStreetAddress falling back to context.traits.address), and hashing String(object)
-  // would ship a useless sha256("[object Object]") identifier. Non-scalar values are deleted
-  // from the payload so they can't leak through unprocessed.
+  // would ship a useless sha256("[object Object]") identifier. Non-scalars are simply not
+  // collected — the returned identifiers are rebuilt from processed values only, so nothing
+  // unprocessed can leak through.
   const rawFields: Record<string, unknown> = {};
-  const collectHashableField = (entry: Record<string, unknown> | null, key: string): void => {
-    if (!entry) {
-      return;
-    }
-    const value = entry[key];
-    if (!value) {
-      return;
-    }
-    if (typeof value === 'string' || typeof value === 'number') {
+  hashableTargets.forEach(({ key, container }) => {
+    const value = container?.[key];
+    if (value && (typeof value === 'string' || typeof value === 'number')) {
       rawFields[key] = value;
-    } else {
-      // eslint-disable-next-line no-param-reassign -- intentional in-place delete of an unusable non-scalar field
-      delete entry[key];
     }
+  });
+
+  const processed: Record<string, unknown> =
+    Object.keys(rawFields).length > 0
+      ? processAudienceRecord(rawFields, {
+          fieldConfigs: GAEC_FIELD_CONFIG,
+          destination: audienceDest,
+        })
+      : {};
+
+  const survivingValue = (key: string): string | null => {
+    const value = processed[key];
+    return value && typeof value === 'string' ? value : null;
   };
-  collectHashableField(emailEntry, 'hashedEmail');
-  collectHashableField(phoneEntry, 'hashedPhoneNumber');
-  collectHashableField(addressInfo, 'hashedFirstName');
-  collectHashableField(addressInfo, 'hashedLastName');
-  collectHashableField(addressInfo, 'hashedStreetAddress');
 
-  if (Object.keys(rawFields).length > 0) {
-    const processed = processAudienceRecord(rawFields, {
-      fieldConfigs: GAEC_FIELD_CONFIG,
-      destination: audienceDest,
-    });
-
-    // Write each processed field back to the entry it came from, or delete it when the
-    // pipeline dropped it (invalid or empty after normalization).
-    const writeBack = (target: Record<string, unknown>, key: string): void => {
-      if (!rawFields[key]) {
-        return;
-      }
-      const processedValue = processed[key];
-      if (processedValue && typeof processedValue === 'string') {
-        // eslint-disable-next-line no-param-reassign -- intentional in-place write-back into the payload entry
-        target[key] = processedValue;
-      } else {
-        // eslint-disable-next-line no-param-reassign -- intentional in-place delete of a field the pipeline dropped
-        delete target[key];
-      }
-    };
-    if (emailEntry) {
-      writeBack(emailEntry, 'hashedEmail');
+  // Rebuild the identifier entries in mapping order from surviving values only.
+  const survivors: UserIdentifierEntry[] = [];
+  const hashedEmail = survivingValue('hashedEmail');
+  if (hashedEmail) {
+    survivors.push({ hashedEmail });
+  }
+  const hashedPhoneNumber = survivingValue('hashedPhoneNumber');
+  if (hashedPhoneNumber) {
+    survivors.push({ hashedPhoneNumber });
+  }
+  if (addressInfo) {
+    // Non-hashable address fields (city, state, countryCode, postalCode) carry through
+    // untouched; hashed fields appear only when they survived the pipeline. Dropping the
+    // rebuilt object when empty replaces the old in-place addressInfo prune.
+    const rebuiltAddressInfo: AddressInfo = { ...addressInfo };
+    delete rebuiltAddressInfo.hashedFirstName;
+    delete rebuiltAddressInfo.hashedLastName;
+    delete rebuiltAddressInfo.hashedStreetAddress;
+    const hashedFirstName = survivingValue('hashedFirstName');
+    if (hashedFirstName) {
+      rebuiltAddressInfo.hashedFirstName = hashedFirstName;
     }
-    if (phoneEntry) {
-      writeBack(phoneEntry, 'hashedPhoneNumber');
+    const hashedLastName = survivingValue('hashedLastName');
+    if (hashedLastName) {
+      rebuiltAddressInfo.hashedLastName = hashedLastName;
     }
-    if (addressInfo) {
-      writeBack(addressInfo, 'hashedFirstName');
-      writeBack(addressInfo, 'hashedLastName');
-      writeBack(addressInfo, 'hashedStreetAddress');
+    const hashedStreetAddress = survivingValue('hashedStreetAddress');
+    if (hashedStreetAddress) {
+      rebuiltAddressInfo.hashedStreetAddress = hashedStreetAddress;
     }
+    if (Object.keys(rebuiltAddressInfo).length > 0) {
+      survivors.push({ addressInfo: rebuiltAddressInfo });
+    }
+  } else if (addressEntry) {
+    // Non-object addressInfo — unreachable via the mapping (it always builds an object when
+    // any address field is present); carried through unchanged for behavior parity.
+    survivors.push(addressEntry);
   }
 
-  // Prune addressInfo if all hashable fields were dropped AND there are no non-hashable
-  // address fields (city, state, countryCode, postalCode) to preserve.
-  if (addressEntry && addressInfo) {
-    const hasHashableField =
-      addressInfo.hashedFirstName || addressInfo.hashedLastName || addressInfo.hashedStreetAddress;
-    const hasNonHashableField =
-      addressInfo.city || addressInfo.state || addressInfo.countryCode || addressInfo.postalCode;
-
-    if (!hasHashableField && !hasNonHashableField) {
-      delete addressEntry.addressInfo;
-    }
-  }
-
-  // Prune identifier entries that are now empty objects (all fields dropped)
-  firstAdjustment.userIdentifiers = userIdentifiers.filter(
-    (entry): entry is UserIdentifierEntry => {
-      if (!entry) return false;
-      return Object.keys(entry).length > 0;
-    },
-  );
+  return survivors;
 };

--- a/src/v0/destinations/google_adwords_remarketing_lists/util.ts
+++ b/src/v0/destinations/google_adwords_remarketing_lists/util.ts
@@ -14,6 +14,7 @@ import {
   isValidPhoneNumber,
   type AudienceField,
 } from '../../util/audienceUtils';
+import { normalizeEmail, normalizePhone } from '../../util/googleUtils/userDataNormalization';
 import logger from '../../../logger';
 import { MappedToDestinationKey } from '../../../constants';
 import { JSON_MIME_TYPE } from '../../util/constant';
@@ -30,27 +31,6 @@ import type { GARLDestinationConfig } from './types';
 import { HashingType } from '../../util/audienceUtils';
 
 const COUNTRY_CODE_REGEX = /^[A-Za-z]{2,3}$/;
-const GMAIL_DOMAINS = new Set(['gmail.com', 'googlemail.com']);
-
-const normalizeEmail = (v: string): string => {
-  const trimmed = v.trim().toLowerCase();
-  const atIdx = trimmed.indexOf('@');
-  if (atIdx === -1) return trimmed;
-  const domain = trimmed.slice(atIdx + 1);
-  if (GMAIL_DOMAINS.has(domain)) {
-    const username = trimmed.slice(0, atIdx).replace(/\./g, '').replace(/\+.*$/, '');
-    return `${username}@${domain}`;
-  }
-  return trimmed;
-};
-
-const normalizePhone = (v: string): string => {
-  const stripped = v.replace(/[\s().-]/g, '');
-  if (!stripped) {
-    return '';
-  }
-  return stripped.startsWith('+') ? stripped : `+${stripped}`;
-};
 
 /**
  * Per-field normalization and validation rules for GARL.

--- a/src/v0/util/googleUtils/userDataNormalization.test.ts
+++ b/src/v0/util/googleUtils/userDataNormalization.test.ts
@@ -1,0 +1,135 @@
+import { normalizeEmail, normalizePhone, normalizeName } from './userDataNormalization';
+
+describe('normalizeEmail', () => {
+  const gmailCases = [
+    {
+      name: 'strips dots from gmail username',
+      input: 'j.o.h.n@gmail.com',
+      expected: 'john@gmail.com',
+    },
+    {
+      name: 'strips +suffix from gmail username',
+      input: 'john+alias@gmail.com',
+      expected: 'john@gmail.com',
+    },
+    {
+      name: 'strips dots and +suffix from gmail username',
+      input: 'j.o.h.n+alias@gmail.com',
+      expected: 'john@gmail.com',
+    },
+    {
+      name: 'treats googlemail.com as gmail domain',
+      input: 'j.o.h.n+alias@googlemail.com',
+      expected: 'john@googlemail.com',
+    },
+    {
+      name: 'lowercases gmail address',
+      input: 'JOHN@GMAIL.COM',
+      expected: 'john@gmail.com',
+    },
+  ];
+
+  const nonGmailCases = [
+    {
+      name: 'lowercases and trims non-gmail address',
+      input: '  TEST@EXAMPLE.COM  ',
+      expected: 'test@example.com',
+    },
+    {
+      name: 'preserves dots in non-gmail username',
+      input: 'first.last@example.com',
+      expected: 'first.last@example.com',
+    },
+    {
+      name: 'preserves +suffix in non-gmail username',
+      input: 'user+tag@example.com',
+      expected: 'user+tag@example.com',
+    },
+    {
+      name: 'returns trimmed+lowercased value when no @ sign',
+      input: '  NOTANEMAIL  ',
+      expected: 'notanemail',
+    },
+  ];
+
+  it.each(gmailCases)('gmail: $name', ({ input, expected }) => {
+    expect(normalizeEmail(input)).toBe(expected);
+  });
+
+  it.each(nonGmailCases)('non-gmail: $name', ({ input, expected }) => {
+    expect(normalizeEmail(input)).toBe(expected);
+  });
+});
+
+describe('normalizePhone', () => {
+  const cases = [
+    {
+      name: 'prepends + when missing',
+      input: '912382193',
+      expected: '+912382193',
+    },
+    {
+      name: 'preserves existing +',
+      input: '+912382193',
+      expected: '+912382193',
+    },
+    {
+      name: 'strips spaces',
+      input: '91 238 2193',
+      expected: '+912382193',
+    },
+    {
+      name: 'strips parentheses',
+      input: '(912)382193',
+      expected: '+912382193',
+    },
+    {
+      name: 'strips dots',
+      input: '912.382.193',
+      expected: '+912382193',
+    },
+    {
+      name: 'strips dashes',
+      input: '912-382-193',
+      expected: '+912382193',
+    },
+    {
+      name: 'returns empty string when only separators',
+      input: '  -  ',
+      expected: '',
+    },
+  ];
+
+  it.each(cases)('$name', ({ input, expected }) => {
+    expect(normalizePhone(input)).toBe(expected);
+  });
+});
+
+describe('normalizeName', () => {
+  const cases = [
+    {
+      name: 'trims and lowercases',
+      input: '  John  ',
+      expected: 'john',
+    },
+    {
+      name: 'already clean name',
+      input: 'gomes',
+      expected: 'gomes',
+    },
+    {
+      name: 'uppercased name',
+      input: 'JOHN',
+      expected: 'john',
+    },
+    {
+      name: 'mixed case name',
+      input: 'McCallister',
+      expected: 'mccallister',
+    },
+  ];
+
+  it.each(cases)('$name', ({ input, expected }) => {
+    expect(normalizeName(input)).toBe(expected);
+  });
+});

--- a/src/v0/util/googleUtils/userDataNormalization.ts
+++ b/src/v0/util/googleUtils/userDataNormalization.ts
@@ -1,0 +1,45 @@
+/**
+ * Shared Google Ads user-data normalizers used by both Google Ads Remarketing Lists (GARL)
+ * and Google Ads Enhanced Conversions (GAEC). Normalization follows Google Customer Match
+ * and Enhanced Conversions requirements:
+ * https://developers.google.com/google-ads/api/docs/remarketing/audience-segments/customer-match/get-started
+ * https://developers.google.com/google-ads/api/docs/conversions/enhance-conversions-leads
+ */
+
+// Gmail and Googlemail are the same mailbox — strip dots and +aliases from the username.
+const GMAIL_DOMAINS = new Set(['gmail.com', 'googlemail.com']);
+
+/**
+ * Normalizes an email address per Google Customer Match / Enhanced Conversions requirements:
+ * trim whitespace, lowercase, and for Gmail domains strip username dots and +suffix.
+ */
+export const normalizeEmail = (v: string): string => {
+  const trimmed = v.trim().toLowerCase();
+  const atIdx = trimmed.indexOf('@');
+  if (atIdx === -1) return trimmed;
+  const domain = trimmed.slice(atIdx + 1);
+  if (GMAIL_DOMAINS.has(domain)) {
+    const username = trimmed.slice(0, atIdx).replace(/\./g, '').replace(/\+.*$/, '');
+    return `${username}@${domain}`;
+  }
+  return trimmed;
+};
+
+/**
+ * Normalizes a phone number per Google Customer Match / Enhanced Conversions requirements:
+ * strip spaces, parentheses, dots, and dashes; prepend '+' if no leading '+'.
+ */
+export const normalizePhone = (v: string): string => {
+  const stripped = v.replace(/[\s().-]/g, '');
+  if (!stripped) {
+    return '';
+  }
+  return stripped.startsWith('+') ? stripped : `+${stripped}`;
+};
+
+/**
+ * Normalizes a name (first or last) per Google Enhanced Conversions requirements:
+ * trim whitespace and lowercase. Proto-exact extras (in-between spaces, punctuation removal)
+ * are deferred as a follow-up pending Google's clarified proto wording.
+ */
+export const normalizeName = (v: string): string => v.trim().toLowerCase();

--- a/test/integrations/destinations/google_adwords_enhanced_conversions/processor/data.ts
+++ b/test/integrations/destinations/google_adwords_enhanced_conversions/processor/data.ts
@@ -1,3 +1,4 @@
+import sha256 from 'sha256';
 import { authHeader1, secret1 } from '../maskedSecrets';
 
 export const data = [
@@ -162,20 +163,16 @@ export const data = [
                         'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36',
                       userIdentifiers: [
                         {
-                          hashedPhoneNumber:
-                            '04387707e6cbed8c4538c81cc570ed9252d579469f36c273839b26d784e4bdbe',
+                          hashedPhoneNumber: sha256('+912382193'),
                         },
                         {
                           addressInfo: {
-                            hashedFirstName:
-                              'a8cfcd74832004951b4408cdb0a5dbcd8c7e52d43f7fe244bf720582e05241da',
-                            hashedLastName:
-                              '1c574b17eefa532b6d61c963550a82d2d3dfca4a7fb69e183374cfafd5328ee4',
+                            hashedFirstName: sha256('john'),
+                            hashedLastName: sha256('gomes'),
                             state: 'UK',
                             city: 'London',
                             countryCode: 'us',
-                            hashedStreetAddress:
-                              '9a4d2e50828448f137f119a3ebdbbbab8d6731234a67595fdbfeb2a2315dd550',
+                            hashedStreetAddress: sha256('71 cherry court southampton so53 5pd uk'),
                           },
                         },
                       ],
@@ -655,15 +652,14 @@ export const data = [
                       userIdentifiers: [
                         {
                           addressInfo: {
-                            hashedFirstName:
-                              'a8cfcd74832004951b4408cdb0a5dbcd8c7e52d43f7fe244bf720582e05241da',
-                            hashedLastName:
-                              '1c574b17eefa532b6d61c963550a82d2d3dfca4a7fb69e183374cfafd5328ee4',
+                            hashedFirstName: sha256('john'),
+                            hashedLastName: sha256('gomes'),
                             state: 'UK',
                             city: 'London',
                             countryCode: 'us',
-                            hashedStreetAddress:
-                              'b28c94b2195c8ed259f0b415aaee3f39b0b2920a4537611499fa044956917a21',
+                            // no hashedStreetAddress: the mapping's context.traits.address
+                            // fallback resolves to an object here, which is dropped rather
+                            // than hashed as String(object)
                           },
                         },
                       ],
@@ -1373,20 +1369,16 @@ export const data = [
                         'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36',
                       userIdentifiers: [
                         {
-                          hashedPhoneNumber:
-                            '04387707e6cbed8c4538c81cc570ed9252d579469f36c273839b26d784e4bdbe',
+                          hashedPhoneNumber: sha256('+912382193'),
                         },
                         {
                           addressInfo: {
-                            hashedFirstName:
-                              'a8cfcd74832004951b4408cdb0a5dbcd8c7e52d43f7fe244bf720582e05241da',
-                            hashedLastName:
-                              '1c574b17eefa532b6d61c963550a82d2d3dfca4a7fb69e183374cfafd5328ee4',
+                            hashedFirstName: sha256('john'),
+                            hashedLastName: sha256('gomes'),
                             state: 'UK',
                             city: 'London',
                             countryCode: 'us',
-                            hashedStreetAddress:
-                              '9a4d2e50828448f137f119a3ebdbbbab8d6731234a67595fdbfeb2a2315dd550',
+                            hashedStreetAddress: sha256('71 cherry court southampton so53 5pd uk'),
                           },
                         },
                       ],
@@ -1417,7 +1409,8 @@ export const data = [
   },
   {
     name: 'google_adwords_enhanced_conversions',
-    description: 'Test 9',
+    description:
+      'Test 9: raw (unhashed) phone with requireHash:false aborts with hashing-consistency error',
     feature: 'processor',
     module: 'destination',
     version: 'v0',
@@ -1531,66 +1524,6 @@ export const data = [
         status: 200,
         body: [
           {
-            output: {
-              version: '1',
-              type: 'REST',
-              method: 'POST',
-              endpoint: '',
-              headers: {
-                Authorization: authHeader1,
-                'Content-Type': 'application/json',
-                'login-customer-id': '1234567890',
-              },
-              params: {
-                accessToken: 'google_adwords_enhanced_conversions1',
-                event: 'Page View',
-                customerId: '1234567890',
-                loginCustomerId: '1234567890',
-                subAccount: true,
-              },
-              body: {
-                JSON: {
-                  conversionAdjustments: [
-                    {
-                      gclidDateTimePair: {
-                        gclid: 'gclid1234',
-                        conversionDateTime: '2022-01-01 12:32:45-08:00',
-                      },
-                      restatementValue: {
-                        adjustedValue: 10,
-                        currencyCode: 'INR',
-                      },
-                      orderId: '10000',
-                      adjustmentDateTime: '2022-01-01 12:32:45-08:00',
-                      userAgent:
-                        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36',
-                      userIdentifiers: [
-                        {
-                          hashedPhoneNumber: '912382193',
-                        },
-                        {
-                          addressInfo: {
-                            hashedFirstName: 'John',
-                            hashedLastName: 'Gomes',
-                            state: 'UK',
-                            city: 'London',
-                            countryCode: 'us',
-                            hashedStreetAddress: '71 Cherry Court SOUTHAMPTON SO53 5PD UK',
-                          },
-                        },
-                      ],
-                      adjustmentType: 'ENHANCEMENT',
-                    },
-                  ],
-                  partialFailure: true,
-                },
-                JSON_ARRAY: {},
-                XML: {},
-                FORM: {},
-              },
-              files: {},
-              userId: '',
-            },
             metadata: {
               secret: {
                 access_token: secret1,
@@ -1598,7 +1531,17 @@ export const data = [
                 developer_token: 'ijkl91011',
               },
             },
-            statusCode: 200,
+            statusCode: 400,
+            error:
+              'Hashing is disabled but the value for field hashedPhoneNumber appears to be unhashed. Either enable hashing or send pre-hashed data.',
+            statTags: {
+              errorCategory: 'dataValidation',
+              errorType: 'instrumentation',
+              destType: 'GOOGLE_ADWORDS_ENHANCED_CONVERSIONS',
+              module: 'destination',
+              implementation: 'native',
+              feature: 'processor',
+            },
           },
         ],
       },
@@ -1939,6 +1882,521 @@ export const data = [
               },
               name: 'ApplicationLoaded',
               sentAt: '2019-10-14T11:15:53.296Z',
+            },
+          },
+        ],
+      },
+    },
+    output: {
+      response: {
+        status: 200,
+        body: [
+          {
+            output: {
+              version: '1',
+              type: 'REST',
+              method: 'POST',
+              endpoint: '',
+              headers: {
+                Authorization: authHeader1,
+                'Content-Type': 'application/json',
+                'login-customer-id': '1234567890',
+              },
+              params: {
+                accessToken: 'google_adwords_enhanced_conversions1',
+                event: 'Page View',
+                customerId: '1234567890',
+                loginCustomerId: '1234567890',
+                subAccount: true,
+              },
+              body: {
+                JSON: {
+                  conversionAdjustments: [
+                    {
+                      gclidDateTimePair: {
+                        gclid: 'gclid1234',
+                        conversionDateTime: '2022-01-01 12:32:45-08:00',
+                      },
+                      restatementValue: {
+                        adjustedValue: 10,
+                        currencyCode: 'INR',
+                      },
+                      orderId: '10000',
+                      adjustmentDateTime: '2022-01-01 12:32:45-08:00',
+                      adjustmentType: 'RESTATEMENT',
+                    },
+                  ],
+                  partialFailure: true,
+                },
+                JSON_ARRAY: {},
+                XML: {},
+                FORM: {},
+              },
+              files: {},
+              userId: '',
+            },
+            metadata: {
+              secret: {
+                access_token: secret1,
+                refresh_token: 'efgh5678',
+                developer_token: 'ijkl91011',
+              },
+              workspaceId: 'workspaceId1',
+            },
+            statusCode: 200,
+          },
+        ],
+      },
+    },
+  },
+  {
+    name: 'google_adwords_enhanced_conversions',
+    description:
+      'Test 13: mixed-case identifiers are normalized before hashing (gmail dots/plus-suffix stripped, names lowercased, phone E.164-cleaned)',
+    feature: 'processor',
+    module: 'destination',
+    version: 'v0',
+    input: {
+      request: {
+        body: [
+          {
+            metadata: {
+              secret: {
+                access_token: secret1,
+                refresh_token: 'efgh5678',
+                developer_token: 'ijkl91011',
+              },
+            },
+            destination: {
+              hasDynamicConfig: false,
+              Config: {
+                rudderAccountId: '25u5whFH7gVTnCiAjn4ykoCLGoC',
+                customerId: '1234567890',
+                subAccount: true,
+                loginCustomerId: '11',
+                listOfConversions: [{ conversions: 'Page View' }],
+                authStatus: 'active',
+              },
+            },
+            message: {
+              channel: 'web',
+              context: {
+                traits: {
+                  email: ' Alex.Doe+shop@GMAIL.com',
+                  phone: '(91) 238-2193',
+                  firstName: ' MARY ',
+                },
+              },
+              event: 'Page View',
+              type: 'track',
+              messageId: '5e10d13a-bf9a-44bf-b884-43a9e591ea71',
+              anonymousId: '00000000000000000000000000',
+              userId: '12345',
+              properties: {
+                gclid: 'gclid1234',
+                conversionDateTime: '2022-01-01 12:32:45-08:00',
+                order_id: 10000,
+              },
+            },
+          },
+        ],
+      },
+    },
+    output: {
+      response: {
+        status: 200,
+        body: [
+          {
+            output: {
+              version: '1',
+              type: 'REST',
+              method: 'POST',
+              endpoint: '',
+              headers: {
+                Authorization: authHeader1,
+                'Content-Type': 'application/json',
+                'login-customer-id': '11',
+              },
+              params: {
+                accessToken: 'google_adwords_enhanced_conversions1',
+                event: 'Page View',
+                customerId: '1234567890',
+                loginCustomerId: '11',
+                subAccount: true,
+              },
+              body: {
+                JSON: {
+                  conversionAdjustments: [
+                    {
+                      gclidDateTimePair: {
+                        gclid: 'gclid1234',
+                        conversionDateTime: '2022-01-01 12:32:45-08:00',
+                      },
+                      orderId: '10000',
+                      userIdentifiers: [
+                        {
+                          hashedEmail: sha256('alexdoe@gmail.com'),
+                        },
+                        {
+                          hashedPhoneNumber: sha256('+912382193'),
+                        },
+                        {
+                          addressInfo: {
+                            hashedFirstName: sha256('mary'),
+                          },
+                        },
+                      ],
+                      adjustmentType: 'ENHANCEMENT',
+                    },
+                  ],
+                  partialFailure: true,
+                },
+                JSON_ARRAY: {},
+                XML: {},
+                FORM: {},
+              },
+              files: {},
+              userId: '',
+            },
+            metadata: {
+              secret: {
+                access_token: secret1,
+                refresh_token: 'efgh5678',
+                developer_token: 'ijkl91011',
+              },
+            },
+            statusCode: 200,
+          },
+        ],
+      },
+    },
+  },
+  {
+    name: 'google_adwords_enhanced_conversions',
+    description:
+      'Test 14: pre-hashed email with hashing enabled (requireHash not disabled) aborts with a hashing-consistency error',
+    feature: 'processor',
+    module: 'destination',
+    version: 'v0',
+    input: {
+      request: {
+        body: [
+          {
+            metadata: {
+              secret: {
+                access_token: secret1,
+                refresh_token: 'efgh5678',
+                developer_token: 'ijkl91011',
+              },
+            },
+            destination: {
+              hasDynamicConfig: false,
+              Config: {
+                rudderAccountId: '25u5whFH7gVTnCiAjn4ykoCLGoC',
+                customerId: '1234567890',
+                subAccount: true,
+                loginCustomerId: '11',
+                listOfConversions: [{ conversions: 'Page View' }],
+                authStatus: 'active',
+              },
+            },
+            message: {
+              channel: 'web',
+              context: {
+                traits: {
+                  email: sha256('alexdoe@gmail.com'),
+                },
+              },
+              event: 'Page View',
+              type: 'track',
+              messageId: '5e10d13a-bf9a-44bf-b884-43a9e591ea71',
+              anonymousId: '00000000000000000000000000',
+              userId: '12345',
+              properties: {
+                gclid: 'gclid1234',
+                order_id: 10000,
+              },
+            },
+          },
+        ],
+      },
+    },
+    output: {
+      response: {
+        status: 200,
+        body: [
+          {
+            metadata: {
+              secret: {
+                access_token: secret1,
+                refresh_token: 'efgh5678',
+                developer_token: 'ijkl91011',
+              },
+            },
+            statusCode: 400,
+            error:
+              'Hashing is enabled but the value for field hashedEmail appears to already be hashed. Either disable hashing or send unhashed data.',
+            statTags: {
+              errorCategory: 'dataValidation',
+              errorType: 'instrumentation',
+              destType: 'GOOGLE_ADWORDS_ENHANCED_CONVERSIONS',
+              module: 'destination',
+              implementation: 'native',
+              feature: 'processor',
+            },
+          },
+        ],
+      },
+    },
+  },
+  {
+    name: 'google_adwords_enhanced_conversions',
+    description:
+      'Test 15: invalid email is dropped while the valid phone identifier is kept and hashed',
+    feature: 'processor',
+    module: 'destination',
+    version: 'v0',
+    input: {
+      request: {
+        body: [
+          {
+            metadata: {
+              secret: {
+                access_token: secret1,
+                refresh_token: 'efgh5678',
+                developer_token: 'ijkl91011',
+              },
+            },
+            destination: {
+              hasDynamicConfig: false,
+              Config: {
+                rudderAccountId: '25u5whFH7gVTnCiAjn4ykoCLGoC',
+                customerId: '1234567890',
+                subAccount: true,
+                loginCustomerId: '11',
+                listOfConversions: [{ conversions: 'Page View' }],
+                authStatus: 'active',
+              },
+            },
+            message: {
+              channel: 'web',
+              context: {
+                traits: {
+                  email: 'not-an-email',
+                  phone: '912382193',
+                },
+              },
+              event: 'Page View',
+              type: 'track',
+              messageId: '5e10d13a-bf9a-44bf-b884-43a9e591ea71',
+              anonymousId: '00000000000000000000000000',
+              userId: '12345',
+              properties: {
+                gclid: 'gclid1234',
+                order_id: 10000,
+              },
+            },
+          },
+        ],
+      },
+    },
+    output: {
+      response: {
+        status: 200,
+        body: [
+          {
+            output: {
+              version: '1',
+              type: 'REST',
+              method: 'POST',
+              endpoint: '',
+              headers: {
+                Authorization: authHeader1,
+                'Content-Type': 'application/json',
+                'login-customer-id': '11',
+              },
+              params: {
+                accessToken: 'google_adwords_enhanced_conversions1',
+                event: 'Page View',
+                customerId: '1234567890',
+                loginCustomerId: '11',
+                subAccount: true,
+              },
+              body: {
+                JSON: {
+                  conversionAdjustments: [
+                    {
+                      gclidDateTimePair: {
+                        gclid: 'gclid1234',
+                      },
+                      orderId: '10000',
+                      userIdentifiers: [
+                        {
+                          hashedPhoneNumber: sha256('+912382193'),
+                        },
+                      ],
+                      adjustmentType: 'ENHANCEMENT',
+                    },
+                  ],
+                  partialFailure: true,
+                },
+                JSON_ARRAY: {},
+                XML: {},
+                FORM: {},
+              },
+              files: {},
+              userId: '',
+            },
+            metadata: {
+              secret: {
+                access_token: secret1,
+                refresh_token: 'efgh5678',
+                developer_token: 'ijkl91011',
+              },
+            },
+            statusCode: 200,
+          },
+        ],
+      },
+    },
+  },
+  {
+    name: 'google_adwords_enhanced_conversions',
+    description:
+      'Test 16: event aborts when every identifier is dropped by validation (invalid email only)',
+    feature: 'processor',
+    module: 'destination',
+    version: 'v0',
+    input: {
+      request: {
+        body: [
+          {
+            metadata: {
+              secret: {
+                access_token: secret1,
+                refresh_token: 'efgh5678',
+                developer_token: 'ijkl91011',
+              },
+            },
+            destination: {
+              hasDynamicConfig: false,
+              Config: {
+                rudderAccountId: '25u5whFH7gVTnCiAjn4ykoCLGoC',
+                customerId: '1234567890',
+                subAccount: true,
+                loginCustomerId: '11',
+                listOfConversions: [{ conversions: 'Page View' }],
+                authStatus: 'active',
+              },
+            },
+            message: {
+              channel: 'web',
+              context: {
+                traits: {
+                  email: 'not-an-email',
+                },
+              },
+              event: 'Page View',
+              type: 'track',
+              messageId: '5e10d13a-bf9a-44bf-b884-43a9e591ea71',
+              anonymousId: '00000000000000000000000000',
+              userId: '12345',
+              properties: {
+                gclid: 'gclid1234',
+                order_id: 10000,
+              },
+            },
+          },
+        ],
+      },
+    },
+    output: {
+      response: {
+        status: 200,
+        body: [
+          {
+            metadata: {
+              secret: {
+                access_token: secret1,
+                refresh_token: 'efgh5678',
+                developer_token: 'ijkl91011',
+              },
+            },
+            statusCode: 400,
+            error:
+              'Any of email, phone, firstName, lastName, city, street, countryCode, postalCode or streetAddress is required in traits.',
+            statTags: {
+              errorCategory: 'dataValidation',
+              errorType: 'instrumentation',
+              destType: 'GOOGLE_ADWORDS_ENHANCED_CONVERSIONS',
+              module: 'destination',
+              implementation: 'native',
+              feature: 'processor',
+            },
+          },
+        ],
+      },
+    },
+  },
+  {
+    name: 'google_adwords_enhanced_conversions',
+    description:
+      'Test 17: RESTATEMENT adjustment with pre-hashed identifiers succeeds — identifiers are deleted before the hashing pipeline, so no hashing-consistency error fires',
+    feature: 'processor',
+    module: 'destination',
+    version: 'v0',
+    input: {
+      request: {
+        body: [
+          {
+            metadata: {
+              secret: {
+                access_token: secret1,
+                refresh_token: 'efgh5678',
+                developer_token: 'ijkl91011',
+              },
+              workspaceId: 'workspaceId1',
+            },
+            destination: {
+              hasDynamicConfig: false,
+              Config: {
+                adjustmentType: 'RESTATEMENT',
+                rudderAccountId: '25u5whFH7gVTnCiAjn4ykoCLGoC',
+                customerId: '123-456-7890',
+                subAccount: true,
+                loginCustomerId: '123-456-7890',
+                listOfConversions: [{ conversions: 'Page View' }],
+                authStatus: 'active',
+              },
+            },
+            message: {
+              channel: 'web',
+              context: {
+                traits: {
+                  phone: sha256('+912382193'),
+                  firstName: sha256('john'),
+                  lastName: sha256('gomes'),
+                  city: 'London',
+                  state: 'UK',
+                  countryCode: 'us',
+                  streetAddress: sha256('71 cherry court southampton so53 5pd uk'),
+                },
+                userAgent:
+                  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36',
+              },
+              event: 'Page View',
+              type: 'track',
+              messageId: '5e10d13a-bf9a-44bf-b884-43a9e591ea71',
+              anonymousId: '00000000000000000000000000',
+              userId: '12345',
+              properties: {
+                gclid: 'gclid1234',
+                conversionDateTime: '2022-01-01 12:32:45-08:00',
+                adjustedValue: '10',
+                currency: 'INR',
+                adjustmentDateTime: '2022-01-01 12:32:45-08:00',
+                order_id: 10000,
+              },
             },
           },
         ],

--- a/test/integrations/destinations/google_adwords_enhanced_conversions/router/batching-data.ts
+++ b/test/integrations/destinations/google_adwords_enhanced_conversions/router/batching-data.ts
@@ -9,6 +9,7 @@
  * same grouping key) are combined into a single request with multiple conversionAdjustments.
  */
 
+import sha256 from 'sha256';
 import { authHeader1, secret1 } from '../maskedSecrets';
 
 const sharedConfig = {
@@ -72,14 +73,14 @@ const enhancementAdjustment = {
     'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36',
   userIdentifiers: [
     {
-      hashedPhoneNumber: '04387707e6cbed8c4538c81cc570ed9252d579469f36c273839b26d784e4bdbe',
+      hashedPhoneNumber: sha256('+912382193'),
     },
     {
       addressInfo: {
         city: 'London',
-        hashedFirstName: 'a8cfcd74832004951b4408cdb0a5dbcd8c7e52d43f7fe244bf720582e05241da',
-        hashedLastName: '1c574b17eefa532b6d61c963550a82d2d3dfca4a7fb69e183374cfafd5328ee4',
-        hashedStreetAddress: '9a4d2e50828448f137f119a3ebdbbbab8d6731234a67595fdbfeb2a2315dd550',
+        hashedFirstName: sha256('john'),
+        hashedLastName: sha256('gomes'),
+        hashedStreetAddress: sha256('71 cherry court southampton so53 5pd uk'),
         state: 'UK',
       },
     },

--- a/test/integrations/destinations/google_adwords_enhanced_conversions/router/data.ts
+++ b/test/integrations/destinations/google_adwords_enhanced_conversions/router/data.ts
@@ -1,3 +1,4 @@
+import sha256 from 'sha256';
 import { authHeader1, secret1 } from '../maskedSecrets';
 import { newData as batchingData } from './batching-data';
 
@@ -636,18 +637,16 @@ export const data = [
                           'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36',
                         userIdentifiers: [
                           {
-                            hashedPhoneNumber:
-                              '04387707e6cbed8c4538c81cc570ed9252d579469f36c273839b26d784e4bdbe',
+                            hashedPhoneNumber: sha256('+912382193'),
                           },
                           {
                             addressInfo: {
                               city: 'London',
-                              hashedFirstName:
-                                'a8cfcd74832004951b4408cdb0a5dbcd8c7e52d43f7fe244bf720582e05241da',
-                              hashedLastName:
-                                '1c574b17eefa532b6d61c963550a82d2d3dfca4a7fb69e183374cfafd5328ee4',
-                              hashedStreetAddress:
-                                '9a4d2e50828448f137f119a3ebdbbbab8d6731234a67595fdbfeb2a2315dd550',
+                              hashedFirstName: sha256('john'),
+                              hashedLastName: sha256('gomes'),
+                              hashedStreetAddress: sha256(
+                                '71 cherry court southampton so53 5pd uk',
+                              ),
                               state: 'UK',
                             },
                           },
@@ -812,18 +811,16 @@ export const data = [
                           'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36',
                         userIdentifiers: [
                           {
-                            hashedPhoneNumber:
-                              '04387707e6cbed8c4538c81cc570ed9252d579469f36c273839b26d784e4bdbe',
+                            hashedPhoneNumber: sha256('+912382193'),
                           },
                           {
                             addressInfo: {
                               city: 'London',
-                              hashedFirstName:
-                                'a8cfcd74832004951b4408cdb0a5dbcd8c7e52d43f7fe244bf720582e05241da',
-                              hashedLastName:
-                                '1c574b17eefa532b6d61c963550a82d2d3dfca4a7fb69e183374cfafd5328ee4',
-                              hashedStreetAddress:
-                                '9a4d2e50828448f137f119a3ebdbbbab8d6731234a67595fdbfeb2a2315dd550',
+                              hashedFirstName: sha256('john'),
+                              hashedLastName: sha256('gomes'),
+                              hashedStreetAddress: sha256(
+                                '71 cherry court southampton so53 5pd uk',
+                              ),
                               state: 'UK',
                             },
                           },
@@ -907,18 +904,16 @@ export const data = [
                           'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36',
                         userIdentifiers: [
                           {
-                            hashedPhoneNumber:
-                              '04387707e6cbed8c4538c81cc570ed9252d579469f36c273839b26d784e4bdbe',
+                            hashedPhoneNumber: sha256('+912382193'),
                           },
                           {
                             addressInfo: {
                               city: 'London',
-                              hashedFirstName:
-                                'a8cfcd74832004951b4408cdb0a5dbcd8c7e52d43f7fe244bf720582e05241da',
-                              hashedLastName:
-                                '1c574b17eefa532b6d61c963550a82d2d3dfca4a7fb69e183374cfafd5328ee4',
-                              hashedStreetAddress:
-                                '9a4d2e50828448f137f119a3ebdbbbab8d6731234a67595fdbfeb2a2315dd550',
+                              hashedFirstName: sha256('john'),
+                              hashedLastName: sha256('gomes'),
+                              hashedStreetAddress: sha256(
+                                '71 cherry court southampton so53 5pd uk',
+                              ),
                               state: 'UK',
                             },
                           },


### PR DESCRIPTION
🔒 Scanned for secrets using gitleaks 8.28.0

## What are the changes introduced in this PR?

Fixes PII hashing in the Google Ads Enhanced Conversions (GAEC) destination to follow Google's documented normalization requirements, and validates that incoming data is consistent with the `requireHash` setting.

- **Normalization before hashing** (previously trim-only): email → trim + lowercase + gmail.com/googlemail.com username dot/`+suffix` stripping; phone → strip `space ( ) . -` separators and prepend `+` (E.164); first/last name and street address → trim + lowercase.
- **Hashing moved out of the mapping**: `hashToSha256` removed from `trackConfig.json`; the five PII fields now flow through a new `processUserIdentifiers` (GAEC `utils.ts`) which runs the shared `processAudienceRecord` pipeline (normalize → hashing-consistency check → validate → hash) — the same machinery GARL, fb_custom_audience, and tiktok_audience already use.
- **Hashing-consistency validation**: a pre-hashed value with hashing enabled, or a raw value with hashing disabled, now aborts with an `InstrumentationError` and emits the `audience_hashing_inconsistency` metric (previously: silent double-hashing / raw values sent to Google).
- **Data hygiene**: invalid identifiers (malformed email, non-numeric phone) are dropped with the `google_adwords_enhanced_conversions_invalid_field` metric; empty values are dropped instead of hashing `''`; identifier entries emptied by drops are pruned, and if nothing survives the existing "Any of email, phone, …" error fires. RESTATEMENT adjustments skip the pipeline (their identifiers are deleted before send).
- **Shared normalizers**: `normalizeEmail`/`normalizePhone` moved verbatim from GARL's `util.ts` into `src/v0/util/googleUtils/userDataNormalization.ts` (plus `normalizeName`); GARL imports them from there — zero behavior change (GARL unit + 81 component tests pass unmodified).

## What is the related Linear task?

Resolves INT-6658

## Please explain the objectives of your changes below

GAEC's trim-only hashing produced hashes Google can never match (e.g. `"John "` / `"USER@Gmail.com"`), and pre-hashed inputs were silently double-hashed — both surfaced as `hashed_email`/`hashed_first_name` failures. This PR brings GAEC to parity with GARL's Google-spec-compliant pipeline (verified against Google's Enhanced Conversions docs and the `OfflineUserAddressInfo` proto).

**Dependent change**: this PR is stacked on the GAEC JS→TS migration — base branch is `feature/int-6744-refactor-migrate-gaec-v0-destination-from-javascript-to` (#5349). Merge #5349 first.

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

Yes — intentional, per the team decision on INT-6658 (customers will be informed before release; no feature flag):

| Input (hashing enabled unless noted) | Before | After |
| --- | --- | --- |
| Mixed-case / unnormalized email, name, phone | hashed as-is → unmatchable at Google | normalized then hashed (matchable) |
| Pre-hashed (64-hex) value | silently double-hashed | `InstrumentationError` + metric |
| Raw value with `requireHash: false` | sent raw → rejected by Google | `InstrumentationError` + metric |
| Empty / whitespace-only value | `sha256('')` sent | dropped |
| Invalid email / non-numeric phone | hashed garbage | dropped + metric |
| No identifiers survive | n/a | existing "Any of email, phone, …" error |

### Any new dependencies introduced with this change?

N/A

### Any new generic utility introduced or modified. Please explain the changes.

`src/v0/util/googleUtils/userDataNormalization.ts` — Google Ads user-data normalizers (`normalizeEmail`, `normalizePhone`, `normalizeName`) shared by GARL and GAEC, relocated verbatim from GARL's `util.ts` into the existing Google-vendor-shared `googleUtils` module. Unit-tested in `userDataNormalization.test.ts`.

### Any technical or performance related pointers to consider with the change?

- Post-release monitoring: `audience_hashing_inconsistency{destType="google_adwords_enhanced_conversions"}` and `google_adwords_enhanced_conversions_invalid_field` show affected-event volume.
- Coverage: 35 GAEC component tests (5 new: normalization/gmail rules, pre-hashed → error, raw + `requireHash: false` → error, invalid-email drop, restatement skip), new unit suites for `utils.ts` and the normalizers; GARL suites pass unchanged as the code-motion regression check.

@coderabbitai review

<hr>

### Developer checklist

- [ ] My code follows the style guidelines of this project

- [ ] **No breaking changes are being introduced.**

- [ ] All related docs linked with the PR?

- [ ] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [ ] Is the PR limited to 10 file changes?

- [ ] Is the PR limited to one linear task?

- [ ] Are relevant unit and component test-cases added in **new readability format**?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.
