### PR TITLE
fix(customerio): accept numeric identifiers in v2 event stream

### DIFF
--- a/src/v0/destinations/customerio/v2/types.ts
+++ b/src/v0/destinations/customerio/v2/types.ts
@@ -56,10 +56,13 @@ export type CustomerIOV2RecordMessage = z.infer<typeof recordMessageSchema>;
 const eventStreamMessageSchema = z
   .object({
     type: z.enum(['identify', 'track', 'page', 'screen', 'alias', 'group']),
-    userId: z.string().nullish(),
-    anonymousId: z.string().nullish(),
-    previousId: z.string().nullish(),
-    groupId: z.string().nullish(),
+    // CustomerIO accepts identifiers as either a string or a number, so both are passed
+    // through as-is. Any other type is rejected by the API with
+    // `{"field": "primary.id", "message": "must be a string or a number"}`.
+    userId: z.union([z.string(), z.number()]).nullish(),
+    anonymousId: z.union([z.string(), z.number()]).nullish(),
+    previousId: z.union([z.string(), z.number()]).nullish(),
+    groupId: z.union([z.string(), z.number()]).nullish(),
     traits: emailTraitSchema,
     context: z
       .object({

--- a/src/v0/destinations/customerio/v2/util.ts
+++ b/src/v0/destinations/customerio/v2/util.ts
@@ -30,13 +30,13 @@ const personIdentifiers = (message): CustomerIOV2Identifiers => {
   const userId = getFieldValueFromMessage(message, 'userIdOnly');
   const email = getFieldValueFromMessage(message, 'email');
   if (userId) {
-    return { id: String(userId) };
+    return { id: userId };
   }
   if (email) {
     return { email: String(email) };
   }
   if (message.anonymousId) {
-    return { anonymous_id: String(message.anonymousId) };
+    return { anonymous_id: message.anonymousId };
   }
   throw new InstrumentationError('userId, email or anonymousId is required');
 };

--- a/test/integrations/destinations/customerio/router/dataV2.ts
+++ b/test/integrations/destinations/customerio/router/dataV2.ts
@@ -2078,6 +2078,139 @@ export const dataV2 = [
     },
   },
   {
+    name: 'customerio',
+    description:
+      'v2: numeric userId/anonymousId/previousId/groupId are accepted and passed through unstringified',
+    feature: 'router',
+    module: 'destination',
+    version: 'v0',
+    envOverrides: {
+      CUSTOMERIO_BATCHING_FRAMEWORK_ENABLED_WORKSPACE_IDS: 'ALL',
+    },
+    input: {
+      request: {
+        body: {
+          input: [
+            {
+              message: {
+                channel: 'web',
+                type: 'identify',
+                userId: 432,
+                traits: { email: 'numeric-id@rudderstack.com', plan: 'enterprise' },
+              },
+              metadata: { jobId: 45, userId: 'u1', workspaceId: 'ws-cio-v2' },
+              destination: { Config: { datacenter: 'US', siteID: secret1, apiKey: secret2 } },
+            },
+            {
+              message: {
+                channel: 'web',
+                type: 'track',
+                anonymousId: 987654,
+                event: 'Product Viewed',
+                properties: { plan: 'enterprise' },
+              },
+              metadata: { jobId: 46, userId: 'u1', workspaceId: 'ws-cio-v2' },
+              destination: { Config: { datacenter: 'US', siteID: secret1, apiKey: secret2 } },
+            },
+            {
+              message: {
+                channel: 'web',
+                type: 'alias',
+                userId: 432,
+                previousId: 306,
+              },
+              metadata: { jobId: 47, userId: 'u1', workspaceId: 'ws-cio-v2' },
+              destination: { Config: { datacenter: 'US', siteID: secret1, apiKey: secret2 } },
+            },
+            {
+              message: {
+                channel: 'web',
+                type: 'group',
+                userId: 432,
+                groupId: 306,
+                traits: { name: 'numeric group' },
+              },
+              metadata: { jobId: 48, userId: 'u1', workspaceId: 'ws-cio-v2' },
+              destination: { Config: { datacenter: 'US', siteID: secret1, apiKey: secret2 } },
+            },
+          ],
+          destType: 'customerio',
+        },
+        method: 'POST',
+      },
+    },
+    output: {
+      response: {
+        status: 200,
+        body: {
+          output: [
+            {
+              batchedRequest: {
+                version: '1',
+                type: 'REST',
+                method: 'POST',
+                endpoint: 'https://track.customer.io/api/v2/batch',
+                endpointPath: 'v2/batch',
+                headers: { Authorization: authHeader1, 'Content-Type': 'application/json' },
+                params: {},
+                body: {
+                  JSON: {
+                    batch: [
+                      {
+                        type: 'person',
+                        action: 'identify',
+                        identifiers: { id: 432 },
+                        attributes: {
+                          email: 'numeric-id@rudderstack.com',
+                          plan: 'enterprise',
+                        },
+                      },
+                      {
+                        type: 'person',
+                        action: 'event',
+                        identifiers: { anonymous_id: 987654 },
+                        name: 'Product Viewed',
+                        attributes: { plan: 'enterprise' },
+                      },
+                      {
+                        type: 'person',
+                        action: 'merge',
+                        primary: { id: 432 },
+                        secondary: { id: 306 },
+                      },
+                      // group/object ids keep the `toString` mapping coercion, so they are
+                      // emitted as strings while person identifiers stay numeric
+                      {
+                        type: 'object',
+                        action: 'identify',
+                        identifiers: { object_id: '306', object_type_id: '1' },
+                        attributes: { name: 'numeric group' },
+                        cio_relationships: [{ identifiers: { id: '432' } }],
+                      },
+                    ],
+                  },
+                  JSON_ARRAY: {},
+                  XML: {},
+                  FORM: {},
+                },
+                files: {},
+              },
+              metadata: [
+                { jobId: 45, userId: 'u1', workspaceId: 'ws-cio-v2' },
+                { jobId: 46, userId: 'u1', workspaceId: 'ws-cio-v2' },
+                { jobId: 47, userId: 'u1', workspaceId: 'ws-cio-v2' },
+                { jobId: 48, userId: 'u1', workspaceId: 'ws-cio-v2' },
+              ],
+              destination: { Config: { datacenter: 'US', siteID: secret1, apiKey: secret2 } },
+              batched: true,
+              statusCode: 200,
+            },
+          ],
+        },
+      },
+    },
+  },
+  {
     id: 'cio-v2-router-record-mirror',
     name: 'customerio',
     description: 'v2: record events (mirror mode) — insert+delete batch into one request',


### PR DESCRIPTION
## What are the changes introduced in this PR?

The v2 zod schema typed userId, anonymousId, previousId and groupId as z.string(), which was strictly narrower than v0 — v0 never type-checked or coerced these, and existing fixtures already send numeric ids. Events that v0 accepted were rejected by v2 schema validation.

Widen the schema to z.union([z.string(), z.number()]) and drop the String() coercion in personIdentifiers so numeric ids reach the payload as-is. The CustomerIO API accepts both types, rejecting anything else with `{"field": "primary.id", "message": "must be a string or a number"}`.

Add a v2 router test covering numeric ids across identify, track, alias and group events.
## What is the related Linear task?

[Resolves INT-6793](https://linear.app/rudderstack/issue/INT-6793/allow-numeric-values-for-identifiers)

## Please explain the objectives of your changes below

Put down any required details on the broader aspect of your changes. If there are any dependent changes, **mandatorily** mention them here

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

N/A

### Any new dependencies introduced with this change?

N/A

### Any new generic utility introduced or modified. Please explain the changes.

N/A

### Any technical or performance related pointers to consider with the change?

N/A

@coderabbitai review

<hr>

### Developer checklist

- [ ] My code follows the style guidelines of this project

- [ ] **No breaking changes are being introduced.**

- [ ] All related docs linked with the PR?

- [ ] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [ ] Is the PR limited to 10 file changes?

- [ ] Is the PR limited to one linear task?

- [ ] Are relevant unit and component test-cases added in **new readability format**?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.
