### PR TITLE
chore: log unknown destinations resolved via handler-name lookup

### DIFF
--- a/src/features.test.ts
+++ b/src/features.test.ts
@@ -7,6 +7,7 @@ import defaultFeaturesConfig, {
 } from './features';
 import { DestHandlerMap } from './constants/destinationCanonicalNames';
 import { getIntegrations } from './routes/utils';
+import logger from './logger';
 
 const getDestinationDirectories = () =>
   ['v0/destinations', 'v1/destinations', 'cdk/v2/destinations'].flatMap((destinationRoot) =>
@@ -66,5 +67,15 @@ describe('destination registry', () => {
     expect(isValidDestination('not_a_destination')).toBe(false);
     expect(isValidDestination('constructor')).toBe(false);
     expect(isValidDestination('__proto__')).toBe(false);
+  });
+
+  it('warns when resolving a handler name for an unknown destination', () => {
+    const warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => {});
+    try {
+      expect(getDestinationHandlerName('not_a_destination')).toBe('not_a_destination');
+      expect(warnSpy).toHaveBeenCalledWith('Unknown destination encountered: not_a_destination');
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 });

--- a/src/features.ts
+++ b/src/features.ts
@@ -1,5 +1,6 @@
 import path from 'path';
 import { ConfigurationError } from '@rudderstack/integrations-lib';
+import logger from './logger';
 import { DestHandlerMap } from './constants/destinationCanonicalNames';
 import { getIntegrations } from './routes/utils';
 
@@ -197,6 +198,7 @@ export const getDestinationHandlerName = (destination: string): string => {
   if (process.env.REJECT_UNKNOWN_DESTINATIONS === 'true') {
     throw new ConfigurationError(`Invalid destination: ${destination}`);
   }
+  logger.warn(`Unknown destination encountered: ${String(destination)}`);
   return normalized;
 };
 


### PR DESCRIPTION
## What

Emit a `warn` log when `getDestinationHandlerName` resolves a destination that isn't in the registry (and `REJECT_UNKNOWN_DESTINATIONS` is not enabled, so the request proceeds).

## Why

The destination-validation middleware already logs `Unknown destination encountered: <name>` on this same fallback path, but the handler-name lookup resolved unknown destinations silently. That left a gap: requests reaching the transformer through this path produced no signal. Mirroring the log across both entry points lets a single log-based alert catch every unknown destination regardless of which path handled it.

## How

- Added the matching `logger.warn(\`Unknown destination encountered: ...\`)` on the fallback branch of `getDestinationHandlerName`.
- Added a unit test asserting the warning fires (and the handler name still resolves) for an unknown destination.

Behavior is unchanged when `REJECT_UNKNOWN_DESTINATIONS=true` — that path still throws a `ConfigurationError`.