### PR TITLE
refactor(hs): remove already-transformed event branch from router

### DIFF
--- a/src/v0/destinations/hs/transform.ts
+++ b/src/v0/destinations/hs/transform.ts
@@ -23,7 +23,6 @@ import type {
   HubspotProcessorTransformationOutput,
   HubSpotBatchProcessingItem,
 } from './types';
-import { isProcessorOutput } from './types';
 
 const processSingleMessage = async (
   { message, destination, metadata }: HubspotRouterRequest,
@@ -108,34 +107,22 @@ const processBatchRouter = async (
   await Promise.all(
     inputs.map(async (input) => {
       try {
-        if (input.message.statusCode && isProcessorOutput(input.message)) {
-          // already transformed event
+        let receivedResponse = await processSingleMessage(
+          { message: input.message, destination, metadata: input.metadata },
+          propertyMap,
+        );
+
+        receivedResponse = Array.isArray(receivedResponse) ? receivedResponse : [receivedResponse];
+
+        // received response can be in array format [{}, {}, {}, ..., {}]
+        // if multiple response is being returned
+        receivedResponse.forEach((element) => {
           successRespList.push({
-            message: input.message,
+            message: element,
             metadata: input.metadata,
             destination,
           });
-        } else {
-          // event is not transformed
-          let receivedResponse = await processSingleMessage(
-            { message: input.message, destination, metadata: input.metadata },
-            propertyMap,
-          );
-
-          receivedResponse = Array.isArray(receivedResponse)
-            ? receivedResponse
-            : [receivedResponse];
-
-          // received response can be in array format [{}, {}, {}, ..., {}]
-          // if multiple response is being returned
-          receivedResponse.forEach((element) => {
-            successRespList.push({
-              message: element,
-              metadata: input.metadata,
-              destination,
-            });
-          });
-        }
+        });
       } catch (error: unknown) {
         const errRespEvent = handleRtTfSingleEventError(input, error, reqMetadata);
         errorRespList.push(errRespEvent);

--- a/src/v0/destinations/hs/types.ts
+++ b/src/v0/destinations/hs/types.ts
@@ -282,33 +282,6 @@ export interface HubspotRudderMessage extends Omit<RudderMessage, 'context' | 'e
 }
 
 /**
- * Router input where message may be raw (HubspotRudderMessage) or already transformed (statusCode set)
- */
-export type HubspotRouterInput =
-  | { message: HubspotRudderMessage; metadata: Metadata; destination: HubSpotDestination }
-  | {
-      message: HubspotProcessorTransformationOutput;
-      metadata: Metadata;
-      destination: HubSpotDestination;
-    };
-
-/**
- * Type guard: message has already been transformed (processor output shape)
- */
-export function isProcessorOutput(
-  msg: HubspotRudderMessage | HubspotProcessorTransformationOutput,
-): msg is HubspotProcessorTransformationOutput {
-  return (
-    typeof msg === 'object' &&
-    msg !== null &&
-    'statusCode' in msg &&
-    'body' in msg &&
-    typeof (msg as Record<string, unknown>).statusCode === 'number' &&
-    (msg as Record<string, unknown>).body !== undefined
-  );
-}
-
-/**
  * Type guard: JSON payload has properties as Record (not array) - for create/update contact
  */
 export function hasPropertiesRecord(

--- a/test/integrations/destinations/hs/router/data.ts
+++ b/test/integrations/destinations/hs/router/data.ts
@@ -598,52 +598,6 @@ export const data = [
             },
             {
               message: {
-                version: '1',
-                type: 'REST',
-                method: 'POST',
-                endpoint:
-                  'https://api.hubapi.com/contacts/v1/contact/createOrUpdate/email/testhubspot2@email.com',
-                headers: { 'Content-Type': 'application/json' },
-                userId: '00000000000000000000000000',
-                params: { hapikey: 'dummy-apikey' },
-                body: {
-                  JSON: {
-                    properties: [
-                      { property: 'email', value: 'testhubspot3@email.com' },
-                      { property: 'firstname', value: 'Test Hubspot3' },
-                    ],
-                  },
-                  XML: {},
-                  FORM: {},
-                },
-                files: {},
-                statusCode: 200,
-              },
-              metadata: { jobId: 3, userId: 'u1' },
-              destination: {
-                Config: { apiKey: 'dummy-apikey', hubID: 'dummy-hubId' },
-                secretConfig: {},
-                ID: '1mMy5cqbtfuaKZv1IhVQKnBdVwe',
-                name: 'Hubspot',
-                enabled: true,
-                workspaceId: '1TSN08muJTZwH8iCDmnnRt1pmLd',
-                deleted: false,
-                createdAt: '2020-12-30T08:39:32.005Z',
-                updatedAt: '2021-02-03T16:22:31.374Z',
-                destinationDefinition: {
-                  id: '1aIXqM806xAVm92nx07YwKbRrO9',
-                  name: 'HS',
-                  displayName: 'Hubspot',
-                  createdAt: '2020-04-09T09:24:31.794Z',
-                  updatedAt: '2021-01-11T11:03:28.103Z',
-                },
-                transformations: [],
-                isConnectionEnabled: true,
-                isProcessorEnabled: true,
-              },
-            },
-            {
-              message: {
                 channel: 'web',
                 context: {
                   app: {
@@ -774,54 +728,6 @@ export const data = [
               },
               metadata: [{ jobId: 2, userId: 'u1' }],
               batched: false,
-              statusCode: 200,
-              destination: {
-                Config: { apiKey: 'dummy-apikey', hubID: 'dummy-hubId' },
-                secretConfig: {},
-                ID: '1mMy5cqbtfuaKZv1IhVQKnBdVwe',
-                name: 'Hubspot',
-                enabled: true,
-                workspaceId: '1TSN08muJTZwH8iCDmnnRt1pmLd',
-                deleted: false,
-                createdAt: '2020-12-30T08:39:32.005Z',
-                updatedAt: '2021-02-03T16:22:31.374Z',
-                destinationDefinition: {
-                  id: '1aIXqM806xAVm92nx07YwKbRrO9',
-                  name: 'HS',
-                  displayName: 'Hubspot',
-                  createdAt: '2020-04-09T09:24:31.794Z',
-                  updatedAt: '2021-01-11T11:03:28.103Z',
-                },
-                transformations: [],
-                isConnectionEnabled: true,
-                isProcessorEnabled: true,
-              },
-            },
-            {
-              batchedRequest: {
-                version: '1',
-                type: 'REST',
-                method: 'POST',
-                endpoint: 'https://api.hubapi.com/contacts/v1/contact/batch/',
-                headers: { 'Content-Type': 'application/json' },
-                params: { hapikey: 'dummy-apikey' },
-                body: {
-                  JSON: {},
-                  JSON_ARRAY: {
-                    batch: JSON.stringify([
-                      {
-                        email: 'testhubspot3@email.com',
-                        properties: [{ property: 'firstname', value: 'Test Hubspot3' }],
-                      },
-                    ]),
-                  },
-                  XML: {},
-                  FORM: {},
-                },
-                files: {},
-              },
-              metadata: [{ jobId: 3, userId: 'u1' }],
-              batched: true,
               statusCode: 200,
               destination: {
                 Config: { apiKey: 'dummy-apikey', hubID: 'dummy-hubId' },


### PR DESCRIPTION
## What are the changes introduced in this PR?

The router batch handler previously short-circuited inputs whose message already looked like processor output (statusCode + body), pushing them straight to the success list instead of transforming them. This path is no longer needed, so all inputs now go through processSingleMessage.

Removes:
- the isProcessorOutput(...) short-circuit branch in processBatchRouter
- the isProcessorOutput type guard and its import
- the unused HubspotRouterInput union type

## What is the related Linear task?

- Resolves INT-6778
