### PR TITLE
chore(ivm): emit metric for sandbox platform errors

### DIFF
--- a/src/util/ivm/scriptRunner.ts
+++ b/src/util/ivm/scriptRunner.ts
@@ -94,9 +94,8 @@ export class IvmScriptRunner {
    * avoiding global mutation and race conditions between concurrent calls.
    */
   async execute<T>(cacheKey: string, expression: string, args: unknown[]): Promise<T> {
-    const entry = await this.getOrCreate(cacheKey);
-
     try {
+      const entry = await this.getOrCreate(cacheKey);
       const result = await entry.context.evalClosure(expression, args, {
         arguments: { copy: true },
         result: { copy: true, promise: true },
@@ -104,8 +103,15 @@ export class IvmScriptRunner {
       });
       return result as T;
     } catch (err: unknown) {
-      // Timeout, OOM, or disposed isolate — evict so next call gets a fresh one
+      // Platform failure: timeout, OOM, disposed isolate, or a failure while
+      // building the isolate. Evict so the next call gets a fresh one, and emit
+      // a metric for observability before rethrowing.
       this.cache.delete(cacheKey);
+      stats.increment('ivm_platform_error', {
+        functionName: expression,
+        workspaceId: cacheKey,
+        cache: this.cache.cacheName,
+      });
       throw err;
     }
   }

--- a/src/v0/destinations/custom_audience/template/ivmScriptRunner.test.ts
+++ b/src/v0/destinations/custom_audience/template/ivmScriptRunner.test.ts
@@ -43,6 +43,15 @@ jest.mock('isolated-vm', () => {
     release() {}
 
     async evalClosure(code: string) {
+      // Test hook: `__THROW__ <kind>` simulates a platform failure inside the
+      // isolate (timeout / OOM / disposed) so execute()'s catch path runs.
+      if (code.includes('__THROW__')) {
+        if (code.includes('timeout')) throw new Error('Script execution timed out.');
+        if (code.includes('memory'))
+          throw new Error('Isolate was disposed during execution due to memory limit');
+        if (code.includes('disposed')) throw new Error('Isolate is disposed');
+        throw new Error('boom');
+      }
       if (code.includes('parseTemplateInSandbox')) {
         return { valid: true, recordFields: ['email'] };
       }
@@ -130,6 +139,7 @@ describe('IvmScriptRunner', () => {
   beforeEach(() => {
     isolateCreateCount = 0;
     mockStats.gauge.mockClear();
+    mockStats.increment.mockClear();
     runner = new IvmScriptRunner({
       bundlePath: BUNDLE_PATH,
       memoryLimitMb: 8,
@@ -213,6 +223,28 @@ describe('IvmScriptRunner', () => {
       const result = await runner.execute('ws-fail', '1+1', []);
       expect(result).toBe('ok');
       expect(callCount).toBe(2);
+    });
+  });
+
+  describe('platform error metrics', () => {
+    it('emits ivm_platform_error tagged with the expression, workspaceId (cacheKey) and cache', async () => {
+      const expression = 'return evaluateTemplateInSandbox($0) /* __THROW__ timeout */';
+
+      await expect(runner.execute('ws-err', expression, [])).rejects.toThrow(
+        'Script execution timed out.',
+      );
+
+      expect(mockStats.increment).toHaveBeenCalledWith('ivm_platform_error', {
+        functionName: expression,
+        workspaceId: 'ws-err',
+        cache: 'custom_audience_ivm',
+      });
+    });
+
+    it('does not emit the platform error metric on success', async () => {
+      await runner.execute('ws-ok', 'return parseTemplateInSandbox($0)', []);
+
+      expect(mockStats.increment).not.toHaveBeenCalledWith('ivm_platform_error', expect.anything());
     });
   });
 


### PR DESCRIPTION
## What

`IvmScriptRunner.execute` runs user-supplied templates and custom mappings inside per-workspace `isolated-vm` isolates. When the isolate itself fails — execution timeout, out-of-memory, a disposed isolate, or a failure while building the isolate — that's a platform problem rather than a user error, and until now it was only visible in per-caller logs. There was no aggregate signal to track how often it happens, or to spot a single workspace repeatedly hitting the limits.

This adds an `ivm_platform_error` counter emitted from `execute` whenever such a failure escapes the isolate, before the error is rethrown.

## Metric

`ivm_platform_error`, tagged with:

- `functionName` — the executed expression, which identifies the sandbox function that was running (e.g. `return evaluateTemplateInSandbox($0, $1, $2)`)
- `workspaceId` — the workspace owning the isolate (the cache key)
- `cache` — the isolate pool (`custom_audience_ivm`, `custom_mappings_ivm`)

The `execute` signature is unchanged: the tags come from the existing `cacheKey` and `expression` arguments. Isolate-*creation* failures are counted too, not just execution failures — both are platform problems worth the same visibility.

## Testing

New unit tests cover that the metric fires with the expected tags on a platform failure, and that no metric is emitted on success. Full runner suite passes.