### PR TITLE
refactor(braze): group-preserving chunking + size caps + per-output metadata

### DIFF
--- a/src/v0/destinations/braze/braze.util.test.ts
+++ b/src/v0/destinations/braze/braze.util.test.ts
@@ -1032,30 +1032,62 @@ const subEndpointOf = (destination: BrazeDestination) =>
 const mergeEndpointOf = (destination: BrazeDestination) =>
   getEndpointFromConfig(destination) + '/users/merge';
 
-// Loose types on these helpers — the test-time assertion is on the shape at
-// runtime, not the static union type of BrazeBatchResponse.
-const isBatchedOutput = (out: any): boolean =>
+// ---- OFF-path (default) helpers ------------------------------------------
+// The OFF path emits a single MultiBatchRequestOutput whose `batchedRequest`
+// is an array of every outgoing HTTP request. These helpers reach into that
+// array; individual requests are filtered by endpoint.
+const offMulti = (result: any[]): any | undefined =>
+  result.find((r) => r?.batchedRequest && Array.isArray(r.batchedRequest));
+
+const offRequests = (result: any[], destination: BrazeDestination, endpoint: string): any[] => {
+  const multi = offMulti(result);
+  if (!multi) return [];
+  return (multi.batchedRequest as any[]).filter((br) => br.endpoint === endpoint);
+};
+
+const offTrackRequests = (result: any[], destination: BrazeDestination): any[] =>
+  offRequests(result, destination, trackEndpointOf(destination));
+const offSubRequests = (result: any[], destination: BrazeDestination): any[] =>
+  offRequests(result, destination, subEndpointOf(destination));
+const offMergeRequests = (result: any[], destination: BrazeDestination): any[] =>
+  offRequests(result, destination, mergeEndpointOf(destination));
+
+const offTotalIn = (requests: any[], key: 'attributes' | 'events' | 'purchases'): number =>
+  requests.reduce((acc, r) => acc + (r.body.JSON[key]?.length ?? 0), 0);
+
+// ---- ON-path helpers -----------------------------------------------------
+// The ON path emits one BatchRequestOutput per outgoing HTTP request; each
+// carries a single non-array `batchedRequest`. Helpers filter by endpoint.
+const isOnBatchedOutput = (out: any): boolean =>
   Boolean(out?.batchedRequest && !Array.isArray(out.batchedRequest));
 
-const trackOutputs = (result: any[], destination: BrazeDestination): any[] =>
+const onTrackOutputs = (result: any[], destination: BrazeDestination): any[] =>
   result.filter(
-    (r) => isBatchedOutput(r) && r.batchedRequest.endpoint === trackEndpointOf(destination),
+    (r) => isOnBatchedOutput(r) && r.batchedRequest.endpoint === trackEndpointOf(destination),
   );
 
-const subOutputs = (result: any[], destination: BrazeDestination): any[] =>
+const onSubOutputs = (result: any[], destination: BrazeDestination): any[] =>
   result.filter(
-    (r) => isBatchedOutput(r) && r.batchedRequest.endpoint === subEndpointOf(destination),
+    (r) => isOnBatchedOutput(r) && r.batchedRequest.endpoint === subEndpointOf(destination),
   );
 
-const mergeOutputs = (result: any[], destination: BrazeDestination): any[] =>
+const onMergeOutputs = (result: any[], destination: BrazeDestination): any[] =>
   result.filter(
-    (r) => isBatchedOutput(r) && r.batchedRequest.endpoint === mergeEndpointOf(destination),
+    (r) => isOnBatchedOutput(r) && r.batchedRequest.endpoint === mergeEndpointOf(destination),
   );
 
-const totalInSubArray = (outs: any[], key: 'attributes' | 'events' | 'purchases'): number =>
+const onTotalInSubArray = (outs: any[], key: 'attributes' | 'events' | 'purchases'): number =>
   outs.reduce((acc, o) => acc + (o.batchedRequest.body.JSON[key]?.length ?? 0), 0);
 
-describe('processBatch — non-MAU workspace (V1 chunking)', () => {
+// ---------------------------------------------------------------------------
+// OFF path (default) — BRAZE_PER_JOB_DELIVERY_MAPPING_ENABLED is unset.
+// processBatch emits a single MultiBatchRequestOutput whose `batchedRequest`
+// is an array of every outgoing HTTP request, with a flat metadata list and
+// no `destInfo`. Group-preserving chunking, byte-size caps, and oversized-job
+// rejection are still active.
+// ---------------------------------------------------------------------------
+
+describe('processBatch — OFF path (default) — non-MAU workspace (V1 chunking)', () => {
   const destination = brazeDestFor();
 
   const buildTrackEvent = (
@@ -1092,30 +1124,33 @@ describe('processBatch — non-MAU workspace (V1 chunking)', () => {
     metadata: [{ jobId: i, workspaceId }],
   });
 
-  test('every output is a single BatchRequestOutput with scoped metadata (no MultiBatchRequestOutput anywhere)', () => {
+  test('emits a single MultiBatchRequestOutput with batchedRequest[] and flat metadata', () => {
     const transformedEvents = Array.from({ length: 20 }, (_, i) => buildTrackEvent(i));
     const result = processBatch(transformedEvents);
-    for (const out of result) {
-      expect(out).toHaveProperty('batchedRequest');
-      expect(Array.isArray((out as any).batchedRequest)).toBe(false);
-      expect(out).toHaveProperty('metadata');
-      expect((out as any).batched).toBe(true);
+    // Exactly one successful output (no failures/filters in this input).
+    expect(result.length).toBe(1);
+    const multi = result[0] as any;
+    expect(Array.isArray(multi.batchedRequest)).toBe(true);
+    expect(multi.batched).toBe(true);
+    expect(multi.statusCode).toBe(200);
+    expect(multi.metadata.length).toBe(20);
+    // No destInfo on any metadata entry in OFF path.
+    for (const m of multi.metadata) {
+      expect((m as any).destInfo).toBeUndefined();
     }
   });
 
-  test('splits track chunks by V1 per-type caps (75) with size-aware, group-preserving chunking', () => {
-    // Each job contributes 1 attribute + 1 event + 1 purchase (3-item group).
-    // 100 jobs → V1 close chunk when any per-type cap (75) would be exceeded.
+  test('splits track chunks by V1 per-type caps (75)', () => {
     const transformedEvents = Array.from({ length: 100 }, (_, i) => buildTrackEvent(i));
     const result = processBatch(transformedEvents);
 
-    const tracks = trackOutputs(result, destination);
+    const tracks = offTrackRequests(result, destination);
     expect(tracks.length).toBeGreaterThanOrEqual(2);
-    expect(totalInSubArray(tracks, 'attributes')).toBe(100);
-    expect(totalInSubArray(tracks, 'events')).toBe(100);
-    expect(totalInSubArray(tracks, 'purchases')).toBe(100);
+    expect(offTotalIn(tracks, 'attributes')).toBe(100);
+    expect(offTotalIn(tracks, 'events')).toBe(100);
+    expect(offTotalIn(tracks, 'purchases')).toBe(100);
     for (const t of tracks) {
-      const body = t.batchedRequest.body.JSON as BrazeTrackRequestBody;
+      const body = t.body.JSON as BrazeTrackRequestBody;
       expect(body.partner).toBe('RudderStack');
       expect(body.attributes?.length ?? 0).toBeLessThanOrEqual(75);
       expect(body.events?.length ?? 0).toBeLessThanOrEqual(75);
@@ -1123,7 +1158,7 @@ describe('processBatch — non-MAU workspace (V1 chunking)', () => {
     }
   });
 
-  test('subscription-group jobs emit one BatchRequestOutput per chunk (no destInfo)', () => {
+  test('subscription-group jobs are chunked (25 per) inside the same MultiBatchRequestOutput', () => {
     const dest = brazeDestFor({ enableSubscriptionGroupInGroupCall: true });
     const transformedEvents: BrazeTransformedEvent[] = [];
     for (let i = 0; i < 100; i += 1) {
@@ -1150,22 +1185,19 @@ describe('processBatch — non-MAU workspace (V1 chunking)', () => {
       });
     }
     const result = processBatch(transformedEvents);
-    const subs = subOutputs(result, dest);
+    expect(result.length).toBe(1);
+    const subs = offSubRequests(result, dest);
     expect(subs.length).toBe(Math.ceil(100 / 25));
     for (const s of subs) {
-      expect((s.batchedRequest.body.JSON as any).subscription_groups).toBeDefined();
-      // Subscription outputs carry scoped metadata but no destInfo.braze.
-      for (const m of s.metadata) {
-        expect(
-          (m.destInfo as any)?.attributesIndices ??
-            (m.destInfo as any)?.eventsIndices ??
-            (m.destInfo as any)?.purchasesIndices,
-        ).toBeUndefined();
-      }
+      expect((s.body.JSON as any).subscription_groups).toBeDefined();
+    }
+    // OFF path: no destInfo on flat metadata list.
+    for (const m of (result[0] as any).metadata) {
+      expect((m as any).destInfo).toBeUndefined();
     }
   });
 
-  test('alias-merge jobs emit one BatchRequestOutput per chunk (no destInfo)', () => {
+  test('alias-merge jobs are chunked (50 per) inside the same MultiBatchRequestOutput', () => {
     const dest = brazeDestFor();
     const transformedEvents: BrazeTransformedEvent[] = [];
     for (let i = 0; i < 100; i += 1) {
@@ -1195,24 +1227,501 @@ describe('processBatch — non-MAU workspace (V1 chunking)', () => {
       });
     }
     const result = processBatch(transformedEvents);
-    const merges = mergeOutputs(result, dest);
+    expect(result.length).toBe(1);
+    const merges = offMergeRequests(result, dest);
     expect(merges.length).toBe(Math.ceil(100 / 50));
     for (const m of merges) {
-      expect((m.batchedRequest.body.JSON as any).merge_updates).toBeDefined();
+      expect((m.body.JSON as any).merge_updates).toBeDefined();
+    }
+    for (const meta of (result[0] as any).metadata) {
+      expect((meta as any).destInfo).toBeUndefined();
+    }
+  });
+
+  test('interleaved input types produce a single MultiBatchRequestOutput with all requests globally concatenated', () => {
+    // OFF path concatenates all track items → chunked → track requests; then
+    // all sub items; then all merges. Insertion-order-run preservation is an
+    // ON-only guarantee.
+    const dest = brazeDestFor({ enableSubscriptionGroupInGroupCall: true });
+    const trackJob = (i: number): BrazeTransformedEvent => ({
+      destination: dest,
+      statusCode: 200,
+      batchedRequest: {
+        version: '1',
+        type: 'REST',
+        method: 'POST',
+        endpoint: '',
+        headers: {},
+        params: {},
+        body: { JSON: { attributes: [{ external_id: `u${i}` }] } },
+        files: {},
+      } as any,
+      metadata: [{ jobId: i, workspaceId: 'workspace-non-mau', userId: 'shared' }],
+    });
+    const subJob = (i: number): BrazeTransformedEvent => ({
+      destination: dest,
+      statusCode: 200,
+      batchedRequest: {
+        version: '1',
+        type: 'REST',
+        method: 'POST',
+        endpoint: '',
+        headers: {},
+        params: {},
+        body: {
+          JSON: {
+            subscription_groups: [
+              { subscription_group_id: `s${i}`, subscription_state: 'subscribed' },
+            ],
+          },
+        },
+        files: {},
+      } as any,
+      metadata: [{ jobId: i, workspaceId: 'workspace-non-mau', userId: 'shared' }],
+    });
+    const mergeJob = (i: number): BrazeTransformedEvent => ({
+      destination: dest,
+      statusCode: 200,
+      batchedRequest: {
+        version: '1',
+        type: 'REST',
+        method: 'POST',
+        endpoint: '',
+        headers: {},
+        params: {},
+        body: {
+          JSON: {
+            merge_updates: [
+              {
+                identifier_to_merge: { external_id: `a${i}` },
+                identifier_to_keep: { external_id: `b${i}` },
+              },
+            ],
+          },
+        },
+        files: {},
+      } as any,
+      metadata: [{ jobId: i, workspaceId: 'workspace-non-mau', userId: 'shared' }],
+    });
+
+    const result = processBatch([
+      trackJob(1),
+      trackJob(2),
+      subJob(3),
+      subJob(4),
+      mergeJob(5),
+      mergeJob(6),
+      subJob(7),
+    ]);
+
+    // Single output. Track requests: 1 chunk of 2. Sub requests: 1 chunk of 3.
+    // Merge requests: 1 chunk of 2. Total inner requests = 3.
+    expect(result.length).toBe(1);
+    const multi = result[0] as any;
+    expect(Array.isArray(multi.batchedRequest)).toBe(true);
+    expect(offTrackRequests(result, dest).length).toBe(1);
+    expect(offSubRequests(result, dest).length).toBe(1);
+    expect(offMergeRequests(result, dest).length).toBe(1);
+    // Flat metadata preserves original job insertion order.
+    expect(multi.metadata.map((m: any) => m.jobId)).toEqual([1, 2, 3, 4, 5, 6, 7]);
+  });
+
+  test('preserves failure and filtered responses alongside the single successful output', () => {
+    const transformedEvents: BrazeTransformedEvent[] = [
+      ...Array.from({ length: 10 }, (_, i) => buildTrackEvent(i)),
+      {
+        destination,
+        statusCode: 400,
+        metadata: [{ jobId: 500, workspaceId: 'workspace-non-mau' }],
+        error: 'Random Error',
+      } as BrazeTransformedEvent,
+    ];
+    const result = processBatch(transformedEvents);
+    const failures = result.filter((r) => (r as any).statusCode === 400);
+    expect(failures.length).toBe(1);
+    expect((failures[0] as any).error).toBe('Random Error');
+    const tracks = offTrackRequests(result, destination);
+    expect(offTotalIn(tracks, 'events')).toBe(10);
+  });
+});
+
+describe('processBatch — OFF path (default) — MAU workspace (V2 chunking)', () => {
+  const destination = brazeDestFor();
+
+  const buildTrackEvent = (i: number): BrazeTransformedEvent => ({
+    destination,
+    statusCode: 200,
+    batchedRequest: {
+      version: '1',
+      type: 'REST',
+      method: 'POST',
+      endpoint: '',
+      headers: {},
+      params: {},
+      body: {
+        JSON: {
+          attributes: [{ external_id: `u${i}`, id: i, name: 'n' }],
+          events: [{ external_id: `u${i}`, id: i, event: 'e' }],
+          purchases: [
+            {
+              external_id: `u${i}`,
+              product_id: `p${i}`,
+              price: 1,
+              currency: 'USD',
+              quantity: 1,
+              time: 't',
+            },
+          ],
+        },
+      },
+      files: {},
+    } as any,
+    metadata: [{ jobId: i, workspaceId: 'workspace-mau' }],
+  });
+
+  test('V2 chunks by total-count cap (75) across sub-arrays', () => {
+    const transformedEvents = Array.from({ length: 100 }, (_, i) => buildTrackEvent(i));
+    const result = processBatch(transformedEvents);
+    expect(result.length).toBe(1);
+    const tracks = offTrackRequests(result, destination);
+    expect(tracks.length).toBe(4);
+    expect(offTotalIn(tracks, 'attributes')).toBe(100);
+    expect(offTotalIn(tracks, 'events')).toBe(100);
+    expect(offTotalIn(tracks, 'purchases')).toBe(100);
+    for (const t of tracks) {
+      const body = t.body.JSON as BrazeTrackRequestBody;
+      const total =
+        (body.attributes?.length ?? 0) + (body.events?.length ?? 0) + (body.purchases?.length ?? 0);
+      expect(total).toBeLessThanOrEqual(75);
+    }
+  });
+});
+
+describe('processBatch — OFF path (default) — size + oversized-job rejection', () => {
+  const destination = brazeDestFor();
+
+  test('single item exceeding TRACK_BRAZE_MAX_ITEM_BYTE_SIZE (100 KB) is rejected with InstrumentationError', () => {
+    const big = 'x'.repeat(150 * 1024);
+    const transformedEvent: BrazeTransformedEvent = {
+      destination,
+      statusCode: 200,
+      batchedRequest: {
+        version: '1',
+        type: 'REST',
+        method: 'POST',
+        endpoint: '',
+        headers: {},
+        params: {},
+        body: {
+          JSON: {
+            events: [{ external_id: 'u1', name: 'BigEvent', time: 't', properties: { blob: big } }],
+          },
+        },
+        files: {},
+      } as any,
+      metadata: [{ jobId: 1, workspaceId: 'workspace-non-mau' }],
+    };
+    const result = processBatch([transformedEvent]);
+    const failures = result.filter((r) => (r as any).statusCode === 400);
+    expect(failures.length).toBe(1);
+    expect((failures[0] as any).error).toMatch(/exceeds .* bytes/);
+    // No successful output when the only job was rejected.
+    expect(offMulti(result)).toBeUndefined();
+  });
+
+  test('single job contributing > 75 track items is rejected — no chunking can accommodate it without straddle', () => {
+    const attributes = Array.from({ length: 40 }, (_, i) => ({ external_id: 'u1', id: i }));
+    const events = Array.from({ length: 40 }, (_, i) => ({ external_id: 'u1', id: i, event: 'e' }));
+    const transformedEvent: BrazeTransformedEvent = {
+      destination,
+      statusCode: 200,
+      batchedRequest: {
+        version: '1',
+        type: 'REST',
+        method: 'POST',
+        endpoint: '',
+        headers: {},
+        params: {},
+        body: { JSON: { attributes, events } },
+        files: {},
+      } as any,
+      metadata: [{ jobId: 1, workspaceId: 'workspace-non-mau' }],
+    };
+    const result = processBatch([transformedEvent]);
+    const failures = result.filter((r) => (r as any).statusCode === 400);
+    expect(failures.length).toBe(1);
+    expect((failures[0] as any).error).toMatch(/max .* per batch/);
+  });
+
+  test('oversized job is rejected without affecting other jobs in the same batch', () => {
+    const big = 'x'.repeat(150 * 1024);
+    const good = {
+      destination,
+      statusCode: 200,
+      batchedRequest: {
+        version: '1',
+        type: 'REST',
+        method: 'POST',
+        endpoint: '',
+        headers: {},
+        params: {},
+        body: { JSON: { events: [{ external_id: 'ok', name: 'Small', time: 't' }] } },
+        files: {},
+      } as any,
+      metadata: [{ jobId: 100, workspaceId: 'workspace-non-mau' }],
+    } as BrazeTransformedEvent;
+    const bad = {
+      destination,
+      statusCode: 200,
+      batchedRequest: {
+        version: '1',
+        type: 'REST',
+        method: 'POST',
+        endpoint: '',
+        headers: {},
+        params: {},
+        body: {
+          JSON: {
+            events: [{ external_id: 'bad', name: 'Big', time: 't', properties: { blob: big } }],
+          },
+        },
+        files: {},
+      } as any,
+      metadata: [{ jobId: 200, workspaceId: 'workspace-non-mau' }],
+    } as BrazeTransformedEvent;
+    const result = processBatch([good, bad]);
+    const failures = result.filter((r) => (r as any).statusCode === 400);
+    expect(failures.length).toBe(1);
+    expect(failures[0].metadata?.[0]).toMatchObject({ jobId: 200 });
+    const tracks = offTrackRequests(result, destination);
+    expect(tracks.length).toBe(1);
+    expect((tracks[0].body.JSON as BrazeTrackRequestBody).events?.length).toBe(1);
+  });
+});
+
+describe('processBatch — OFF path (default) — straddle prevention', () => {
+  const destination = brazeDestFor();
+
+  const buildOrderCompletedJob = (i: number, numProducts: number): BrazeTransformedEvent => ({
+    destination,
+    statusCode: 200,
+    batchedRequest: {
+      version: '1',
+      type: 'REST',
+      method: 'POST',
+      endpoint: '',
+      headers: {},
+      params: {},
+      body: {
+        JSON: {
+          attributes: [{ external_id: `u${i}`, name: 'A' }],
+          purchases: Array.from({ length: numProducts }, (_, k) => ({
+            external_id: `u${i}`,
+            product_id: `p${i}-${k}`,
+            price: 1,
+            currency: 'USD',
+            quantity: 1,
+            time: 't',
+          })),
+        },
+      },
+      files: {},
+    } as any,
+    metadata: [{ jobId: i, workspaceId: 'workspace-mau' }],
+  });
+
+  test('every track chunk stays within V2 total-count cap (75) — no single job straddles', () => {
+    // Group-preserving chunking keeps a job's contributions whole even in OFF
+    // path (kept as an INT-6808 improvement). We can't verify per-jobId
+    // occurrence without destInfo, but we CAN verify no chunk breaches the
+    // cap AND every job's user_id ends up in some chunk.
+    const jobs: BrazeTransformedEvent[] = [];
+    for (let i = 0; i < 24; i += 1) jobs.push(buildOrderCompletedJob(i, 3));
+    jobs.push(buildOrderCompletedJob(24, 6));
+
+    const result = processBatch(jobs);
+    const tracks = offTrackRequests(result, destination);
+    for (const t of tracks) {
+      const b = t.body.JSON as BrazeTrackRequestBody;
+      const total =
+        (b.attributes?.length ?? 0) + (b.events?.length ?? 0) + (b.purchases?.length ?? 0);
+      expect(total).toBeLessThanOrEqual(75);
+    }
+    // Every source-job's user_id (u0..u24) must appear somewhere in the
+    // concatenated payloads (25 unique externalIds across 25 jobs).
+    const allExternalIds = new Set<string>();
+    for (const t of tracks) {
+      const b = t.body.JSON as BrazeTrackRequestBody;
+      for (const a of b.attributes ?? []) allExternalIds.add(a.external_id as string);
+      for (const p of b.purchases ?? []) allExternalIds.add(p.external_id as string);
+    }
+    expect(allExternalIds.size).toBe(25);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ON path — BRAZE_PER_JOB_DELIVERY_MAPPING_ENABLED=true. processBatch emits
+// one BatchRequestOutput per outgoing HTTP request, with insertion-order-
+// preserving runs. Track outputs carry per-metadata `destInfo` positional
+// maps; sub/merge outputs carry `destInfo: {}` for correlation-shape
+// uniformity. The flag is read dynamically inside processBatch, so a plain
+// env swap is sufficient.
+// ---------------------------------------------------------------------------
+
+describe('processBatch — ON path (BRAZE_PER_JOB_DELIVERY_MAPPING_ENABLED=true)', () => {
+  beforeEach(() => {
+    process.env.BRAZE_PER_JOB_DELIVERY_MAPPING_ENABLED = 'true';
+  });
+  afterEach(() => {
+    delete process.env.BRAZE_PER_JOB_DELIVERY_MAPPING_ENABLED;
+  });
+
+  const destination = brazeDestFor();
+
+  const buildTrackEvent = (
+    i: number,
+    workspaceId = 'workspace-non-mau',
+  ): BrazeTransformedEvent => ({
+    destination,
+    statusCode: 200,
+    batchedRequest: {
+      version: '1',
+      type: 'REST',
+      method: 'POST',
+      endpoint: '',
+      headers: {},
+      params: {},
+      body: {
+        JSON: {
+          attributes: [{ external_id: `u${i}`, id: i, name: 'n' }],
+          events: [{ external_id: `u${i}`, id: i, event: 'e' }],
+          purchases: [
+            {
+              external_id: `u${i}`,
+              product_id: `p${i}`,
+              price: 1,
+              currency: 'USD',
+              quantity: 1,
+              time: 't',
+            },
+          ],
+        },
+      },
+      files: {},
+    } as any,
+    metadata: [{ jobId: i, workspaceId }],
+  });
+
+  test('every output is a single BatchRequestOutput (no MultiBatchRequestOutput anywhere)', () => {
+    const transformedEvents = Array.from({ length: 20 }, (_, i) => buildTrackEvent(i));
+    const result = processBatch(transformedEvents);
+    for (const out of result) {
+      expect(Array.isArray((out as any).batchedRequest)).toBe(false);
+      expect((out as any).batched).toBe(true);
+    }
+  });
+
+  test('V1 chunks track outputs by per-type caps (75); every job has a destInfo positional map', () => {
+    const transformedEvents = Array.from({ length: 100 }, (_, i) => buildTrackEvent(i));
+    const result = processBatch(transformedEvents);
+    const tracks = onTrackOutputs(result, destination);
+    expect(tracks.length).toBeGreaterThanOrEqual(2);
+    expect(onTotalInSubArray(tracks, 'attributes')).toBe(100);
+    for (const t of tracks) {
+      for (const m of t.metadata) {
+        const info = (m as any).destInfo;
+        expect(info).toBeDefined();
+        // Each track metadata must have at least one non-empty indices array.
+        const anyIndex =
+          info.attributesIndices?.length ||
+          info.eventsIndices?.length ||
+          info.purchasesIndices?.length;
+        expect(anyIndex).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  test('subscription-group outputs carry destInfo: {} on every metadata entry', () => {
+    const dest = brazeDestFor({ enableSubscriptionGroupInGroupCall: true });
+    const transformedEvents: BrazeTransformedEvent[] = [];
+    for (let i = 0; i < 30; i += 1) {
+      transformedEvents.push({
+        destination: dest,
+        statusCode: 200,
+        batchedRequest: {
+          version: '1',
+          type: 'REST',
+          method: 'POST',
+          endpoint: '',
+          headers: {},
+          params: {},
+          body: {
+            JSON: {
+              subscription_groups: [
+                { subscription_group_id: `s${i}`, subscription_state: 'subscribed' },
+              ],
+            },
+          },
+          files: {},
+        } as any,
+        metadata: [{ jobId: i, workspaceId: 'workspace-non-mau' }],
+      });
+    }
+    const result = processBatch(transformedEvents);
+    const subs = onSubOutputs(result, dest);
+    expect(subs.length).toBe(Math.ceil(30 / 25));
+    for (const s of subs) {
+      for (const m of s.metadata) {
+        // destInfo must be present (present-but-empty), not undefined. The
+        // networkHandler relies on it being a defined object per metadata
+        // entry regardless of endpoint.
+        expect((m as any).destInfo).toBeDefined();
+        expect((m as any).destInfo).toEqual({});
+      }
+    }
+  });
+
+  test('alias-merge outputs carry destInfo: {} on every metadata entry', () => {
+    const dest = brazeDestFor();
+    const transformedEvents: BrazeTransformedEvent[] = [];
+    for (let i = 0; i < 60; i += 1) {
+      transformedEvents.push({
+        destination: dest,
+        statusCode: 200,
+        batchedRequest: {
+          version: '1',
+          type: 'REST',
+          method: 'POST',
+          endpoint: '',
+          headers: {},
+          params: {},
+          body: {
+            JSON: {
+              merge_updates: [
+                {
+                  identifier_to_merge: { external_id: `a${i}` },
+                  identifier_to_keep: { external_id: `b${i}` },
+                },
+              ],
+            },
+          },
+          files: {},
+        } as any,
+        metadata: [{ jobId: i, workspaceId: 'workspace-non-mau' }],
+      });
+    }
+    const result = processBatch(transformedEvents);
+    const merges = onMergeOutputs(result, dest);
+    expect(merges.length).toBe(Math.ceil(60 / 50));
+    for (const m of merges) {
       for (const meta of m.metadata) {
-        expect(
-          (meta.destInfo as any)?.attributesIndices ??
-            (meta.destInfo as any)?.eventsIndices ??
-            (meta.destInfo as any)?.purchasesIndices,
-        ).toBeUndefined();
+        expect((meta as any).destInfo).toBeDefined();
+        expect((meta as any).destInfo).toEqual({});
       }
     }
   });
 
   test('interleaved input types produce outputs in insertion-order runs (jobIds ascending across outputs)', () => {
-    // Real Braze events never fan out to multiple endpoints, but a single
-    // router batch mixes event types. Verify that we emit outputs in the
-    // input's insertion-order runs so per-user jobIds remain monotonic.
     const dest = brazeDestFor({ enableSubscriptionGroupInGroupCall: true });
     const trackJob = (i: number): BrazeTransformedEvent => ({
       destination: dest,
@@ -1291,104 +1800,7 @@ describe('processBatch — non-MAU workspace (V1 chunking)', () => {
     expect(jobIdsPerOutput).toEqual([[1, 2], [3, 4], [5, 6], [7]]);
   });
 
-  test('preserves failure and filtered responses alongside successful outputs', () => {
-    const transformedEvents: BrazeTransformedEvent[] = [
-      ...Array.from({ length: 10 }, (_, i) => buildTrackEvent(i)),
-      {
-        destination,
-        statusCode: 400,
-        metadata: [{ jobId: 500, workspaceId: 'workspace-non-mau' }],
-        error: 'Random Error',
-      } as BrazeTransformedEvent,
-    ];
-    const result = processBatch(transformedEvents);
-    const failures = result.filter((r) => (r as any).statusCode === 400);
-    expect(failures.length).toBe(1);
-    expect((failures[0] as any).error).toBe('Random Error');
-    const tracks = trackOutputs(result, destination);
-    expect(totalInSubArray(tracks, 'events')).toBe(10);
-  });
-});
-
-describe('processBatch — MAU workspace (V2 chunking)', () => {
-  const destination = brazeDestFor();
-
-  const buildTrackEvent = (i: number): BrazeTransformedEvent => ({
-    destination,
-    statusCode: 200,
-    batchedRequest: {
-      version: '1',
-      type: 'REST',
-      method: 'POST',
-      endpoint: '',
-      headers: {},
-      params: {},
-      body: {
-        JSON: {
-          attributes: [{ external_id: `u${i}`, id: i, name: 'n' }],
-          events: [{ external_id: `u${i}`, id: i, event: 'e' }],
-          purchases: [
-            {
-              external_id: `u${i}`,
-              product_id: `p${i}`,
-              price: 1,
-              currency: 'USD',
-              quantity: 1,
-              time: 't',
-            },
-          ],
-        },
-      },
-      files: {},
-    } as any,
-    metadata: [{ jobId: i, workspaceId: 'workspace-mau' }],
-  });
-
-  test('V2 chunks by total-count cap (75) across sub-arrays', () => {
-    // Each job = 3 items. 100 jobs = 300 items. V2 total-count cap 75 →
-    // straddle-safe chunking groups 3 items atomically, so 25 groups per chunk
-    // → 4 track chunks. 100 subs / 25 = 4 sub chunks. 100 merges / 50 = 2 merge
-    // chunks. Total = 10 outputs.
-    const transformedEvents = Array.from({ length: 100 }, (_, i) => buildTrackEvent(i));
-    const result = processBatch(transformedEvents);
-
-    const tracks = trackOutputs(result, destination);
-    expect(tracks.length).toBe(4);
-    expect(totalInSubArray(tracks, 'attributes')).toBe(100);
-    expect(totalInSubArray(tracks, 'events')).toBe(100);
-    expect(totalInSubArray(tracks, 'purchases')).toBe(100);
-    for (const t of tracks) {
-      const body = t.batchedRequest.body.JSON as BrazeTrackRequestBody;
-      const total =
-        (body.attributes?.length ?? 0) + (body.events?.length ?? 0) + (body.purchases?.length ?? 0);
-      expect(total).toBeLessThanOrEqual(75);
-    }
-  });
-
-  test('metadata is scoped per output — no cross-chunk leakage', () => {
-    const transformedEvents = Array.from({ length: 100 }, (_, i) => buildTrackEvent(i));
-    const result = processBatch(transformedEvents);
-    const tracks = trackOutputs(result, destination);
-    // The full set of jobIds seen across all track outputs must exactly
-    // equal the input jobIds, with no repeats.
-    const seen = new Set<number>();
-    for (const t of tracks) {
-      for (const m of t.metadata) {
-        const jid = (m as { jobId?: number }).jobId;
-        if (jid !== undefined) {
-          expect(seen.has(jid)).toBe(false);
-          seen.add(jid);
-        }
-      }
-    }
-    expect(seen.size).toBe(100);
-  });
-});
-
-describe('processBatch — destInfo positional map', () => {
-  const destination = brazeDestFor();
-
-  test('single track job (attribute + event) → destInfo carries attributesIndices + eventsIndices', () => {
+  test('single track job (attribute + event) → destInfo has attributesIndices + eventsIndices; purchasesIndices absent', () => {
     const transformedEvent: BrazeTransformedEvent = {
       destination,
       statusCode: 200,
@@ -1410,7 +1822,7 @@ describe('processBatch — destInfo positional map', () => {
       metadata: [{ jobId: 42, workspaceId: 'workspace-non-mau' }],
     };
     const result = processBatch([transformedEvent]);
-    const tracks = trackOutputs(result, destination);
+    const tracks = onTrackOutputs(result, destination);
     expect(tracks.length).toBe(1);
     expect(tracks[0].metadata.length).toBe(1);
     const info = (tracks[0].metadata[0] as any).destInfo;
@@ -1466,7 +1878,7 @@ describe('processBatch — destInfo positional map', () => {
       metadata: [{ jobId: 42, workspaceId: 'workspace-non-mau' }],
     };
     const result = processBatch([transformedEvent]);
-    const tracks = trackOutputs(result, destination);
+    const tracks = onTrackOutputs(result, destination);
     expect(tracks.length).toBe(1);
     const info = (tracks[0].metadata[0] as any).destInfo;
     expect(info.attributesIndices).toEqual([0]);
@@ -1474,10 +1886,7 @@ describe('processBatch — destInfo positional map', () => {
     expect(info.eventsIndices).toBeUndefined();
   });
 
-  test('mixed batch: each job’s destInfo indices match its actual positions in the chunk', () => {
-    // Job 1: identify (attribute only) for user "u1"
-    // Job 2: track (attribute + event) for user "u2"
-    // Job 3: order-completed (attribute + 2 purchases) for user "u3"
+  test('mixed batch: each job’s destInfo indices point to payload entries whose external_id matches', () => {
     const jobs: BrazeTransformedEvent[] = [
       {
         destination,
@@ -1553,17 +1962,13 @@ describe('processBatch — destInfo positional map', () => {
       },
     ];
     const result = processBatch(jobs);
-    const tracks = trackOutputs(result, destination);
+    const tracks = onTrackOutputs(result, destination);
     expect(tracks.length).toBe(1);
     const chunk = tracks[0];
     const body = chunk.batchedRequest.body.JSON as BrazeTrackRequestBody;
-    // Sanity: 3 attributes, 1 event, 2 purchases in the chunk.
     expect(body.attributes?.length).toBe(3);
     expect(body.events?.length).toBe(1);
     expect(body.purchases?.length).toBe(2);
-    // Every metadata's destInfo indices must point to a payload entry whose
-    // externalId matches — this is what the networkHandler will rely on to
-    // correlate Braze warnings back to the right jobId.
     for (const m of chunk.metadata) {
       const info = (m as any).destInfo;
       const jobId = (m as any).jobId;
@@ -1579,13 +1984,61 @@ describe('processBatch — destInfo positional map', () => {
       }
     }
   });
-});
 
-describe('processBatch — size + oversized-job rejection', () => {
-  const destination = brazeDestFor();
+  test('a single job’s items never straddle chunk boundaries (ON path preserves group-preserving chunking)', () => {
+    const buildOrderCompletedJob = (i: number, numProducts: number): BrazeTransformedEvent => ({
+      destination,
+      statusCode: 200,
+      batchedRequest: {
+        version: '1',
+        type: 'REST',
+        method: 'POST',
+        endpoint: '',
+        headers: {},
+        params: {},
+        body: {
+          JSON: {
+            attributes: [{ external_id: `u${i}`, name: 'A' }],
+            purchases: Array.from({ length: numProducts }, (_, k) => ({
+              external_id: `u${i}`,
+              product_id: `p${i}-${k}`,
+              price: 1,
+              currency: 'USD',
+              quantity: 1,
+              time: 't',
+            })),
+          },
+        },
+        files: {},
+      } as any,
+      metadata: [{ jobId: i, workspaceId: 'workspace-mau' }],
+    });
 
-  test('single item exceeding TRACK_BRAZE_MAX_ITEM_BYTE_SIZE (100 KB) is rejected with InstrumentationError', () => {
-    const big = 'x'.repeat(150 * 1024); // ~150 KB payload → serialized > 100 KB
+    const jobs: BrazeTransformedEvent[] = [];
+    for (let i = 0; i < 24; i += 1) jobs.push(buildOrderCompletedJob(i, 3));
+    jobs.push(buildOrderCompletedJob(24, 6));
+
+    const result = processBatch(jobs);
+    const tracks = onTrackOutputs(result, destination);
+
+    for (const job of jobs) {
+      const jobId = job.metadata?.[0]?.jobId;
+      let occurrences = 0;
+      for (const t of tracks) {
+        if (t.metadata.some((m: any) => m.jobId === jobId)) occurrences += 1;
+      }
+      expect(occurrences).toBe(1);
+    }
+    for (const t of tracks) {
+      const b = t.batchedRequest.body.JSON as BrazeTrackRequestBody;
+      const total =
+        (b.attributes?.length ?? 0) + (b.events?.length ?? 0) + (b.purchases?.length ?? 0);
+      expect(total).toBeLessThanOrEqual(75);
+    }
+  });
+
+  test('single item exceeding TRACK_BRAZE_MAX_ITEM_BYTE_SIZE (100 KB) is rejected with InstrumentationError (flag-independent)', () => {
+    const big = 'x'.repeat(150 * 1024);
     const transformedEvent: BrazeTransformedEvent = {
       destination,
       statusCode: 200,
@@ -1609,139 +2062,7 @@ describe('processBatch — size + oversized-job rejection', () => {
     const failures = result.filter((r) => (r as any).statusCode === 400);
     expect(failures.length).toBe(1);
     expect((failures[0] as any).error).toMatch(/exceeds .* bytes/);
-    expect(trackOutputs(result, destination).length).toBe(0);
-  });
-
-  test('single job contributing > 75 track items is rejected — no chunking can accommodate it without straddle', () => {
-    const attributes = Array.from({ length: 40 }, (_, i) => ({ external_id: 'u1', id: i }));
-    const events = Array.from({ length: 40 }, (_, i) => ({ external_id: 'u1', id: i, event: 'e' }));
-    const transformedEvent: BrazeTransformedEvent = {
-      destination,
-      statusCode: 200,
-      batchedRequest: {
-        version: '1',
-        type: 'REST',
-        method: 'POST',
-        endpoint: '',
-        headers: {},
-        params: {},
-        body: { JSON: { attributes, events } },
-        files: {},
-      } as any,
-      metadata: [{ jobId: 1, workspaceId: 'workspace-non-mau' }],
-    };
-    const result = processBatch([transformedEvent]);
-    const failures = result.filter((r) => (r as any).statusCode === 400);
-    expect(failures.length).toBe(1);
-    expect((failures[0] as any).error).toMatch(/max .* per batch/);
-  });
-
-  test('oversized job is rejected without affecting other jobs in the same batch', () => {
-    const big = 'x'.repeat(150 * 1024);
-    const good = {
-      destination,
-      statusCode: 200,
-      batchedRequest: {
-        version: '1',
-        type: 'REST',
-        method: 'POST',
-        endpoint: '',
-        headers: {},
-        params: {},
-        body: { JSON: { events: [{ external_id: 'ok', name: 'Small', time: 't' }] } },
-        files: {},
-      } as any,
-      metadata: [{ jobId: 100, workspaceId: 'workspace-non-mau' }],
-    } as BrazeTransformedEvent;
-    const bad = {
-      destination,
-      statusCode: 200,
-      batchedRequest: {
-        version: '1',
-        type: 'REST',
-        method: 'POST',
-        endpoint: '',
-        headers: {},
-        params: {},
-        body: {
-          JSON: {
-            events: [{ external_id: 'bad', name: 'Big', time: 't', properties: { blob: big } }],
-          },
-        },
-        files: {},
-      } as any,
-      metadata: [{ jobId: 200, workspaceId: 'workspace-non-mau' }],
-    } as BrazeTransformedEvent;
-    const result = processBatch([good, bad]);
-    const failures = result.filter((r) => (r as any).statusCode === 400);
-    expect(failures.length).toBe(1);
-    expect(failures[0].metadata?.[0]).toMatchObject({ jobId: 200 });
-    const tracks = trackOutputs(result, destination);
-    expect(tracks.length).toBe(1);
-    expect((tracks[0].batchedRequest.body.JSON as BrazeTrackRequestBody).events?.length).toBe(1);
-  });
-});
-
-describe('processBatch — straddle prevention', () => {
-  const destination = brazeDestFor();
-
-  const buildOrderCompletedJob = (i: number, numProducts: number): BrazeTransformedEvent => ({
-    destination,
-    statusCode: 200,
-    batchedRequest: {
-      version: '1',
-      type: 'REST',
-      method: 'POST',
-      endpoint: '',
-      headers: {},
-      params: {},
-      body: {
-        JSON: {
-          attributes: [{ external_id: `u${i}`, name: 'A' }],
-          purchases: Array.from({ length: numProducts }, (_, k) => ({
-            external_id: `u${i}`,
-            product_id: `p${i}-${k}`,
-            price: 1,
-            currency: 'USD',
-            quantity: 1,
-            time: 't',
-          })),
-        },
-      },
-      files: {},
-    } as any,
-    metadata: [{ jobId: i, workspaceId: 'workspace-mau' }],
-  });
-
-  test('a single job’s items never straddle chunk boundaries', () => {
-    // Craft a case where V2's flat 75-item boundary would fall mid-way through
-    // job 25's contributions if we chunked item-by-item. Group-preserving
-    // chunking must keep job 25 whole in the next chunk.
-    const jobs: BrazeTransformedEvent[] = [];
-    for (let i = 0; i < 24; i += 1) jobs.push(buildOrderCompletedJob(i, 3)); // 24 * 4 = 96 items
-    jobs.push(buildOrderCompletedJob(24, 6)); // 6 more items — would push chunk over 75
-
-    const result = processBatch(jobs);
-    const tracks = trackOutputs(result, destination);
-
-    // Every jobId should appear in exactly one track output (never split).
-    for (const job of jobs) {
-      const jobId = job.metadata?.[0]?.jobId;
-      let occurrences = 0;
-      for (const t of tracks) {
-        if (t.metadata.some((m) => (m as { jobId?: number }).jobId === jobId)) {
-          occurrences += 1;
-        }
-      }
-      expect(occurrences).toBe(1);
-    }
-    // Also verify all chunks stay within V2's 75-item total-count cap.
-    for (const t of tracks) {
-      const b = t.batchedRequest.body.JSON as BrazeTrackRequestBody;
-      const total =
-        (b.attributes?.length ?? 0) + (b.events?.length ?? 0) + (b.purchases?.length ?? 0);
-      expect(total).toBeLessThanOrEqual(75);
-    }
+    expect(onTrackOutputs(result, destination).length).toBe(0);
   });
 });
 describe('addAppId', () => {

--- a/src/v0/destinations/braze/braze.util.test.ts
+++ b/src/v0/destinations/braze/braze.util.test.ts
@@ -1156,7 +1156,11 @@ describe('processBatch — non-MAU workspace (V1 chunking)', () => {
       expect((s.batchedRequest.body.JSON as any).subscription_groups).toBeDefined();
       // Subscription outputs carry scoped metadata but no destInfo.braze.
       for (const m of s.metadata) {
-        expect(m.destInfo?.braze).toBeUndefined();
+        expect(
+          (m.destInfo as any)?.attributesIndices ??
+            (m.destInfo as any)?.eventsIndices ??
+            (m.destInfo as any)?.purchasesIndices,
+        ).toBeUndefined();
       }
     }
   });
@@ -1196,7 +1200,11 @@ describe('processBatch — non-MAU workspace (V1 chunking)', () => {
     for (const m of merges) {
       expect((m.batchedRequest.body.JSON as any).merge_updates).toBeDefined();
       for (const meta of m.metadata) {
-        expect(meta.destInfo?.braze).toBeUndefined();
+        expect(
+          (meta.destInfo as any)?.attributesIndices ??
+            (meta.destInfo as any)?.eventsIndices ??
+            (meta.destInfo as any)?.purchasesIndices,
+        ).toBeUndefined();
       }
     }
   });
@@ -1377,10 +1385,10 @@ describe('processBatch — MAU workspace (V2 chunking)', () => {
   });
 });
 
-describe('processBatch — destInfo.braze positional map', () => {
+describe('processBatch — destInfo positional map', () => {
   const destination = brazeDestFor();
 
-  test('single track job (attribute + event) → destInfo carries attributesIndex + eventsIndex', () => {
+  test('single track job (attribute + event) → destInfo carries attributesIndices + eventsIndices', () => {
     const transformedEvent: BrazeTransformedEvent = {
       destination,
       statusCode: 200,
@@ -1405,13 +1413,13 @@ describe('processBatch — destInfo.braze positional map', () => {
     const tracks = trackOutputs(result, destination);
     expect(tracks.length).toBe(1);
     expect(tracks[0].metadata.length).toBe(1);
-    const info = (tracks[0].metadata[0] as any).destInfo.braze;
-    expect(info.attributesIndex).toBe(0);
-    expect(info.eventsIndex).toBe(0);
-    expect(info.purchasesIndexes).toBeUndefined();
+    const info = (tracks[0].metadata[0] as any).destInfo;
+    expect(info.attributesIndices).toEqual([0]);
+    expect(info.eventsIndices).toEqual([0]);
+    expect(info.purchasesIndices).toBeUndefined();
   });
 
-  test('order-completed job (attribute + multiple purchases) → destInfo.purchasesIndexes is an array of all indices', () => {
+  test('order-completed job (attribute + multiple purchases) → destInfo.purchasesIndices is an array of all indices', () => {
     const transformedEvent: BrazeTransformedEvent = {
       destination,
       statusCode: 200,
@@ -1460,10 +1468,10 @@ describe('processBatch — destInfo.braze positional map', () => {
     const result = processBatch([transformedEvent]);
     const tracks = trackOutputs(result, destination);
     expect(tracks.length).toBe(1);
-    const info = (tracks[0].metadata[0] as any).destInfo.braze;
-    expect(info.attributesIndex).toBe(0);
-    expect(info.purchasesIndexes).toEqual([0, 1, 2]);
-    expect(info.eventsIndex).toBeUndefined();
+    const info = (tracks[0].metadata[0] as any).destInfo;
+    expect(info.attributesIndices).toEqual([0]);
+    expect(info.purchasesIndices).toEqual([0, 1, 2]);
+    expect(info.eventsIndices).toBeUndefined();
   });
 
   test('mixed batch: each job’s destInfo indices match its actual positions in the chunk', () => {
@@ -1557,19 +1565,17 @@ describe('processBatch — destInfo.braze positional map', () => {
     // externalId matches — this is what the networkHandler will rely on to
     // correlate Braze warnings back to the right jobId.
     for (const m of chunk.metadata) {
-      const info = (m as any).destInfo.braze;
+      const info = (m as any).destInfo;
       const jobId = (m as any).jobId;
       const externalId = `u${jobId}`;
-      if (info.attributesIndex !== undefined) {
-        expect((body.attributes as any)[info.attributesIndex].external_id).toBe(externalId);
+      for (const idx of info.attributesIndices ?? []) {
+        expect((body.attributes as any)[idx].external_id).toBe(externalId);
       }
-      if (info.eventsIndex !== undefined) {
-        expect((body.events as any)[info.eventsIndex].external_id).toBe(externalId);
+      for (const idx of info.eventsIndices ?? []) {
+        expect((body.events as any)[idx].external_id).toBe(externalId);
       }
-      if (info.purchasesIndexes) {
-        for (const idx of info.purchasesIndexes) {
-          expect((body.purchases as any)[idx].external_id).toBe(externalId);
-        }
+      for (const idx of info.purchasesIndices ?? []) {
+        expect((body.purchases as any)[idx].external_id).toBe(externalId);
       }
     }
   });

--- a/src/v0/destinations/braze/braze.util.test.ts
+++ b/src/v0/destinations/braze/braze.util.test.ts
@@ -1002,30 +1002,133 @@ describe('dedup utility tests', () => {
   });
 });
 
-describe('processBatch for workspaces on non MAU plan', () => {
-  test('processBatch handles more than 75 attributes, events, purchases, subscription_groups and merge users', () => {
-    // Create input data with more than 75 attributes, events, and purchases
-    const transformedEvents: BrazeTransformedEvent[] = [];
-    for (let i = 0; i < 100; i++) {
-      transformedEvents.push({
-        destination: {
-          ID: 'braze',
-          Name: 'braze',
-          Enabled: true,
-          Config: {
-            restApiKey: 'restApiKey',
-            dataCenter: 'US-03',
-            enableSubscriptionGroupInGroupCall: true,
-          },
-          DestinationDefinition: {
-            ID: 'braze',
-            Name: 'braze',
-            DisplayName: '',
-            Config: {},
-          },
-          WorkspaceID: '123',
-          Transformations: [],
+// ---------------------------------------------------------------------------
+// processBatch shared helpers
+// ---------------------------------------------------------------------------
+
+const brazeDestFor = (extras: Partial<BrazeDestinationConfig> = {}): BrazeDestination => ({
+  ID: 'braze',
+  Name: 'braze',
+  Enabled: true,
+  Config: {
+    restApiKey: 'restApiKey',
+    dataCenter: 'eu',
+    ...extras,
+  } as BrazeDestinationConfig,
+  DestinationDefinition: {
+    ID: 'braze',
+    Name: 'braze',
+    DisplayName: '',
+    Config: {},
+  },
+  WorkspaceID: '123',
+  Transformations: [],
+});
+
+const trackEndpointOf = (destination: BrazeDestination) =>
+  getEndpointFromConfig(destination) + '/users/track';
+const subEndpointOf = (destination: BrazeDestination) =>
+  getEndpointFromConfig(destination) + '/v2/subscription/status/set';
+const mergeEndpointOf = (destination: BrazeDestination) =>
+  getEndpointFromConfig(destination) + '/users/merge';
+
+// Loose types on these helpers — the test-time assertion is on the shape at
+// runtime, not the static union type of BrazeBatchResponse.
+const isBatchedOutput = (out: any): boolean =>
+  Boolean(out?.batchedRequest && !Array.isArray(out.batchedRequest));
+
+const trackOutputs = (result: any[], destination: BrazeDestination): any[] =>
+  result.filter(
+    (r) => isBatchedOutput(r) && r.batchedRequest.endpoint === trackEndpointOf(destination),
+  );
+
+const subOutputs = (result: any[], destination: BrazeDestination): any[] =>
+  result.filter(
+    (r) => isBatchedOutput(r) && r.batchedRequest.endpoint === subEndpointOf(destination),
+  );
+
+const mergeOutputs = (result: any[], destination: BrazeDestination): any[] =>
+  result.filter(
+    (r) => isBatchedOutput(r) && r.batchedRequest.endpoint === mergeEndpointOf(destination),
+  );
+
+const totalInSubArray = (outs: any[], key: 'attributes' | 'events' | 'purchases'): number =>
+  outs.reduce((acc, o) => acc + (o.batchedRequest.body.JSON[key]?.length ?? 0), 0);
+
+describe('processBatch — non-MAU workspace (V1 chunking)', () => {
+  const destination = brazeDestFor();
+
+  const buildTrackEvent = (
+    i: number,
+    workspaceId = 'workspace-non-mau',
+  ): BrazeTransformedEvent => ({
+    destination,
+    statusCode: 200,
+    batchedRequest: {
+      version: '1',
+      type: 'REST',
+      method: 'POST',
+      endpoint: '',
+      headers: {},
+      params: {},
+      body: {
+        JSON: {
+          attributes: [{ external_id: `u${i}`, id: i, name: 'n', xyz: 'a' }],
+          events: [{ external_id: `u${i}`, id: i, event: 'e' }],
+          purchases: [
+            {
+              external_id: `u${i}`,
+              product_id: `p${i}`,
+              price: 1,
+              currency: 'USD',
+              quantity: 1,
+              time: 't',
+            },
+          ],
         },
+      },
+      files: {},
+    } as any,
+    metadata: [{ jobId: i, workspaceId }],
+  });
+
+  test('every output is a single BatchRequestOutput with scoped metadata (no MultiBatchRequestOutput anywhere)', () => {
+    const transformedEvents = Array.from({ length: 20 }, (_, i) => buildTrackEvent(i));
+    const result = processBatch(transformedEvents);
+    for (const out of result) {
+      expect(out).toHaveProperty('batchedRequest');
+      expect(Array.isArray((out as any).batchedRequest)).toBe(false);
+      expect(out).toHaveProperty('metadata');
+      expect((out as any).batched).toBe(true);
+    }
+  });
+
+  test('splits track chunks by V1 per-type caps (75) with size-aware, group-preserving chunking', () => {
+    // Each job contributes 1 attribute + 1 event + 1 purchase (3-item group).
+    // 100 jobs → V1 close chunk when any per-type cap (75) would be exceeded.
+    const transformedEvents = Array.from({ length: 100 }, (_, i) => buildTrackEvent(i));
+    const result = processBatch(transformedEvents);
+
+    const tracks = trackOutputs(result, destination);
+    expect(tracks.length).toBeGreaterThanOrEqual(2);
+    expect(totalInSubArray(tracks, 'attributes')).toBe(100);
+    expect(totalInSubArray(tracks, 'events')).toBe(100);
+    expect(totalInSubArray(tracks, 'purchases')).toBe(100);
+    for (const t of tracks) {
+      const body = t.batchedRequest.body.JSON as BrazeTrackRequestBody;
+      expect(body.partner).toBe('RudderStack');
+      expect(body.attributes?.length ?? 0).toBeLessThanOrEqual(75);
+      expect(body.events?.length ?? 0).toBeLessThanOrEqual(75);
+      expect(body.purchases?.length ?? 0).toBeLessThanOrEqual(75);
+    }
+  });
+
+  test('subscription-group jobs emit one BatchRequestOutput per chunk (no destInfo)', () => {
+    const dest = brazeDestFor({ enableSubscriptionGroupInGroupCall: true });
+    const transformedEvents: BrazeTransformedEvent[] = [];
+    for (let i = 0; i < 100; i += 1) {
+      transformedEvents.push({
+        destination: dest,
         statusCode: 200,
         batchedRequest: {
           version: '1',
@@ -1036,103 +1139,75 @@ describe('processBatch for workspaces on non MAU plan', () => {
           params: {},
           body: {
             JSON: {
-              attributes: [{ id: i, name: 'test', xyz: 'abc' }],
-              events: [{ id: i, event: 'test', xyz: 'abc' }],
-              purchases: [{ id: i, purchase: 'test', xyz: 'abc' }],
               subscription_groups: [
-                { subscription_group_id: i, group: 'test', subscription_state: 'abc' },
+                { subscription_group_id: `s${i}`, subscription_state: 'subscribed' },
               ],
-              merge_updates: [{ id: i, alias: 'test', xyz: 'abc' }],
             },
           },
-        },
-        metadata: [{ job_id: i, workspaceId: 'workspace-non-mau' }],
+          files: {},
+        } as any,
+        metadata: [{ jobId: i, workspaceId: 'workspace-non-mau' }],
       });
     }
-
-    // Call the processBatch function
     const result = processBatch(transformedEvents);
-
-    // Assert that the response is as expected
-    expect(result.length).toBe(1); // One successful batched request and one failure response
-    const firstResult = result[0];
-
-    // Ensure batchedRequest exists and is an array
-    expect(firstResult.batchedRequest).toBeDefined();
-    expect(Array.isArray(firstResult.batchedRequest)).toBe(true);
-
-    if (firstResult.batchedRequest && Array.isArray(firstResult.batchedRequest)) {
-      expect(firstResult.batchedRequest.length).toBe(8); // Two batched requests
-      expect((firstResult.batchedRequest[0].body.JSON as BrazeTrackRequestBody).partner).toBe(
-        'RudderStack',
-      ); // Verify partner name
-      expect(
-        (firstResult.batchedRequest[0].body.JSON as BrazeTrackRequestBody).attributes?.length,
-      ).toBe(75); // First batch contains 75 attributes
-      expect(
-        (firstResult.batchedRequest[0].body.JSON as BrazeTrackRequestBody).events?.length,
-      ).toBe(75); // First batch contains 75 events
-      expect(
-        (firstResult.batchedRequest[0].body.JSON as BrazeTrackRequestBody).purchases?.length,
-      ).toBe(75); // First batch contains 75 purchases
-      expect((firstResult.batchedRequest[1].body.JSON as BrazeTrackRequestBody).partner).toBe(
-        'RudderStack',
-      ); // Verify partner name
-      expect(
-        (firstResult.batchedRequest[1].body.JSON as BrazeTrackRequestBody).attributes?.length,
-      ).toBe(25); // Second batch contains remaining 25 attributes
-      expect(
-        (firstResult.batchedRequest[1].body.JSON as BrazeTrackRequestBody).events?.length,
-      ).toBe(25); // Second batch contains remaining 25 events
-      expect(
-        (firstResult.batchedRequest[1].body.JSON as BrazeTrackRequestBody).purchases?.length,
-      ).toBe(25); // Second batch contains remaining 25 purchases
-      expect(
-        (firstResult.batchedRequest[2].body.JSON as BrazeSubscriptionBatchPayload)
-          .subscription_groups?.length,
-      ).toBe(25); // First batch contains 25 subscription group
-      expect(
-        (firstResult.batchedRequest[3].body.JSON as BrazeSubscriptionBatchPayload)
-          .subscription_groups?.length,
-      ).toBe(25); // Second batch contains 25 subscription group
-      expect(
-        (firstResult.batchedRequest[4].body.JSON as BrazeSubscriptionBatchPayload)
-          .subscription_groups?.length,
-      ).toBe(25); // Third batch contains 25 subscription group
-      expect(
-        (firstResult.batchedRequest[5].body.JSON as BrazeSubscriptionBatchPayload)
-          .subscription_groups?.length,
-      ).toBe(25); // Fourth batch contains 25 subscription group
-      expect(
-        (firstResult.batchedRequest[6].body.JSON as BrazeMergeBatchPayload).merge_updates?.length,
-      ).toBe(50); // First batch contains 50 merge_updates
-      expect(
-        (firstResult.batchedRequest[7].body.JSON as BrazeMergeBatchPayload).merge_updates?.length,
-      ).toBe(50); // First batch contains 25 merge_updates
+    const subs = subOutputs(result, dest);
+    expect(subs.length).toBe(Math.ceil(100 / 25));
+    for (const s of subs) {
+      expect((s.batchedRequest.body.JSON as any).subscription_groups).toBeDefined();
+      // Subscription outputs carry scoped metadata but no destInfo.braze.
+      for (const m of s.metadata) {
+        expect(m.destInfo?.braze).toBeUndefined();
+      }
     }
   });
 
-  test('processBatch handles more than 75 attributes, events, and purchases with non uniform distribution', () => {
-    const destination: BrazeDestination = {
-      ID: 'braze',
-      Name: 'braze',
-      Enabled: true,
-      Config: {
-        restApiKey: 'restApiKey',
-        dataCenter: 'eu',
-      },
-      DestinationDefinition: {
-        ID: 'braze',
-        Name: 'braze',
-        DisplayName: '',
-        Config: {},
-      },
-      WorkspaceID: '123',
-      Transformations: [],
-    };
-    // Create input data with more than 75 attributes, events, and purchases
-    const transformedEventsSet1: BrazeTransformedEvent[] = new Array(120).fill(0).map((_, i) => ({
-      destination,
+  test('alias-merge jobs emit one BatchRequestOutput per chunk (no destInfo)', () => {
+    const dest = brazeDestFor();
+    const transformedEvents: BrazeTransformedEvent[] = [];
+    for (let i = 0; i < 100; i += 1) {
+      transformedEvents.push({
+        destination: dest,
+        statusCode: 200,
+        batchedRequest: {
+          version: '1',
+          type: 'REST',
+          method: 'POST',
+          endpoint: '',
+          headers: {},
+          params: {},
+          body: {
+            JSON: {
+              merge_updates: [
+                {
+                  identifier_to_merge: { external_id: `a${i}` },
+                  identifier_to_keep: { external_id: `b${i}` },
+                },
+              ],
+            },
+          },
+          files: {},
+        } as any,
+        metadata: [{ jobId: i, workspaceId: 'workspace-non-mau' }],
+      });
+    }
+    const result = processBatch(transformedEvents);
+    const merges = mergeOutputs(result, dest);
+    expect(merges.length).toBe(Math.ceil(100 / 50));
+    for (const m of merges) {
+      expect((m.batchedRequest.body.JSON as any).merge_updates).toBeDefined();
+      for (const meta of m.metadata) {
+        expect(meta.destInfo?.braze).toBeUndefined();
+      }
+    }
+  });
+
+  test('interleaved input types produce outputs in insertion-order runs (jobIds ascending across outputs)', () => {
+    // Real Braze events never fan out to multiple endpoints, but a single
+    // router batch mixes event types. Verify that we emit outputs in the
+    // input's insertion-order runs so per-user jobIds remain monotonic.
+    const dest = brazeDestFor({ enableSubscriptionGroupInGroupCall: true });
+    const trackJob = (i: number): BrazeTransformedEvent => ({
+      destination: dest,
       statusCode: 200,
       batchedRequest: {
         version: '1',
@@ -1141,55 +1216,13 @@ describe('processBatch for workspaces on non MAU plan', () => {
         endpoint: '',
         headers: {},
         params: {},
-        body: {
-          JSON: {
-            events: [{ id: i, event: 'test', xyz: 'abc' }],
-          },
-        },
-      },
-      metadata: [{ job_id: i, workspaceId: 'workspace-non-mau' }],
-    }));
-
-    const transformedEventsSet2: BrazeTransformedEvent[] = new Array(160).fill(0).map((_, i) => ({
-      destination,
-      statusCode: 200,
-      batchedRequest: {
-        version: '1',
-        type: 'REST',
-        method: 'POST',
-        endpoint: '',
-        headers: {},
-        params: {},
-        body: {
-          JSON: {
-            purchases: [{ id: i, name: 'test', xyz: 'abc' }],
-          },
-        },
-      },
-      metadata: [{ job_id: 120 + i, workspaceId: 'workspace-non-mau' }],
-    }));
-
-    const transformedEventsSet3: BrazeTransformedEvent[] = new Array(100).fill(0).map((_, i) => ({
-      destination,
-      statusCode: 200,
-      batchedRequest: {
-        version: '1',
-        type: 'REST',
-        method: 'POST',
-        endpoint: '',
-        headers: {},
-        params: {},
-        body: {
-          JSON: {
-            attributes: [{ id: i, name: 'test', xyz: 'abc' }],
-          },
-        },
-      },
-      metadata: [{ job_id: 280 + i, workspaceId: 'workspace-non-mau' }],
-    }));
-
-    const transformedEventsSet4: BrazeTransformedEvent[] = new Array(70).fill(0).map((_, i) => ({
-      destination,
+        body: { JSON: { attributes: [{ external_id: `u${i}` }] } },
+        files: {},
+      } as any,
+      metadata: [{ jobId: i, workspaceId: 'workspace-non-mau', userId: 'shared' }],
+    });
+    const subJob = (i: number): BrazeTransformedEvent => ({
+      destination: dest,
       statusCode: 200,
       batchedRequest: {
         version: '1',
@@ -1201,15 +1234,154 @@ describe('processBatch for workspaces on non MAU plan', () => {
         body: {
           JSON: {
             subscription_groups: [
-              { subscription_group_id: i, group: 'test', subscription_state: 'abc' },
+              { subscription_group_id: `s${i}`, subscription_state: 'subscribed' },
             ],
           },
         },
-      },
-      metadata: [{ job_id: 280 + i, workspaceId: 'workspace-non-mau' }],
-    }));
+        files: {},
+      } as any,
+      metadata: [{ jobId: i, workspaceId: 'workspace-non-mau', userId: 'shared' }],
+    });
+    const mergeJob = (i: number): BrazeTransformedEvent => ({
+      destination: dest,
+      statusCode: 200,
+      batchedRequest: {
+        version: '1',
+        type: 'REST',
+        method: 'POST',
+        endpoint: '',
+        headers: {},
+        params: {},
+        body: {
+          JSON: {
+            merge_updates: [
+              {
+                identifier_to_merge: { external_id: `a${i}` },
+                identifier_to_keep: { external_id: `b${i}` },
+              },
+            ],
+          },
+        },
+        files: {},
+      } as any,
+      metadata: [{ jobId: i, workspaceId: 'workspace-non-mau', userId: 'shared' }],
+    });
 
-    const transformedEventsSet5: BrazeTransformedEvent[] = new Array(40).fill(0).map((_, i) => ({
+    const result = processBatch([
+      trackJob(1),
+      trackJob(2),
+      subJob(3),
+      subJob(4),
+      mergeJob(5),
+      mergeJob(6),
+      subJob(7),
+    ]);
+
+    // Expect 4 outputs: track [1,2], sub [3,4], merge [5,6], sub [7]
+    expect(result.length).toBe(4);
+    const jobIdsPerOutput = result.map((r: any) => r.metadata.map((m: any) => m.jobId));
+    expect(jobIdsPerOutput).toEqual([[1, 2], [3, 4], [5, 6], [7]]);
+  });
+
+  test('preserves failure and filtered responses alongside successful outputs', () => {
+    const transformedEvents: BrazeTransformedEvent[] = [
+      ...Array.from({ length: 10 }, (_, i) => buildTrackEvent(i)),
+      {
+        destination,
+        statusCode: 400,
+        metadata: [{ jobId: 500, workspaceId: 'workspace-non-mau' }],
+        error: 'Random Error',
+      } as BrazeTransformedEvent,
+    ];
+    const result = processBatch(transformedEvents);
+    const failures = result.filter((r) => (r as any).statusCode === 400);
+    expect(failures.length).toBe(1);
+    expect((failures[0] as any).error).toBe('Random Error');
+    const tracks = trackOutputs(result, destination);
+    expect(totalInSubArray(tracks, 'events')).toBe(10);
+  });
+});
+
+describe('processBatch — MAU workspace (V2 chunking)', () => {
+  const destination = brazeDestFor();
+
+  const buildTrackEvent = (i: number): BrazeTransformedEvent => ({
+    destination,
+    statusCode: 200,
+    batchedRequest: {
+      version: '1',
+      type: 'REST',
+      method: 'POST',
+      endpoint: '',
+      headers: {},
+      params: {},
+      body: {
+        JSON: {
+          attributes: [{ external_id: `u${i}`, id: i, name: 'n' }],
+          events: [{ external_id: `u${i}`, id: i, event: 'e' }],
+          purchases: [
+            {
+              external_id: `u${i}`,
+              product_id: `p${i}`,
+              price: 1,
+              currency: 'USD',
+              quantity: 1,
+              time: 't',
+            },
+          ],
+        },
+      },
+      files: {},
+    } as any,
+    metadata: [{ jobId: i, workspaceId: 'workspace-mau' }],
+  });
+
+  test('V2 chunks by total-count cap (75) across sub-arrays', () => {
+    // Each job = 3 items. 100 jobs = 300 items. V2 total-count cap 75 →
+    // straddle-safe chunking groups 3 items atomically, so 25 groups per chunk
+    // → 4 track chunks. 100 subs / 25 = 4 sub chunks. 100 merges / 50 = 2 merge
+    // chunks. Total = 10 outputs.
+    const transformedEvents = Array.from({ length: 100 }, (_, i) => buildTrackEvent(i));
+    const result = processBatch(transformedEvents);
+
+    const tracks = trackOutputs(result, destination);
+    expect(tracks.length).toBe(4);
+    expect(totalInSubArray(tracks, 'attributes')).toBe(100);
+    expect(totalInSubArray(tracks, 'events')).toBe(100);
+    expect(totalInSubArray(tracks, 'purchases')).toBe(100);
+    for (const t of tracks) {
+      const body = t.batchedRequest.body.JSON as BrazeTrackRequestBody;
+      const total =
+        (body.attributes?.length ?? 0) + (body.events?.length ?? 0) + (body.purchases?.length ?? 0);
+      expect(total).toBeLessThanOrEqual(75);
+    }
+  });
+
+  test('metadata is scoped per output — no cross-chunk leakage', () => {
+    const transformedEvents = Array.from({ length: 100 }, (_, i) => buildTrackEvent(i));
+    const result = processBatch(transformedEvents);
+    const tracks = trackOutputs(result, destination);
+    // The full set of jobIds seen across all track outputs must exactly
+    // equal the input jobIds, with no repeats.
+    const seen = new Set<number>();
+    for (const t of tracks) {
+      for (const m of t.metadata) {
+        const jid = (m as { jobId?: number }).jobId;
+        if (jid !== undefined) {
+          expect(seen.has(jid)).toBe(false);
+          seen.add(jid);
+        }
+      }
+    }
+    expect(seen.size).toBe(100);
+  });
+});
+
+describe('processBatch — destInfo.braze positional map', () => {
+  const destination = brazeDestFor();
+
+  test('single track job (attribute + event) → destInfo carries attributesIndex + eventsIndex', () => {
+    const transformedEvent: BrazeTransformedEvent = {
       destination,
       statusCode: 200,
       batchedRequest: {
@@ -1221,194 +1393,101 @@ describe('processBatch for workspaces on non MAU plan', () => {
         params: {},
         body: {
           JSON: {
-            merge_updates: [{ id: i, alias: 'test', xyz: 'abc' }],
+            attributes: [{ external_id: 'u1', name: 'attr' }],
+            events: [{ external_id: 'u1', name: 'Purchase', time: 't' }],
           },
         },
-      },
-      metadata: [{ job_id: 280 + i, workspaceId: 'workspace-non-mau' }],
-    }));
-
-    // Call the processBatch function
-    const result = processBatch([
-      ...transformedEventsSet1,
-      ...transformedEventsSet2,
-      ...transformedEventsSet3,
-      ...transformedEventsSet4,
-      ...transformedEventsSet5,
-    ]);
-
-    // Assert that the response is as expected
-    expect(result.length).toBe(1); // One successful batched request and one failure response
-    const firstResult = result[0];
-
-    // Ensure batchedRequest exists, is an array, and metadata exists
-    expect(firstResult.batchedRequest).toBeDefined();
-    expect(Array.isArray(firstResult.batchedRequest)).toBe(true);
-    expect(firstResult.metadata).toBeDefined();
-
-    if (
-      firstResult.batchedRequest &&
-      Array.isArray(firstResult.batchedRequest) &&
-      firstResult.metadata
-    ) {
-      expect(firstResult.metadata.length).toBe(490); // Check the total length is same as input jobs (120 + 160 + 100 + 70 +40)
-      expect(firstResult.batchedRequest.length).toBe(7); // Two batched requests
-      expect((firstResult.batchedRequest[0].body.JSON as BrazeTrackRequestBody).partner).toBe(
-        'RudderStack',
-      ); // Verify partner name
-      expect(
-        (firstResult.batchedRequest[0].body.JSON as BrazeTrackRequestBody).attributes?.length,
-      ).toBe(75); // First batch contains 75 attributes
-      expect(
-        (firstResult.batchedRequest[0].body.JSON as BrazeTrackRequestBody).events?.length,
-      ).toBe(75); // First batch contains 75 events
-      expect(
-        (firstResult.batchedRequest[0].body.JSON as BrazeTrackRequestBody).purchases?.length,
-      ).toBe(75); // First batch contains 75 purchases
-      expect((firstResult.batchedRequest[1].body.JSON as BrazeTrackRequestBody).partner).toBe(
-        'RudderStack',
-      ); // Verify partner name
-      expect(
-        (firstResult.batchedRequest[1].body.JSON as BrazeTrackRequestBody).attributes?.length,
-      ).toBe(25); // Second batch contains remaining 25 attributes
-      expect(
-        (firstResult.batchedRequest[1].body.JSON as BrazeTrackRequestBody).events?.length,
-      ).toBe(45); // Second batch contains remaining 45 events
-      expect(
-        (firstResult.batchedRequest[1].body.JSON as BrazeTrackRequestBody).purchases?.length,
-      ).toBe(75); // Second batch contains remaining 75 purchases
-      expect(
-        (firstResult.batchedRequest[2].body.JSON as BrazeTrackRequestBody).purchases?.length,
-      ).toBe(10); // Third batch contains remaining 10 purchases
-      expect(
-        (firstResult.batchedRequest[3].body.JSON as BrazeSubscriptionBatchPayload)
-          .subscription_groups?.length,
-      ).toBe(25); // First batch contains 25 subscription group
-      expect(
-        (firstResult.batchedRequest[4].body.JSON as BrazeSubscriptionBatchPayload)
-          .subscription_groups?.length,
-      ).toBe(25); // Second batch contains 25 subscription group
-      expect(
-        (firstResult.batchedRequest[5].body.JSON as BrazeSubscriptionBatchPayload)
-          .subscription_groups?.length,
-      ).toBe(20); // Third batch contains 20 subscription group
-      expect(
-        (firstResult.batchedRequest[6].body.JSON as BrazeMergeBatchPayload).merge_updates?.length,
-      ).toBe(40); // First batch contains 50 merge_updates
-    }
-  });
-
-  test('check success and failure scenarios both for processBatch', () => {
-    const transformedEvents: BrazeTransformedEvent[] = [];
-    const destination: BrazeDestination = {
-      ID: 'braze',
-      Name: 'braze',
-      Enabled: true,
-      Config: {
-        restApiKey: 'restApiKey',
-        dataCenter: 'eu',
-      },
-      DestinationDefinition: {
-        ID: 'braze',
-        Name: 'braze',
-        DisplayName: '',
-        Config: {},
-      },
-      WorkspaceID: '123',
-      Transformations: [],
+        files: {},
+      } as any,
+      metadata: [{ jobId: 42, workspaceId: 'workspace-non-mau' }],
     };
-    let successCount = 0;
-    let failureCount = 0;
-    for (let i = 0; i < 100; i++) {
-      const rando = Math.random() * 100;
-      if (rando < 50) {
-        transformedEvents.push({
-          destination,
-          statusCode: 200,
-          batchedRequest: {
-            version: '1',
-            type: 'REST',
-            method: 'POST',
-            endpoint: '',
-            headers: {},
-            params: {},
-            body: {
-              JSON: {
-                attributes: [{ id: i, name: 'test', xyz: 'abc' }],
-                events: [{ id: i, event: 'test', xyz: 'abc' }],
-                purchases: [{ id: i, purchase: 'test', xyz: 'abc' }],
-              },
-            },
-          },
-          metadata: [{ job_id: i, workspaceId: 'workspace-non-mau' }],
-        });
-        successCount = successCount + 1;
-      } else {
-        transformedEvents.push({
-          destination,
-          statusCode: 400,
-          metadata: [{ job_id: i, workspaceId: 'workspace-non-mau' }],
-          error: 'Random Error',
-        });
-        failureCount = failureCount + 1;
-      }
-    }
-    // Call the processBatch function
-    const result = processBatch(transformedEvents);
-    expect(result.length).toBe(failureCount + 1);
-    const firstResult = result[0];
-
-    // Ensure batchedRequest exists, is an array, and metadata exists
-    expect(firstResult.batchedRequest).toBeDefined();
-    expect(Array.isArray(firstResult.batchedRequest)).toBe(true);
-    expect(firstResult.metadata).toBeDefined();
-
-    if (
-      firstResult.batchedRequest &&
-      Array.isArray(firstResult.batchedRequest) &&
-      firstResult.metadata
-    ) {
-      expect(
-        (firstResult.batchedRequest[0].body.JSON as BrazeTrackRequestBody).attributes?.length,
-      ).toBe(successCount);
-      expect(
-        (firstResult.batchedRequest[0].body.JSON as BrazeTrackRequestBody).events?.length,
-      ).toBe(successCount);
-      expect(
-        (firstResult.batchedRequest[0].body.JSON as BrazeTrackRequestBody).purchases?.length,
-      ).toBe(successCount);
-      expect((firstResult.batchedRequest[0].body.JSON as BrazeTrackRequestBody).partner).toBe(
-        'RudderStack',
-      );
-      expect(firstResult.metadata.length).toBe(successCount);
-    }
+    const result = processBatch([transformedEvent]);
+    const tracks = trackOutputs(result, destination);
+    expect(tracks.length).toBe(1);
+    expect(tracks[0].metadata.length).toBe(1);
+    const info = (tracks[0].metadata[0] as any).destInfo.braze;
+    expect(info.attributesIndex).toBe(0);
+    expect(info.eventsIndex).toBe(0);
+    expect(info.purchasesIndexes).toBeUndefined();
   });
-});
 
-describe('processBatch for workspaces on MAU plan', () => {
-  test('processBatch handles more than 75 attributes, events, purchases, subscription_groups and merge users', () => {
-    // Create input data with more than 75 attributes, events, and purchases
-    const transformedEvents: BrazeTransformedEvent[] = [];
-    for (let i = 0; i < 100; i++) {
-      transformedEvents.push({
-        destination: {
-          ID: 'braze',
-          Name: 'braze',
-          Enabled: true,
-          DestinationDefinition: {
-            ID: 'braze',
-            Name: 'braze',
-            DisplayName: '',
-            Config: {},
-          },
-          WorkspaceID: '123',
-          Transformations: [],
-          Config: {
-            restApiKey: 'restApiKey',
-            dataCenter: 'US-03',
-            enableSubscriptionGroupInGroupCall: true,
+  test('order-completed job (attribute + multiple purchases) → destInfo.purchasesIndexes is an array of all indices', () => {
+    const transformedEvent: BrazeTransformedEvent = {
+      destination,
+      statusCode: 200,
+      batchedRequest: {
+        version: '1',
+        type: 'REST',
+        method: 'POST',
+        endpoint: '',
+        headers: {},
+        params: {},
+        body: {
+          JSON: {
+            attributes: [{ external_id: 'u1', name: 'attr' }],
+            purchases: [
+              {
+                external_id: 'u1',
+                product_id: 'p1',
+                price: 1,
+                currency: 'USD',
+                quantity: 1,
+                time: 't',
+              },
+              {
+                external_id: 'u1',
+                product_id: 'p2',
+                price: 2,
+                currency: 'USD',
+                quantity: 1,
+                time: 't',
+              },
+              {
+                external_id: 'u1',
+                product_id: 'p3',
+                price: 3,
+                currency: 'USD',
+                quantity: 1,
+                time: 't',
+              },
+            ],
           },
         },
+        files: {},
+      } as any,
+      metadata: [{ jobId: 42, workspaceId: 'workspace-non-mau' }],
+    };
+    const result = processBatch([transformedEvent]);
+    const tracks = trackOutputs(result, destination);
+    expect(tracks.length).toBe(1);
+    const info = (tracks[0].metadata[0] as any).destInfo.braze;
+    expect(info.attributesIndex).toBe(0);
+    expect(info.purchasesIndexes).toEqual([0, 1, 2]);
+    expect(info.eventsIndex).toBeUndefined();
+  });
+
+  test('mixed batch: each job’s destInfo indices match its actual positions in the chunk', () => {
+    // Job 1: identify (attribute only) for user "u1"
+    // Job 2: track (attribute + event) for user "u2"
+    // Job 3: order-completed (attribute + 2 purchases) for user "u3"
+    const jobs: BrazeTransformedEvent[] = [
+      {
+        destination,
+        statusCode: 200,
+        batchedRequest: {
+          version: '1',
+          type: 'REST',
+          method: 'POST',
+          endpoint: '',
+          headers: {},
+          params: {},
+          body: { JSON: { attributes: [{ external_id: 'u1', name: 'A' }] } },
+          files: {},
+        } as any,
+        metadata: [{ jobId: 1, workspaceId: 'workspace-non-mau' }],
+      },
+      {
+        destination,
         statusCode: 200,
         batchedRequest: {
           version: '1',
@@ -1419,401 +1498,246 @@ describe('processBatch for workspaces on MAU plan', () => {
           params: {},
           body: {
             JSON: {
-              attributes: [{ id: i, name: 'test', xyz: 'abc' }],
-              events: [{ id: i, event: 'test', xyz: 'abc' }],
-              purchases: [{ id: i, purchase: 'test', xyz: 'abc' }],
-              subscription_groups: [
-                { subscription_group_id: i, group: 'test', subscription_state: 'abc' },
+              attributes: [{ external_id: 'u2', name: 'B' }],
+              events: [{ external_id: 'u2', name: 'E', time: 't' }],
+            },
+          },
+          files: {},
+        } as any,
+        metadata: [{ jobId: 2, workspaceId: 'workspace-non-mau' }],
+      },
+      {
+        destination,
+        statusCode: 200,
+        batchedRequest: {
+          version: '1',
+          type: 'REST',
+          method: 'POST',
+          endpoint: '',
+          headers: {},
+          params: {},
+          body: {
+            JSON: {
+              attributes: [{ external_id: 'u3', name: 'C' }],
+              purchases: [
+                {
+                  external_id: 'u3',
+                  product_id: 'x',
+                  price: 1,
+                  currency: 'USD',
+                  quantity: 1,
+                  time: 't',
+                },
+                {
+                  external_id: 'u3',
+                  product_id: 'y',
+                  price: 2,
+                  currency: 'USD',
+                  quantity: 1,
+                  time: 't',
+                },
               ],
-              merge_updates: [{ id: i, alias: 'test', xyz: 'abc' }],
             },
           },
-        },
-        metadata: [{ job_id: i, workspaceId: 'workspace-mau' }],
-      });
-    }
-
-    // Call the processBatch function
-    const result = processBatch(transformedEvents);
-    expect(result.length).toBe(1);
-    const firstResult = result[0];
-
-    // Ensure batchedRequest exists, is an array, and metadata exists
-    expect(firstResult.batchedRequest).toBeDefined();
-    expect(Array.isArray(firstResult.batchedRequest)).toBe(true);
-    expect(firstResult.metadata).toBeDefined();
-
-    if (
-      firstResult.batchedRequest &&
-      Array.isArray(firstResult.batchedRequest) &&
-      firstResult.metadata
-    ) {
-      expect(firstResult.batchedRequest.length).toBe(10);
-      // First batch contains 75 attributes
-      expect((firstResult.batchedRequest[0].body.JSON as BrazeTrackRequestBody).partner).toBe(
-        'RudderStack',
-      );
-      expect(
-        (firstResult.batchedRequest[0].body.JSON as BrazeTrackRequestBody).attributes?.length,
-      ).toBe(75);
-
-      // Second batch contains 25 attributes and 50 events
-      expect((firstResult.batchedRequest[1].body.JSON as BrazeTrackRequestBody).partner).toBe(
-        'RudderStack',
-      ); // Verify partner name
-      expect(
-        (firstResult.batchedRequest[1].body.JSON as BrazeTrackRequestBody).attributes?.length,
-      ).toBe(25);
-      expect(
-        (firstResult.batchedRequest[1].body.JSON as BrazeTrackRequestBody).events?.length,
-      ).toBe(50);
-
-      // Third batch contains 50 events and 25 purchases
-      expect((firstResult.batchedRequest[2].body.JSON as BrazeTrackRequestBody).partner).toBe(
-        'RudderStack',
-      ); // Verify partner name
-      expect(
-        (firstResult.batchedRequest[2].body.JSON as BrazeTrackRequestBody).events?.length,
-      ).toBe(50);
-      expect(
-        (firstResult.batchedRequest[2].body.JSON as BrazeTrackRequestBody).purchases?.length,
-      ).toBe(25);
-
-      // Fourth batch contains 75 purchases
-      expect((firstResult.batchedRequest[3].body.JSON as BrazeTrackRequestBody).partner).toBe(
-        'RudderStack',
-      ); // Verify partner name
-      expect(
-        (firstResult.batchedRequest[3].body.JSON as BrazeTrackRequestBody).purchases?.length,
-      ).toBe(75);
-
-      // Fifth batch contains 25 subscription groups
-      expect(
-        (firstResult.batchedRequest[4].body.JSON as BrazeSubscriptionBatchPayload)
-          .subscription_groups?.length,
-      ).toBe(25);
-      // Sixth batch contains 25 subscription groups
-      expect(
-        (firstResult.batchedRequest[5].body.JSON as BrazeSubscriptionBatchPayload)
-          .subscription_groups?.length,
-      ).toBe(25);
-      // Seventh batch contains 25 subscription groups
-      expect(
-        (firstResult.batchedRequest[6].body.JSON as BrazeSubscriptionBatchPayload)
-          .subscription_groups?.length,
-      ).toBe(25);
-      // Eighth batch contains 25 subscription groups
-      expect(
-        (firstResult.batchedRequest[7].body.JSON as BrazeSubscriptionBatchPayload)
-          .subscription_groups?.length,
-      ).toBe(25);
-
-      // Ninth batch contains 50 merge_updates
-      expect(
-        (firstResult.batchedRequest[8].body.JSON as BrazeMergeBatchPayload).merge_updates?.length,
-      ).toBe(50);
-      // Tenth batch contains 50 merge_updates
-      expect(
-        (firstResult.batchedRequest[9].body.JSON as BrazeMergeBatchPayload).merge_updates?.length,
-      ).toBe(50);
-    }
-  });
-
-  test('processBatch handles more than 75 attributes, events, and purchases with non uniform distribution', () => {
-    const destination: BrazeDestination = {
-      ID: 'braze',
-      Name: 'braze',
-      Enabled: true,
-      Config: {
-        restApiKey: 'restApiKey',
-        dataCenter: 'eu',
+          files: {},
+        } as any,
+        metadata: [{ jobId: 3, workspaceId: 'workspace-non-mau' }],
       },
-      DestinationDefinition: {
-        ID: 'braze',
-        Name: 'braze',
-        DisplayName: '',
-        Config: {},
-      },
-      WorkspaceID: '123',
-      Transformations: [],
-    };
-    // Create input data with more than 75 attributes, events, and purchases
-    const transformedEventsSet1: BrazeTransformedEvent[] = new Array(120).fill(0).map((_, i) => ({
-      destination,
-      statusCode: 200,
-      batchedRequest: {
-        version: '1',
-        type: 'REST',
-        method: 'POST',
-        endpoint: '',
-        headers: {},
-        params: {},
-        body: {
-          JSON: {
-            events: [{ id: i, event: 'test', xyz: 'abc' }],
-          },
-        },
-      },
-      metadata: [{ job_id: i, workspaceId: 'workspace-mau' }],
-    }));
-
-    const transformedEventsSet2: BrazeTransformedEvent[] = new Array(160).fill(0).map((_, i) => ({
-      destination,
-      statusCode: 200,
-      batchedRequest: {
-        version: '1',
-        type: 'REST',
-        method: 'POST',
-        endpoint: '',
-        headers: {},
-        params: {},
-        body: {
-          JSON: {
-            purchases: [{ id: i, name: 'test', xyz: 'abc' }],
-          },
-        },
-      },
-      metadata: [{ job_id: 120 + i, workspaceId: 'workspace-mau' }],
-    }));
-
-    const transformedEventsSet3: BrazeTransformedEvent[] = new Array(100).fill(0).map((_, i) => ({
-      destination,
-      statusCode: 200,
-      batchedRequest: {
-        version: '1',
-        type: 'REST',
-        method: 'POST',
-        endpoint: '',
-        headers: {},
-        params: {},
-        body: {
-          JSON: {
-            attributes: [{ id: i, name: 'test', xyz: 'abc' }],
-          },
-        },
-      },
-      metadata: [{ job_id: 280 + i, workspaceId: 'workspace-mau' }],
-    }));
-
-    const transformedEventsSet4: BrazeTransformedEvent[] = new Array(70).fill(0).map((_, i) => ({
-      destination,
-      statusCode: 200,
-      batchedRequest: {
-        version: '1',
-        type: 'REST',
-        method: 'POST',
-        endpoint: '',
-        headers: {},
-        params: {},
-        body: {
-          JSON: {
-            subscription_groups: [
-              { subscription_group_id: i, group: 'test', subscription_state: 'abc' },
-            ],
-          },
-        },
-      },
-      metadata: [{ job_id: 280 + i, workspaceId: 'workspace-mau' }],
-    }));
-
-    const transformedEventsSet5: BrazeTransformedEvent[] = new Array(40).fill(0).map((_, i) => ({
-      destination,
-      statusCode: 200,
-      batchedRequest: {
-        version: '1',
-        type: 'REST',
-        method: 'POST',
-        endpoint: '',
-        headers: {},
-        params: {},
-        body: {
-          JSON: {
-            merge_updates: [{ id: i, alias: 'test', xyz: 'abc' }],
-          },
-        },
-      },
-      metadata: [{ job_id: 280 + i, workspaceId: 'workspace-mau' }],
-    }));
-
-    // Call the processBatch function
-    const result = processBatch([
-      ...transformedEventsSet1,
-      ...transformedEventsSet2,
-      ...transformedEventsSet3,
-      ...transformedEventsSet4,
-      ...transformedEventsSet5,
-    ]);
-
-    // Assert that the response is as expected
-    expect(result.length).toBe(1); // One successful batched response
-
-    const firstResult = result[0];
-    // Ensure batchedRequest exists, is an array, and metadata exists
-    expect(firstResult.batchedRequest).toBeDefined();
-    expect(Array.isArray(firstResult.batchedRequest)).toBe(true);
-    expect(firstResult.metadata).toBeDefined();
-
-    if (
-      firstResult.batchedRequest &&
-      Array.isArray(firstResult.batchedRequest) &&
-      firstResult.metadata
-    ) {
-      expect(firstResult.metadata.length).toBe(490); // Total metadata count: 120 events + 160 purchases + 100 attributes + 70 subscription_groups + 40 merge_updates
-      expect(firstResult.batchedRequest.length).toBe(10); // 10 batched requests total (6 track API batches + 3 subscription batches + 1 merge batch)
-
-      // Track API Batch 1: First 75 attributes (out of 100 total)
-      expect((firstResult.batchedRequest[0].body.JSON as BrazeTrackRequestBody).partner).toBe(
-        'RudderStack',
-      );
-      expect(
-        (firstResult.batchedRequest[0].body.JSON as BrazeTrackRequestBody).attributes?.length,
-      ).toBe(75);
-
-      // Track API Batch 2: Remaining 25 attributes + 50 events (out of 120 total)
-      expect((firstResult.batchedRequest[1].body.JSON as BrazeTrackRequestBody).partner).toBe(
-        'RudderStack',
-      );
-      expect(
-        (firstResult.batchedRequest[1].body.JSON as BrazeTrackRequestBody).attributes?.length,
-      ).toBe(25);
-      expect(
-        (firstResult.batchedRequest[1].body.JSON as BrazeTrackRequestBody).events?.length,
-      ).toBe(50);
-
-      // Track API Batch 3: Remaining 70 events + 5 purchases (out of 160 total)
-      expect((firstResult.batchedRequest[2].body.JSON as BrazeTrackRequestBody).partner).toBe(
-        'RudderStack',
-      );
-      expect(
-        (firstResult.batchedRequest[2].body.JSON as BrazeTrackRequestBody).events?.length,
-      ).toBe(70);
-      expect(
-        (firstResult.batchedRequest[2].body.JSON as BrazeTrackRequestBody).purchases?.length,
-      ).toBe(5);
-
-      // Track API Batch 4: Next 75 purchases
-      expect((firstResult.batchedRequest[3].body.JSON as BrazeTrackRequestBody).partner).toBe(
-        'RudderStack',
-      );
-      expect(
-        (firstResult.batchedRequest[3].body.JSON as BrazeTrackRequestBody).purchases?.length,
-      ).toBe(75);
-
-      // Track API Batch 5: Next 75 purchases
-      expect((firstResult.batchedRequest[4].body.JSON as BrazeTrackRequestBody).partner).toBe(
-        'RudderStack',
-      );
-      expect(
-        (firstResult.batchedRequest[4].body.JSON as BrazeTrackRequestBody).purchases?.length,
-      ).toBe(75);
-
-      // Track API Batch 6: Remaining 5 purchases
-      expect((firstResult.batchedRequest[5].body.JSON as BrazeTrackRequestBody).partner).toBe(
-        'RudderStack',
-      );
-      expect(
-        (firstResult.batchedRequest[5].body.JSON as BrazeTrackRequestBody).purchases?.length,
-      ).toBe(5);
-
-      // Subscription Groups Batches: 70 total subscription_groups chunked by 25
-      expect(
-        (firstResult.batchedRequest[6].body.JSON as BrazeSubscriptionBatchPayload)
-          .subscription_groups?.length,
-      ).toBe(25); // First 25
-      expect(
-        (firstResult.batchedRequest[7].body.JSON as BrazeSubscriptionBatchPayload)
-          .subscription_groups?.length,
-      ).toBe(25); // Next 25
-      expect(
-        (firstResult.batchedRequest[8].body.JSON as BrazeSubscriptionBatchPayload)
-          .subscription_groups?.length,
-      ).toBe(20); // Remaining 20
-
-      // Merge Updates Batch: 40 total merge_updates in single batch
-      expect(
-        (firstResult.batchedRequest[9].body.JSON as BrazeMergeBatchPayload).merge_updates?.length,
-      ).toBe(40);
-    }
-  });
-
-  test('check success and failure scenarios both for processBatch', () => {
-    const transformedEvents: BrazeTransformedEvent[] = [];
-    let successCount = 0;
-    let failureCount = 0;
-    const destination: BrazeDestination = {
-      ID: 'braze',
-      Name: 'braze',
-      Enabled: true,
-      Config: {
-        restApiKey: 'restApiKey',
-        dataCenter: 'eu',
-      },
-      DestinationDefinition: {
-        ID: 'braze',
-        Name: 'braze',
-        DisplayName: '',
-        Config: {},
-      },
-      WorkspaceID: '123',
-      Transformations: [],
-    };
-    for (let i = 0; i < 100; i++) {
-      const rando = Math.random() * 100;
-      if (rando < 50) {
-        transformedEvents.push({
-          destination,
-          statusCode: 200,
-          batchedRequest: {
-            version: '1',
-            type: 'REST',
-            method: 'POST',
-            endpoint: '',
-            headers: {},
-            params: {},
-            body: {
-              JSON: {
-                attributes: [{ id: i, name: 'test', xyz: 'abc' }],
-                events: [{ id: i, event: 'test', xyz: 'abc' }],
-                purchases: [{ id: i, purchase: 'test', xyz: 'abc' }],
-              },
-            },
-          },
-          metadata: [{ job_id: i, workspaceId: 'workspace-mau' }],
-        });
-        successCount = successCount + 1;
-      } else {
-        transformedEvents.push({
-          destination,
-          statusCode: 400,
-          metadata: [{ job_id: i, workspaceId: 'workspace-mau' }],
-          error: 'Random Error',
-        });
-        failureCount = failureCount + 1;
+    ];
+    const result = processBatch(jobs);
+    const tracks = trackOutputs(result, destination);
+    expect(tracks.length).toBe(1);
+    const chunk = tracks[0];
+    const body = chunk.batchedRequest.body.JSON as BrazeTrackRequestBody;
+    // Sanity: 3 attributes, 1 event, 2 purchases in the chunk.
+    expect(body.attributes?.length).toBe(3);
+    expect(body.events?.length).toBe(1);
+    expect(body.purchases?.length).toBe(2);
+    // Every metadata's destInfo indices must point to a payload entry whose
+    // externalId matches — this is what the networkHandler will rely on to
+    // correlate Braze warnings back to the right jobId.
+    for (const m of chunk.metadata) {
+      const info = (m as any).destInfo.braze;
+      const jobId = (m as any).jobId;
+      const externalId = `u${jobId}`;
+      if (info.attributesIndex !== undefined) {
+        expect((body.attributes as any)[info.attributesIndex].external_id).toBe(externalId);
       }
-    }
-    // Call the processBatch function
-    const result = processBatch(transformedEvents);
-    expect(result.length).toBe(failureCount + 1);
-    const firstResult = result[0];
-
-    // Ensure batchedRequest exists, is an array, and metadata exists
-    expect(firstResult.batchedRequest).toBeDefined();
-    expect(Array.isArray(firstResult.batchedRequest)).toBe(true);
-    expect(firstResult.metadata).toBeDefined();
-
-    if (
-      firstResult.batchedRequest &&
-      Array.isArray(firstResult.batchedRequest) &&
-      firstResult.metadata
-    ) {
-      expect((firstResult.batchedRequest[0].body.JSON as BrazeTrackRequestBody).partner).toBe(
-        'RudderStack',
-      );
-      expect(firstResult.metadata.length).toBe(successCount);
+      if (info.eventsIndex !== undefined) {
+        expect((body.events as any)[info.eventsIndex].external_id).toBe(externalId);
+      }
+      if (info.purchasesIndexes) {
+        for (const idx of info.purchasesIndexes) {
+          expect((body.purchases as any)[idx].external_id).toBe(externalId);
+        }
+      }
     }
   });
 });
 
+describe('processBatch — size + oversized-job rejection', () => {
+  const destination = brazeDestFor();
+
+  test('single item exceeding TRACK_BRAZE_MAX_ITEM_BYTE_SIZE (100 KB) is rejected with InstrumentationError', () => {
+    const big = 'x'.repeat(150 * 1024); // ~150 KB payload → serialized > 100 KB
+    const transformedEvent: BrazeTransformedEvent = {
+      destination,
+      statusCode: 200,
+      batchedRequest: {
+        version: '1',
+        type: 'REST',
+        method: 'POST',
+        endpoint: '',
+        headers: {},
+        params: {},
+        body: {
+          JSON: {
+            events: [{ external_id: 'u1', name: 'BigEvent', time: 't', properties: { blob: big } }],
+          },
+        },
+        files: {},
+      } as any,
+      metadata: [{ jobId: 1, workspaceId: 'workspace-non-mau' }],
+    };
+    const result = processBatch([transformedEvent]);
+    const failures = result.filter((r) => (r as any).statusCode === 400);
+    expect(failures.length).toBe(1);
+    expect((failures[0] as any).error).toMatch(/exceeds .* bytes/);
+    expect(trackOutputs(result, destination).length).toBe(0);
+  });
+
+  test('single job contributing > 75 track items is rejected — no chunking can accommodate it without straddle', () => {
+    const attributes = Array.from({ length: 40 }, (_, i) => ({ external_id: 'u1', id: i }));
+    const events = Array.from({ length: 40 }, (_, i) => ({ external_id: 'u1', id: i, event: 'e' }));
+    const transformedEvent: BrazeTransformedEvent = {
+      destination,
+      statusCode: 200,
+      batchedRequest: {
+        version: '1',
+        type: 'REST',
+        method: 'POST',
+        endpoint: '',
+        headers: {},
+        params: {},
+        body: { JSON: { attributes, events } },
+        files: {},
+      } as any,
+      metadata: [{ jobId: 1, workspaceId: 'workspace-non-mau' }],
+    };
+    const result = processBatch([transformedEvent]);
+    const failures = result.filter((r) => (r as any).statusCode === 400);
+    expect(failures.length).toBe(1);
+    expect((failures[0] as any).error).toMatch(/max .* per batch/);
+  });
+
+  test('oversized job is rejected without affecting other jobs in the same batch', () => {
+    const big = 'x'.repeat(150 * 1024);
+    const good = {
+      destination,
+      statusCode: 200,
+      batchedRequest: {
+        version: '1',
+        type: 'REST',
+        method: 'POST',
+        endpoint: '',
+        headers: {},
+        params: {},
+        body: { JSON: { events: [{ external_id: 'ok', name: 'Small', time: 't' }] } },
+        files: {},
+      } as any,
+      metadata: [{ jobId: 100, workspaceId: 'workspace-non-mau' }],
+    } as BrazeTransformedEvent;
+    const bad = {
+      destination,
+      statusCode: 200,
+      batchedRequest: {
+        version: '1',
+        type: 'REST',
+        method: 'POST',
+        endpoint: '',
+        headers: {},
+        params: {},
+        body: {
+          JSON: {
+            events: [{ external_id: 'bad', name: 'Big', time: 't', properties: { blob: big } }],
+          },
+        },
+        files: {},
+      } as any,
+      metadata: [{ jobId: 200, workspaceId: 'workspace-non-mau' }],
+    } as BrazeTransformedEvent;
+    const result = processBatch([good, bad]);
+    const failures = result.filter((r) => (r as any).statusCode === 400);
+    expect(failures.length).toBe(1);
+    expect(failures[0].metadata?.[0]).toMatchObject({ jobId: 200 });
+    const tracks = trackOutputs(result, destination);
+    expect(tracks.length).toBe(1);
+    expect((tracks[0].batchedRequest.body.JSON as BrazeTrackRequestBody).events?.length).toBe(1);
+  });
+});
+
+describe('processBatch — straddle prevention', () => {
+  const destination = brazeDestFor();
+
+  const buildOrderCompletedJob = (i: number, numProducts: number): BrazeTransformedEvent => ({
+    destination,
+    statusCode: 200,
+    batchedRequest: {
+      version: '1',
+      type: 'REST',
+      method: 'POST',
+      endpoint: '',
+      headers: {},
+      params: {},
+      body: {
+        JSON: {
+          attributes: [{ external_id: `u${i}`, name: 'A' }],
+          purchases: Array.from({ length: numProducts }, (_, k) => ({
+            external_id: `u${i}`,
+            product_id: `p${i}-${k}`,
+            price: 1,
+            currency: 'USD',
+            quantity: 1,
+            time: 't',
+          })),
+        },
+      },
+      files: {},
+    } as any,
+    metadata: [{ jobId: i, workspaceId: 'workspace-mau' }],
+  });
+
+  test('a single job’s items never straddle chunk boundaries', () => {
+    // Craft a case where V2's flat 75-item boundary would fall mid-way through
+    // job 25's contributions if we chunked item-by-item. Group-preserving
+    // chunking must keep job 25 whole in the next chunk.
+    const jobs: BrazeTransformedEvent[] = [];
+    for (let i = 0; i < 24; i += 1) jobs.push(buildOrderCompletedJob(i, 3)); // 24 * 4 = 96 items
+    jobs.push(buildOrderCompletedJob(24, 6)); // 6 more items — would push chunk over 75
+
+    const result = processBatch(jobs);
+    const tracks = trackOutputs(result, destination);
+
+    // Every jobId should appear in exactly one track output (never split).
+    for (const job of jobs) {
+      const jobId = job.metadata?.[0]?.jobId;
+      let occurrences = 0;
+      for (const t of tracks) {
+        if (t.metadata.some((m) => (m as { jobId?: number }).jobId === jobId)) {
+          occurrences += 1;
+        }
+      }
+      expect(occurrences).toBe(1);
+    }
+    // Also verify all chunks stay within V2's 75-item total-count cap.
+    for (const t of tracks) {
+      const b = t.batchedRequest.body.JSON as BrazeTrackRequestBody;
+      const total =
+        (b.attributes?.length ?? 0) + (b.events?.length ?? 0) + (b.purchases?.length ?? 0);
+      expect(total).toBeLessThanOrEqual(75);
+    }
+  });
+});
 describe('addAppId', () => {
   it('test_no_integrations_object', () => {
     const payload = { foo: 'bar' };

--- a/src/v0/destinations/braze/braze.util.test.ts
+++ b/src/v0/destinations/braze/braze.util.test.ts
@@ -1627,10 +1627,23 @@ describe('processBatchWithDeliveryMapping', () => {
       subJob(7),
     ]);
 
-    // Expect 4 outputs: track [1,2], sub [3,4], merge [5,6], sub [7]
-    expect(result.length).toBe(4);
-    const jobIdsPerOutput = result.map((r: any) => r.metadata.map((m: any) => m.jobId));
-    expect(jobIdsPerOutput).toEqual([[1, 2], [3, 4], [5, 6], [7]]);
+    // Items are coalesced globally per endpoint type — insertion-order runs
+    // are NOT preserved. Expect 3 outputs: track [1, 2], sub [3, 4, 7],
+    // merge [5, 6]. Within each output, jobIds accumulate in the order jobs
+    // appear in the input (subscription/merge use plain _.chunk), so they
+    // remain monotonically ascending inside each output.
+    expect(result.length).toBe(3);
+    const tracks = onTrackOutputs(result, dest);
+    const subs = onSubOutputs(result, dest);
+    const merges = onMergeOutputs(result, dest);
+    expect(tracks.length).toBe(1);
+    expect(subs.length).toBe(1);
+    expect(merges.length).toBe(1);
+    expect(
+      tracks[0].metadata.map((m: any) => m.jobId).sort((a: number, b: number) => a - b),
+    ).toEqual([1, 2]);
+    expect(subs[0].metadata.map((m: any) => m.jobId)).toEqual([3, 4, 7]);
+    expect(merges[0].metadata.map((m: any) => m.jobId)).toEqual([5, 6]);
   });
 
   test('single track job (attribute + event) → destInfo has attributesIndices + eventsIndices; purchasesIndices absent', () => {

--- a/src/v0/destinations/braze/braze.util.test.ts
+++ b/src/v0/destinations/braze/braze.util.test.ts
@@ -10,6 +10,7 @@ import {
   combineSubscriptionGroups,
   getEndpointFromConfig,
   processBatch,
+  processBatchWithDeliveryMapping,
 } from './util';
 import { removeUndefinedAndNullValues, removeUndefinedAndNullAndEmptyValues } from '../../util';
 import { generateRandomString } from '@rudderstack/integrations-lib';
@@ -1397,185 +1398,17 @@ describe('processBatch — OFF path (default) — MAU workspace (V2 chunking)', 
   });
 });
 
-describe('processBatch — OFF path (default) — size + oversized-job rejection', () => {
-  const destination = brazeDestFor();
-
-  test('single item exceeding TRACK_BRAZE_MAX_ITEM_BYTE_SIZE (100 KB) is rejected with InstrumentationError', () => {
-    const big = 'x'.repeat(150 * 1024);
-    const transformedEvent: BrazeTransformedEvent = {
-      destination,
-      statusCode: 200,
-      batchedRequest: {
-        version: '1',
-        type: 'REST',
-        method: 'POST',
-        endpoint: '',
-        headers: {},
-        params: {},
-        body: {
-          JSON: {
-            events: [{ external_id: 'u1', name: 'BigEvent', time: 't', properties: { blob: big } }],
-          },
-        },
-        files: {},
-      } as any,
-      metadata: [{ jobId: 1, workspaceId: 'workspace-non-mau' }],
-    };
-    const result = processBatch([transformedEvent]);
-    const failures = result.filter((r) => (r as any).statusCode === 400);
-    expect(failures.length).toBe(1);
-    expect((failures[0] as any).error).toMatch(/exceeds .* bytes/);
-    // No successful output when the only job was rejected.
-    expect(offMulti(result)).toBeUndefined();
-  });
-
-  test('single job contributing > 75 track items is rejected — no chunking can accommodate it without straddle', () => {
-    const attributes = Array.from({ length: 40 }, (_, i) => ({ external_id: 'u1', id: i }));
-    const events = Array.from({ length: 40 }, (_, i) => ({ external_id: 'u1', id: i, event: 'e' }));
-    const transformedEvent: BrazeTransformedEvent = {
-      destination,
-      statusCode: 200,
-      batchedRequest: {
-        version: '1',
-        type: 'REST',
-        method: 'POST',
-        endpoint: '',
-        headers: {},
-        params: {},
-        body: { JSON: { attributes, events } },
-        files: {},
-      } as any,
-      metadata: [{ jobId: 1, workspaceId: 'workspace-non-mau' }],
-    };
-    const result = processBatch([transformedEvent]);
-    const failures = result.filter((r) => (r as any).statusCode === 400);
-    expect(failures.length).toBe(1);
-    expect((failures[0] as any).error).toMatch(/max .* per batch/);
-  });
-
-  test('oversized job is rejected without affecting other jobs in the same batch', () => {
-    const big = 'x'.repeat(150 * 1024);
-    const good = {
-      destination,
-      statusCode: 200,
-      batchedRequest: {
-        version: '1',
-        type: 'REST',
-        method: 'POST',
-        endpoint: '',
-        headers: {},
-        params: {},
-        body: { JSON: { events: [{ external_id: 'ok', name: 'Small', time: 't' }] } },
-        files: {},
-      } as any,
-      metadata: [{ jobId: 100, workspaceId: 'workspace-non-mau' }],
-    } as BrazeTransformedEvent;
-    const bad = {
-      destination,
-      statusCode: 200,
-      batchedRequest: {
-        version: '1',
-        type: 'REST',
-        method: 'POST',
-        endpoint: '',
-        headers: {},
-        params: {},
-        body: {
-          JSON: {
-            events: [{ external_id: 'bad', name: 'Big', time: 't', properties: { blob: big } }],
-          },
-        },
-        files: {},
-      } as any,
-      metadata: [{ jobId: 200, workspaceId: 'workspace-non-mau' }],
-    } as BrazeTransformedEvent;
-    const result = processBatch([good, bad]);
-    const failures = result.filter((r) => (r as any).statusCode === 400);
-    expect(failures.length).toBe(1);
-    expect(failures[0].metadata?.[0]).toMatchObject({ jobId: 200 });
-    const tracks = offTrackRequests(result, destination);
-    expect(tracks.length).toBe(1);
-    expect((tracks[0].body.JSON as BrazeTrackRequestBody).events?.length).toBe(1);
-  });
-});
-
-describe('processBatch — OFF path (default) — straddle prevention', () => {
-  const destination = brazeDestFor();
-
-  const buildOrderCompletedJob = (i: number, numProducts: number): BrazeTransformedEvent => ({
-    destination,
-    statusCode: 200,
-    batchedRequest: {
-      version: '1',
-      type: 'REST',
-      method: 'POST',
-      endpoint: '',
-      headers: {},
-      params: {},
-      body: {
-        JSON: {
-          attributes: [{ external_id: `u${i}`, name: 'A' }],
-          purchases: Array.from({ length: numProducts }, (_, k) => ({
-            external_id: `u${i}`,
-            product_id: `p${i}-${k}`,
-            price: 1,
-            currency: 'USD',
-            quantity: 1,
-            time: 't',
-          })),
-        },
-      },
-      files: {},
-    } as any,
-    metadata: [{ jobId: i, workspaceId: 'workspace-mau' }],
-  });
-
-  test('every track chunk stays within V2 total-count cap (75) — no single job straddles', () => {
-    // Group-preserving chunking keeps a job's contributions whole even in OFF
-    // path (kept as an INT-6808 improvement). We can't verify per-jobId
-    // occurrence without destInfo, but we CAN verify no chunk breaches the
-    // cap AND every job's user_id ends up in some chunk.
-    const jobs: BrazeTransformedEvent[] = [];
-    for (let i = 0; i < 24; i += 1) jobs.push(buildOrderCompletedJob(i, 3));
-    jobs.push(buildOrderCompletedJob(24, 6));
-
-    const result = processBatch(jobs);
-    const tracks = offTrackRequests(result, destination);
-    for (const t of tracks) {
-      const b = t.body.JSON as BrazeTrackRequestBody;
-      const total =
-        (b.attributes?.length ?? 0) + (b.events?.length ?? 0) + (b.purchases?.length ?? 0);
-      expect(total).toBeLessThanOrEqual(75);
-    }
-    // Every source-job's user_id (u0..u24) must appear somewhere in the
-    // concatenated payloads (25 unique externalIds across 25 jobs).
-    const allExternalIds = new Set<string>();
-    for (const t of tracks) {
-      const b = t.body.JSON as BrazeTrackRequestBody;
-      for (const a of b.attributes ?? []) allExternalIds.add(a.external_id as string);
-      for (const p of b.purchases ?? []) allExternalIds.add(p.external_id as string);
-    }
-    expect(allExternalIds.size).toBe(25);
-  });
-});
-
 // ---------------------------------------------------------------------------
-// ON path — BRAZE_PER_JOB_DELIVERY_MAPPING_ENABLED=true. processBatch emits
-// one BatchRequestOutput per outgoing HTTP request, with insertion-order-
-// preserving runs. Track outputs carry per-metadata `destInfo` positional
-// maps; sub/merge outputs carry `destInfo: {}` for correlation-shape
-// uniformity. The flag is read dynamically inside processBatch, so a plain
-// env swap is sufficient.
+// `processBatchWithDeliveryMapping` — invoked directly (no env-var gating in
+// util.ts; the flag is read only by `transform.ts` at the call site).
+// Emits one BatchRequestOutput per outgoing HTTP request, preserves insertion-
+// order runs, attaches per-metadata `destInfo` positional maps on track
+// outputs, and carries `destInfo: {}` on sub/merge outputs for correlation-
+// shape uniformity. Applies group-preserving chunking, byte-size caps, and
+// oversized-job rejection which do not exist on the OFF path.
 // ---------------------------------------------------------------------------
 
-describe('processBatch — ON path (BRAZE_PER_JOB_DELIVERY_MAPPING_ENABLED=true)', () => {
-  beforeEach(() => {
-    process.env.BRAZE_PER_JOB_DELIVERY_MAPPING_ENABLED = 'true';
-  });
-  afterEach(() => {
-    delete process.env.BRAZE_PER_JOB_DELIVERY_MAPPING_ENABLED;
-  });
-
+describe('processBatchWithDeliveryMapping', () => {
   const destination = brazeDestFor();
 
   const buildTrackEvent = (
@@ -1614,7 +1447,7 @@ describe('processBatch — ON path (BRAZE_PER_JOB_DELIVERY_MAPPING_ENABLED=true)
 
   test('every output is a single BatchRequestOutput (no MultiBatchRequestOutput anywhere)', () => {
     const transformedEvents = Array.from({ length: 20 }, (_, i) => buildTrackEvent(i));
-    const result = processBatch(transformedEvents);
+    const result = processBatchWithDeliveryMapping(transformedEvents);
     for (const out of result) {
       expect(Array.isArray((out as any).batchedRequest)).toBe(false);
       expect((out as any).batched).toBe(true);
@@ -1623,7 +1456,7 @@ describe('processBatch — ON path (BRAZE_PER_JOB_DELIVERY_MAPPING_ENABLED=true)
 
   test('V1 chunks track outputs by per-type caps (75); every job has a destInfo positional map', () => {
     const transformedEvents = Array.from({ length: 100 }, (_, i) => buildTrackEvent(i));
-    const result = processBatch(transformedEvents);
+    const result = processBatchWithDeliveryMapping(transformedEvents);
     const tracks = onTrackOutputs(result, destination);
     expect(tracks.length).toBeGreaterThanOrEqual(2);
     expect(onTotalInSubArray(tracks, 'attributes')).toBe(100);
@@ -1667,7 +1500,7 @@ describe('processBatch — ON path (BRAZE_PER_JOB_DELIVERY_MAPPING_ENABLED=true)
         metadata: [{ jobId: i, workspaceId: 'workspace-non-mau' }],
       });
     }
-    const result = processBatch(transformedEvents);
+    const result = processBatchWithDeliveryMapping(transformedEvents);
     const subs = onSubOutputs(result, dest);
     expect(subs.length).toBe(Math.ceil(30 / 25));
     for (const s of subs) {
@@ -1710,7 +1543,7 @@ describe('processBatch — ON path (BRAZE_PER_JOB_DELIVERY_MAPPING_ENABLED=true)
         metadata: [{ jobId: i, workspaceId: 'workspace-non-mau' }],
       });
     }
-    const result = processBatch(transformedEvents);
+    const result = processBatchWithDeliveryMapping(transformedEvents);
     const merges = onMergeOutputs(result, dest);
     expect(merges.length).toBe(Math.ceil(60 / 50));
     for (const m of merges) {
@@ -1784,7 +1617,7 @@ describe('processBatch — ON path (BRAZE_PER_JOB_DELIVERY_MAPPING_ENABLED=true)
       metadata: [{ jobId: i, workspaceId: 'workspace-non-mau', userId: 'shared' }],
     });
 
-    const result = processBatch([
+    const result = processBatchWithDeliveryMapping([
       trackJob(1),
       trackJob(2),
       subJob(3),
@@ -1821,7 +1654,7 @@ describe('processBatch — ON path (BRAZE_PER_JOB_DELIVERY_MAPPING_ENABLED=true)
       } as any,
       metadata: [{ jobId: 42, workspaceId: 'workspace-non-mau' }],
     };
-    const result = processBatch([transformedEvent]);
+    const result = processBatchWithDeliveryMapping([transformedEvent]);
     const tracks = onTrackOutputs(result, destination);
     expect(tracks.length).toBe(1);
     expect(tracks[0].metadata.length).toBe(1);
@@ -1877,7 +1710,7 @@ describe('processBatch — ON path (BRAZE_PER_JOB_DELIVERY_MAPPING_ENABLED=true)
       } as any,
       metadata: [{ jobId: 42, workspaceId: 'workspace-non-mau' }],
     };
-    const result = processBatch([transformedEvent]);
+    const result = processBatchWithDeliveryMapping([transformedEvent]);
     const tracks = onTrackOutputs(result, destination);
     expect(tracks.length).toBe(1);
     const info = (tracks[0].metadata[0] as any).destInfo;
@@ -1961,7 +1794,7 @@ describe('processBatch — ON path (BRAZE_PER_JOB_DELIVERY_MAPPING_ENABLED=true)
         metadata: [{ jobId: 3, workspaceId: 'workspace-non-mau' }],
       },
     ];
-    const result = processBatch(jobs);
+    const result = processBatchWithDeliveryMapping(jobs);
     const tracks = onTrackOutputs(result, destination);
     expect(tracks.length).toBe(1);
     const chunk = tracks[0];
@@ -2018,7 +1851,7 @@ describe('processBatch — ON path (BRAZE_PER_JOB_DELIVERY_MAPPING_ENABLED=true)
     for (let i = 0; i < 24; i += 1) jobs.push(buildOrderCompletedJob(i, 3));
     jobs.push(buildOrderCompletedJob(24, 6));
 
-    const result = processBatch(jobs);
+    const result = processBatchWithDeliveryMapping(jobs);
     const tracks = onTrackOutputs(result, destination);
 
     for (const job of jobs) {
@@ -2058,7 +1891,7 @@ describe('processBatch — ON path (BRAZE_PER_JOB_DELIVERY_MAPPING_ENABLED=true)
       } as any,
       metadata: [{ jobId: 1, workspaceId: 'workspace-non-mau' }],
     };
-    const result = processBatch([transformedEvent]);
+    const result = processBatchWithDeliveryMapping([transformedEvent]);
     const failures = result.filter((r) => (r as any).statusCode === 400);
     expect(failures.length).toBe(1);
     expect((failures[0] as any).error).toMatch(/exceeds .* bytes/);

--- a/src/v0/destinations/braze/braze.util.test.ts
+++ b/src/v0/destinations/braze/braze.util.test.ts
@@ -12,6 +12,7 @@ import {
   processBatch,
   processBatchWithDeliveryMapping,
 } from './util';
+import { isPerJobDeliveryMappingEnabled } from './config';
 import { removeUndefinedAndNullValues, removeUndefinedAndNullAndEmptyValues } from '../../util';
 import { generateRandomString } from '@rudderstack/integrations-lib';
 import {
@@ -1081,7 +1082,7 @@ const onTotalInSubArray = (outs: any[], key: 'attributes' | 'events' | 'purchase
   outs.reduce((acc, o) => acc + (o.batchedRequest.body.JSON[key]?.length ?? 0), 0);
 
 // ---------------------------------------------------------------------------
-// OFF path (default) — BRAZE_PER_JOB_DELIVERY_MAPPING_ENABLED is unset.
+// OFF path (default) — BRAZE_PER_JOB_DELIVERY_MAPPING_WORKSPACE_IDS is unset.
 // processBatch emits a single MultiBatchRequestOutput whose `batchedRequest`
 // is an array of every outgoing HTTP request, with a flat metadata list and
 // no `destInfo`. Group-preserving chunking, byte-size caps, and oversized-job
@@ -2781,5 +2782,51 @@ describe('formatGender', () => {
     expect(formatGender(123)).toBeNull();
     expect(formatGender({})).toBeNull();
     expect(formatGender([])).toBeNull();
+  });
+});
+
+describe('isPerJobDeliveryMappingEnabled — per-workspace rollout gate', () => {
+  const ENV_KEY = 'BRAZE_PER_JOB_DELIVERY_MAPPING_WORKSPACE_IDS';
+  const original = process.env[ENV_KEY];
+
+  const setEnv = (value?: string) => {
+    if (typeof value === 'string') {
+      process.env[ENV_KEY] = value;
+    } else {
+      delete process.env[ENV_KEY];
+    }
+  };
+
+  afterEach(() => setEnv(original));
+
+  it('is OFF for every workspace when unset', () => {
+    setEnv(undefined);
+    expect(isPerJobDeliveryMappingEnabled('ws1')).toBe(false);
+  });
+
+  it('is OFF for empty string and for NONE', () => {
+    setEnv('');
+    expect(isPerJobDeliveryMappingEnabled('ws1')).toBe(false);
+    setEnv('NONE');
+    expect(isPerJobDeliveryMappingEnabled('ws1')).toBe(false);
+  });
+
+  it('is ON for every workspace when ALL', () => {
+    setEnv('ALL');
+    expect(isPerJobDeliveryMappingEnabled('ws1')).toBe(true);
+    expect(isPerJobDeliveryMappingEnabled('anything')).toBe(true);
+  });
+
+  it('is ON only for the listed workspaceIds', () => {
+    setEnv('ws1,ws2');
+    expect(isPerJobDeliveryMappingEnabled('ws1')).toBe(true);
+    expect(isPerJobDeliveryMappingEnabled('ws2')).toBe(true);
+    expect(isPerJobDeliveryMappingEnabled('ws3')).toBe(false);
+  });
+
+  it('trims whitespace around the listed workspaceIds', () => {
+    setEnv('  ws1 ,  ws2  ');
+    expect(isPerJobDeliveryMappingEnabled('ws1')).toBe(true);
+    expect(isPerJobDeliveryMappingEnabled('ws2')).toBe(true);
   });
 });

--- a/src/v0/destinations/braze/config.ts
+++ b/src/v0/destinations/braze/config.ts
@@ -1,4 +1,5 @@
 import { getMappingConfig } from '../../util';
+import { isFeatureEnabled } from '../../../util/featureFlags';
 import type { BrazeEndpointDetails } from './types';
 
 const ConfigCategory = {
@@ -106,16 +107,25 @@ const SUBSCRIPTION_BRAZE_MAX_REQ_COUNT = 25;
 const DEL_MAX_BATCH_SIZE = 50;
 const DESTINATION = 'braze';
 
-// Rollout gate for the per-job delivery-mapping output shape (INT-6808 +
-// INT-6634). When OFF (default), processBatch emits the legacy single
-// MultiBatchRequestOutput with a flat metadata list and no destInfo.
+// Per-workspace rollout gate for the per-job delivery-mapping output shape
+// (INT-6808 + INT-6634). When OFF (default), processBatch emits the legacy
+// single MultiBatchRequestOutput with a flat metadata list and no destInfo.
 // When ON, processBatch emits one BatchRequestOutput per outgoing HTTP
 // request, with per-metadata destInfo positional maps used by the v1
 // networkHandler to correlate Braze per-item warnings back to jobs.
-// Read dynamically (not at module load) so tests and rollout can flip the
-// flag between runs without a process restart.
-const isPerJobDeliveryMappingEnabled = () =>
-  process.env.BRAZE_PER_JOB_DELIVERY_MAPPING_ENABLED === 'true';
+//
+// Delegates to the shared per-workspace feature-flag reader, with
+// BRAZE_PER_JOB_DELIVERY_MAPPING_WORKSPACE_IDS as an ENABLE (allow) list so the
+// ON path can be rolled out to a subset of workspaces:
+//   - unset (default): OFF for every workspace
+//   - 'ALL':           ON for every workspace
+//   - 'ws1,ws2,…':     ON only for the listed workspaceIds
+//   - any other value: OFF (not ALL, not a listed id)
+// isFeatureEnabled reads process.env dynamically (not cached at module load) so
+// the component-test envOverrides and a rollout config change take effect
+// without a process restart.
+const isPerJobDeliveryMappingEnabled = (workspaceId: string): boolean =>
+  isFeatureEnabled('BRAZE_PER_JOB_DELIVERY_MAPPING_WORKSPACE_IDS', workspaceId);
 
 const CustomAttributeOperationTypes = {
   REMOVE: 'remove',

--- a/src/v0/destinations/braze/config.ts
+++ b/src/v0/destinations/braze/config.ts
@@ -93,6 +93,11 @@ const BRAZE_PARTNER_NAME = 'RudderStack';
 const TRACK_BRAZE_MAX_REQ_COUNT = 75;
 const TRACK_BRAZE_MAX_EXTERNAL_ID_COUNT = 75;
 const IDENTIFY_BRAZE_MAX_REQ_COUNT = 50;
+
+// Per-item and per-batch byte-size caps enforced during chunking.
+// Ref: https://www.braze.com/docs/user_guide/data/activation/events/recommended_events#event-size-limit
+const TRACK_BRAZE_MAX_ITEM_BYTE_SIZE = 100 * 1024; // 100 KB
+const TRACK_BRAZE_MAX_BATCH_BYTE_SIZE = 4 * 1024 * 1024; // 4 MB
 // https://www.braze.com/docs/api/endpoints/user_data/post_user_delete/
 
 const ALIAS_BRAZE_MAX_REQ_COUNT = 50;
@@ -136,4 +141,6 @@ export {
   BRAZE_NON_BILLABLE_ATTRIBUTES,
   ALIAS_BRAZE_MAX_REQ_COUNT,
   SUBSCRIPTION_BRAZE_MAX_REQ_COUNT,
+  TRACK_BRAZE_MAX_ITEM_BYTE_SIZE,
+  TRACK_BRAZE_MAX_BATCH_BYTE_SIZE,
 };

--- a/src/v0/destinations/braze/config.ts
+++ b/src/v0/destinations/braze/config.ts
@@ -106,6 +106,17 @@ const SUBSCRIPTION_BRAZE_MAX_REQ_COUNT = 25;
 const DEL_MAX_BATCH_SIZE = 50;
 const DESTINATION = 'braze';
 
+// Rollout gate for the per-job delivery-mapping output shape (INT-6808 +
+// INT-6634). When OFF (default), processBatch emits the legacy single
+// MultiBatchRequestOutput with a flat metadata list and no destInfo.
+// When ON, processBatch emits one BatchRequestOutput per outgoing HTTP
+// request, with per-metadata destInfo positional maps used by the v1
+// networkHandler to correlate Braze per-item warnings back to jobs.
+// Read dynamically (not at module load) so tests and rollout can flip the
+// flag between runs without a process restart.
+const isPerJobDeliveryMappingEnabled = () =>
+  process.env.BRAZE_PER_JOB_DELIVERY_MAPPING_ENABLED === 'true';
+
 const CustomAttributeOperationTypes = {
   REMOVE: 'remove',
   UPDATE: 'update',
@@ -143,4 +154,5 @@ export {
   SUBSCRIPTION_BRAZE_MAX_REQ_COUNT,
   TRACK_BRAZE_MAX_ITEM_BYTE_SIZE,
   TRACK_BRAZE_MAX_BATCH_BYTE_SIZE,
+  isPerJobDeliveryMappingEnabled,
 };

--- a/src/v0/destinations/braze/transform.ts
+++ b/src/v0/destinations/braze/transform.ts
@@ -8,6 +8,7 @@ import {
   CustomAttributeOperationUtil,
   processDeduplication,
   processBatch,
+  processBatchWithDeliveryMapping,
   addAppId,
   setExternalIdOrAliasObject,
   getPurchaseObjs,
@@ -57,6 +58,7 @@ import {
   BRAZE_PARTNER_NAME,
   CustomAttributeOperationTypes,
   DESTINATION,
+  isPerJobDeliveryMappingEnabled,
 } from './config';
 import { buildEcommerceEventProperties, getEcommerceMapping } from './ecommerceUtil';
 
@@ -659,7 +661,14 @@ const processRouterDest = async (
   }
 
   const allTransfomredEvents = lodash.flatMap(output);
-  return processBatch(allTransfomredEvents);
+  // Rollout gate: when the per-job delivery-mapping flag is ON, emit one
+  // BatchRequestOutput per outgoing HTTP request with a per-metadata
+  // `destInfo` positional map (consumed by the v1 networkHandler's 296
+  // correlation). Default (OFF) preserves the legacy single
+  // MultiBatchRequestOutput shape.
+  return isPerJobDeliveryMappingEnabled()
+    ? processBatchWithDeliveryMapping(allTransfomredEvents)
+    : processBatch(allTransfomredEvents);
 };
 
 export { process, processRouterDest };

--- a/src/v0/destinations/braze/transform.ts
+++ b/src/v0/destinations/braze/transform.ts
@@ -666,7 +666,7 @@ const processRouterDest = async (
   // `destInfo` positional map (consumed by the v1 networkHandler's 296
   // correlation). Default (OFF) preserves the legacy single
   // MultiBatchRequestOutput shape.
-  return isPerJobDeliveryMappingEnabled()
+  return isPerJobDeliveryMappingEnabled(destination.WorkspaceID)
     ? processBatchWithDeliveryMapping(allTransfomredEvents)
     : processBatch(allTransfomredEvents);
 };

--- a/src/v0/destinations/braze/types.ts
+++ b/src/v0/destinations/braze/types.ts
@@ -331,7 +331,7 @@ export type BrazeTransformedEvent = {
   authErrorCategory?: string;
 };
 
-// `processBatch` emits either shape depending on `BRAZE_PER_JOB_DELIVERY_MAPPING_ENABLED`:
+// `processBatch` emits either shape depending on `BRAZE_PER_JOB_DELIVERY_MAPPING_WORKSPACE_IDS`:
 // - OFF (default): a single `MultiBatchRequestOutput` per invocation, its
 //   `batchedRequest` an array of every outgoing HTTP request across track/
 //   subscription/merge, and a flat success-metadata list — matches the

--- a/src/v0/destinations/braze/types.ts
+++ b/src/v0/destinations/braze/types.ts
@@ -6,6 +6,7 @@ import {
 } from '../../../types';
 import {
   BatchedRequest,
+  BatchedRequestBody,
   BatchRequestOutput,
   ProcessorTransformationOutput,
   ProxyMetdata,
@@ -156,14 +157,23 @@ export interface BrazeError {
   index: number;
 }
 
-// Sidecar populated on the metadata of `/users/track` router outputs so the v1
+// Populated on the metadata of `/users/track` router outputs so the v1
 // networkHandler can correlate Braze's per-item `errors[]` entries (keyed by
-// input_array + index) back to the originating job. Populated in `processBatch`
+// input_array + index) back to the originating job. Set in `processBatch`
 // when the outgoing chunk is assembled.
+//
+// Design-doc contract (Braze partial-error handling, Option 1, Section 4):
+// - Every index field is an array. Length-1 arrays for the standard single-
+//   contribution case; longer only when a job legitimately contributes
+//   multiple entries to the same sub-array (e.g. order-completed with
+//   multiple purchase items).
+// - Fields live at the top of `destInfo` (no per-destination wrapper) — the
+//   fields are populated only by Braze's router transform and read only by
+//   Braze's network handler within a single destination's request flow.
 export interface BrazeDestInfo {
-  attributesIndex?: number;
-  eventsIndex?: number;
-  purchasesIndexes?: number[];
+  attributesIndices?: number[];
+  eventsIndices?: number[];
+  purchasesIndices?: number[];
 }
 
 export interface BrazeResponseHandlerParams {
@@ -268,7 +278,7 @@ export interface BrazeEndpointDetails {
 
 // Braze Subscription Group request body structure
 export interface BrazeSubscriptionBatchPayload {
-  subscription_groups?: unknown[];
+  subscription_groups?: BrazeSubscriptionGroup[];
 }
 
 // Braze Merge Update Object
@@ -286,7 +296,11 @@ export interface BrazeMergeBatchPayload {
   merge_updates?: BrazeMergeUpdate[];
 }
 
-// Union of all possible Braze batch payload types
+// Union of all possible Braze batch payload types. Each outgoing HTTP request
+// populates fields for exactly one endpoint (`/users/track` OR subscription-
+// groups OR alias-merge), so a body is one of these three shapes at runtime.
+// Consumers reading `body.JSON` must narrow (via `in` guards or a boundary
+// cast to a specific member) before accessing member-specific fields.
 export type BrazeBatchPayload =
   | BrazeTrackRequestBody
   | BrazeSubscriptionBatchPayload
@@ -309,7 +323,9 @@ export type BrazeBatchRequest = BatchedRequest<
 
 export type BrazeTransformedEvent = {
   statusCode: number;
-  batchedRequest?: ProcessorTransformationOutput;
+  batchedRequest?: Omit<ProcessorTransformationOutput, 'body'> & {
+    body?: BatchedRequestBody<BrazeBatchPayload>;
+  };
   metadata?: Partial<Metadata>[];
   destination: BrazeDestination;
   error?: string;

--- a/src/v0/destinations/braze/types.ts
+++ b/src/v0/destinations/braze/types.ts
@@ -6,7 +6,7 @@ import {
 } from '../../../types';
 import {
   BatchedRequest,
-  MultiBatchRequestOutput,
+  BatchRequestOutput,
   ProcessorTransformationOutput,
   ProxyMetdata,
   ProxyV1Request,
@@ -154,6 +154,16 @@ export interface BrazeError {
   type: string;
   input_array: string;
   index: number;
+}
+
+// Sidecar populated on the metadata of `/users/track` router outputs so the v1
+// networkHandler can correlate Braze's per-item `errors[]` entries (keyed by
+// input_array + index) back to the originating job. Populated in `processBatch`
+// when the outgoing chunk is assembled.
+export interface BrazeDestInfo {
+  attributesIndex?: number;
+  eventsIndex?: number;
+  purchasesIndexes?: number[];
 }
 
 export interface BrazeResponseHandlerParams {
@@ -308,12 +318,7 @@ export type BrazeTransformedEvent = {
 };
 
 export type BrazeBatchResponse =
-  | MultiBatchRequestOutput<
-      BrazeBatchPayload,
-      BrazeBatchHeaders,
-      BrazeBatchParams,
-      BrazeDestination
-    >
+  | BatchRequestOutput<BrazeBatchPayload, BrazeBatchHeaders, BrazeBatchParams, BrazeDestination>
   | BrazeTransformedEvent;
 
 // Delete user types

--- a/src/v0/destinations/braze/types.ts
+++ b/src/v0/destinations/braze/types.ts
@@ -8,6 +8,7 @@ import {
   BatchedRequest,
   BatchedRequestBody,
   BatchRequestOutput,
+  MultiBatchRequestOutput,
   ProcessorTransformationOutput,
   ProxyMetdata,
   ProxyV1Request,
@@ -333,8 +334,22 @@ export type BrazeTransformedEvent = {
   authErrorCategory?: string;
 };
 
+// `processBatch` emits either shape depending on `BRAZE_PER_JOB_DELIVERY_MAPPING_ENABLED`:
+// - OFF (default): a single `MultiBatchRequestOutput` per invocation, its
+//   `batchedRequest` an array of every outgoing HTTP request across track/
+//   subscription/merge, and a flat success-metadata list — matches the
+//   pre-INT-6808 shape callers still expect.
+// - ON: one `BatchRequestOutput` per outgoing HTTP request, each carrying
+//   its scoped metadata slice and (for track chunks) per-metadata `destInfo`
+//   positional maps consumed by the v1 networkHandler.
 export type BrazeBatchResponse =
   | BatchRequestOutput<BrazeBatchPayload, BrazeBatchHeaders, BrazeBatchParams, BrazeDestination>
+  | MultiBatchRequestOutput<
+      BrazeBatchPayload,
+      BrazeBatchHeaders,
+      BrazeBatchParams,
+      BrazeDestination
+    >
   | BrazeTransformedEvent;
 
 // Delete user types

--- a/src/v0/destinations/braze/types.ts
+++ b/src/v0/destinations/braze/types.ts
@@ -6,7 +6,6 @@ import {
 } from '../../../types';
 import {
   BatchedRequest,
-  BatchedRequestBody,
   BatchRequestOutput,
   MultiBatchRequestOutput,
   ProcessorTransformationOutput,
@@ -324,9 +323,7 @@ export type BrazeBatchRequest = BatchedRequest<
 
 export type BrazeTransformedEvent = {
   statusCode: number;
-  batchedRequest?: Omit<ProcessorTransformationOutput, 'body'> & {
-    body?: BatchedRequestBody<BrazeBatchPayload>;
-  };
+  batchedRequest?: ProcessorTransformationOutput;
   metadata?: Partial<Metadata>[];
   destination: BrazeDestination;
   error?: string;

--- a/src/v0/destinations/braze/util.ts
+++ b/src/v0/destinations/braze/util.ts
@@ -947,7 +947,7 @@ const processBatch = (transformedEvents: BrazeTransformedEvent[]) => {
  */
 // ===========================================================================
 // ON-path helpers & processBatchWithDeliveryMapping
-// Selected by transform.ts when BRAZE_PER_JOB_DELIVERY_MAPPING_ENABLED='true'.
+// Selected by transform.ts when BRAZE_PER_JOB_DELIVERY_MAPPING_WORKSPACE_IDS enables the workspace.
 // Everything above this section is bit-identical to develop.
 // ===========================================================================
 
@@ -1365,8 +1365,8 @@ const classifyJobRun = (json: unknown): JobClassification => {
 // byte-size caps per item (100 KB) and per batch (4 MB), and up-front
 // oversized-job rejection.
 //
-// Selected by `transform.ts` when `BRAZE_PER_JOB_DELIVERY_MAPPING_ENABLED`
-// is set to `'true'`.
+// Selected by `transform.ts` when `BRAZE_PER_JOB_DELIVERY_MAPPING_WORKSPACE_IDS`
+// enables the invocation's workspace.
 // ---------------------------------------------------------------------------
 const processBatchWithDeliveryMapping = (
   transformedEvents: BrazeTransformedEvent[],

--- a/src/v0/destinations/braze/util.ts
+++ b/src/v0/destinations/braze/util.ts
@@ -34,16 +34,16 @@ import {
 } from './config';
 import { JSON_MIME_TYPE, HTTP_STATUS_CODES } from '../../util/constant';
 import {
-  BrazeTrackRequestBody,
-  BrazeSubscriptionBatchPayload,
-  BrazeMergeBatchPayload,
-  BrazeBatchRequest,
   BrazeDestination,
   BrazeRouterRequest,
   BrazeBatchHeaders,
   BrazeTransformedEvent,
   BrazeBatchResponse,
+  BrazeBatchRequest,
   BrazeDestInfo,
+  BrazeTrackRequestBody,
+  BrazeSubscriptionBatchPayload,
+  BrazeMergeBatchPayload,
   BrazeSubscriptionGroup,
   BrazeAliasToIdentify,
   BrazeUserExportResponse,
@@ -56,6 +56,13 @@ import {
   BrazeMergeUpdate,
 } from './types';
 import type { Metadata } from '../../../types';
+
+type TrackChunk = {
+  attributes: BrazeUserAttributes[];
+  events: BrazeEvent[];
+  purchases: BrazePurchase[];
+  externalIds: Set<string>;
+};
 
 const formatGender = (gender: unknown) => {
   if (typeof gender !== 'string') {
@@ -537,6 +544,413 @@ const processDeduplication = (
   return null;
 };
 
+function prepareGroupAndAliasBatch({
+  arrayChunks,
+  responseArray,
+  destination,
+  type,
+}:
+  | {
+      arrayChunks: BrazeSubscriptionGroup[][];
+      responseArray: unknown[];
+      destination: BrazeDestination;
+      type: 'subscription';
+    }
+  | {
+      arrayChunks: BrazeMergeUpdate[][];
+      responseArray: unknown[];
+      destination: BrazeDestination;
+      type: 'merge';
+    }) {
+  const headers = {
+    'Content-Type': JSON_MIME_TYPE,
+    Accept: JSON_MIME_TYPE,
+    Authorization: `Bearer ${destination.Config.restApiKey}`,
+  };
+
+  // Type narrowing: Check type BEFORE the loop so TypeScript can narrow arrayChunks
+  if (type === 'merge') {
+    // TypeScript now knows arrayChunks is BrazeMergeUpdate[][]
+    for (const chunk of arrayChunks) {
+      const response = defaultRequestConfig();
+      const { endpoint, path } = getAliasMergeEndPoint(getEndpointFromConfig(destination));
+      response.endpoint = endpoint;
+      response.endpointPath = path;
+      response.body.JSON = removeUndefinedAndNullValues({
+        merge_updates: chunk,
+      });
+      responseArray.push({
+        ...response,
+        headers,
+      });
+    }
+  } else {
+    // TypeScript now knows arrayChunks is BrazeSubscriptionGroup[][]
+    for (const chunk of arrayChunks) {
+      const response = defaultRequestConfig();
+      const { endpoint, path } = getSubscriptionGroupEndPoint(getEndpointFromConfig(destination));
+      response.endpoint = endpoint;
+      response.endpointPath = path;
+
+      stats.gauge('braze_batch_subscription_size', chunk.length, {
+        destination_id: destination.ID,
+      });
+
+      // Deduplicate the subscription groups before constructing the response body
+      // No type casting needed - TypeScript knows chunk is BrazeSubscriptionGroup[]
+      const deduplicatedSubscriptionGroups = combineSubscriptionGroups(chunk);
+
+      stats.gauge('braze_batch_subscription_combined_size', deduplicatedSubscriptionGroups.length, {
+        destination_id: destination.ID,
+      });
+
+      response.body.JSON = removeUndefinedAndNullValues({
+        subscription_groups: deduplicatedSubscriptionGroups,
+      });
+      responseArray.push({
+        ...response,
+        headers,
+      });
+    }
+  }
+}
+
+const createTrackChunk = (): TrackChunk => ({
+  attributes: [],
+  events: [],
+  purchases: [],
+  externalIds: new Set<string>(),
+});
+
+type AllItems = {
+  data: BrazeUserAttributes | BrazeEvent | BrazePurchase;
+  type: string;
+  externalId?: string;
+};
+
+const batchForTrackAPI = (
+  attributesArray: BrazeUserAttributes[],
+  eventsArray: BrazeEvent[],
+  purchasesArray: BrazePurchase[],
+) => {
+  const allItems: AllItems[] = [];
+  const maxLength = Math.max(attributesArray.length, eventsArray.length, purchasesArray.length);
+
+  const addItem = (item: AllItems['data'], type: string) => {
+    if (item) {
+      allItems.push({
+        data: item,
+        type,
+        externalId: item.external_id,
+      });
+    }
+  };
+
+  const canAddToChunk = (
+    item: AllItems,
+    chunk: {
+      externalIds: Set<string>;
+      attributes: unknown[];
+      events: unknown[];
+      purchases: unknown[];
+    },
+  ) => {
+    const { type, externalId } = item;
+    return (
+      ((externalId && chunk.externalIds.has(externalId)) ||
+        chunk.externalIds.size < TRACK_BRAZE_MAX_EXTERNAL_ID_COUNT) &&
+      chunk[type].length < TRACK_BRAZE_MAX_REQ_COUNT
+    );
+  };
+
+  // eslint-disable-next-line no-plusplus
+  for (let i = 0; i < maxLength; i++) {
+    addItem(attributesArray[i], 'attributes');
+    addItem(eventsArray[i], 'events');
+    addItem(purchasesArray[i], 'purchases');
+  }
+  const sortedItems = _.sortBy(allItems, 'externalId');
+  let currentChunk = createTrackChunk();
+  const trackChunks: ReturnType<typeof createTrackChunk>[] = [];
+  for (const item of sortedItems) {
+    if (canAddToChunk(item, currentChunk)) {
+      currentChunk[item.type].push(item.data);
+      currentChunk.externalIds.add(item.externalId!);
+    } else {
+      trackChunks.push(currentChunk);
+      currentChunk = createTrackChunk();
+      currentChunk[item.type].push(item.data);
+      currentChunk.externalIds.add(item.externalId!);
+    }
+  }
+  if (currentChunk.externalIds.size > 0) {
+    trackChunks.push(currentChunk);
+  }
+  return trackChunks;
+};
+
+// braze batching as per new MAU plan
+const batchForTrackAPIV2 = (
+  attributesArray: BrazeUserAttributes[],
+  eventsArray: BrazeEvent[],
+  purchasesArray: BrazePurchase[],
+) => {
+  // Collect all items with their types, filtering out null/undefined
+  const allItems: AllItems[] = [
+    ...attributesArray
+      .filter((item) => isDefinedAndNotNull(item))
+      .map((item) => ({
+        data: item,
+        type: 'attributes',
+        externalId: item.external_id,
+      })),
+    ...eventsArray
+      .filter((item) => isDefinedAndNotNull(item))
+      .map((item) => ({ data: item, type: 'events', externalId: item.external_id })),
+    ...purchasesArray
+      .filter((item) => isDefinedAndNotNull(item))
+      .map((item) => ({
+        data: item,
+        type: 'purchases',
+        externalId: item.external_id,
+      })),
+  ];
+
+  const sortedItems: AllItems[] = _.sortBy(allItems, 'externalId');
+  const trackChunks: ReturnType<typeof createTrackChunk>[] = [];
+  let currentChunk = createTrackChunk();
+
+  const getChunkSize = (chunk: ReturnType<typeof createTrackChunk>) =>
+    chunk.attributes.length + chunk.events.length + chunk.purchases.length;
+
+  const addItemToChunk = (item: AllItems, chunk: ReturnType<typeof createTrackChunk>) => {
+    chunk[item.type].push(item.data);
+  };
+
+  for (const item of sortedItems) {
+    if (getChunkSize(currentChunk) === TRACK_BRAZE_MAX_REQ_COUNT) {
+      trackChunks.push(currentChunk);
+      currentChunk = createTrackChunk();
+    }
+    addItemToChunk(item, currentChunk);
+  }
+
+  if (getChunkSize(currentChunk) > 0) {
+    trackChunks.push(currentChunk);
+  }
+
+  return trackChunks;
+};
+
+const cleanTrackChunk = (chunk: {
+  attributes: unknown[];
+  events: unknown[];
+  purchases: unknown[];
+}) => {
+  const { attributes, events, purchases } = chunk;
+  const cleanChunk: Record<string, unknown> = {};
+  if (attributes.length > 0) {
+    cleanChunk.attributes = attributes;
+  }
+  if (events.length > 0) {
+    cleanChunk.events = events;
+  }
+  if (purchases.length > 0) {
+    cleanChunk.purchases = purchases;
+  }
+  return cleanChunk;
+};
+
+const addTrackStats = (
+  chunk: { attributes?: unknown[]; events?: unknown[]; purchases?: unknown[] },
+  destination: BrazeDestination,
+) => {
+  const { attributes, events, purchases } = chunk;
+  let totalCount = 0;
+  if (attributes) {
+    totalCount += attributes.length;
+    stats.histogram('braze_batch_attributes_pack_size', attributes.length, {
+      destination_id: destination.ID,
+    });
+  }
+  if (events) {
+    totalCount += events.length;
+    stats.histogram('braze_batch_events_pack_size', events.length, {
+      destination_id: destination.ID,
+    });
+  }
+  if (purchases) {
+    totalCount += purchases.length;
+    stats.histogram('braze_batch_purchase_pack_size', purchases.length, {
+      destination_id: destination.ID,
+    });
+  }
+  stats.histogram('braze_batch_total_pack_size', totalCount, {
+    destination_id: destination.ID,
+  });
+};
+
+let mauWorkspaceSkipIds: string | Map<string, boolean> = 'ALL';
+if (isDefinedAndNotNull(process.env.DEST_BRAZE_MAU_WORKSPACE_IDS_SKIP_LIST)) {
+  const skipList = process.env.DEST_BRAZE_MAU_WORKSPACE_IDS_SKIP_LIST!;
+  switch (skipList) {
+    case 'ALL':
+      mauWorkspaceSkipIds = 'ALL';
+      break;
+    case 'NONE':
+      mauWorkspaceSkipIds = 'NONE';
+      break;
+    default:
+      mauWorkspaceSkipIds = new Map(skipList.split(',').map((s) => [s.trim(), true]));
+  }
+}
+
+const isWorkspaceOnMauPlan = (workspaceId) => {
+  const environmentVariable = mauWorkspaceSkipIds;
+  switch (environmentVariable) {
+    case 'ALL':
+      return false;
+    case 'NONE':
+      return true;
+    default: {
+      return !(mauWorkspaceSkipIds as Map<string, boolean>).has(workspaceId);
+    }
+  }
+};
+
+const processBatch = (transformedEvents: BrazeTransformedEvent[]) => {
+  const { destination, metadata } = transformedEvents[0];
+  const workspaceId = metadata?.[0]?.workspaceId || '';
+  const dest = destination;
+  const attributesArray: BrazeUserAttributes[] = [];
+  const eventsArray: BrazeEvent[] = [];
+  const purchaseArray: BrazePurchase[] = [];
+  const successMetadata: Partial<Metadata>[] = [];
+  const failureResponses: BrazeTransformedEvent[] = [];
+  const filteredResponses: BrazeTransformedEvent[] = [];
+  const subscriptionsArray: BrazeSubscriptionGroup[] = [];
+  const mergeUsersArray: BrazeMergeUpdate[] = [];
+  for (const transformedEvent of transformedEvents) {
+    if (!isHttpStatusSuccess(transformedEvent.statusCode)) {
+      failureResponses.push(transformedEvent);
+    } else if (transformedEvent.statusCode === HTTP_STATUS_CODES.FILTER_EVENTS) {
+      filteredResponses.push(transformedEvent);
+    } else if (transformedEvent.batchedRequest?.body?.JSON) {
+      const { attributes, events, purchases, subscription_groups, merge_updates } =
+        transformedEvent.batchedRequest.body.JSON;
+      if (Array.isArray(attributes)) {
+        attributesArray.push(...attributes);
+      }
+      if (Array.isArray(events)) {
+        eventsArray.push(...events);
+      }
+      if (Array.isArray(purchases)) {
+        purchaseArray.push(...purchases);
+      }
+
+      if (Array.isArray(subscription_groups)) {
+        subscriptionsArray.push(...subscription_groups);
+      }
+
+      if (Array.isArray(merge_updates)) {
+        mergeUsersArray.push(...merge_updates);
+      }
+
+      if (transformedEvent.metadata) {
+        successMetadata.push(...transformedEvent.metadata);
+      }
+    }
+  }
+  const isWorkspaceOnMauPlanFlag = isWorkspaceOnMauPlan(workspaceId);
+  const trackChunks = isWorkspaceOnMauPlanFlag
+    ? batchForTrackAPIV2(attributesArray, eventsArray, purchaseArray)
+    : batchForTrackAPI(attributesArray, eventsArray, purchaseArray);
+  const subscriptionArrayChunks = _.chunk(subscriptionsArray, SUBSCRIPTION_BRAZE_MAX_REQ_COUNT);
+  const mergeUsersArrayChunks = _.chunk(mergeUsersArray, ALIAS_BRAZE_MAX_REQ_COUNT);
+
+  const responseArray: BrazeBatchRequest[] = [];
+  const finalResponse: BrazeBatchResponse[] = [];
+  const headers: BrazeBatchHeaders = {
+    'Content-Type': JSON_MIME_TYPE,
+    Accept: JSON_MIME_TYPE,
+    Authorization: `Bearer ${dest.Config.restApiKey}`,
+  };
+
+  const { endpoint, path } = getTrackEndPoint(getEndpointFromConfig(destination));
+  for (const chunk of trackChunks) {
+    const cleanedChunk = cleanTrackChunk(chunk);
+    const { attributes, events, purchases } = cleanedChunk;
+    addTrackStats(chunk, destination);
+
+    const response = defaultRequestConfig();
+    response.endpoint = endpoint;
+    response.endpointPath = path;
+    response.body.JSON = {
+      partner: 'RudderStack',
+      attributes,
+      events,
+      purchases,
+    };
+    responseArray.push({
+      ...response,
+      headers,
+    });
+  }
+
+  prepareGroupAndAliasBatch({
+    arrayChunks: subscriptionArrayChunks,
+    responseArray,
+    destination,
+    type: 'subscription',
+  });
+  prepareGroupAndAliasBatch({
+    arrayChunks: mergeUsersArrayChunks,
+    responseArray,
+    destination,
+    type: 'merge',
+  });
+
+  if (successMetadata.length > 0) {
+    finalResponse.push({
+      batchedRequest: responseArray,
+      metadata: successMetadata,
+      batched: true,
+      statusCode: 200,
+      destination,
+    });
+  }
+  if (failureResponses.length > 0) {
+    finalResponse.push(...failureResponses);
+  }
+
+  if (filteredResponses.length > 0) {
+    finalResponse.push(...filteredResponses);
+  }
+
+  return finalResponse;
+};
+
+/**
+ *
+ * @param {*} payload
+ * @param {*} message
+ * @returns payload along with appId that is supposed to be passed by the user via
+ * integrations object.
+ * format will be as below:
+ *  "integrations": {
+                "All": true,
+                "braze": {
+                    "appId": "123"
+                }
+            }
+    Ref: https://www.braze.com/docs/api/identifier_types/?tab=app%20ids
+ */
+// ===========================================================================
+// ON-path helpers & processBatchWithDeliveryMapping
+// Selected by transform.ts when BRAZE_PER_JOB_DELIVERY_MAPPING_ENABLED='true'.
+// Everything above this section is bit-identical to develop.
+// ===========================================================================
+
 // ---------------------------------------------------------------------------
 // Batching data structures
 //
@@ -698,224 +1112,6 @@ const chunkTaggedItems = (items: TaggedItem[], mode: 'v1' | 'v2'): TaggedTrackCh
     chunks.push(currentChunk);
   }
   return chunks;
-};
-
-// ---------------------------------------------------------------------------
-// OFF-path chunking & helpers (used by `processBatch` only). Restored
-// verbatim from develop — per-item chunking with per-type caps (V1) or a
-// total-count cap (V2). No straddle prevention, no byte-size caps.
-// ---------------------------------------------------------------------------
-type TrackChunk = {
-  attributes: BrazeUserAttributes[];
-  events: BrazeEvent[];
-  purchases: BrazePurchase[];
-  externalIds: Set<string>;
-};
-
-const createTrackChunk = (): TrackChunk => ({
-  attributes: [],
-  events: [],
-  purchases: [],
-  externalIds: new Set<string>(),
-});
-
-type AllItems = {
-  data: BrazeUserAttributes | BrazeEvent | BrazePurchase;
-  type: string;
-  externalId?: string;
-};
-
-const batchForTrackAPI = (
-  attributesArray: BrazeUserAttributes[],
-  eventsArray: BrazeEvent[],
-  purchasesArray: BrazePurchase[],
-) => {
-  const allItems: AllItems[] = [];
-  const maxLength = Math.max(attributesArray.length, eventsArray.length, purchasesArray.length);
-
-  const addItem = (item: AllItems['data'], type: string) => {
-    if (item) {
-      allItems.push({
-        data: item,
-        type,
-        externalId: item.external_id,
-      });
-    }
-  };
-
-  const canAddToChunk = (
-    item: AllItems,
-    chunk: {
-      externalIds: Set<string>;
-      attributes: unknown[];
-      events: unknown[];
-      purchases: unknown[];
-    },
-  ) => {
-    const { type, externalId } = item;
-    return (
-      ((externalId && chunk.externalIds.has(externalId)) ||
-        chunk.externalIds.size < TRACK_BRAZE_MAX_EXTERNAL_ID_COUNT) &&
-      chunk[type].length < TRACK_BRAZE_MAX_REQ_COUNT
-    );
-  };
-
-  // eslint-disable-next-line no-plusplus
-  for (let i = 0; i < maxLength; i++) {
-    addItem(attributesArray[i], 'attributes');
-    addItem(eventsArray[i], 'events');
-    addItem(purchasesArray[i], 'purchases');
-  }
-  const sortedItems = _.sortBy(allItems, 'externalId');
-  let currentChunk = createTrackChunk();
-  const trackChunks: ReturnType<typeof createTrackChunk>[] = [];
-  for (const item of sortedItems) {
-    if (canAddToChunk(item, currentChunk)) {
-      currentChunk[item.type].push(item.data);
-      currentChunk.externalIds.add(item.externalId!);
-    } else {
-      trackChunks.push(currentChunk);
-      currentChunk = createTrackChunk();
-      currentChunk[item.type].push(item.data);
-      currentChunk.externalIds.add(item.externalId!);
-    }
-  }
-  if (currentChunk.externalIds.size > 0) {
-    trackChunks.push(currentChunk);
-  }
-  return trackChunks;
-};
-
-// braze batching as per new MAU plan
-const batchForTrackAPIV2 = (
-  attributesArray: BrazeUserAttributes[],
-  eventsArray: BrazeEvent[],
-  purchasesArray: BrazePurchase[],
-) => {
-  // Collect all items with their types, filtering out null/undefined
-  const allItems: AllItems[] = [
-    ...attributesArray
-      .filter((item) => isDefinedAndNotNull(item))
-      .map((item) => ({
-        data: item,
-        type: 'attributes',
-        externalId: item.external_id,
-      })),
-    ...eventsArray
-      .filter((item) => isDefinedAndNotNull(item))
-      .map((item) => ({ data: item, type: 'events', externalId: item.external_id })),
-    ...purchasesArray
-      .filter((item) => isDefinedAndNotNull(item))
-      .map((item) => ({
-        data: item,
-        type: 'purchases',
-        externalId: item.external_id,
-      })),
-  ];
-
-  const sortedItems: AllItems[] = _.sortBy(allItems, 'externalId');
-  const trackChunks: ReturnType<typeof createTrackChunk>[] = [];
-  let currentChunk = createTrackChunk();
-
-  const getChunkSize = (chunk: ReturnType<typeof createTrackChunk>) =>
-    chunk.attributes.length + chunk.events.length + chunk.purchases.length;
-
-  const addItemToChunk = (item: AllItems, chunk: ReturnType<typeof createTrackChunk>) => {
-    chunk[item.type].push(item.data);
-  };
-
-  for (const item of sortedItems) {
-    if (getChunkSize(currentChunk) === TRACK_BRAZE_MAX_REQ_COUNT) {
-      trackChunks.push(currentChunk);
-      currentChunk = createTrackChunk();
-    }
-    addItemToChunk(item, currentChunk);
-  }
-
-  if (getChunkSize(currentChunk) > 0) {
-    trackChunks.push(currentChunk);
-  }
-
-  return trackChunks;
-};
-
-// Shared between `processBatch` (OFF) and `processBatchWithDeliveryMapping`
-// (ON). Both `TrackChunk` and `TaggedTrackChunk` carry `attributes` /
-// `events` / `purchases` arrays; the structural signatures fit both.
-const cleanTrackChunk = (chunk: {
-  attributes: unknown[];
-  events: unknown[];
-  purchases: unknown[];
-}) => {
-  const { attributes, events, purchases } = chunk;
-  const cleanChunk: Record<string, unknown> = {};
-  if (attributes.length > 0) {
-    cleanChunk.attributes = attributes;
-  }
-  if (events.length > 0) {
-    cleanChunk.events = events;
-  }
-  if (purchases.length > 0) {
-    cleanChunk.purchases = purchases;
-  }
-  return cleanChunk;
-};
-
-const addTrackStats = (
-  chunk: { attributes?: unknown[]; events?: unknown[]; purchases?: unknown[] },
-  destination: BrazeDestination,
-) => {
-  const { attributes, events, purchases } = chunk;
-  let totalCount = 0;
-  if (attributes) {
-    totalCount += attributes.length;
-    stats.histogram('braze_batch_attributes_pack_size', attributes.length, {
-      destination_id: destination.ID,
-    });
-  }
-  if (events) {
-    totalCount += events.length;
-    stats.histogram('braze_batch_events_pack_size', events.length, {
-      destination_id: destination.ID,
-    });
-  }
-  if (purchases) {
-    totalCount += purchases.length;
-    stats.histogram('braze_batch_purchase_pack_size', purchases.length, {
-      destination_id: destination.ID,
-    });
-  }
-  stats.histogram('braze_batch_total_pack_size', totalCount, {
-    destination_id: destination.ID,
-  });
-};
-
-let mauWorkspaceSkipIds: string | Map<string, boolean> = 'ALL';
-if (isDefinedAndNotNull(process.env.DEST_BRAZE_MAU_WORKSPACE_IDS_SKIP_LIST)) {
-  const skipList = process.env.DEST_BRAZE_MAU_WORKSPACE_IDS_SKIP_LIST!;
-  switch (skipList) {
-    case 'ALL':
-      mauWorkspaceSkipIds = 'ALL';
-      break;
-    case 'NONE':
-      mauWorkspaceSkipIds = 'NONE';
-      break;
-    default:
-      mauWorkspaceSkipIds = new Map(skipList.split(',').map((s) => [s.trim(), true]));
-  }
-}
-
-const isWorkspaceOnMauPlan = (workspaceId) => {
-  const environmentVariable = mauWorkspaceSkipIds;
-  switch (environmentVariable) {
-    case 'ALL':
-      return false;
-    case 'NONE':
-      return true;
-    default: {
-      return !(mauWorkspaceSkipIds as Map<string, boolean>).has(workspaceId);
-    }
-  }
 };
 
 // Collect tagged /users/track items for a single transformedEvent while
@@ -1200,199 +1396,6 @@ const classifyJobRun = (json: unknown): JobClassification | null => {
   return null;
 };
 
-function prepareGroupAndAliasBatch({
-  arrayChunks,
-  responseArray,
-  destination,
-  type,
-}:
-  | {
-      arrayChunks: BrazeSubscriptionGroup[][];
-      responseArray: unknown[];
-      destination: BrazeDestination;
-      type: 'subscription';
-    }
-  | {
-      arrayChunks: BrazeMergeUpdate[][];
-      responseArray: unknown[];
-      destination: BrazeDestination;
-      type: 'merge';
-    }) {
-  const headers = {
-    'Content-Type': JSON_MIME_TYPE,
-    Accept: JSON_MIME_TYPE,
-    Authorization: `Bearer ${destination.Config.restApiKey}`,
-  };
-
-  // Type narrowing: Check type BEFORE the loop so TypeScript can narrow arrayChunks
-  if (type === 'merge') {
-    // TypeScript now knows arrayChunks is BrazeMergeUpdate[][]
-    for (const chunk of arrayChunks) {
-      const response = defaultRequestConfig();
-      const { endpoint, path } = getAliasMergeEndPoint(getEndpointFromConfig(destination));
-      response.endpoint = endpoint;
-      response.endpointPath = path;
-      response.body.JSON = removeUndefinedAndNullValues({
-        merge_updates: chunk,
-      });
-      responseArray.push({
-        ...response,
-        headers,
-      });
-    }
-  } else {
-    // TypeScript now knows arrayChunks is BrazeSubscriptionGroup[][]
-    for (const chunk of arrayChunks) {
-      const response = defaultRequestConfig();
-      const { endpoint, path } = getSubscriptionGroupEndPoint(getEndpointFromConfig(destination));
-      response.endpoint = endpoint;
-      response.endpointPath = path;
-
-      stats.gauge('braze_batch_subscription_size', chunk.length, {
-        destination_id: destination.ID,
-      });
-
-      // Deduplicate the subscription groups before constructing the response body
-      // No type casting needed - TypeScript knows chunk is BrazeSubscriptionGroup[]
-      const deduplicatedSubscriptionGroups = combineSubscriptionGroups(chunk);
-
-      stats.gauge('braze_batch_subscription_combined_size', deduplicatedSubscriptionGroups.length, {
-        destination_id: destination.ID,
-      });
-
-      response.body.JSON = removeUndefinedAndNullValues({
-        subscription_groups: deduplicatedSubscriptionGroups,
-      });
-      responseArray.push({
-        ...response,
-        headers,
-      });
-    }
-  }
-}
-
-// ---------------------------------------------------------------------------
-// `processBatch` (OFF path — default).
-//
-// Restored verbatim from `develop` so the OFF path stays bit-identical to
-// the version reviewers have already accepted. Any change to the batching
-// semantics belongs in `processBatchWithDeliveryMapping` below.
-//
-// Selected by `transform.ts` when `BRAZE_PER_JOB_DELIVERY_MAPPING_ENABLED`
-// is unset — the default rollout state.
-// ---------------------------------------------------------------------------
-const processBatch = (transformedEvents: BrazeTransformedEvent[]) => {
-  const { destination, metadata } = transformedEvents[0];
-  const workspaceId = metadata?.[0]?.workspaceId || '';
-  const dest = destination;
-  const attributesArray: BrazeUserAttributes[] = [];
-  const eventsArray: BrazeEvent[] = [];
-  const purchaseArray: BrazePurchase[] = [];
-  const successMetadata: Partial<Metadata>[] = [];
-  const failureResponses: BrazeTransformedEvent[] = [];
-  const filteredResponses: BrazeTransformedEvent[] = [];
-  const subscriptionsArray: BrazeSubscriptionGroup[] = [];
-  const mergeUsersArray: BrazeMergeUpdate[] = [];
-  for (const transformedEvent of transformedEvents) {
-    if (!isHttpStatusSuccess(transformedEvent.statusCode)) {
-      failureResponses.push(transformedEvent);
-    } else if (transformedEvent.statusCode === HTTP_STATUS_CODES.FILTER_EVENTS) {
-      filteredResponses.push(transformedEvent);
-    } else if (transformedEvent.batchedRequest?.body?.JSON) {
-      const { attributes, events, purchases, subscription_groups, merge_updates } =
-        transformedEvent.batchedRequest.body.JSON;
-      if (Array.isArray(attributes)) {
-        attributesArray.push(...attributes);
-      }
-      if (Array.isArray(events)) {
-        eventsArray.push(...events);
-      }
-      if (Array.isArray(purchases)) {
-        purchaseArray.push(...purchases);
-      }
-
-      if (Array.isArray(subscription_groups)) {
-        subscriptionsArray.push(...subscription_groups);
-      }
-
-      if (Array.isArray(merge_updates)) {
-        mergeUsersArray.push(...merge_updates);
-      }
-
-      if (transformedEvent.metadata) {
-        successMetadata.push(...transformedEvent.metadata);
-      }
-    }
-  }
-  const isWorkspaceOnMauPlanFlag = isWorkspaceOnMauPlan(workspaceId);
-  const trackChunks = isWorkspaceOnMauPlanFlag
-    ? batchForTrackAPIV2(attributesArray, eventsArray, purchaseArray)
-    : batchForTrackAPI(attributesArray, eventsArray, purchaseArray);
-  const subscriptionArrayChunks = _.chunk(subscriptionsArray, SUBSCRIPTION_BRAZE_MAX_REQ_COUNT);
-  const mergeUsersArrayChunks = _.chunk(mergeUsersArray, ALIAS_BRAZE_MAX_REQ_COUNT);
-
-  const responseArray: BrazeBatchRequest[] = [];
-  const finalResponse: BrazeBatchResponse[] = [];
-  const headers: BrazeBatchHeaders = {
-    'Content-Type': JSON_MIME_TYPE,
-    Accept: JSON_MIME_TYPE,
-    Authorization: `Bearer ${dest.Config.restApiKey}`,
-  };
-
-  const { endpoint, path } = getTrackEndPoint(getEndpointFromConfig(destination));
-  for (const chunk of trackChunks) {
-    const cleanedChunk = cleanTrackChunk(chunk);
-    const { attributes, events, purchases } = cleanedChunk;
-    addTrackStats(chunk, destination);
-
-    const response = defaultRequestConfig();
-    response.endpoint = endpoint;
-    response.endpointPath = path;
-    response.body.JSON = {
-      partner: 'RudderStack',
-      attributes,
-      events,
-      purchases,
-    };
-    responseArray.push({
-      ...response,
-      headers,
-    });
-  }
-
-  prepareGroupAndAliasBatch({
-    arrayChunks: subscriptionArrayChunks,
-    responseArray,
-    destination,
-    type: 'subscription',
-  });
-  prepareGroupAndAliasBatch({
-    arrayChunks: mergeUsersArrayChunks,
-    responseArray,
-    destination,
-    type: 'merge',
-  });
-
-  if (successMetadata.length > 0) {
-    finalResponse.push({
-      batchedRequest: responseArray,
-      metadata: successMetadata,
-      batched: true,
-      statusCode: 200,
-      destination,
-    });
-  }
-  if (failureResponses.length > 0) {
-    finalResponse.push(...failureResponses);
-  }
-
-  if (filteredResponses.length > 0) {
-    finalResponse.push(...filteredResponses);
-  }
-
-  return finalResponse;
-};
-
 // ---------------------------------------------------------------------------
 // `processBatchWithDeliveryMapping` (ON path).
 //
@@ -1532,22 +1535,6 @@ const processBatchWithDeliveryMapping = (
   if (filteredResponses.length > 0) finalResponse.push(...filteredResponses);
   return finalResponse;
 };
-
-/**
- *
- * @param {*} payload
- * @param {*} message
- * @returns payload along with appId that is supposed to be passed by the user via
- * integrations object.
- * format will be as below:
- *  "integrations": {
-                "All": true,
-                "braze": {
-                    "appId": "123"
-                }
-            }
-    Ref: https://www.braze.com/docs/api/identifier_types/?tab=app%20ids
- */
 const addAppId = (payload: Record<string, unknown>, message: Record<string, unknown>) => {
   const integrationsObj = getIntegrationsObj(message, DESTINATION.toUpperCase() as any);
   if (integrationsObj?.appId) {

--- a/src/v0/destinations/braze/util.ts
+++ b/src/v0/destinations/braze/util.ts
@@ -1371,8 +1371,8 @@ const classifyJobRun = (json: unknown): JobClassification => {
 const processBatchWithDeliveryMapping = (
   transformedEvents: BrazeTransformedEvent[],
 ): BrazeBatchResponse[] => {
-  const { destination } = transformedEvents[0];
-  const workspaceId = transformedEvents[0].metadata?.[0]?.workspaceId || '';
+  const { destination, metadata } = transformedEvents[0];
+  const workspaceId = metadata?.[0]?.workspaceId || '';
 
   const failureResponses: BrazeTransformedEvent[] = [];
   const filteredResponses: BrazeTransformedEvent[] = [];

--- a/src/v0/destinations/braze/util.ts
+++ b/src/v0/destinations/braze/util.ts
@@ -31,11 +31,9 @@ import {
   TRACK_BRAZE_MAX_BATCH_BYTE_SIZE,
   BRAZE_PURCHASE_STANDARD_PROPERTIES,
   DESTINATION,
-  isPerJobDeliveryMappingEnabled,
 } from './config';
 import { JSON_MIME_TYPE, HTTP_STATUS_CODES } from '../../util/constant';
 import {
-  BrazeBatchPayload,
   BrazeTrackRequestBody,
   BrazeSubscriptionBatchPayload,
   BrazeMergeBatchPayload,
@@ -548,7 +546,7 @@ const processDeduplication = (
 // keeps same-user AND same-job items contiguous so `chunkTaggedItems` can add
 // an entire job's items atomically to a chunk, preventing cross-chunk straddle.
 //
-// Each `TrackChunk` also stores parallel `*SourceJobIndex` arrays so that
+// Each `TaggedTrackChunk` also stores parallel `*SourceJobIndex` arrays so that
 // `processBatch` can build the per-metadata `destInfo` positional map
 // (attributesIndices / eventsIndices / purchasesIndices) that the v1
 // networkHandler uses to correlate Braze's per-item warnings back to
@@ -576,7 +574,7 @@ type TrackContribution =
   | { type: 'events'; data: BrazeEvent }
   | { type: 'purchases'; data: BrazePurchase };
 
-type TrackChunk = {
+type TaggedTrackChunk = {
   attributes: BrazeUserAttributes[];
   attributesSourceJobIndex: number[];
   events: BrazeEvent[];
@@ -590,7 +588,7 @@ type TrackChunk = {
 
 const computeItemByteSize = (item: unknown): number => Buffer.byteLength(JSON.stringify(item));
 
-const createTrackChunk = (): TrackChunk => ({
+const createTaggedTrackChunk = (): TaggedTrackChunk => ({
   attributes: [],
   attributesSourceJobIndex: [],
   events: [],
@@ -601,49 +599,6 @@ const createTrackChunk = (): TrackChunk => ({
   sourceJobIndexes: new Set<number>(),
   byteSize: 0,
 });
-
-// Build tagged items from raw sub-arrays. Each item is assigned its own
-// sourceJobIndex, so group-preserving chunking degenerates to per-item
-// chunking — matches legacy behavior for the exported wrappers used by tests.
-const buildTaggedItemsFromArrays = (
-  attributesArray: BrazeUserAttributes[],
-  eventsArray: BrazeEvent[],
-  purchasesArray: BrazePurchase[],
-): TaggedItem[] => {
-  const items: TaggedItem[] = [];
-  let idx = 0;
-  attributesArray.filter(isDefinedAndNotNull).forEach((attr) => {
-    items.push({
-      data: attr,
-      type: 'attributes',
-      externalId: attr.external_id,
-      sourceJobIndex: idx,
-      byteSize: computeItemByteSize(attr),
-    });
-    idx += 1;
-  });
-  eventsArray.filter(isDefinedAndNotNull).forEach((evt) => {
-    items.push({
-      data: evt,
-      type: 'events',
-      externalId: evt.external_id,
-      sourceJobIndex: idx,
-      byteSize: computeItemByteSize(evt),
-    });
-    idx += 1;
-  });
-  purchasesArray.filter(isDefinedAndNotNull).forEach((pur) => {
-    items.push({
-      data: pur,
-      type: 'purchases',
-      externalId: pur.external_id,
-      sourceJobIndex: idx,
-      byteSize: computeItemByteSize(pur),
-    });
-    idx += 1;
-  });
-  return items;
-};
 
 // Contiguous same-sourceJobIndex runs in a sorted item list. Because we
 // stable-sort by (externalId, sourceJobIndex), items from the same source job
@@ -666,7 +621,7 @@ const groupBySourceJob = (sortedItems: TaggedItem[]): TaggedItem[][] => {
   return groups;
 };
 
-const addGroupToChunk = (chunk: TrackChunk, group: TaggedItem[]): void => {
+const addGroupToChunk = (chunk: TaggedTrackChunk, group: TaggedItem[]): void => {
   for (const item of group) {
     if (item.type === 'attributes') {
       chunk.attributes.push(item.data);
@@ -687,7 +642,7 @@ const addGroupToChunk = (chunk: TrackChunk, group: TaggedItem[]): void => {
 };
 
 // V1 semantics: per-type item cap + externalId cap + byte-size cap.
-const groupFitsV1 = (chunk: TrackChunk, group: TaggedItem[]): boolean => {
+const groupFitsV1 = (chunk: TaggedTrackChunk, group: TaggedItem[]): boolean => {
   let addAttrs = 0;
   let addEvents = 0;
   let addPurchases = 0;
@@ -710,7 +665,7 @@ const groupFitsV1 = (chunk: TrackChunk, group: TaggedItem[]): boolean => {
 };
 
 // V2 (MAU plan) semantics: total-count cap + byte-size cap.
-const groupFitsV2 = (chunk: TrackChunk, group: TaggedItem[]): boolean => {
+const groupFitsV2 = (chunk: TaggedTrackChunk, group: TaggedItem[]): boolean => {
   let addByteSize = 0;
   for (const item of group) {
     addByteSize += item.byteSize;
@@ -726,16 +681,16 @@ const groupFitsV2 = (chunk: TrackChunk, group: TaggedItem[]): boolean => {
 // group can never fit into an empty chunk. `processBatch` enforces that
 // pre-check; the exported wrappers below use per-item sourceJobIndex so no
 // group ever exceeds a single item.
-const chunkTaggedItems = (items: TaggedItem[], mode: 'v1' | 'v2'): TrackChunk[] => {
+const chunkTaggedItems = (items: TaggedItem[], mode: 'v1' | 'v2'): TaggedTrackChunk[] => {
   const sortedItems = _.orderBy(items, ['externalId', 'sourceJobIndex']);
   const groups = groupBySourceJob(sortedItems);
-  const chunks: TrackChunk[] = [];
-  let currentChunk = createTrackChunk();
+  const chunks: TaggedTrackChunk[] = [];
+  let currentChunk = createTaggedTrackChunk();
   const fits = mode === 'v1' ? groupFitsV1 : groupFitsV2;
   for (const group of groups) {
     if (currentChunk.sourceJobIndexes.size > 0 && !fits(currentChunk, group)) {
       chunks.push(currentChunk);
-      currentChunk = createTrackChunk();
+      currentChunk = createTaggedTrackChunk();
     }
     addGroupToChunk(currentChunk, group);
   }
@@ -745,45 +700,191 @@ const chunkTaggedItems = (items: TaggedItem[], mode: 'v1' | 'v2'): TrackChunk[] 
   return chunks;
 };
 
+// ---------------------------------------------------------------------------
+// OFF-path chunking & helpers (used by `processBatch` only). Restored
+// verbatim from develop — per-item chunking with per-type caps (V1) or a
+// total-count cap (V2). No straddle prevention, no byte-size caps.
+// ---------------------------------------------------------------------------
+type TrackChunk = {
+  attributes: BrazeUserAttributes[];
+  events: BrazeEvent[];
+  purchases: BrazePurchase[];
+  externalIds: Set<string>;
+};
+
+const createTrackChunk = (): TrackChunk => ({
+  attributes: [],
+  events: [],
+  purchases: [],
+  externalIds: new Set<string>(),
+});
+
+type AllItems = {
+  data: BrazeUserAttributes | BrazeEvent | BrazePurchase;
+  type: string;
+  externalId?: string;
+};
+
 const batchForTrackAPI = (
   attributesArray: BrazeUserAttributes[],
   eventsArray: BrazeEvent[],
   purchasesArray: BrazePurchase[],
-): TrackChunk[] =>
-  chunkTaggedItems(buildTaggedItemsFromArrays(attributesArray, eventsArray, purchasesArray), 'v1');
+) => {
+  const allItems: AllItems[] = [];
+  const maxLength = Math.max(attributesArray.length, eventsArray.length, purchasesArray.length);
 
+  const addItem = (item: AllItems['data'], type: string) => {
+    if (item) {
+      allItems.push({
+        data: item,
+        type,
+        externalId: item.external_id,
+      });
+    }
+  };
+
+  const canAddToChunk = (
+    item: AllItems,
+    chunk: {
+      externalIds: Set<string>;
+      attributes: unknown[];
+      events: unknown[];
+      purchases: unknown[];
+    },
+  ) => {
+    const { type, externalId } = item;
+    return (
+      ((externalId && chunk.externalIds.has(externalId)) ||
+        chunk.externalIds.size < TRACK_BRAZE_MAX_EXTERNAL_ID_COUNT) &&
+      chunk[type].length < TRACK_BRAZE_MAX_REQ_COUNT
+    );
+  };
+
+  // eslint-disable-next-line no-plusplus
+  for (let i = 0; i < maxLength; i++) {
+    addItem(attributesArray[i], 'attributes');
+    addItem(eventsArray[i], 'events');
+    addItem(purchasesArray[i], 'purchases');
+  }
+  const sortedItems = _.sortBy(allItems, 'externalId');
+  let currentChunk = createTrackChunk();
+  const trackChunks: ReturnType<typeof createTrackChunk>[] = [];
+  for (const item of sortedItems) {
+    if (canAddToChunk(item, currentChunk)) {
+      currentChunk[item.type].push(item.data);
+      currentChunk.externalIds.add(item.externalId!);
+    } else {
+      trackChunks.push(currentChunk);
+      currentChunk = createTrackChunk();
+      currentChunk[item.type].push(item.data);
+      currentChunk.externalIds.add(item.externalId!);
+    }
+  }
+  if (currentChunk.externalIds.size > 0) {
+    trackChunks.push(currentChunk);
+  }
+  return trackChunks;
+};
+
+// braze batching as per new MAU plan
 const batchForTrackAPIV2 = (
   attributesArray: BrazeUserAttributes[],
   eventsArray: BrazeEvent[],
   purchasesArray: BrazePurchase[],
-): TrackChunk[] =>
-  chunkTaggedItems(buildTaggedItemsFromArrays(attributesArray, eventsArray, purchasesArray), 'v2');
+) => {
+  // Collect all items with their types, filtering out null/undefined
+  const allItems: AllItems[] = [
+    ...attributesArray
+      .filter((item) => isDefinedAndNotNull(item))
+      .map((item) => ({
+        data: item,
+        type: 'attributes',
+        externalId: item.external_id,
+      })),
+    ...eventsArray
+      .filter((item) => isDefinedAndNotNull(item))
+      .map((item) => ({ data: item, type: 'events', externalId: item.external_id })),
+    ...purchasesArray
+      .filter((item) => isDefinedAndNotNull(item))
+      .map((item) => ({
+        data: item,
+        type: 'purchases',
+        externalId: item.external_id,
+      })),
+  ];
 
-const cleanTrackChunk = (chunk: TrackChunk) => {
+  const sortedItems: AllItems[] = _.sortBy(allItems, 'externalId');
+  const trackChunks: ReturnType<typeof createTrackChunk>[] = [];
+  let currentChunk = createTrackChunk();
+
+  const getChunkSize = (chunk: ReturnType<typeof createTrackChunk>) =>
+    chunk.attributes.length + chunk.events.length + chunk.purchases.length;
+
+  const addItemToChunk = (item: AllItems, chunk: ReturnType<typeof createTrackChunk>) => {
+    chunk[item.type].push(item.data);
+  };
+
+  for (const item of sortedItems) {
+    if (getChunkSize(currentChunk) === TRACK_BRAZE_MAX_REQ_COUNT) {
+      trackChunks.push(currentChunk);
+      currentChunk = createTrackChunk();
+    }
+    addItemToChunk(item, currentChunk);
+  }
+
+  if (getChunkSize(currentChunk) > 0) {
+    trackChunks.push(currentChunk);
+  }
+
+  return trackChunks;
+};
+
+// Shared between `processBatch` (OFF) and `processBatchWithDeliveryMapping`
+// (ON). Both `TrackChunk` and `TaggedTrackChunk` carry `attributes` /
+// `events` / `purchases` arrays; the structural signatures fit both.
+const cleanTrackChunk = (chunk: {
+  attributes: unknown[];
+  events: unknown[];
+  purchases: unknown[];
+}) => {
+  const { attributes, events, purchases } = chunk;
   const cleanChunk: Record<string, unknown> = {};
-  if (chunk.attributes.length > 0) {
-    cleanChunk.attributes = chunk.attributes;
+  if (attributes.length > 0) {
+    cleanChunk.attributes = attributes;
   }
-  if (chunk.events.length > 0) {
-    cleanChunk.events = chunk.events;
+  if (events.length > 0) {
+    cleanChunk.events = events;
   }
-  if (chunk.purchases.length > 0) {
-    cleanChunk.purchases = chunk.purchases;
+  if (purchases.length > 0) {
+    cleanChunk.purchases = purchases;
   }
   return cleanChunk;
 };
 
-const addTrackStats = (chunk: TrackChunk, destination: BrazeDestination) => {
-  const totalCount = chunk.attributes.length + chunk.events.length + chunk.purchases.length;
-  stats.histogram('braze_batch_attributes_pack_size', chunk.attributes.length, {
-    destination_id: destination.ID,
-  });
-  stats.histogram('braze_batch_events_pack_size', chunk.events.length, {
-    destination_id: destination.ID,
-  });
-  stats.histogram('braze_batch_purchase_pack_size', chunk.purchases.length, {
-    destination_id: destination.ID,
-  });
+const addTrackStats = (
+  chunk: { attributes?: unknown[]; events?: unknown[]; purchases?: unknown[] },
+  destination: BrazeDestination,
+) => {
+  const { attributes, events, purchases } = chunk;
+  let totalCount = 0;
+  if (attributes) {
+    totalCount += attributes.length;
+    stats.histogram('braze_batch_attributes_pack_size', attributes.length, {
+      destination_id: destination.ID,
+    });
+  }
+  if (events) {
+    totalCount += events.length;
+    stats.histogram('braze_batch_events_pack_size', events.length, {
+      destination_id: destination.ID,
+    });
+  }
+  if (purchases) {
+    totalCount += purchases.length;
+    stats.histogram('braze_batch_purchase_pack_size', purchases.length, {
+      destination_id: destination.ID,
+    });
+  }
   stats.histogram('braze_batch_total_pack_size', totalCount, {
     destination_id: destination.ID,
   });
@@ -898,7 +999,7 @@ const collectTrackItemsForJob = (
 // job's items landed within this chunk's attributes[]/events[]/purchases[].
 // All three fields are arrays (length 1 for the standard single-contribution
 // case; longer for e.g. order-completed contributing multiple purchases).
-const buildDestInfoByJob = (chunk: TrackChunk): Map<number, BrazeDestInfo> => {
+const buildDestInfoByJob = (chunk: TaggedTrackChunk): Map<number, BrazeDestInfo> => {
   const map = new Map<number, BrazeDestInfo>();
   const ensure = (sji: number): BrazeDestInfo => {
     let existing = map.get(sji);
@@ -932,7 +1033,7 @@ const buildDestInfoByJob = (chunk: TrackChunk): Map<number, BrazeDestInfo> => {
 // OFF and ON emission paths — the request shape itself doesn't depend on the
 // flag; only the wrapping output structure and metadata do.
 const buildTrackRequest = (
-  chunk: TrackChunk,
+  chunk: TaggedTrackChunk,
   destination: BrazeDestination,
   headers: BrazeBatchHeaders,
   trackEndpoint: string,
@@ -949,7 +1050,7 @@ const buildTrackRequest = (
 // ON path: one BatchRequestOutput per track chunk, with per-metadata destInfo
 // positional maps consumed by the v1 networkHandler.
 const trackChunkResponse = (
-  chunk: TrackChunk,
+  chunk: TaggedTrackChunk,
   destination: BrazeDestination,
   headers: BrazeBatchHeaders,
   trackEndpoint: string,
@@ -1061,15 +1162,17 @@ type MergeRun = {
 };
 type Run = TrackRun | SubscriptionRun | MergeRun;
 
-// Type predicates narrow `BrazeBatchPayload` (a union) to its specific member
-// via `in` narrowing on each shape's distinguishing field. TS uses these to
-// eliminate the boundary casts we'd otherwise need at every read site.
-const isTrackBody = (json: BrazeBatchPayload): json is BrazeTrackRequestBody =>
-  'attributes' in json || 'events' in json || 'purchases' in json;
-const isSubscriptionBody = (json: BrazeBatchPayload): json is BrazeSubscriptionBatchPayload =>
-  'subscription_groups' in json;
-const isMergeBody = (json: BrazeBatchPayload): json is BrazeMergeBatchPayload =>
-  'merge_updates' in json;
+// Type predicates narrow an untyped body (whatever `body.JSON` is at runtime)
+// to a specific Braze payload shape via `in` narrowing on each shape's
+// distinguishing field. Consumers can then read member fields without casts.
+const isObjectPayload = (json: unknown): json is Record<string, unknown> =>
+  typeof json === 'object' && json !== null;
+const isTrackBody = (json: unknown): json is BrazeTrackRequestBody =>
+  isObjectPayload(json) && ('attributes' in json || 'events' in json || 'purchases' in json);
+const isSubscriptionBody = (json: unknown): json is BrazeSubscriptionBatchPayload =>
+  isObjectPayload(json) && 'subscription_groups' in json;
+const isMergeBody = (json: unknown): json is BrazeMergeBatchPayload =>
+  isObjectPayload(json) && 'merge_updates' in json;
 
 // Discriminated classification result: the run type + the narrowed body. The
 // caller can consume `classification.body` without casts.
@@ -1078,7 +1181,7 @@ type JobClassification =
   | { type: 'subscription'; body: BrazeSubscriptionBatchPayload }
   | { type: 'merge'; body: BrazeMergeBatchPayload };
 
-const classifyJobRun = (json: BrazeBatchPayload): JobClassification | null => {
+const classifyJobRun = (json: unknown): JobClassification | null => {
   if (isTrackBody(json)) {
     const hasTrackItems =
       (Array.isArray(json.attributes) && json.attributes.length > 0) ||
@@ -1097,42 +1200,307 @@ const classifyJobRun = (json: BrazeBatchPayload): JobClassification | null => {
   return null;
 };
 
-// Endpoints resolved once per invocation; passed into both emission helpers.
-type BrazeEndpoints = {
-  headers: BrazeBatchHeaders;
-  trackEndpoint: string;
-  trackPath: string;
-  subEndpoint: string;
-  subPath: string;
-  mergeEndpoint: string;
-  mergePath: string;
+function prepareGroupAndAliasBatch({
+  arrayChunks,
+  responseArray,
+  destination,
+  type,
+}:
+  | {
+      arrayChunks: BrazeSubscriptionGroup[][];
+      responseArray: unknown[];
+      destination: BrazeDestination;
+      type: 'subscription';
+    }
+  | {
+      arrayChunks: BrazeMergeUpdate[][];
+      responseArray: unknown[];
+      destination: BrazeDestination;
+      type: 'merge';
+    }) {
+  const headers = {
+    'Content-Type': JSON_MIME_TYPE,
+    Accept: JSON_MIME_TYPE,
+    Authorization: `Bearer ${destination.Config.restApiKey}`,
+  };
+
+  // Type narrowing: Check type BEFORE the loop so TypeScript can narrow arrayChunks
+  if (type === 'merge') {
+    // TypeScript now knows arrayChunks is BrazeMergeUpdate[][]
+    for (const chunk of arrayChunks) {
+      const response = defaultRequestConfig();
+      const { endpoint, path } = getAliasMergeEndPoint(getEndpointFromConfig(destination));
+      response.endpoint = endpoint;
+      response.endpointPath = path;
+      response.body.JSON = removeUndefinedAndNullValues({
+        merge_updates: chunk,
+      });
+      responseArray.push({
+        ...response,
+        headers,
+      });
+    }
+  } else {
+    // TypeScript now knows arrayChunks is BrazeSubscriptionGroup[][]
+    for (const chunk of arrayChunks) {
+      const response = defaultRequestConfig();
+      const { endpoint, path } = getSubscriptionGroupEndPoint(getEndpointFromConfig(destination));
+      response.endpoint = endpoint;
+      response.endpointPath = path;
+
+      stats.gauge('braze_batch_subscription_size', chunk.length, {
+        destination_id: destination.ID,
+      });
+
+      // Deduplicate the subscription groups before constructing the response body
+      // No type casting needed - TypeScript knows chunk is BrazeSubscriptionGroup[]
+      const deduplicatedSubscriptionGroups = combineSubscriptionGroups(chunk);
+
+      stats.gauge('braze_batch_subscription_combined_size', deduplicatedSubscriptionGroups.length, {
+        destination_id: destination.ID,
+      });
+
+      response.body.JSON = removeUndefinedAndNullValues({
+        subscription_groups: deduplicatedSubscriptionGroups,
+      });
+      responseArray.push({
+        ...response,
+        headers,
+      });
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// `processBatch` (OFF path — default).
+//
+// Restored verbatim from `develop` so the OFF path stays bit-identical to
+// the version reviewers have already accepted. Any change to the batching
+// semantics belongs in `processBatchWithDeliveryMapping` below.
+//
+// Selected by `transform.ts` when `BRAZE_PER_JOB_DELIVERY_MAPPING_ENABLED`
+// is unset — the default rollout state.
+// ---------------------------------------------------------------------------
+const processBatch = (transformedEvents: BrazeTransformedEvent[]) => {
+  const { destination, metadata } = transformedEvents[0];
+  const workspaceId = metadata?.[0]?.workspaceId || '';
+  const dest = destination;
+  const attributesArray: BrazeUserAttributes[] = [];
+  const eventsArray: BrazeEvent[] = [];
+  const purchaseArray: BrazePurchase[] = [];
+  const successMetadata: Partial<Metadata>[] = [];
+  const failureResponses: BrazeTransformedEvent[] = [];
+  const filteredResponses: BrazeTransformedEvent[] = [];
+  const subscriptionsArray: BrazeSubscriptionGroup[] = [];
+  const mergeUsersArray: BrazeMergeUpdate[] = [];
+  for (const transformedEvent of transformedEvents) {
+    if (!isHttpStatusSuccess(transformedEvent.statusCode)) {
+      failureResponses.push(transformedEvent);
+    } else if (transformedEvent.statusCode === HTTP_STATUS_CODES.FILTER_EVENTS) {
+      filteredResponses.push(transformedEvent);
+    } else if (transformedEvent.batchedRequest?.body?.JSON) {
+      const { attributes, events, purchases, subscription_groups, merge_updates } =
+        transformedEvent.batchedRequest.body.JSON;
+      if (Array.isArray(attributes)) {
+        attributesArray.push(...attributes);
+      }
+      if (Array.isArray(events)) {
+        eventsArray.push(...events);
+      }
+      if (Array.isArray(purchases)) {
+        purchaseArray.push(...purchases);
+      }
+
+      if (Array.isArray(subscription_groups)) {
+        subscriptionsArray.push(...subscription_groups);
+      }
+
+      if (Array.isArray(merge_updates)) {
+        mergeUsersArray.push(...merge_updates);
+      }
+
+      if (transformedEvent.metadata) {
+        successMetadata.push(...transformedEvent.metadata);
+      }
+    }
+  }
+  const isWorkspaceOnMauPlanFlag = isWorkspaceOnMauPlan(workspaceId);
+  const trackChunks = isWorkspaceOnMauPlanFlag
+    ? batchForTrackAPIV2(attributesArray, eventsArray, purchaseArray)
+    : batchForTrackAPI(attributesArray, eventsArray, purchaseArray);
+  const subscriptionArrayChunks = _.chunk(subscriptionsArray, SUBSCRIPTION_BRAZE_MAX_REQ_COUNT);
+  const mergeUsersArrayChunks = _.chunk(mergeUsersArray, ALIAS_BRAZE_MAX_REQ_COUNT);
+
+  const responseArray: BrazeBatchRequest[] = [];
+  const finalResponse: BrazeBatchResponse[] = [];
+  const headers: BrazeBatchHeaders = {
+    'Content-Type': JSON_MIME_TYPE,
+    Accept: JSON_MIME_TYPE,
+    Authorization: `Bearer ${dest.Config.restApiKey}`,
+  };
+
+  const { endpoint, path } = getTrackEndPoint(getEndpointFromConfig(destination));
+  for (const chunk of trackChunks) {
+    const cleanedChunk = cleanTrackChunk(chunk);
+    const { attributes, events, purchases } = cleanedChunk;
+    addTrackStats(chunk, destination);
+
+    const response = defaultRequestConfig();
+    response.endpoint = endpoint;
+    response.endpointPath = path;
+    response.body.JSON = {
+      partner: 'RudderStack',
+      attributes,
+      events,
+      purchases,
+    };
+    responseArray.push({
+      ...response,
+      headers,
+    });
+  }
+
+  prepareGroupAndAliasBatch({
+    arrayChunks: subscriptionArrayChunks,
+    responseArray,
+    destination,
+    type: 'subscription',
+  });
+  prepareGroupAndAliasBatch({
+    arrayChunks: mergeUsersArrayChunks,
+    responseArray,
+    destination,
+    type: 'merge',
+  });
+
+  if (successMetadata.length > 0) {
+    finalResponse.push({
+      batchedRequest: responseArray,
+      metadata: successMetadata,
+      batched: true,
+      statusCode: 200,
+      destination,
+    });
+  }
+  if (failureResponses.length > 0) {
+    finalResponse.push(...failureResponses);
+  }
+
+  if (filteredResponses.length > 0) {
+    finalResponse.push(...filteredResponses);
+  }
+
+  return finalResponse;
 };
 
-// ON path: one BatchRequestOutput per outgoing HTTP request, run-preserving.
-// Track chunks carry per-metadata destInfo positional maps; sub/merge chunks
-// carry destInfo:{} for correlation-shape uniformity across every chunk.
-const emitOnPath = (
-  runs: Run[],
-  destination: BrazeDestination,
-  endpoints: BrazeEndpoints,
-  jobMetadata: (Partial<Metadata>[] | undefined)[],
-  isWorkspaceOnMauPlanFlag: boolean,
+// ---------------------------------------------------------------------------
+// `processBatchWithDeliveryMapping` (ON path).
+//
+// Emits one BatchRequestOutput per outgoing HTTP request. Preserves the
+// input's insertion-order runs so per-user jobIds stay monotonic across the
+// emitted outputs. Track outputs carry per-metadata `destInfo` positional
+// maps consumed by the v1 networkHandler; subscription and alias-merge
+// outputs carry `destInfo: {}` for correlation-shape uniformity.
+//
+// Applies always-on batching improvements not present on the OFF path:
+// group-preserving chunking (a job's contributions never straddle chunks),
+// byte-size caps per item (100 KB) and per batch (4 MB), and up-front
+// oversized-job rejection.
+//
+// Selected by `transform.ts` when `BRAZE_PER_JOB_DELIVERY_MAPPING_ENABLED`
+// is set to `'true'`.
+// ---------------------------------------------------------------------------
+const processBatchWithDeliveryMapping = (
+  transformedEvents: BrazeTransformedEvent[],
 ): BrazeBatchResponse[] => {
-  const out: BrazeBatchResponse[] = [];
-  const { headers, trackEndpoint, trackPath, subEndpoint, subPath, mergeEndpoint, mergePath } =
-    endpoints;
+  const { destination } = transformedEvents[0];
+  const workspaceId = transformedEvents[0].metadata?.[0]?.workspaceId || '';
+
+  const failureResponses: BrazeTransformedEvent[] = [];
+  const filteredResponses: BrazeTransformedEvent[] = [];
+  const runs: Run[] = [];
+  const jobMetadata: (Partial<Metadata>[] | undefined)[] = new Array(transformedEvents.length);
+  let currentRun: Run | null = null;
+
+  transformedEvents.forEach((transformedEvent, jobIndex) => {
+    if (!isHttpStatusSuccess(transformedEvent.statusCode)) {
+      failureResponses.push(transformedEvent);
+      return;
+    }
+    if (transformedEvent.statusCode === HTTP_STATUS_CODES.FILTER_EVENTS) {
+      filteredResponses.push(transformedEvent);
+      return;
+    }
+    const json = transformedEvent.batchedRequest?.body?.JSON;
+    if (!json) return;
+
+    const classification = classifyJobRun(json);
+    if (!classification) return;
+
+    if (!currentRun || currentRun.type !== classification.type) {
+      if (classification.type === 'track') currentRun = { type: 'track', items: [] };
+      else if (classification.type === 'subscription')
+        currentRun = { type: 'subscription', items: [] };
+      else currentRun = { type: 'merge', items: [] };
+      runs.push(currentRun);
+    }
+
+    if (currentRun.type === 'track' && classification.type === 'track') {
+      const collection = collectTrackItemsForJob(classification.body, jobIndex);
+      if ('error' in collection) {
+        failureResponses.push({
+          ...transformedEvent,
+          statusCode: 400,
+          error: collection.error.message,
+          statTags: { errorType: 'aborted', errorCategory: 'dataValidation' },
+        });
+        return;
+      }
+      currentRun.items.push(...collection.items);
+    } else if (currentRun.type === 'subscription' && classification.type === 'subscription') {
+      for (const sg of classification.body.subscription_groups ?? []) {
+        currentRun.items.push({ data: sg, sourceJobIndex: jobIndex });
+      }
+    } else if (currentRun.type === 'merge' && classification.type === 'merge') {
+      for (const mu of classification.body.merge_updates ?? []) {
+        currentRun.items.push({ data: mu, sourceJobIndex: jobIndex });
+      }
+    }
+
+    if (transformedEvent.metadata) {
+      jobMetadata[jobIndex] = transformedEvent.metadata;
+    }
+  });
+
+  const isWorkspaceOnMauPlanFlag = isWorkspaceOnMauPlan(workspaceId);
+  const headers: BrazeBatchHeaders = {
+    'Content-Type': JSON_MIME_TYPE,
+    Accept: JSON_MIME_TYPE,
+    Authorization: `Bearer ${destination.Config.restApiKey}`,
+  };
+  const { endpoint: trackEndpoint, path: trackPath } = getTrackEndPoint(
+    getEndpointFromConfig(destination),
+  );
+  const { endpoint: subEndpoint, path: subPath } = getSubscriptionGroupEndPoint(
+    getEndpointFromConfig(destination),
+  );
+  const { endpoint: mergeEndpoint, path: mergePath } = getAliasMergeEndPoint(
+    getEndpointFromConfig(destination),
+  );
+
+  const finalResponse: BrazeBatchResponse[] = [];
   for (const run of runs) {
     if (run.type === 'track') {
       const chunks = chunkTaggedItems(run.items, isWorkspaceOnMauPlanFlag ? 'v2' : 'v1');
       for (const chunk of chunks) {
-        out.push(
+        finalResponse.push(
           trackChunkResponse(chunk, destination, headers, trackEndpoint, trackPath, jobMetadata),
         );
       }
     } else if (run.type === 'subscription') {
       const chunks = _.chunk(run.items, SUBSCRIPTION_BRAZE_MAX_REQ_COUNT);
       for (const chunk of chunks) {
-        out.push({
+        finalResponse.push({
           batchedRequest: buildSubscriptionRequest(
             chunk,
             destination,
@@ -1149,7 +1517,7 @@ const emitOnPath = (
     } else {
       const chunks = _.chunk(run.items, ALIAS_BRAZE_MAX_REQ_COUNT);
       for (const chunk of chunks) {
-        out.push({
+        finalResponse.push({
           batchedRequest: buildMergeRequest(chunk, headers, mergeEndpoint, mergePath),
           metadata: scopedMetadataForChunk(chunk, jobMetadata, true),
           batched: true,
@@ -1159,177 +1527,6 @@ const emitOnPath = (
       }
     }
   }
-  return out;
-};
-
-// OFF path (legacy pre-INT-6808 shape): a single MultiBatchRequestOutput
-// whose `batchedRequest` is a flat array of every outgoing HTTP request
-// across track/subscription/merge, paired with a flat successMetadata list.
-// Group-preserving chunking + byte-size caps + oversized-job rejection are
-// still enforced (kept as INT-6808 improvements applicable in both modes).
-const emitOffPath = (
-  runs: Run[],
-  destination: BrazeDestination,
-  endpoints: BrazeEndpoints,
-  jobMetadata: (Partial<Metadata>[] | undefined)[],
-  isWorkspaceOnMauPlanFlag: boolean,
-): BrazeBatchResponse[] => {
-  const { headers, trackEndpoint, trackPath, subEndpoint, subPath, mergeEndpoint, mergePath } =
-    endpoints;
-  const allTrackItems: TaggedItem[] = [];
-  const allSubItems: Array<{ data: BrazeSubscriptionGroup; sourceJobIndex: number }> = [];
-  const allMergeItems: Array<{ data: BrazeMergeUpdate; sourceJobIndex: number }> = [];
-  for (const run of runs) {
-    if (run.type === 'track') allTrackItems.push(...run.items);
-    else if (run.type === 'subscription') allSubItems.push(...run.items);
-    else allMergeItems.push(...run.items);
-  }
-
-  const batchedRequests: BrazeBatchRequest[] = [];
-  const trackChunks = chunkTaggedItems(allTrackItems, isWorkspaceOnMauPlanFlag ? 'v2' : 'v1');
-  for (const chunk of trackChunks) {
-    batchedRequests.push(buildTrackRequest(chunk, destination, headers, trackEndpoint, trackPath));
-  }
-  const subChunks = _.chunk(allSubItems, SUBSCRIPTION_BRAZE_MAX_REQ_COUNT);
-  for (const chunk of subChunks) {
-    batchedRequests.push(
-      buildSubscriptionRequest(chunk, destination, headers, subEndpoint, subPath),
-    );
-  }
-  const mergeChunks = _.chunk(allMergeItems, ALIAS_BRAZE_MAX_REQ_COUNT);
-  for (const chunk of mergeChunks) {
-    batchedRequests.push(buildMergeRequest(chunk, headers, mergeEndpoint, mergePath));
-  }
-
-  const successMetadata: Partial<Metadata>[] = [];
-  for (const meta of jobMetadata) {
-    if (meta) successMetadata.push(...meta);
-  }
-  if (successMetadata.length === 0) return [];
-  return [
-    {
-      batchedRequest: batchedRequests,
-      metadata: successMetadata,
-      batched: true,
-      statusCode: 200,
-      destination,
-    },
-  ];
-};
-
-// Ingest one transformedEvent into the appropriate collection bucket. Returns
-// true if the caller should stash `jobMetadata[jobIndex]`, false otherwise
-// (job was rejected or filtered).
-const ingestTransformedEvent = (
-  transformedEvent: BrazeTransformedEvent,
-  jobIndex: number,
-  buckets: {
-    failureResponses: BrazeTransformedEvent[];
-    filteredResponses: BrazeTransformedEvent[];
-    runs: Run[];
-    currentRunRef: { current: Run | null };
-  },
-): boolean => {
-  if (!isHttpStatusSuccess(transformedEvent.statusCode)) {
-    buckets.failureResponses.push(transformedEvent);
-    return false;
-  }
-  if (transformedEvent.statusCode === HTTP_STATUS_CODES.FILTER_EVENTS) {
-    buckets.filteredResponses.push(transformedEvent);
-    return false;
-  }
-  const json = transformedEvent.batchedRequest?.body?.JSON;
-  if (!json) return false;
-
-  const classification = classifyJobRun(json);
-  if (!classification) return false;
-
-  if (
-    !buckets.currentRunRef.current ||
-    buckets.currentRunRef.current.type !== classification.type
-  ) {
-    let run: Run;
-    if (classification.type === 'track') run = { type: 'track', items: [] };
-    else if (classification.type === 'subscription') run = { type: 'subscription', items: [] };
-    else run = { type: 'merge', items: [] };
-    buckets.runs.push(run);
-    buckets.currentRunRef.current = run;
-  }
-
-  const currentRun = buckets.currentRunRef.current;
-  if (currentRun.type === 'track' && classification.type === 'track') {
-    const collection = collectTrackItemsForJob(classification.body, jobIndex);
-    if ('error' in collection) {
-      buckets.failureResponses.push({
-        ...transformedEvent,
-        statusCode: 400,
-        error: collection.error.message,
-        statTags: { errorType: 'aborted', errorCategory: 'dataValidation' },
-      });
-      return false;
-    }
-    currentRun.items.push(...collection.items);
-  } else if (currentRun.type === 'subscription' && classification.type === 'subscription') {
-    for (const sg of classification.body.subscription_groups ?? []) {
-      currentRun.items.push({ data: sg, sourceJobIndex: jobIndex });
-    }
-  } else if (currentRun.type === 'merge' && classification.type === 'merge') {
-    for (const mu of classification.body.merge_updates ?? []) {
-      currentRun.items.push({ data: mu, sourceJobIndex: jobIndex });
-    }
-  }
-  return true;
-};
-
-const processBatch = (transformedEvents: BrazeTransformedEvent[]): BrazeBatchResponse[] => {
-  const { destination } = transformedEvents[0];
-  const workspaceId = transformedEvents[0].metadata?.[0]?.workspaceId || '';
-
-  const failureResponses: BrazeTransformedEvent[] = [];
-  const filteredResponses: BrazeTransformedEvent[] = [];
-  const runs: Run[] = [];
-  const jobMetadata: (Partial<Metadata>[] | undefined)[] = new Array(transformedEvents.length);
-  const currentRunRef: { current: Run | null } = { current: null };
-
-  transformedEvents.forEach((transformedEvent, jobIndex) => {
-    const kept = ingestTransformedEvent(transformedEvent, jobIndex, {
-      failureResponses,
-      filteredResponses,
-      runs,
-      currentRunRef,
-    });
-    if (kept && transformedEvent.metadata) {
-      jobMetadata[jobIndex] = transformedEvent.metadata;
-    }
-  });
-
-  const isWorkspaceOnMauPlanFlag = isWorkspaceOnMauPlan(workspaceId);
-  const baseEndpoint = getEndpointFromConfig(destination);
-  const trackEp = getTrackEndPoint(baseEndpoint);
-  const subEp = getSubscriptionGroupEndPoint(baseEndpoint);
-  const mergeEp = getAliasMergeEndPoint(baseEndpoint);
-  const endpoints: BrazeEndpoints = {
-    headers: {
-      'Content-Type': JSON_MIME_TYPE,
-      Accept: JSON_MIME_TYPE,
-      Authorization: `Bearer ${destination.Config.restApiKey}`,
-    },
-    trackEndpoint: trackEp.endpoint,
-    trackPath: trackEp.path,
-    subEndpoint: subEp.endpoint,
-    subPath: subEp.path,
-    mergeEndpoint: mergeEp.endpoint,
-    mergePath: mergeEp.path,
-  };
-
-  const emit = isPerJobDeliveryMappingEnabled() ? emitOnPath : emitOffPath;
-  const finalResponse: BrazeBatchResponse[] = emit(
-    runs,
-    destination,
-    endpoints,
-    jobMetadata,
-    isWorkspaceOnMauPlanFlag,
-  );
 
   if (failureResponses.length > 0) finalResponse.push(...failureResponses);
   if (filteredResponses.length > 0) finalResponse.push(...filteredResponses);
@@ -1589,6 +1786,7 @@ export {
   getEndpointFromConfig,
   processDeduplication,
   processBatch,
+  processBatchWithDeliveryMapping,
   addAppId,
   formatGender,
   getPurchaseObjs,

--- a/src/v0/destinations/braze/util.ts
+++ b/src/v0/destinations/braze/util.ts
@@ -1119,9 +1119,7 @@ const chunkTaggedItems = (items: TaggedItem[], mode: 'v1' | 'v2'): TaggedTrackCh
 // any cap is breached — caller pushes the event onto failureResponses. The
 // track body is passed in already-narrowed by the caller (typically after
 // `classifyJobRun` returned a `track` classification), so no cast is needed.
-type TrackCollectionResult =
-  | { items: TaggedItem[]; totalByteSize: number }
-  | { error: InstrumentationError };
+type TrackCollectionResult = { items: TaggedItem[] } | { error: InstrumentationError };
 
 const collectTrackItemsForJob = (
   body: BrazeTrackRequestBody,
@@ -1187,7 +1185,7 @@ const collectTrackItemsForJob = (
       ),
     };
   }
-  return { items, totalByteSize };
+  return { items };
 };
 
 // Build the per-metadata destInfo positional map for a chunk. Every unique
@@ -1197,31 +1195,18 @@ const collectTrackItemsForJob = (
 // case; longer for e.g. order-completed contributing multiple purchases).
 const buildDestInfoByJob = (chunk: TaggedTrackChunk): Map<number, BrazeDestInfo> => {
   const map = new Map<number, BrazeDestInfo>();
-  const ensure = (sji: number): BrazeDestInfo => {
-    let existing = map.get(sji);
-    if (!existing) {
-      existing = {};
-      map.set(sji, existing);
-    }
-    return existing;
-  };
-  const appendIdx = (
-    info: BrazeDestInfo,
+  const record = (
+    sji: number,
     key: 'attributesIndices' | 'eventsIndices' | 'purchasesIndices',
     idx: number,
   ) => {
-    info[key] = info[key] ?? [];
-    info[key]!.push(idx);
+    const info = map.get(sji) ?? {};
+    (info[key] ??= []).push(idx);
+    map.set(sji, info);
   };
-  chunk.attributesSourceJobIndex.forEach((sji: number, idx: number) => {
-    appendIdx(ensure(sji), 'attributesIndices', idx);
-  });
-  chunk.eventsSourceJobIndex.forEach((sji: number, idx: number) => {
-    appendIdx(ensure(sji), 'eventsIndices', idx);
-  });
-  chunk.purchasesSourceJobIndex.forEach((sji: number, idx: number) => {
-    appendIdx(ensure(sji), 'purchasesIndices', idx);
-  });
+  chunk.attributesSourceJobIndex.forEach((sji, idx) => record(sji, 'attributesIndices', idx));
+  chunk.eventsSourceJobIndex.forEach((sji, idx) => record(sji, 'eventsIndices', idx));
+  chunk.purchasesSourceJobIndex.forEach((sji, idx) => record(sji, 'purchasesIndices', idx));
   return map;
 };
 
@@ -1251,24 +1236,21 @@ const trackChunkResponse = (
   headers: BrazeBatchHeaders,
   trackEndpoint: string,
   trackPath: string,
-  jobMetadata: (Partial<Metadata>[] | undefined)[],
+  jobMetadata: Partial<Metadata>[][],
 ) => {
   const destInfoByJob = buildDestInfoByJob(chunk);
   const chunkMetadata: Partial<Metadata>[] = [];
   // Iterate sourceJobIndexes in insertion order (Set preserves it) so the
   // metadata slice ordering is deterministic and stable.
   for (const sji of chunk.sourceJobIndexes) {
-    const jobMeta = jobMetadata[sji];
-    if (jobMeta) {
-      // destInfo carries top-level index-array fields; no per-destination
-      // wrapper — Braze is the sole producer AND consumer of these fields.
-      const info = destInfoByJob.get(sji) ?? {};
-      for (const m of jobMeta) {
-        chunkMetadata.push({
-          ...m,
-          destInfo: { ...(m.destInfo ?? {}), ...info },
-        });
-      }
+    // destInfo carries top-level index-array fields; no per-destination
+    // wrapper — Braze is the sole producer AND consumer of these fields.
+    const info = destInfoByJob.get(sji) ?? {};
+    for (const m of jobMetadata[sji]) {
+      chunkMetadata.push({
+        ...m,
+        destInfo: { ...(m.destInfo ?? {}), ...info },
+      });
     }
   }
   return {
@@ -1282,12 +1264,11 @@ const trackChunkResponse = (
 
 // Collect scoped metadata for a subscription/merge chunk. A single job may
 // contribute multiple entries but must be listed once in the chunk's metadata.
-// Under the ON path, sub/merge outputs must still carry `destInfo: {}` per the
-// design doc (present-but-empty for correlation-shape uniformity across every
-// chunk); OFF path preserves raw metadata unchanged.
+// Under the ON path, sub/merge outputs still carry `destInfo: {}` (present-
+// but-empty for correlation-shape uniformity across every chunk).
 const scopedMetadataForChunk = <T extends { sourceJobIndex: number }>(
   chunk: T[],
-  jobMetadata: (Partial<Metadata>[] | undefined)[],
+  jobMetadata: Partial<Metadata>[][],
   withEmptyDestInfo: boolean,
 ): Partial<Metadata>[] => {
   const seen = new Set<number>();
@@ -1295,11 +1276,8 @@ const scopedMetadataForChunk = <T extends { sourceJobIndex: number }>(
   for (const entry of chunk) {
     if (!seen.has(entry.sourceJobIndex)) {
       seen.add(entry.sourceJobIndex);
-      const jobMeta = jobMetadata[entry.sourceJobIndex];
-      if (jobMeta) {
-        for (const m of jobMeta) {
-          out.push(withEmptyDestInfo ? { ...m, destInfo: { ...(m.destInfo ?? {}) } } : m);
-        }
+      for (const m of jobMetadata[entry.sourceJobIndex]) {
+        out.push(withEmptyDestInfo ? { ...m, destInfo: { ...(m.destInfo ?? {}) } } : m);
       }
     }
   }
@@ -1342,22 +1320,6 @@ const buildMergeRequest = (
   return { ...request, headers };
 };
 
-// A run is a contiguous stretch of same-endpoint jobs in the input's insertion
-// order. Walking the input job-by-job and emitting outputs at endpoint
-// boundaries preserves the invariant that jobIds within a user remain
-// monotonically ascending across the emitted outputs — the semantic
-// rudder-server relies on for causal ordering.
-type TrackRun = { type: 'track'; items: TaggedItem[] };
-type SubscriptionRun = {
-  type: 'subscription';
-  items: Array<{ data: BrazeSubscriptionGroup; sourceJobIndex: number }>;
-};
-type MergeRun = {
-  type: 'merge';
-  items: Array<{ data: BrazeMergeUpdate; sourceJobIndex: number }>;
-};
-type Run = TrackRun | SubscriptionRun | MergeRun;
-
 // Type predicates narrow an untyped body (whatever `body.JSON` is at runtime)
 // to a specific Braze payload shape via `in` narrowing on each shape's
 // distinguishing field. Consumers can then read member fields without casts.
@@ -1377,23 +1339,16 @@ type JobClassification =
   | { type: 'subscription'; body: BrazeSubscriptionBatchPayload }
   | { type: 'merge'; body: BrazeMergeBatchPayload };
 
-const classifyJobRun = (json: unknown): JobClassification | null => {
-  if (isTrackBody(json)) {
-    const hasTrackItems =
-      (Array.isArray(json.attributes) && json.attributes.length > 0) ||
-      (Array.isArray(json.events) && json.events.length > 0) ||
-      (Array.isArray(json.purchases) && json.purchases.length > 0);
-    if (hasTrackItems) return { type: 'track', body: json };
-  }
-  if (
-    isSubscriptionBody(json) &&
-    Array.isArray(json.subscription_groups) &&
-    json.subscription_groups.length > 0
-  )
-    return { type: 'subscription', body: json };
-  if (isMergeBody(json) && Array.isArray(json.merge_updates) && json.merge_updates.length > 0)
-    return { type: 'merge', body: json };
-  return null;
+// The upstream router transform always produces a body matching one of the
+// three Braze payload shapes, so this classifier is total. If the contract
+// is ever violated we throw rather than silently drop the job.
+const classifyJobRun = (json: unknown): JobClassification => {
+  if (isTrackBody(json)) return { type: 'track', body: json };
+  if (isSubscriptionBody(json)) return { type: 'subscription', body: json };
+  if (isMergeBody(json)) return { type: 'merge', body: json };
+  throw new InstrumentationError(
+    'Braze processBatchWithDeliveryMapping: body is neither track, subscription, nor merge',
+  );
 };
 
 // ---------------------------------------------------------------------------
@@ -1421,10 +1376,13 @@ const processBatchWithDeliveryMapping = (
 
   const failureResponses: BrazeTransformedEvent[] = [];
   const filteredResponses: BrazeTransformedEvent[] = [];
-  const runs: Run[] = [];
-  const jobMetadata: (Partial<Metadata>[] | undefined)[] = new Array(transformedEvents.length);
-  let currentRun: Run | null = null;
-
+  const trackItems: TaggedItem[] = [];
+  const subItems: Array<{ data: BrazeSubscriptionGroup; sourceJobIndex: number }> = [];
+  const mergeItems: Array<{ data: BrazeMergeUpdate; sourceJobIndex: number }> = [];
+  const jobMetadata: Partial<Metadata>[][] = Array.from(
+    { length: transformedEvents.length },
+    () => [],
+  );
   transformedEvents.forEach((transformedEvent, jobIndex) => {
     if (!isHttpStatusSuccess(transformedEvent.statusCode)) {
       failureResponses.push(transformedEvent);
@@ -1434,21 +1392,9 @@ const processBatchWithDeliveryMapping = (
       filteredResponses.push(transformedEvent);
       return;
     }
-    const json = transformedEvent.batchedRequest?.body?.JSON;
-    if (!json) return;
+    const classification = classifyJobRun(transformedEvent.batchedRequest?.body?.JSON);
 
-    const classification = classifyJobRun(json);
-    if (!classification) return;
-
-    if (!currentRun || currentRun.type !== classification.type) {
-      if (classification.type === 'track') currentRun = { type: 'track', items: [] };
-      else if (classification.type === 'subscription')
-        currentRun = { type: 'subscription', items: [] };
-      else currentRun = { type: 'merge', items: [] };
-      runs.push(currentRun);
-    }
-
-    if (currentRun.type === 'track' && classification.type === 'track') {
+    if (classification.type === 'track') {
       const collection = collectTrackItemsForJob(classification.body, jobIndex);
       if ('error' in collection) {
         failureResponses.push({
@@ -1459,14 +1405,14 @@ const processBatchWithDeliveryMapping = (
         });
         return;
       }
-      currentRun.items.push(...collection.items);
-    } else if (currentRun.type === 'subscription' && classification.type === 'subscription') {
+      trackItems.push(...collection.items);
+    } else if (classification.type === 'subscription') {
       for (const sg of classification.body.subscription_groups ?? []) {
-        currentRun.items.push({ data: sg, sourceJobIndex: jobIndex });
+        subItems.push({ data: sg, sourceJobIndex: jobIndex });
       }
-    } else if (currentRun.type === 'merge' && classification.type === 'merge') {
+    } else {
       for (const mu of classification.body.merge_updates ?? []) {
-        currentRun.items.push({ data: mu, sourceJobIndex: jobIndex });
+        mergeItems.push({ data: mu, sourceJobIndex: jobIndex });
       }
     }
 
@@ -1492,43 +1438,31 @@ const processBatchWithDeliveryMapping = (
   );
 
   const finalResponse: BrazeBatchResponse[] = [];
-  for (const run of runs) {
-    if (run.type === 'track') {
-      const chunks = chunkTaggedItems(run.items, isWorkspaceOnMauPlanFlag ? 'v2' : 'v1');
-      for (const chunk of chunks) {
-        finalResponse.push(
-          trackChunkResponse(chunk, destination, headers, trackEndpoint, trackPath, jobMetadata),
-        );
-      }
-    } else if (run.type === 'subscription') {
-      const chunks = _.chunk(run.items, SUBSCRIPTION_BRAZE_MAX_REQ_COUNT);
-      for (const chunk of chunks) {
-        finalResponse.push({
-          batchedRequest: buildSubscriptionRequest(
-            chunk,
-            destination,
-            headers,
-            subEndpoint,
-            subPath,
-          ),
-          metadata: scopedMetadataForChunk(chunk, jobMetadata, true),
-          batched: true,
-          statusCode: 200,
-          destination,
-        });
-      }
-    } else {
-      const chunks = _.chunk(run.items, ALIAS_BRAZE_MAX_REQ_COUNT);
-      for (const chunk of chunks) {
-        finalResponse.push({
-          batchedRequest: buildMergeRequest(chunk, headers, mergeEndpoint, mergePath),
-          metadata: scopedMetadataForChunk(chunk, jobMetadata, true),
-          batched: true,
-          statusCode: 200,
-          destination,
-        });
-      }
-    }
+  const trackChunks = chunkTaggedItems(trackItems, isWorkspaceOnMauPlanFlag ? 'v2' : 'v1');
+  for (const chunk of trackChunks) {
+    finalResponse.push(
+      trackChunkResponse(chunk, destination, headers, trackEndpoint, trackPath, jobMetadata),
+    );
+  }
+  const subChunks = _.chunk(subItems, SUBSCRIPTION_BRAZE_MAX_REQ_COUNT);
+  for (const chunk of subChunks) {
+    finalResponse.push({
+      batchedRequest: buildSubscriptionRequest(chunk, destination, headers, subEndpoint, subPath),
+      metadata: scopedMetadataForChunk(chunk, jobMetadata, true),
+      batched: true,
+      statusCode: 200,
+      destination,
+    });
+  }
+  const mergeChunks = _.chunk(mergeItems, ALIAS_BRAZE_MAX_REQ_COUNT);
+  for (const chunk of mergeChunks) {
+    finalResponse.push({
+      batchedRequest: buildMergeRequest(chunk, headers, mergeEndpoint, mergePath),
+      metadata: scopedMetadataForChunk(chunk, jobMetadata, true),
+      batched: true,
+      statusCode: 200,
+      destination,
+    });
   }
 
   if (failureResponses.length > 0) finalResponse.push(...failureResponses);

--- a/src/v0/destinations/braze/util.ts
+++ b/src/v0/destinations/braze/util.ts
@@ -34,6 +34,10 @@ import {
 } from './config';
 import { JSON_MIME_TYPE, HTTP_STATUS_CODES } from '../../util/constant';
 import {
+  BrazeBatchPayload,
+  BrazeTrackRequestBody,
+  BrazeSubscriptionBatchPayload,
+  BrazeMergeBatchPayload,
   BrazeDestination,
   BrazeRouterRequest,
   BrazeBatchHeaders,
@@ -543,20 +547,32 @@ const processDeduplication = (
 // an entire job's items atomically to a chunk, preventing cross-chunk straddle.
 //
 // Each `TrackChunk` also stores parallel `*SourceJobIndex` arrays so that
-// `processBatch` can build the per-metadata `destInfo.braze` positional map
-// (attributesIndex / eventsIndex / purchasesIndexes) that the v1 networkHandler
-// uses to correlate Braze's per-item warnings back to originating jobs.
+// `processBatch` can build the per-metadata `destInfo` positional map
+// (attributesIndices / eventsIndices / purchasesIndices) that the v1
+// networkHandler uses to correlate Braze's per-item warnings back to
+// originating jobs.
 // ---------------------------------------------------------------------------
 
-type ItemType = 'attributes' | 'events' | 'purchases';
-
-type TaggedItem = {
-  data: BrazeUserAttributes | BrazeEvent | BrazePurchase;
-  type: ItemType;
+type TaggedItemCommon = {
   externalId?: string;
   sourceJobIndex: number;
   byteSize: number;
 };
+
+// Discriminated union so `item.type === 'attributes'` narrows `item.data` to
+// `BrazeUserAttributes` (etc.) at every read site — no casts.
+type TaggedItem =
+  | (TaggedItemCommon & { type: 'attributes'; data: BrazeUserAttributes })
+  | (TaggedItemCommon & { type: 'events'; data: BrazeEvent })
+  | (TaggedItemCommon & { type: 'purchases'; data: BrazePurchase });
+
+// Contribution shape used by `collectTrackItemsForJob`'s inner helper: the
+// per-item data plus its type discriminant. Callers construct one of these
+// three shapes at the call site, so TS knows `data`'s type without casts.
+type TrackContribution =
+  | { type: 'attributes'; data: BrazeUserAttributes }
+  | { type: 'events'; data: BrazeEvent }
+  | { type: 'purchases'; data: BrazePurchase };
 
 type TrackChunk = {
   attributes: BrazeUserAttributes[];
@@ -651,13 +667,13 @@ const groupBySourceJob = (sortedItems: TaggedItem[]): TaggedItem[][] => {
 const addGroupToChunk = (chunk: TrackChunk, group: TaggedItem[]): void => {
   for (const item of group) {
     if (item.type === 'attributes') {
-      chunk.attributes.push(item.data as BrazeUserAttributes);
+      chunk.attributes.push(item.data);
       chunk.attributesSourceJobIndex.push(item.sourceJobIndex);
     } else if (item.type === 'events') {
-      chunk.events.push(item.data as BrazeEvent);
+      chunk.events.push(item.data);
       chunk.eventsSourceJobIndex.push(item.sourceJobIndex);
     } else {
-      chunk.purchases.push(item.data as BrazePurchase);
+      chunk.purchases.push(item.data);
       chunk.purchasesSourceJobIndex.push(item.sourceJobIndex);
     }
     if (item.externalId) {
@@ -800,43 +816,35 @@ const isWorkspaceOnMauPlan = (workspaceId) => {
 };
 
 // Collect tagged /users/track items for a single transformedEvent while
-// enforcing per-item and per-job byte-size caps. Returns null if any cap
-// is breached — caller pushes the event onto failureResponses.
+// enforcing per-item and per-job byte-size caps. Returns an error result if
+// any cap is breached — caller pushes the event onto failureResponses. The
+// track body is passed in already-narrowed by the caller (typically after
+// `classifyJobRun` returned a `track` classification), so no cast is needed.
 type TrackCollectionResult =
   | { items: TaggedItem[]; totalByteSize: number }
   | { error: InstrumentationError };
 
 const collectTrackItemsForJob = (
-  transformedEvent: BrazeTransformedEvent,
+  body: BrazeTrackRequestBody,
   jobIndex: number,
 ): TrackCollectionResult => {
-  const json = transformedEvent.batchedRequest?.body?.JSON as
-    | { attributes?: unknown; events?: unknown; purchases?: unknown }
-    | undefined;
-  const attrArr = Array.isArray(json?.attributes)
-    ? (json!.attributes as BrazeUserAttributes[])
-    : [];
-  const evtArr = Array.isArray(json?.events) ? (json!.events as BrazeEvent[]) : [];
-  const purArr = Array.isArray(json?.purchases) ? (json!.purchases as BrazePurchase[]) : [];
+  const attrArr = Array.isArray(body.attributes) ? body.attributes : [];
+  const evtArr = Array.isArray(body.events) ? body.events : [];
+  const purArr = Array.isArray(body.purchases) ? body.purchases : [];
 
   const items: TaggedItem[] = [];
   let totalByteSize = 0;
 
-  const tryAdd = (
-    data: unknown,
-    type: ItemType,
-    externalId?: string,
-  ): InstrumentationError | null => {
-    const byteSize = computeItemByteSize(data);
+  const tryAdd = (contribution: TrackContribution): InstrumentationError | null => {
+    const byteSize = computeItemByteSize(contribution.data);
     if (byteSize > TRACK_BRAZE_MAX_ITEM_BYTE_SIZE) {
       return new InstrumentationError(
-        `[Braze] Single ${type} item exceeds ${TRACK_BRAZE_MAX_ITEM_BYTE_SIZE} bytes (got ${byteSize})`,
+        `[Braze] Single ${contribution.type} item exceeds ${TRACK_BRAZE_MAX_ITEM_BYTE_SIZE} bytes (got ${byteSize})`,
       );
     }
     items.push({
-      data: data as TaggedItem['data'],
-      type,
-      externalId,
+      ...contribution,
+      externalId: contribution.data.external_id,
       sourceJobIndex: jobIndex,
       byteSize,
     });
@@ -846,19 +854,19 @@ const collectTrackItemsForJob = (
 
   for (const attr of attrArr) {
     if (isDefinedAndNotNull(attr)) {
-      const err = tryAdd(attr, 'attributes', attr.external_id);
+      const err = tryAdd({ type: 'attributes', data: attr });
       if (err) return { error: err };
     }
   }
   for (const evt of evtArr) {
     if (isDefinedAndNotNull(evt)) {
-      const err = tryAdd(evt, 'events', evt.external_id);
+      const err = tryAdd({ type: 'events', data: evt });
       if (err) return { error: err };
     }
   }
   for (const pur of purArr) {
     if (isDefinedAndNotNull(pur)) {
-      const err = tryAdd(pur, 'purchases', pur.external_id);
+      const err = tryAdd({ type: 'purchases', data: pur });
       if (err) return { error: err };
     }
   }
@@ -883,9 +891,11 @@ const collectTrackItemsForJob = (
   return { items, totalByteSize };
 };
 
-// Build the per-metadata destInfo.braze positional map for a chunk. Every
-// unique sourceJobIndex in the chunk gets one BrazeDestInfo describing where
-// that job's items landed within this chunk's attributes[]/events[]/purchases[].
+// Build the per-metadata destInfo positional map for a chunk. Every unique
+// sourceJobIndex in the chunk gets one BrazeDestInfo describing where that
+// job's items landed within this chunk's attributes[]/events[]/purchases[].
+// All three fields are arrays (length 1 for the standard single-contribution
+// case; longer for e.g. order-completed contributing multiple purchases).
 const buildDestInfoByJob = (chunk: TrackChunk): Map<number, BrazeDestInfo> => {
   const map = new Map<number, BrazeDestInfo>();
   const ensure = (sji: number): BrazeDestInfo => {
@@ -896,16 +906,22 @@ const buildDestInfoByJob = (chunk: TrackChunk): Map<number, BrazeDestInfo> => {
     }
     return existing;
   };
+  const appendIdx = (
+    info: BrazeDestInfo,
+    key: 'attributesIndices' | 'eventsIndices' | 'purchasesIndices',
+    idx: number,
+  ) => {
+    info[key] = info[key] ?? [];
+    info[key]!.push(idx);
+  };
   chunk.attributesSourceJobIndex.forEach((sji: number, idx: number) => {
-    ensure(sji).attributesIndex = idx;
+    appendIdx(ensure(sji), 'attributesIndices', idx);
   });
   chunk.eventsSourceJobIndex.forEach((sji: number, idx: number) => {
-    ensure(sji).eventsIndex = idx;
+    appendIdx(ensure(sji), 'eventsIndices', idx);
   });
   chunk.purchasesSourceJobIndex.forEach((sji: number, idx: number) => {
-    const info = ensure(sji);
-    info.purchasesIndexes = info.purchasesIndexes ?? [];
-    info.purchasesIndexes.push(idx);
+    appendIdx(ensure(sji), 'purchasesIndices', idx);
   });
   return map;
 };
@@ -931,11 +947,13 @@ const trackChunkResponse = (
   for (const sji of chunk.sourceJobIndexes) {
     const jobMeta = jobMetadata[sji];
     if (jobMeta) {
-      const braze = destInfoByJob.get(sji);
+      // destInfo carries top-level index-array fields; no per-destination
+      // wrapper — Braze is the sole producer AND consumer of these fields.
+      const info = destInfoByJob.get(sji) ?? {};
       for (const m of jobMeta) {
         chunkMetadata.push({
           ...m,
-          destInfo: { ...(m.destInfo ?? {}), braze },
+          destInfo: { ...(m.destInfo ?? {}), ...info },
         });
       }
     }
@@ -975,24 +993,47 @@ const scopedMetadataForChunk = <T extends { sourceJobIndex: number }>(
 type TrackRun = { type: 'track'; items: TaggedItem[] };
 type SubscriptionRun = {
   type: 'subscription';
-  entries: Array<{ data: BrazeSubscriptionGroup; sourceJobIndex: number }>;
+  items: Array<{ data: BrazeSubscriptionGroup; sourceJobIndex: number }>;
 };
 type MergeRun = {
   type: 'merge';
-  entries: Array<{ data: BrazeMergeUpdate; sourceJobIndex: number }>;
+  items: Array<{ data: BrazeMergeUpdate; sourceJobIndex: number }>;
 };
 type Run = TrackRun | SubscriptionRun | MergeRun;
 
-const classifyJobRun = (json: Record<string, unknown>): Run['type'] | null => {
-  const hasTrackItems =
-    (Array.isArray(json.attributes) && (json.attributes as unknown[]).length > 0) ||
-    (Array.isArray(json.events) && (json.events as unknown[]).length > 0) ||
-    (Array.isArray(json.purchases) && (json.purchases as unknown[]).length > 0);
-  if (hasTrackItems) return 'track';
-  if (Array.isArray(json.subscription_groups) && (json.subscription_groups as unknown[]).length > 0)
-    return 'subscription';
-  if (Array.isArray(json.merge_updates) && (json.merge_updates as unknown[]).length > 0)
-    return 'merge';
+// Type predicates narrow `BrazeBatchPayload` (a union) to its specific member
+// via `in` narrowing on each shape's distinguishing field. TS uses these to
+// eliminate the boundary casts we'd otherwise need at every read site.
+const isTrackBody = (json: BrazeBatchPayload): json is BrazeTrackRequestBody =>
+  'attributes' in json || 'events' in json || 'purchases' in json;
+const isSubscriptionBody = (json: BrazeBatchPayload): json is BrazeSubscriptionBatchPayload =>
+  'subscription_groups' in json;
+const isMergeBody = (json: BrazeBatchPayload): json is BrazeMergeBatchPayload =>
+  'merge_updates' in json;
+
+// Discriminated classification result: the run type + the narrowed body. The
+// caller can consume `classification.body` without casts.
+type JobClassification =
+  | { type: 'track'; body: BrazeTrackRequestBody }
+  | { type: 'subscription'; body: BrazeSubscriptionBatchPayload }
+  | { type: 'merge'; body: BrazeMergeBatchPayload };
+
+const classifyJobRun = (json: BrazeBatchPayload): JobClassification | null => {
+  if (isTrackBody(json)) {
+    const hasTrackItems =
+      (Array.isArray(json.attributes) && json.attributes.length > 0) ||
+      (Array.isArray(json.events) && json.events.length > 0) ||
+      (Array.isArray(json.purchases) && json.purchases.length > 0);
+    if (hasTrackItems) return { type: 'track', body: json };
+  }
+  if (
+    isSubscriptionBody(json) &&
+    Array.isArray(json.subscription_groups) &&
+    json.subscription_groups.length > 0
+  )
+    return { type: 'subscription', body: json };
+  if (isMergeBody(json) && Array.isArray(json.merge_updates) && json.merge_updates.length > 0)
+    return { type: 'merge', body: json };
   return null;
 };
 
@@ -1008,8 +1049,8 @@ const processBatch = (transformedEvents: BrazeTransformedEvent[]): BrazeBatchRes
   const openNewRun = (type: Run['type']): Run => {
     let run: Run;
     if (type === 'track') run = { type: 'track', items: [] };
-    else if (type === 'subscription') run = { type: 'subscription', entries: [] };
-    else run = { type: 'merge', entries: [] };
+    else if (type === 'subscription') run = { type: 'subscription', items: [] };
+    else run = { type: 'merge', items: [] };
     runs.push(run);
     return run;
   };
@@ -1025,18 +1066,18 @@ const processBatch = (transformedEvents: BrazeTransformedEvent[]): BrazeBatchRes
       filteredResponses.push(transformedEvent);
       return;
     }
-    const json = transformedEvent.batchedRequest?.body?.JSON as Record<string, unknown> | undefined;
+    const json = transformedEvent.batchedRequest?.body?.JSON;
     if (!json) return;
 
-    const runType = classifyJobRun(json);
-    if (!runType) return;
+    const classification = classifyJobRun(json);
+    if (!classification) return;
 
-    if (!currentRun || currentRun.type !== runType) {
-      currentRun = openNewRun(runType);
+    if (!currentRun || currentRun.type !== classification.type) {
+      currentRun = openNewRun(classification.type);
     }
 
-    if (currentRun.type === 'track') {
-      const collection = collectTrackItemsForJob(transformedEvent, jobIndex);
+    if (currentRun.type === 'track' && classification.type === 'track') {
+      const collection = collectTrackItemsForJob(classification.body, jobIndex);
       if ('error' in collection) {
         failureResponses.push({
           ...transformedEvent,
@@ -1047,13 +1088,13 @@ const processBatch = (transformedEvents: BrazeTransformedEvent[]): BrazeBatchRes
         return;
       }
       currentRun.items.push(...collection.items);
-    } else if (currentRun.type === 'subscription') {
-      for (const sg of json.subscription_groups as BrazeSubscriptionGroup[]) {
-        currentRun.entries.push({ data: sg, sourceJobIndex: jobIndex });
+    } else if (currentRun.type === 'subscription' && classification.type === 'subscription') {
+      for (const sg of classification.body.subscription_groups ?? []) {
+        currentRun.items.push({ data: sg, sourceJobIndex: jobIndex });
       }
-    } else {
-      for (const mu of json.merge_updates as BrazeMergeUpdate[]) {
-        currentRun.entries.push({ data: mu, sourceJobIndex: jobIndex });
+    } else if (currentRun.type === 'merge' && classification.type === 'merge') {
+      for (const mu of classification.body.merge_updates ?? []) {
+        currentRun.items.push({ data: mu, sourceJobIndex: jobIndex });
       }
     }
 
@@ -1089,7 +1130,7 @@ const processBatch = (transformedEvents: BrazeTransformedEvent[]): BrazeBatchRes
         );
       }
     } else if (run.type === 'subscription') {
-      const chunks = _.chunk(run.entries, SUBSCRIPTION_BRAZE_MAX_REQ_COUNT);
+      const chunks = _.chunk(run.items, SUBSCRIPTION_BRAZE_MAX_REQ_COUNT);
       for (const chunk of chunks) {
         const rawGroups = chunk.map((e) => e.data);
         stats.gauge('braze_batch_subscription_size', rawGroups.length, {
@@ -1112,7 +1153,7 @@ const processBatch = (transformedEvents: BrazeTransformedEvent[]): BrazeBatchRes
         });
       }
     } else {
-      const chunks = _.chunk(run.entries, ALIAS_BRAZE_MAX_REQ_COUNT);
+      const chunks = _.chunk(run.items, ALIAS_BRAZE_MAX_REQ_COUNT);
       for (const chunk of chunks) {
         const rawMerges = chunk.map((e) => e.data);
         const request = defaultRequestConfig();

--- a/src/v0/destinations/braze/util.ts
+++ b/src/v0/destinations/braze/util.ts
@@ -18,6 +18,7 @@ import {
 } from '../../util';
 import {
   BRAZE_NON_BILLABLE_ATTRIBUTES,
+  BRAZE_PARTNER_NAME,
   TRACK_BRAZE_MAX_EXTERNAL_ID_COUNT,
   CustomAttributeOperationTypes,
   getTrackEndPoint,
@@ -26,6 +27,8 @@ import {
   SUBSCRIPTION_BRAZE_MAX_REQ_COUNT,
   ALIAS_BRAZE_MAX_REQ_COUNT,
   TRACK_BRAZE_MAX_REQ_COUNT,
+  TRACK_BRAZE_MAX_ITEM_BYTE_SIZE,
+  TRACK_BRAZE_MAX_BATCH_BYTE_SIZE,
   BRAZE_PURCHASE_STANDARD_PROPERTIES,
   DESTINATION,
 } from './config';
@@ -36,7 +39,7 @@ import {
   BrazeBatchHeaders,
   BrazeTransformedEvent,
   BrazeBatchResponse,
-  BrazeBatchRequest,
+  BrazeDestInfo,
   BrazeSubscriptionGroup,
   BrazeAliasToIdentify,
   BrazeUserExportResponse,
@@ -49,13 +52,6 @@ import {
   BrazeMergeUpdate,
 } from './types';
 import type { Metadata } from '../../../types';
-
-type TrackChunk = {
-  attributes: BrazeUserAttributes[];
-  events: BrazeEvent[];
-  purchases: BrazePurchase[];
-  externalIds: Set<string>;
-};
 
 const formatGender = (gender: unknown) => {
   if (typeof gender !== 'string') {
@@ -537,247 +533,239 @@ const processDeduplication = (
   return null;
 };
 
-function prepareGroupAndAliasBatch({
-  arrayChunks,
-  responseArray,
-  destination,
-  type,
-}:
-  | {
-      arrayChunks: BrazeSubscriptionGroup[][];
-      responseArray: unknown[];
-      destination: BrazeDestination;
-      type: 'subscription';
-    }
-  | {
-      arrayChunks: BrazeMergeUpdate[][];
-      responseArray: unknown[];
-      destination: BrazeDestination;
-      type: 'merge';
-    }) {
-  const headers = {
-    'Content-Type': JSON_MIME_TYPE,
-    Accept: JSON_MIME_TYPE,
-    Authorization: `Bearer ${destination.Config.restApiKey}`,
-  };
+// ---------------------------------------------------------------------------
+// Batching data structures
+//
+// The batching pipeline flattens every job's contributions into tagged items,
+// each carrying a back-pointer to its source job (`sourceJobIndex`) plus its
+// pre-computed serialized byte size. A stable sort by (externalId, sourceJob)
+// keeps same-user AND same-job items contiguous so `chunkTaggedItems` can add
+// an entire job's items atomically to a chunk, preventing cross-chunk straddle.
+//
+// Each `TrackChunk` also stores parallel `*SourceJobIndex` arrays so that
+// `processBatch` can build the per-metadata `destInfo.braze` positional map
+// (attributesIndex / eventsIndex / purchasesIndexes) that the v1 networkHandler
+// uses to correlate Braze's per-item warnings back to originating jobs.
+// ---------------------------------------------------------------------------
 
-  // Type narrowing: Check type BEFORE the loop so TypeScript can narrow arrayChunks
-  if (type === 'merge') {
-    // TypeScript now knows arrayChunks is BrazeMergeUpdate[][]
-    for (const chunk of arrayChunks) {
-      const response = defaultRequestConfig();
-      const { endpoint, path } = getAliasMergeEndPoint(getEndpointFromConfig(destination));
-      response.endpoint = endpoint;
-      response.endpointPath = path;
-      response.body.JSON = removeUndefinedAndNullValues({
-        merge_updates: chunk,
-      });
-      responseArray.push({
-        ...response,
-        headers,
-      });
-    }
-  } else {
-    // TypeScript now knows arrayChunks is BrazeSubscriptionGroup[][]
-    for (const chunk of arrayChunks) {
-      const response = defaultRequestConfig();
-      const { endpoint, path } = getSubscriptionGroupEndPoint(getEndpointFromConfig(destination));
-      response.endpoint = endpoint;
-      response.endpointPath = path;
+type ItemType = 'attributes' | 'events' | 'purchases';
 
-      stats.gauge('braze_batch_subscription_size', chunk.length, {
-        destination_id: destination.ID,
-      });
+type TaggedItem = {
+  data: BrazeUserAttributes | BrazeEvent | BrazePurchase;
+  type: ItemType;
+  externalId?: string;
+  sourceJobIndex: number;
+  byteSize: number;
+};
 
-      // Deduplicate the subscription groups before constructing the response body
-      // No type casting needed - TypeScript knows chunk is BrazeSubscriptionGroup[]
-      const deduplicatedSubscriptionGroups = combineSubscriptionGroups(chunk);
+type TrackChunk = {
+  attributes: BrazeUserAttributes[];
+  attributesSourceJobIndex: number[];
+  events: BrazeEvent[];
+  eventsSourceJobIndex: number[];
+  purchases: BrazePurchase[];
+  purchasesSourceJobIndex: number[];
+  externalIds: Set<string>;
+  sourceJobIndexes: Set<number>;
+  byteSize: number;
+};
 
-      stats.gauge('braze_batch_subscription_combined_size', deduplicatedSubscriptionGroups.length, {
-        destination_id: destination.ID,
-      });
-
-      response.body.JSON = removeUndefinedAndNullValues({
-        subscription_groups: deduplicatedSubscriptionGroups,
-      });
-      responseArray.push({
-        ...response,
-        headers,
-      });
-    }
-  }
-}
+const computeItemByteSize = (item: unknown): number => Buffer.byteLength(JSON.stringify(item));
 
 const createTrackChunk = (): TrackChunk => ({
   attributes: [],
+  attributesSourceJobIndex: [],
   events: [],
+  eventsSourceJobIndex: [],
   purchases: [],
+  purchasesSourceJobIndex: [],
   externalIds: new Set<string>(),
+  sourceJobIndexes: new Set<number>(),
+  byteSize: 0,
 });
 
-type AllItems = {
-  data: BrazeUserAttributes | BrazeEvent | BrazePurchase;
-  type: string;
-  externalId?: string;
+// Build tagged items from raw sub-arrays. Each item is assigned its own
+// sourceJobIndex, so group-preserving chunking degenerates to per-item
+// chunking — matches legacy behavior for the exported wrappers used by tests.
+const buildTaggedItemsFromArrays = (
+  attributesArray: BrazeUserAttributes[],
+  eventsArray: BrazeEvent[],
+  purchasesArray: BrazePurchase[],
+): TaggedItem[] => {
+  const items: TaggedItem[] = [];
+  let idx = 0;
+  attributesArray.filter(isDefinedAndNotNull).forEach((attr) => {
+    items.push({
+      data: attr,
+      type: 'attributes',
+      externalId: attr.external_id,
+      sourceJobIndex: idx,
+      byteSize: computeItemByteSize(attr),
+    });
+    idx += 1;
+  });
+  eventsArray.filter(isDefinedAndNotNull).forEach((evt) => {
+    items.push({
+      data: evt,
+      type: 'events',
+      externalId: evt.external_id,
+      sourceJobIndex: idx,
+      byteSize: computeItemByteSize(evt),
+    });
+    idx += 1;
+  });
+  purchasesArray.filter(isDefinedAndNotNull).forEach((pur) => {
+    items.push({
+      data: pur,
+      type: 'purchases',
+      externalId: pur.external_id,
+      sourceJobIndex: idx,
+      byteSize: computeItemByteSize(pur),
+    });
+    idx += 1;
+  });
+  return items;
+};
+
+// Contiguous same-sourceJobIndex runs in a sorted item list. Because we
+// stable-sort by (externalId, sourceJobIndex), items from the same source job
+// end up adjacent regardless of type.
+const groupBySourceJob = (sortedItems: TaggedItem[]): TaggedItem[][] => {
+  const groups: TaggedItem[][] = [];
+  if (sortedItems.length === 0) {
+    return groups;
+  }
+  let start = 0;
+  for (let i = 1; i <= sortedItems.length; i += 1) {
+    if (
+      i === sortedItems.length ||
+      sortedItems[i].sourceJobIndex !== sortedItems[start].sourceJobIndex
+    ) {
+      groups.push(sortedItems.slice(start, i));
+      start = i;
+    }
+  }
+  return groups;
+};
+
+const addGroupToChunk = (chunk: TrackChunk, group: TaggedItem[]): void => {
+  for (const item of group) {
+    if (item.type === 'attributes') {
+      chunk.attributes.push(item.data as BrazeUserAttributes);
+      chunk.attributesSourceJobIndex.push(item.sourceJobIndex);
+    } else if (item.type === 'events') {
+      chunk.events.push(item.data as BrazeEvent);
+      chunk.eventsSourceJobIndex.push(item.sourceJobIndex);
+    } else {
+      chunk.purchases.push(item.data as BrazePurchase);
+      chunk.purchasesSourceJobIndex.push(item.sourceJobIndex);
+    }
+    if (item.externalId) {
+      chunk.externalIds.add(item.externalId);
+    }
+    chunk.sourceJobIndexes.add(item.sourceJobIndex);
+    chunk.byteSize += item.byteSize;
+  }
+};
+
+// V1 semantics: per-type item cap + externalId cap + byte-size cap.
+const groupFitsV1 = (chunk: TrackChunk, group: TaggedItem[]): boolean => {
+  let addAttrs = 0;
+  let addEvents = 0;
+  let addPurchases = 0;
+  let addByteSize = 0;
+  const newExternalIds = new Set(chunk.externalIds);
+  for (const item of group) {
+    if (item.type === 'attributes') addAttrs += 1;
+    else if (item.type === 'events') addEvents += 1;
+    else addPurchases += 1;
+    if (item.externalId) newExternalIds.add(item.externalId);
+    addByteSize += item.byteSize;
+  }
+  return (
+    chunk.attributes.length + addAttrs <= TRACK_BRAZE_MAX_REQ_COUNT &&
+    chunk.events.length + addEvents <= TRACK_BRAZE_MAX_REQ_COUNT &&
+    chunk.purchases.length + addPurchases <= TRACK_BRAZE_MAX_REQ_COUNT &&
+    newExternalIds.size <= TRACK_BRAZE_MAX_EXTERNAL_ID_COUNT &&
+    chunk.byteSize + addByteSize <= TRACK_BRAZE_MAX_BATCH_BYTE_SIZE
+  );
+};
+
+// V2 (MAU plan) semantics: total-count cap + byte-size cap.
+const groupFitsV2 = (chunk: TrackChunk, group: TaggedItem[]): boolean => {
+  let addByteSize = 0;
+  for (const item of group) {
+    addByteSize += item.byteSize;
+  }
+  return (
+    chunk.attributes.length + chunk.events.length + chunk.purchases.length + group.length <=
+      TRACK_BRAZE_MAX_REQ_COUNT && chunk.byteSize + addByteSize <= TRACK_BRAZE_MAX_BATCH_BYTE_SIZE
+  );
+};
+
+// Group-preserving, size-aware chunking. Callers are responsible for
+// rejecting jobs whose contributions exceed the caps on their own — such a
+// group can never fit into an empty chunk. `processBatch` enforces that
+// pre-check; the exported wrappers below use per-item sourceJobIndex so no
+// group ever exceeds a single item.
+const chunkTaggedItems = (items: TaggedItem[], mode: 'v1' | 'v2'): TrackChunk[] => {
+  const sortedItems = _.orderBy(items, ['externalId', 'sourceJobIndex']);
+  const groups = groupBySourceJob(sortedItems);
+  const chunks: TrackChunk[] = [];
+  let currentChunk = createTrackChunk();
+  const fits = mode === 'v1' ? groupFitsV1 : groupFitsV2;
+  for (const group of groups) {
+    if (currentChunk.sourceJobIndexes.size > 0 && !fits(currentChunk, group)) {
+      chunks.push(currentChunk);
+      currentChunk = createTrackChunk();
+    }
+    addGroupToChunk(currentChunk, group);
+  }
+  if (currentChunk.sourceJobIndexes.size > 0) {
+    chunks.push(currentChunk);
+  }
+  return chunks;
 };
 
 const batchForTrackAPI = (
   attributesArray: BrazeUserAttributes[],
   eventsArray: BrazeEvent[],
   purchasesArray: BrazePurchase[],
-) => {
-  const allItems: AllItems[] = [];
-  const maxLength = Math.max(attributesArray.length, eventsArray.length, purchasesArray.length);
+): TrackChunk[] =>
+  chunkTaggedItems(buildTaggedItemsFromArrays(attributesArray, eventsArray, purchasesArray), 'v1');
 
-  const addItem = (item: AllItems['data'], type: string) => {
-    if (item) {
-      allItems.push({
-        data: item,
-        type,
-        externalId: item.external_id,
-      });
-    }
-  };
-
-  const canAddToChunk = (
-    item: AllItems,
-    chunk: {
-      externalIds: Set<string>;
-      attributes: unknown[];
-      events: unknown[];
-      purchases: unknown[];
-    },
-  ) => {
-    const { type, externalId } = item;
-    return (
-      ((externalId && chunk.externalIds.has(externalId)) ||
-        chunk.externalIds.size < TRACK_BRAZE_MAX_EXTERNAL_ID_COUNT) &&
-      chunk[type].length < TRACK_BRAZE_MAX_REQ_COUNT
-    );
-  };
-
-  // eslint-disable-next-line no-plusplus
-  for (let i = 0; i < maxLength; i++) {
-    addItem(attributesArray[i], 'attributes');
-    addItem(eventsArray[i], 'events');
-    addItem(purchasesArray[i], 'purchases');
-  }
-  const sortedItems = _.sortBy(allItems, 'externalId');
-  let currentChunk = createTrackChunk();
-  const trackChunks: ReturnType<typeof createTrackChunk>[] = [];
-  for (const item of sortedItems) {
-    if (canAddToChunk(item, currentChunk)) {
-      currentChunk[item.type].push(item.data);
-      currentChunk.externalIds.add(item.externalId!);
-    } else {
-      trackChunks.push(currentChunk);
-      currentChunk = createTrackChunk();
-      currentChunk[item.type].push(item.data);
-      currentChunk.externalIds.add(item.externalId!);
-    }
-  }
-  if (currentChunk.externalIds.size > 0) {
-    trackChunks.push(currentChunk);
-  }
-  return trackChunks;
-};
-
-// braze batching as per new MAU plan
 const batchForTrackAPIV2 = (
   attributesArray: BrazeUserAttributes[],
   eventsArray: BrazeEvent[],
   purchasesArray: BrazePurchase[],
-) => {
-  // Collect all items with their types, filtering out null/undefined
-  const allItems: AllItems[] = [
-    ...attributesArray
-      .filter((item) => isDefinedAndNotNull(item))
-      .map((item) => ({
-        data: item,
-        type: 'attributes',
-        externalId: item.external_id,
-      })),
-    ...eventsArray
-      .filter((item) => isDefinedAndNotNull(item))
-      .map((item) => ({ data: item, type: 'events', externalId: item.external_id })),
-    ...purchasesArray
-      .filter((item) => isDefinedAndNotNull(item))
-      .map((item) => ({
-        data: item,
-        type: 'purchases',
-        externalId: item.external_id,
-      })),
-  ];
+): TrackChunk[] =>
+  chunkTaggedItems(buildTaggedItemsFromArrays(attributesArray, eventsArray, purchasesArray), 'v2');
 
-  const sortedItems: AllItems[] = _.sortBy(allItems, 'externalId');
-  const trackChunks: ReturnType<typeof createTrackChunk>[] = [];
-  let currentChunk = createTrackChunk();
-
-  const getChunkSize = (chunk: ReturnType<typeof createTrackChunk>) =>
-    chunk.attributes.length + chunk.events.length + chunk.purchases.length;
-
-  const addItemToChunk = (item: AllItems, chunk: ReturnType<typeof createTrackChunk>) => {
-    chunk[item.type].push(item.data);
-  };
-
-  for (const item of sortedItems) {
-    if (getChunkSize(currentChunk) === TRACK_BRAZE_MAX_REQ_COUNT) {
-      trackChunks.push(currentChunk);
-      currentChunk = createTrackChunk();
-    }
-    addItemToChunk(item, currentChunk);
-  }
-
-  if (getChunkSize(currentChunk) > 0) {
-    trackChunks.push(currentChunk);
-  }
-
-  return trackChunks;
-};
-
-const cleanTrackChunk = (chunk: {
-  attributes: unknown[];
-  events: unknown[];
-  purchases: unknown[];
-}) => {
-  const { attributes, events, purchases } = chunk;
+const cleanTrackChunk = (chunk: TrackChunk) => {
   const cleanChunk: Record<string, unknown> = {};
-  if (attributes.length > 0) {
-    cleanChunk.attributes = attributes;
+  if (chunk.attributes.length > 0) {
+    cleanChunk.attributes = chunk.attributes;
   }
-  if (events.length > 0) {
-    cleanChunk.events = events;
+  if (chunk.events.length > 0) {
+    cleanChunk.events = chunk.events;
   }
-  if (purchases.length > 0) {
-    cleanChunk.purchases = purchases;
+  if (chunk.purchases.length > 0) {
+    cleanChunk.purchases = chunk.purchases;
   }
   return cleanChunk;
 };
 
-const addTrackStats = (
-  chunk: { attributes?: unknown[]; events?: unknown[]; purchases?: unknown[] },
-  destination: BrazeDestination,
-) => {
-  const { attributes, events, purchases } = chunk;
-  let totalCount = 0;
-  if (attributes) {
-    totalCount += attributes.length;
-    stats.histogram('braze_batch_attributes_pack_size', attributes.length, {
-      destination_id: destination.ID,
-    });
-  }
-  if (events) {
-    totalCount += events.length;
-    stats.histogram('braze_batch_events_pack_size', events.length, {
-      destination_id: destination.ID,
-    });
-  }
-  if (purchases) {
-    totalCount += purchases.length;
-    stats.histogram('braze_batch_purchase_pack_size', purchases.length, {
-      destination_id: destination.ID,
-    });
-  }
+const addTrackStats = (chunk: TrackChunk, destination: BrazeDestination) => {
+  const totalCount = chunk.attributes.length + chunk.events.length + chunk.purchases.length;
+  stats.histogram('braze_batch_attributes_pack_size', chunk.attributes.length, {
+    destination_id: destination.ID,
+  });
+  stats.histogram('braze_batch_events_pack_size', chunk.events.length, {
+    destination_id: destination.ID,
+  });
+  stats.histogram('braze_batch_purchase_pack_size', chunk.purchases.length, {
+    destination_id: destination.ID,
+  });
   stats.histogram('braze_batch_total_pack_size', totalCount, {
     destination_id: destination.ID,
   });
@@ -811,111 +799,340 @@ const isWorkspaceOnMauPlan = (workspaceId) => {
   }
 };
 
-const processBatch = (transformedEvents: BrazeTransformedEvent[]) => {
-  const { destination, metadata } = transformedEvents[0];
-  const workspaceId = metadata?.[0]?.workspaceId || '';
-  const dest = destination;
-  const attributesArray: BrazeUserAttributes[] = [];
-  const eventsArray: BrazeEvent[] = [];
-  const purchaseArray: BrazePurchase[] = [];
-  const successMetadata: Partial<Metadata>[] = [];
-  const failureResponses: BrazeTransformedEvent[] = [];
-  const filteredResponses: BrazeTransformedEvent[] = [];
-  const subscriptionsArray: BrazeSubscriptionGroup[] = [];
-  const mergeUsersArray: BrazeMergeUpdate[] = [];
-  for (const transformedEvent of transformedEvents) {
-    if (!isHttpStatusSuccess(transformedEvent.statusCode)) {
-      failureResponses.push(transformedEvent);
-    } else if (transformedEvent.statusCode === HTTP_STATUS_CODES.FILTER_EVENTS) {
-      filteredResponses.push(transformedEvent);
-    } else if (transformedEvent.batchedRequest?.body?.JSON) {
-      const { attributes, events, purchases, subscription_groups, merge_updates } =
-        transformedEvent.batchedRequest.body.JSON;
-      if (Array.isArray(attributes)) {
-        attributesArray.push(...attributes);
-      }
-      if (Array.isArray(events)) {
-        eventsArray.push(...events);
-      }
-      if (Array.isArray(purchases)) {
-        purchaseArray.push(...purchases);
-      }
+// Collect tagged /users/track items for a single transformedEvent while
+// enforcing per-item and per-job byte-size caps. Returns null if any cap
+// is breached — caller pushes the event onto failureResponses.
+type TrackCollectionResult =
+  | { items: TaggedItem[]; totalByteSize: number }
+  | { error: InstrumentationError };
 
-      if (Array.isArray(subscription_groups)) {
-        subscriptionsArray.push(...subscription_groups);
-      }
+const collectTrackItemsForJob = (
+  transformedEvent: BrazeTransformedEvent,
+  jobIndex: number,
+): TrackCollectionResult => {
+  const json = transformedEvent.batchedRequest?.body?.JSON as
+    | { attributes?: unknown; events?: unknown; purchases?: unknown }
+    | undefined;
+  const attrArr = Array.isArray(json?.attributes)
+    ? (json!.attributes as BrazeUserAttributes[])
+    : [];
+  const evtArr = Array.isArray(json?.events) ? (json!.events as BrazeEvent[]) : [];
+  const purArr = Array.isArray(json?.purchases) ? (json!.purchases as BrazePurchase[]) : [];
 
-      if (Array.isArray(merge_updates)) {
-        mergeUsersArray.push(...merge_updates);
-      }
+  const items: TaggedItem[] = [];
+  let totalByteSize = 0;
 
-      if (transformedEvent.metadata) {
-        successMetadata.push(...transformedEvent.metadata);
+  const tryAdd = (
+    data: unknown,
+    type: ItemType,
+    externalId?: string,
+  ): InstrumentationError | null => {
+    const byteSize = computeItemByteSize(data);
+    if (byteSize > TRACK_BRAZE_MAX_ITEM_BYTE_SIZE) {
+      return new InstrumentationError(
+        `[Braze] Single ${type} item exceeds ${TRACK_BRAZE_MAX_ITEM_BYTE_SIZE} bytes (got ${byteSize})`,
+      );
+    }
+    items.push({
+      data: data as TaggedItem['data'],
+      type,
+      externalId,
+      sourceJobIndex: jobIndex,
+      byteSize,
+    });
+    totalByteSize += byteSize;
+    return null;
+  };
+
+  for (const attr of attrArr) {
+    if (isDefinedAndNotNull(attr)) {
+      const err = tryAdd(attr, 'attributes', attr.external_id);
+      if (err) return { error: err };
+    }
+  }
+  for (const evt of evtArr) {
+    if (isDefinedAndNotNull(evt)) {
+      const err = tryAdd(evt, 'events', evt.external_id);
+      if (err) return { error: err };
+    }
+  }
+  for (const pur of purArr) {
+    if (isDefinedAndNotNull(pur)) {
+      const err = tryAdd(pur, 'purchases', pur.external_id);
+      if (err) return { error: err };
+    }
+  }
+
+  // A single job's items must all fit into one chunk to preserve
+  // metadata↔chunk ownership (a job can't span two proxy responses). If a
+  // job alone exceeds the per-batch caps, no chunking can accommodate it.
+  if (items.length > TRACK_BRAZE_MAX_REQ_COUNT) {
+    return {
+      error: new InstrumentationError(
+        `[Braze] Single job contributes ${items.length} track items (max ${TRACK_BRAZE_MAX_REQ_COUNT} per batch)`,
+      ),
+    };
+  }
+  if (totalByteSize > TRACK_BRAZE_MAX_BATCH_BYTE_SIZE) {
+    return {
+      error: new InstrumentationError(
+        `[Braze] Single job's track items total ${totalByteSize} bytes (max ${TRACK_BRAZE_MAX_BATCH_BYTE_SIZE} per batch)`,
+      ),
+    };
+  }
+  return { items, totalByteSize };
+};
+
+// Build the per-metadata destInfo.braze positional map for a chunk. Every
+// unique sourceJobIndex in the chunk gets one BrazeDestInfo describing where
+// that job's items landed within this chunk's attributes[]/events[]/purchases[].
+const buildDestInfoByJob = (chunk: TrackChunk): Map<number, BrazeDestInfo> => {
+  const map = new Map<number, BrazeDestInfo>();
+  const ensure = (sji: number): BrazeDestInfo => {
+    let existing = map.get(sji);
+    if (!existing) {
+      existing = {};
+      map.set(sji, existing);
+    }
+    return existing;
+  };
+  chunk.attributesSourceJobIndex.forEach((sji: number, idx: number) => {
+    ensure(sji).attributesIndex = idx;
+  });
+  chunk.eventsSourceJobIndex.forEach((sji: number, idx: number) => {
+    ensure(sji).eventsIndex = idx;
+  });
+  chunk.purchasesSourceJobIndex.forEach((sji: number, idx: number) => {
+    const info = ensure(sji);
+    info.purchasesIndexes = info.purchasesIndexes ?? [];
+    info.purchasesIndexes.push(idx);
+  });
+  return map;
+};
+
+const trackChunkResponse = (
+  chunk: TrackChunk,
+  destination: BrazeDestination,
+  headers: BrazeBatchHeaders,
+  trackEndpoint: string,
+  trackPath: string,
+  jobMetadata: (Partial<Metadata>[] | undefined)[],
+) => {
+  addTrackStats(chunk, destination);
+  const request = defaultRequestConfig();
+  request.endpoint = trackEndpoint;
+  request.endpointPath = trackPath;
+  request.body.JSON = { partner: BRAZE_PARTNER_NAME, ...cleanTrackChunk(chunk) };
+
+  const destInfoByJob = buildDestInfoByJob(chunk);
+  const chunkMetadata: Partial<Metadata>[] = [];
+  // Iterate sourceJobIndexes in insertion order (Set preserves it) so the
+  // metadata slice ordering is deterministic and stable.
+  for (const sji of chunk.sourceJobIndexes) {
+    const jobMeta = jobMetadata[sji];
+    if (jobMeta) {
+      const braze = destInfoByJob.get(sji);
+      for (const m of jobMeta) {
+        chunkMetadata.push({
+          ...m,
+          destInfo: { ...(m.destInfo ?? {}), braze },
+        });
       }
     }
   }
-  const isWorkspaceOnMauPlanFlag = isWorkspaceOnMauPlan(workspaceId);
-  const trackChunks = isWorkspaceOnMauPlanFlag
-    ? batchForTrackAPIV2(attributesArray, eventsArray, purchaseArray)
-    : batchForTrackAPI(attributesArray, eventsArray, purchaseArray);
-  const subscriptionArrayChunks = _.chunk(subscriptionsArray, SUBSCRIPTION_BRAZE_MAX_REQ_COUNT);
-  const mergeUsersArrayChunks = _.chunk(mergeUsersArray, ALIAS_BRAZE_MAX_REQ_COUNT);
+  return {
+    batchedRequest: { ...request, headers },
+    metadata: chunkMetadata,
+    batched: true,
+    statusCode: 200,
+    destination,
+  };
+};
 
-  const responseArray: BrazeBatchRequest[] = [];
-  const finalResponse: BrazeBatchResponse[] = [];
+// Collect scoped metadata for a subscription/merge chunk. A single job may
+// contribute multiple entries but must be listed once in the chunk's metadata.
+const scopedMetadataForChunk = <T extends { sourceJobIndex: number }>(
+  chunk: T[],
+  jobMetadata: (Partial<Metadata>[] | undefined)[],
+): Partial<Metadata>[] => {
+  const seen = new Set<number>();
+  const out: Partial<Metadata>[] = [];
+  for (const entry of chunk) {
+    if (!seen.has(entry.sourceJobIndex)) {
+      seen.add(entry.sourceJobIndex);
+      const jobMeta = jobMetadata[entry.sourceJobIndex];
+      if (jobMeta) out.push(...jobMeta);
+    }
+  }
+  return out;
+};
+
+// A run is a contiguous stretch of same-endpoint jobs in the input's insertion
+// order. Walking the input job-by-job and emitting outputs at endpoint
+// boundaries preserves the invariant that jobIds within a user remain
+// monotonically ascending across the emitted outputs — the semantic
+// rudder-server relies on for causal ordering.
+type TrackRun = { type: 'track'; items: TaggedItem[] };
+type SubscriptionRun = {
+  type: 'subscription';
+  entries: Array<{ data: BrazeSubscriptionGroup; sourceJobIndex: number }>;
+};
+type MergeRun = {
+  type: 'merge';
+  entries: Array<{ data: BrazeMergeUpdate; sourceJobIndex: number }>;
+};
+type Run = TrackRun | SubscriptionRun | MergeRun;
+
+const classifyJobRun = (json: Record<string, unknown>): Run['type'] | null => {
+  const hasTrackItems =
+    (Array.isArray(json.attributes) && (json.attributes as unknown[]).length > 0) ||
+    (Array.isArray(json.events) && (json.events as unknown[]).length > 0) ||
+    (Array.isArray(json.purchases) && (json.purchases as unknown[]).length > 0);
+  if (hasTrackItems) return 'track';
+  if (Array.isArray(json.subscription_groups) && (json.subscription_groups as unknown[]).length > 0)
+    return 'subscription';
+  if (Array.isArray(json.merge_updates) && (json.merge_updates as unknown[]).length > 0)
+    return 'merge';
+  return null;
+};
+
+const processBatch = (transformedEvents: BrazeTransformedEvent[]): BrazeBatchResponse[] => {
+  const { destination } = transformedEvents[0];
+  const workspaceId = transformedEvents[0].metadata?.[0]?.workspaceId || '';
+
+  const failureResponses: BrazeTransformedEvent[] = [];
+  const filteredResponses: BrazeTransformedEvent[] = [];
+  const runs: Run[] = [];
+  const jobMetadata: (Partial<Metadata>[] | undefined)[] = new Array(transformedEvents.length);
+
+  const openNewRun = (type: Run['type']): Run => {
+    let run: Run;
+    if (type === 'track') run = { type: 'track', items: [] };
+    else if (type === 'subscription') run = { type: 'subscription', entries: [] };
+    else run = { type: 'merge', entries: [] };
+    runs.push(run);
+    return run;
+  };
+
+  let currentRun: Run | null = null;
+
+  transformedEvents.forEach((transformedEvent, jobIndex) => {
+    if (!isHttpStatusSuccess(transformedEvent.statusCode)) {
+      failureResponses.push(transformedEvent);
+      return;
+    }
+    if (transformedEvent.statusCode === HTTP_STATUS_CODES.FILTER_EVENTS) {
+      filteredResponses.push(transformedEvent);
+      return;
+    }
+    const json = transformedEvent.batchedRequest?.body?.JSON as Record<string, unknown> | undefined;
+    if (!json) return;
+
+    const runType = classifyJobRun(json);
+    if (!runType) return;
+
+    if (!currentRun || currentRun.type !== runType) {
+      currentRun = openNewRun(runType);
+    }
+
+    if (currentRun.type === 'track') {
+      const collection = collectTrackItemsForJob(transformedEvent, jobIndex);
+      if ('error' in collection) {
+        failureResponses.push({
+          ...transformedEvent,
+          statusCode: 400,
+          error: collection.error.message,
+          statTags: { errorType: 'aborted', errorCategory: 'dataValidation' },
+        });
+        return;
+      }
+      currentRun.items.push(...collection.items);
+    } else if (currentRun.type === 'subscription') {
+      for (const sg of json.subscription_groups as BrazeSubscriptionGroup[]) {
+        currentRun.entries.push({ data: sg, sourceJobIndex: jobIndex });
+      }
+    } else {
+      for (const mu of json.merge_updates as BrazeMergeUpdate[]) {
+        currentRun.entries.push({ data: mu, sourceJobIndex: jobIndex });
+      }
+    }
+
+    if (transformedEvent.metadata) {
+      jobMetadata[jobIndex] = transformedEvent.metadata;
+    }
+  });
+
+  const isWorkspaceOnMauPlanFlag = isWorkspaceOnMauPlan(workspaceId);
   const headers: BrazeBatchHeaders = {
     'Content-Type': JSON_MIME_TYPE,
     Accept: JSON_MIME_TYPE,
-    Authorization: `Bearer ${dest.Config.restApiKey}`,
+    Authorization: `Bearer ${destination.Config.restApiKey}`,
   };
+  const { endpoint: trackEndpoint, path: trackPath } = getTrackEndPoint(
+    getEndpointFromConfig(destination),
+  );
+  const { endpoint: subEndpoint, path: subPath } = getSubscriptionGroupEndPoint(
+    getEndpointFromConfig(destination),
+  );
+  const { endpoint: mergeEndpoint, path: mergePath } = getAliasMergeEndPoint(
+    getEndpointFromConfig(destination),
+  );
 
-  const { endpoint, path } = getTrackEndPoint(getEndpointFromConfig(destination));
-  for (const chunk of trackChunks) {
-    const cleanedChunk = cleanTrackChunk(chunk);
-    const { attributes, events, purchases } = cleanedChunk;
-    addTrackStats(chunk, destination);
+  const finalResponse: BrazeBatchResponse[] = [];
 
-    const response = defaultRequestConfig();
-    response.endpoint = endpoint;
-    response.endpointPath = path;
-    response.body.JSON = {
-      partner: 'RudderStack',
-      attributes,
-      events,
-      purchases,
-    };
-    responseArray.push({
-      ...response,
-      headers,
-    });
+  for (const run of runs) {
+    if (run.type === 'track') {
+      const chunks = chunkTaggedItems(run.items, isWorkspaceOnMauPlanFlag ? 'v2' : 'v1');
+      for (const chunk of chunks) {
+        finalResponse.push(
+          trackChunkResponse(chunk, destination, headers, trackEndpoint, trackPath, jobMetadata),
+        );
+      }
+    } else if (run.type === 'subscription') {
+      const chunks = _.chunk(run.entries, SUBSCRIPTION_BRAZE_MAX_REQ_COUNT);
+      for (const chunk of chunks) {
+        const rawGroups = chunk.map((e) => e.data);
+        stats.gauge('braze_batch_subscription_size', rawGroups.length, {
+          destination_id: destination.ID,
+        });
+        const deduplicated = combineSubscriptionGroups(rawGroups);
+        stats.gauge('braze_batch_subscription_combined_size', deduplicated.length, {
+          destination_id: destination.ID,
+        });
+        const request = defaultRequestConfig();
+        request.endpoint = subEndpoint;
+        request.endpointPath = subPath;
+        request.body.JSON = removeUndefinedAndNullValues({ subscription_groups: deduplicated });
+        finalResponse.push({
+          batchedRequest: { ...request, headers },
+          metadata: scopedMetadataForChunk(chunk, jobMetadata),
+          batched: true,
+          statusCode: 200,
+          destination,
+        });
+      }
+    } else {
+      const chunks = _.chunk(run.entries, ALIAS_BRAZE_MAX_REQ_COUNT);
+      for (const chunk of chunks) {
+        const rawMerges = chunk.map((e) => e.data);
+        const request = defaultRequestConfig();
+        request.endpoint = mergeEndpoint;
+        request.endpointPath = mergePath;
+        request.body.JSON = removeUndefinedAndNullValues({ merge_updates: rawMerges });
+        finalResponse.push({
+          batchedRequest: { ...request, headers },
+          metadata: scopedMetadataForChunk(chunk, jobMetadata),
+          batched: true,
+          statusCode: 200,
+          destination,
+        });
+      }
+    }
   }
 
-  prepareGroupAndAliasBatch({
-    arrayChunks: subscriptionArrayChunks,
-    responseArray,
-    destination,
-    type: 'subscription',
-  });
-  prepareGroupAndAliasBatch({
-    arrayChunks: mergeUsersArrayChunks,
-    responseArray,
-    destination,
-    type: 'merge',
-  });
-
-  if (successMetadata.length > 0) {
-    finalResponse.push({
-      batchedRequest: responseArray,
-      metadata: successMetadata,
-      batched: true,
-      statusCode: 200,
-      destination,
-    });
-  }
   if (failureResponses.length > 0) {
     finalResponse.push(...failureResponses);
   }
-
   if (filteredResponses.length > 0) {
     finalResponse.push(...filteredResponses);
   }

--- a/src/v0/destinations/braze/util.ts
+++ b/src/v0/destinations/braze/util.ts
@@ -31,6 +31,7 @@ import {
   TRACK_BRAZE_MAX_BATCH_BYTE_SIZE,
   BRAZE_PURCHASE_STANDARD_PROPERTIES,
   DESTINATION,
+  isPerJobDeliveryMappingEnabled,
 } from './config';
 import { JSON_MIME_TYPE, HTTP_STATUS_CODES } from '../../util/constant';
 import {
@@ -38,6 +39,7 @@ import {
   BrazeTrackRequestBody,
   BrazeSubscriptionBatchPayload,
   BrazeMergeBatchPayload,
+  BrazeBatchRequest,
   BrazeDestination,
   BrazeRouterRequest,
   BrazeBatchHeaders,
@@ -926,6 +928,26 @@ const buildDestInfoByJob = (chunk: TrackChunk): Map<number, BrazeDestInfo> => {
   return map;
 };
 
+// Build the /users/track HTTP request body for one chunk. Shared by both the
+// OFF and ON emission paths — the request shape itself doesn't depend on the
+// flag; only the wrapping output structure and metadata do.
+const buildTrackRequest = (
+  chunk: TrackChunk,
+  destination: BrazeDestination,
+  headers: BrazeBatchHeaders,
+  trackEndpoint: string,
+  trackPath: string,
+) => {
+  addTrackStats(chunk, destination);
+  const request = defaultRequestConfig();
+  request.endpoint = trackEndpoint;
+  request.endpointPath = trackPath;
+  request.body.JSON = { partner: BRAZE_PARTNER_NAME, ...cleanTrackChunk(chunk) };
+  return { ...request, headers };
+};
+
+// ON path: one BatchRequestOutput per track chunk, with per-metadata destInfo
+// positional maps consumed by the v1 networkHandler.
 const trackChunkResponse = (
   chunk: TrackChunk,
   destination: BrazeDestination,
@@ -934,12 +956,6 @@ const trackChunkResponse = (
   trackPath: string,
   jobMetadata: (Partial<Metadata>[] | undefined)[],
 ) => {
-  addTrackStats(chunk, destination);
-  const request = defaultRequestConfig();
-  request.endpoint = trackEndpoint;
-  request.endpointPath = trackPath;
-  request.body.JSON = { partner: BRAZE_PARTNER_NAME, ...cleanTrackChunk(chunk) };
-
   const destInfoByJob = buildDestInfoByJob(chunk);
   const chunkMetadata: Partial<Metadata>[] = [];
   // Iterate sourceJobIndexes in insertion order (Set preserves it) so the
@@ -959,7 +975,7 @@ const trackChunkResponse = (
     }
   }
   return {
-    batchedRequest: { ...request, headers },
+    batchedRequest: buildTrackRequest(chunk, destination, headers, trackEndpoint, trackPath),
     metadata: chunkMetadata,
     batched: true,
     statusCode: 200,
@@ -969,9 +985,13 @@ const trackChunkResponse = (
 
 // Collect scoped metadata for a subscription/merge chunk. A single job may
 // contribute multiple entries but must be listed once in the chunk's metadata.
+// Under the ON path, sub/merge outputs must still carry `destInfo: {}` per the
+// design doc (present-but-empty for correlation-shape uniformity across every
+// chunk); OFF path preserves raw metadata unchanged.
 const scopedMetadataForChunk = <T extends { sourceJobIndex: number }>(
   chunk: T[],
   jobMetadata: (Partial<Metadata>[] | undefined)[],
+  withEmptyDestInfo: boolean,
 ): Partial<Metadata>[] => {
   const seen = new Set<number>();
   const out: Partial<Metadata>[] = [];
@@ -979,10 +999,50 @@ const scopedMetadataForChunk = <T extends { sourceJobIndex: number }>(
     if (!seen.has(entry.sourceJobIndex)) {
       seen.add(entry.sourceJobIndex);
       const jobMeta = jobMetadata[entry.sourceJobIndex];
-      if (jobMeta) out.push(...jobMeta);
+      if (jobMeta) {
+        for (const m of jobMeta) {
+          out.push(withEmptyDestInfo ? { ...m, destInfo: { ...(m.destInfo ?? {}) } } : m);
+        }
+      }
     }
   }
   return out;
+};
+
+const buildSubscriptionRequest = (
+  chunk: Array<{ data: BrazeSubscriptionGroup; sourceJobIndex: number }>,
+  destination: BrazeDestination,
+  headers: BrazeBatchHeaders,
+  subEndpoint: string,
+  subPath: string,
+) => {
+  const rawGroups = chunk.map((e) => e.data);
+  stats.gauge('braze_batch_subscription_size', rawGroups.length, {
+    destination_id: destination.ID,
+  });
+  const deduplicated = combineSubscriptionGroups(rawGroups);
+  stats.gauge('braze_batch_subscription_combined_size', deduplicated.length, {
+    destination_id: destination.ID,
+  });
+  const request = defaultRequestConfig();
+  request.endpoint = subEndpoint;
+  request.endpointPath = subPath;
+  request.body.JSON = removeUndefinedAndNullValues({ subscription_groups: deduplicated });
+  return { ...request, headers };
+};
+
+const buildMergeRequest = (
+  chunk: Array<{ data: BrazeMergeUpdate; sourceJobIndex: number }>,
+  headers: BrazeBatchHeaders,
+  mergeEndpoint: string,
+  mergePath: string,
+) => {
+  const rawMerges = chunk.map((e) => e.data);
+  const request = defaultRequestConfig();
+  request.endpoint = mergeEndpoint;
+  request.endpointPath = mergePath;
+  request.body.JSON = removeUndefinedAndNullValues({ merge_updates: rawMerges });
+  return { ...request, headers };
 };
 
 // A run is a contiguous stretch of same-endpoint jobs in the input's insertion
@@ -1037,116 +1097,50 @@ const classifyJobRun = (json: BrazeBatchPayload): JobClassification | null => {
   return null;
 };
 
-const processBatch = (transformedEvents: BrazeTransformedEvent[]): BrazeBatchResponse[] => {
-  const { destination } = transformedEvents[0];
-  const workspaceId = transformedEvents[0].metadata?.[0]?.workspaceId || '';
+// Endpoints resolved once per invocation; passed into both emission helpers.
+type BrazeEndpoints = {
+  headers: BrazeBatchHeaders;
+  trackEndpoint: string;
+  trackPath: string;
+  subEndpoint: string;
+  subPath: string;
+  mergeEndpoint: string;
+  mergePath: string;
+};
 
-  const failureResponses: BrazeTransformedEvent[] = [];
-  const filteredResponses: BrazeTransformedEvent[] = [];
-  const runs: Run[] = [];
-  const jobMetadata: (Partial<Metadata>[] | undefined)[] = new Array(transformedEvents.length);
-
-  const openNewRun = (type: Run['type']): Run => {
-    let run: Run;
-    if (type === 'track') run = { type: 'track', items: [] };
-    else if (type === 'subscription') run = { type: 'subscription', items: [] };
-    else run = { type: 'merge', items: [] };
-    runs.push(run);
-    return run;
-  };
-
-  let currentRun: Run | null = null;
-
-  transformedEvents.forEach((transformedEvent, jobIndex) => {
-    if (!isHttpStatusSuccess(transformedEvent.statusCode)) {
-      failureResponses.push(transformedEvent);
-      return;
-    }
-    if (transformedEvent.statusCode === HTTP_STATUS_CODES.FILTER_EVENTS) {
-      filteredResponses.push(transformedEvent);
-      return;
-    }
-    const json = transformedEvent.batchedRequest?.body?.JSON;
-    if (!json) return;
-
-    const classification = classifyJobRun(json);
-    if (!classification) return;
-
-    if (!currentRun || currentRun.type !== classification.type) {
-      currentRun = openNewRun(classification.type);
-    }
-
-    if (currentRun.type === 'track' && classification.type === 'track') {
-      const collection = collectTrackItemsForJob(classification.body, jobIndex);
-      if ('error' in collection) {
-        failureResponses.push({
-          ...transformedEvent,
-          statusCode: 400,
-          error: collection.error.message,
-          statTags: { errorType: 'aborted', errorCategory: 'dataValidation' },
-        });
-        return;
-      }
-      currentRun.items.push(...collection.items);
-    } else if (currentRun.type === 'subscription' && classification.type === 'subscription') {
-      for (const sg of classification.body.subscription_groups ?? []) {
-        currentRun.items.push({ data: sg, sourceJobIndex: jobIndex });
-      }
-    } else if (currentRun.type === 'merge' && classification.type === 'merge') {
-      for (const mu of classification.body.merge_updates ?? []) {
-        currentRun.items.push({ data: mu, sourceJobIndex: jobIndex });
-      }
-    }
-
-    if (transformedEvent.metadata) {
-      jobMetadata[jobIndex] = transformedEvent.metadata;
-    }
-  });
-
-  const isWorkspaceOnMauPlanFlag = isWorkspaceOnMauPlan(workspaceId);
-  const headers: BrazeBatchHeaders = {
-    'Content-Type': JSON_MIME_TYPE,
-    Accept: JSON_MIME_TYPE,
-    Authorization: `Bearer ${destination.Config.restApiKey}`,
-  };
-  const { endpoint: trackEndpoint, path: trackPath } = getTrackEndPoint(
-    getEndpointFromConfig(destination),
-  );
-  const { endpoint: subEndpoint, path: subPath } = getSubscriptionGroupEndPoint(
-    getEndpointFromConfig(destination),
-  );
-  const { endpoint: mergeEndpoint, path: mergePath } = getAliasMergeEndPoint(
-    getEndpointFromConfig(destination),
-  );
-
-  const finalResponse: BrazeBatchResponse[] = [];
-
+// ON path: one BatchRequestOutput per outgoing HTTP request, run-preserving.
+// Track chunks carry per-metadata destInfo positional maps; sub/merge chunks
+// carry destInfo:{} for correlation-shape uniformity across every chunk.
+const emitOnPath = (
+  runs: Run[],
+  destination: BrazeDestination,
+  endpoints: BrazeEndpoints,
+  jobMetadata: (Partial<Metadata>[] | undefined)[],
+  isWorkspaceOnMauPlanFlag: boolean,
+): BrazeBatchResponse[] => {
+  const out: BrazeBatchResponse[] = [];
+  const { headers, trackEndpoint, trackPath, subEndpoint, subPath, mergeEndpoint, mergePath } =
+    endpoints;
   for (const run of runs) {
     if (run.type === 'track') {
       const chunks = chunkTaggedItems(run.items, isWorkspaceOnMauPlanFlag ? 'v2' : 'v1');
       for (const chunk of chunks) {
-        finalResponse.push(
+        out.push(
           trackChunkResponse(chunk, destination, headers, trackEndpoint, trackPath, jobMetadata),
         );
       }
     } else if (run.type === 'subscription') {
       const chunks = _.chunk(run.items, SUBSCRIPTION_BRAZE_MAX_REQ_COUNT);
       for (const chunk of chunks) {
-        const rawGroups = chunk.map((e) => e.data);
-        stats.gauge('braze_batch_subscription_size', rawGroups.length, {
-          destination_id: destination.ID,
-        });
-        const deduplicated = combineSubscriptionGroups(rawGroups);
-        stats.gauge('braze_batch_subscription_combined_size', deduplicated.length, {
-          destination_id: destination.ID,
-        });
-        const request = defaultRequestConfig();
-        request.endpoint = subEndpoint;
-        request.endpointPath = subPath;
-        request.body.JSON = removeUndefinedAndNullValues({ subscription_groups: deduplicated });
-        finalResponse.push({
-          batchedRequest: { ...request, headers },
-          metadata: scopedMetadataForChunk(chunk, jobMetadata),
+        out.push({
+          batchedRequest: buildSubscriptionRequest(
+            chunk,
+            destination,
+            headers,
+            subEndpoint,
+            subPath,
+          ),
+          metadata: scopedMetadataForChunk(chunk, jobMetadata, true),
           batched: true,
           statusCode: 200,
           destination,
@@ -1155,14 +1149,9 @@ const processBatch = (transformedEvents: BrazeTransformedEvent[]): BrazeBatchRes
     } else {
       const chunks = _.chunk(run.items, ALIAS_BRAZE_MAX_REQ_COUNT);
       for (const chunk of chunks) {
-        const rawMerges = chunk.map((e) => e.data);
-        const request = defaultRequestConfig();
-        request.endpoint = mergeEndpoint;
-        request.endpointPath = mergePath;
-        request.body.JSON = removeUndefinedAndNullValues({ merge_updates: rawMerges });
-        finalResponse.push({
-          batchedRequest: { ...request, headers },
-          metadata: scopedMetadataForChunk(chunk, jobMetadata),
+        out.push({
+          batchedRequest: buildMergeRequest(chunk, headers, mergeEndpoint, mergePath),
+          metadata: scopedMetadataForChunk(chunk, jobMetadata, true),
           batched: true,
           statusCode: 200,
           destination,
@@ -1170,14 +1159,180 @@ const processBatch = (transformedEvents: BrazeTransformedEvent[]): BrazeBatchRes
       }
     }
   }
+  return out;
+};
 
-  if (failureResponses.length > 0) {
-    finalResponse.push(...failureResponses);
-  }
-  if (filteredResponses.length > 0) {
-    finalResponse.push(...filteredResponses);
+// OFF path (legacy pre-INT-6808 shape): a single MultiBatchRequestOutput
+// whose `batchedRequest` is a flat array of every outgoing HTTP request
+// across track/subscription/merge, paired with a flat successMetadata list.
+// Group-preserving chunking + byte-size caps + oversized-job rejection are
+// still enforced (kept as INT-6808 improvements applicable in both modes).
+const emitOffPath = (
+  runs: Run[],
+  destination: BrazeDestination,
+  endpoints: BrazeEndpoints,
+  jobMetadata: (Partial<Metadata>[] | undefined)[],
+  isWorkspaceOnMauPlanFlag: boolean,
+): BrazeBatchResponse[] => {
+  const { headers, trackEndpoint, trackPath, subEndpoint, subPath, mergeEndpoint, mergePath } =
+    endpoints;
+  const allTrackItems: TaggedItem[] = [];
+  const allSubItems: Array<{ data: BrazeSubscriptionGroup; sourceJobIndex: number }> = [];
+  const allMergeItems: Array<{ data: BrazeMergeUpdate; sourceJobIndex: number }> = [];
+  for (const run of runs) {
+    if (run.type === 'track') allTrackItems.push(...run.items);
+    else if (run.type === 'subscription') allSubItems.push(...run.items);
+    else allMergeItems.push(...run.items);
   }
 
+  const batchedRequests: BrazeBatchRequest[] = [];
+  const trackChunks = chunkTaggedItems(allTrackItems, isWorkspaceOnMauPlanFlag ? 'v2' : 'v1');
+  for (const chunk of trackChunks) {
+    batchedRequests.push(buildTrackRequest(chunk, destination, headers, trackEndpoint, trackPath));
+  }
+  const subChunks = _.chunk(allSubItems, SUBSCRIPTION_BRAZE_MAX_REQ_COUNT);
+  for (const chunk of subChunks) {
+    batchedRequests.push(
+      buildSubscriptionRequest(chunk, destination, headers, subEndpoint, subPath),
+    );
+  }
+  const mergeChunks = _.chunk(allMergeItems, ALIAS_BRAZE_MAX_REQ_COUNT);
+  for (const chunk of mergeChunks) {
+    batchedRequests.push(buildMergeRequest(chunk, headers, mergeEndpoint, mergePath));
+  }
+
+  const successMetadata: Partial<Metadata>[] = [];
+  for (const meta of jobMetadata) {
+    if (meta) successMetadata.push(...meta);
+  }
+  if (successMetadata.length === 0) return [];
+  return [
+    {
+      batchedRequest: batchedRequests,
+      metadata: successMetadata,
+      batched: true,
+      statusCode: 200,
+      destination,
+    },
+  ];
+};
+
+// Ingest one transformedEvent into the appropriate collection bucket. Returns
+// true if the caller should stash `jobMetadata[jobIndex]`, false otherwise
+// (job was rejected or filtered).
+const ingestTransformedEvent = (
+  transformedEvent: BrazeTransformedEvent,
+  jobIndex: number,
+  buckets: {
+    failureResponses: BrazeTransformedEvent[];
+    filteredResponses: BrazeTransformedEvent[];
+    runs: Run[];
+    currentRunRef: { current: Run | null };
+  },
+): boolean => {
+  if (!isHttpStatusSuccess(transformedEvent.statusCode)) {
+    buckets.failureResponses.push(transformedEvent);
+    return false;
+  }
+  if (transformedEvent.statusCode === HTTP_STATUS_CODES.FILTER_EVENTS) {
+    buckets.filteredResponses.push(transformedEvent);
+    return false;
+  }
+  const json = transformedEvent.batchedRequest?.body?.JSON;
+  if (!json) return false;
+
+  const classification = classifyJobRun(json);
+  if (!classification) return false;
+
+  if (
+    !buckets.currentRunRef.current ||
+    buckets.currentRunRef.current.type !== classification.type
+  ) {
+    let run: Run;
+    if (classification.type === 'track') run = { type: 'track', items: [] };
+    else if (classification.type === 'subscription') run = { type: 'subscription', items: [] };
+    else run = { type: 'merge', items: [] };
+    buckets.runs.push(run);
+    buckets.currentRunRef.current = run;
+  }
+
+  const currentRun = buckets.currentRunRef.current;
+  if (currentRun.type === 'track' && classification.type === 'track') {
+    const collection = collectTrackItemsForJob(classification.body, jobIndex);
+    if ('error' in collection) {
+      buckets.failureResponses.push({
+        ...transformedEvent,
+        statusCode: 400,
+        error: collection.error.message,
+        statTags: { errorType: 'aborted', errorCategory: 'dataValidation' },
+      });
+      return false;
+    }
+    currentRun.items.push(...collection.items);
+  } else if (currentRun.type === 'subscription' && classification.type === 'subscription') {
+    for (const sg of classification.body.subscription_groups ?? []) {
+      currentRun.items.push({ data: sg, sourceJobIndex: jobIndex });
+    }
+  } else if (currentRun.type === 'merge' && classification.type === 'merge') {
+    for (const mu of classification.body.merge_updates ?? []) {
+      currentRun.items.push({ data: mu, sourceJobIndex: jobIndex });
+    }
+  }
+  return true;
+};
+
+const processBatch = (transformedEvents: BrazeTransformedEvent[]): BrazeBatchResponse[] => {
+  const { destination } = transformedEvents[0];
+  const workspaceId = transformedEvents[0].metadata?.[0]?.workspaceId || '';
+
+  const failureResponses: BrazeTransformedEvent[] = [];
+  const filteredResponses: BrazeTransformedEvent[] = [];
+  const runs: Run[] = [];
+  const jobMetadata: (Partial<Metadata>[] | undefined)[] = new Array(transformedEvents.length);
+  const currentRunRef: { current: Run | null } = { current: null };
+
+  transformedEvents.forEach((transformedEvent, jobIndex) => {
+    const kept = ingestTransformedEvent(transformedEvent, jobIndex, {
+      failureResponses,
+      filteredResponses,
+      runs,
+      currentRunRef,
+    });
+    if (kept && transformedEvent.metadata) {
+      jobMetadata[jobIndex] = transformedEvent.metadata;
+    }
+  });
+
+  const isWorkspaceOnMauPlanFlag = isWorkspaceOnMauPlan(workspaceId);
+  const baseEndpoint = getEndpointFromConfig(destination);
+  const trackEp = getTrackEndPoint(baseEndpoint);
+  const subEp = getSubscriptionGroupEndPoint(baseEndpoint);
+  const mergeEp = getAliasMergeEndPoint(baseEndpoint);
+  const endpoints: BrazeEndpoints = {
+    headers: {
+      'Content-Type': JSON_MIME_TYPE,
+      Accept: JSON_MIME_TYPE,
+      Authorization: `Bearer ${destination.Config.restApiKey}`,
+    },
+    trackEndpoint: trackEp.endpoint,
+    trackPath: trackEp.path,
+    subEndpoint: subEp.endpoint,
+    subPath: subEp.path,
+    mergeEndpoint: mergeEp.endpoint,
+    mergePath: mergeEp.path,
+  };
+
+  const emit = isPerJobDeliveryMappingEnabled() ? emitOnPath : emitOffPath;
+  const finalResponse: BrazeBatchResponse[] = emit(
+    runs,
+    destination,
+    endpoints,
+    jobMetadata,
+    isWorkspaceOnMauPlanFlag,
+  );
+
+  if (failureResponses.length > 0) finalResponse.push(...failureResponses);
+  if (filteredResponses.length > 0) finalResponse.push(...filteredResponses);
   return finalResponse;
 };
 

--- a/test/integrations/destinations/braze/router/data.ts
+++ b/test/integrations/destinations/braze/router/data.ts
@@ -269,135 +269,273 @@ const basicRouterTests = [
         body: {
           output: [
             {
-              batchedRequest: [
+              batchedRequest: {
+                version: '1',
+                type: 'REST',
+                method: 'POST',
+                endpoint: 'https://rest.fra-01.braze.eu/users/track',
+                headers: {
+                  'Content-Type': 'application/json',
+                  Accept: 'application/json',
+                  Authorization: authHeader1,
+                },
+                params: {},
+                body: {
+                  JSON: {
+                    partner: 'RudderStack',
+                    attributes: [
+                      {
+                        email: 'mickey@disney.com',
+                        city: 'Disney',
+                        country: 'USA',
+                        firstname: 'Mickey',
+                        _update_existing_only: false,
+                        user_alias: {
+                          alias_name: 'e6ab2c5e-2cda-44a9-a962-e2f67df78bca',
+                          alias_label: 'rudder_id',
+                        },
+                      },
+                    ],
+                    events: [
+                      {
+                        name: 'Page Viewed',
+                        time: '2020-01-24T11:59:02.402+05:30',
+                        properties: {
+                          path: '/tests/html/index2.html',
+                          referrer: '',
+                          search: '',
+                          title: '',
+                          url: 'http://localhost/tests/html/index2.html',
+                        },
+                        _update_existing_only: false,
+                        user_alias: {
+                          alias_name: 'e6ab2c5e-2cda-44a9-a962-e2f67df78bca',
+                          alias_label: 'rudder_id',
+                        },
+                      },
+                    ],
+                  },
+                  JSON_ARRAY: {},
+                  XML: {},
+                  FORM: {},
+                },
+                files: {},
+                endpointPath: 'users/track',
+              },
+              metadata: [
                 {
-                  version: '1',
-                  type: 'REST',
-                  method: 'POST',
-                  endpoint: 'https://rest.fra-01.braze.eu/users/track',
-                  endpointPath: 'users/track',
-                  headers: {
-                    'Content-Type': 'application/json',
-                    Accept: 'application/json',
-                    Authorization: authHeader1,
-                  },
-                  params: {},
-                  body: {
-                    JSON: {
-                      partner: 'RudderStack',
-                      events: [
-                        {
-                          name: 'Page Viewed',
-                          time: '2020-01-24T11:59:02.402+05:30',
-                          properties: {
-                            path: '/tests/html/index2.html',
-                            referrer: '',
-                            search: '',
-                            title: '',
-                            url: 'http://localhost/tests/html/index2.html',
-                          },
-                          _update_existing_only: false,
-                          user_alias: {
-                            alias_name: 'e6ab2c5e-2cda-44a9-a962-e2f67df78bca',
-                            alias_label: 'rudder_id',
-                          },
-                        },
-                      ],
-                      attributes: [
-                        {
-                          email: 'mickey@disney.com',
-                          city: 'Disney',
-                          country: 'USA',
-                          firstname: 'Mickey',
-                          _update_existing_only: false,
-                          user_alias: {
-                            alias_name: 'e6ab2c5e-2cda-44a9-a962-e2f67df78bca',
-                            alias_label: 'rudder_id',
-                          },
-                        },
-                      ],
+                  jobId: 1,
+                  userId: 'u1',
+                  destInfo: {
+                    braze: {
+                      eventsIndex: 0,
                     },
-                    XML: {},
-                    JSON_ARRAY: {},
-                    FORM: {},
                   },
-                  files: {},
                 },
                 {
-                  version: '1',
-                  type: 'REST',
-                  method: 'POST',
-                  endpoint: 'https://rest.fra-01.braze.eu/v2/subscription/status/set',
-                  endpointPath: 'v2/subscription/status/set',
-                  headers: {
-                    'Content-Type': 'application/json',
-                    Accept: 'application/json',
-                    Authorization: authHeader1,
-                  },
-                  params: {},
-                  body: {
-                    JSON: {
-                      subscription_groups: [
-                        {
-                          external_ids: ['user123', 'user12345'],
-                          phones: ['5055077683'],
-                          subscription_group_id: 'c90f0fd2-2a02-4f2f-bf07-7e7d2c2ed2b1',
-                          subscription_state: 'subscribed',
-                        },
-                        {
-                          external_ids: ['user877'],
-                          phones: ['5055077683'],
-                          subscription_group_id: '58d0a278-b55b-4f10-b7d2-98d1c5dd4c30',
-                          subscription_state: 'subscribed',
-                        },
-                      ],
+                  jobId: 2,
+                  userId: 'u1',
+                  destInfo: {
+                    braze: {
+                      attributesIndex: 0,
                     },
-                    XML: {},
-                    JSON_ARRAY: {},
-                    FORM: {},
                   },
-                  files: {},
-                },
-                {
-                  version: '1',
-                  type: 'REST',
-                  method: 'POST',
-                  endpoint: 'https://rest.fra-01.braze.eu/users/merge',
-                  endpointPath: 'users/merge',
-                  headers: {
-                    'Content-Type': 'application/json',
-                    Accept: 'application/json',
-                    Authorization: authHeader1,
-                  },
-                  params: {},
-                  body: {
-                    JSON: {
-                      merge_updates: [
-                        {
-                          identifier_to_keep: { external_id: 'dsafsdf' },
-                          identifier_to_merge: { external_id: 'adsfsaf' },
-                        },
-                        {
-                          identifier_to_keep: { external_id: 'dsafsdf2' },
-                          identifier_to_merge: { external_id: 'adsfsaf2' },
-                        },
-                      ],
-                    },
-                    XML: {},
-                    JSON_ARRAY: {},
-                    FORM: {},
-                  },
-                  files: {},
                 },
               ],
+              batched: true,
+              statusCode: 200,
+              destination: {
+                hasDynamicConfig: false,
+                Config: {
+                  restApiKey: secret1,
+                  prefixProperties: true,
+                  useNativeSDK: false,
+                  dataCenter: 'eu-01',
+                },
+                DestinationDefinition: {
+                  DisplayName: 'Braze',
+                  ID: '1WhbSZ6uA3H5ChVifHpfL2H6sie',
+                  Name: 'BRAZE',
+                },
+                Enabled: true,
+                ID: '1WhcOCGgj9asZu850HvugU2C3Aq',
+                Name: 'Braze',
+                Transformations: [],
+              },
+            },
+            {
+              batchedRequest: {
+                version: '1',
+                type: 'REST',
+                method: 'POST',
+                endpoint: 'https://rest.fra-01.braze.eu/v2/subscription/status/set',
+                headers: {
+                  'Content-Type': 'application/json',
+                  Accept: 'application/json',
+                  Authorization: authHeader1,
+                },
+                params: {},
+                body: {
+                  JSON: {
+                    subscription_groups: [
+                      {
+                        subscription_group_id: 'c90f0fd2-2a02-4f2f-bf07-7e7d2c2ed2b1',
+                        subscription_state: 'subscribed',
+                        phones: ['5055077683'],
+                        external_ids: ['user123'],
+                      },
+                      {
+                        subscription_group_id: '58d0a278-b55b-4f10-b7d2-98d1c5dd4c30',
+                        subscription_state: 'subscribed',
+                        phones: ['5055077683'],
+                        external_ids: ['user877'],
+                      },
+                    ],
+                  },
+                  JSON_ARRAY: {},
+                  XML: {},
+                  FORM: {},
+                },
+                files: {},
+                endpointPath: 'v2/subscription/status/set',
+              },
               metadata: [
-                { jobId: 1, userId: 'u1' },
-                { jobId: 2, userId: 'u1' },
-                { jobId: 3, userId: 'u1' },
-                { jobId: 4, userId: 'u1' },
-                { jobId: 5, userId: 'u1' },
-                { jobId: 6, userId: 'u1' },
-                { jobId: 7, userId: 'u1' },
+                {
+                  jobId: 3,
+                  userId: 'u1',
+                },
+                {
+                  jobId: 4,
+                  userId: 'u1',
+                },
+              ],
+              batched: true,
+              statusCode: 200,
+              destination: {
+                hasDynamicConfig: false,
+                Config: {
+                  restApiKey: secret1,
+                  prefixProperties: true,
+                  useNativeSDK: false,
+                  dataCenter: 'eu-01',
+                },
+                DestinationDefinition: {
+                  DisplayName: 'Braze',
+                  ID: '1WhbSZ6uA3H5ChVifHpfL2H6sie',
+                  Name: 'BRAZE',
+                },
+                Enabled: true,
+                ID: '1WhcOCGgj9asZu850HvugU2C3Aq',
+                Name: 'Braze',
+                Transformations: [],
+              },
+            },
+            {
+              batchedRequest: {
+                version: '1',
+                type: 'REST',
+                method: 'POST',
+                endpoint: 'https://rest.fra-01.braze.eu/users/merge',
+                headers: {
+                  'Content-Type': 'application/json',
+                  Accept: 'application/json',
+                  Authorization: authHeader1,
+                },
+                params: {},
+                body: {
+                  JSON: {
+                    merge_updates: [
+                      {
+                        identifier_to_merge: {
+                          external_id: 'adsfsaf',
+                        },
+                        identifier_to_keep: {
+                          external_id: 'dsafsdf',
+                        },
+                      },
+                      {
+                        identifier_to_merge: {
+                          external_id: 'adsfsaf2',
+                        },
+                        identifier_to_keep: {
+                          external_id: 'dsafsdf2',
+                        },
+                      },
+                    ],
+                  },
+                  JSON_ARRAY: {},
+                  XML: {},
+                  FORM: {},
+                },
+                files: {},
+                endpointPath: 'users/merge',
+              },
+              metadata: [
+                {
+                  jobId: 5,
+                  userId: 'u1',
+                },
+                {
+                  jobId: 6,
+                  userId: 'u1',
+                },
+              ],
+              batched: true,
+              statusCode: 200,
+              destination: {
+                hasDynamicConfig: false,
+                Config: {
+                  restApiKey: secret1,
+                  prefixProperties: true,
+                  useNativeSDK: false,
+                  dataCenter: 'eu-01',
+                },
+                DestinationDefinition: {
+                  DisplayName: 'Braze',
+                  ID: '1WhbSZ6uA3H5ChVifHpfL2H6sie',
+                  Name: 'BRAZE',
+                },
+                Enabled: true,
+                ID: '1WhcOCGgj9asZu850HvugU2C3Aq',
+                Name: 'Braze',
+                Transformations: [],
+              },
+            },
+            {
+              batchedRequest: {
+                version: '1',
+                type: 'REST',
+                method: 'POST',
+                endpoint: 'https://rest.fra-01.braze.eu/v2/subscription/status/set',
+                headers: {
+                  'Content-Type': 'application/json',
+                  Accept: 'application/json',
+                  Authorization: authHeader1,
+                },
+                params: {},
+                body: {
+                  JSON: {
+                    subscription_groups: [
+                      {
+                        subscription_group_id: 'c90f0fd2-2a02-4f2f-bf07-7e7d2c2ed2b1',
+                        subscription_state: 'subscribed',
+                        phones: ['5055077683'],
+                        external_ids: ['user12345'],
+                      },
+                    ],
+                  },
+                  JSON_ARRAY: {},
+                  XML: {},
+                  FORM: {},
+                },
+                files: {},
+                endpointPath: 'v2/subscription/status/set',
+              },
+              metadata: [
+                {
+                  jobId: 7,
+                  userId: 'u1',
+                },
               ],
               batched: true,
               statusCode: 200,
@@ -751,93 +889,129 @@ const basicRouterTests = [
         body: {
           output: [
             {
-              batchedRequest: [
-                {
-                  version: '1',
-                  type: 'REST',
-                  method: 'POST',
-                  endpoint: 'https://rest.iad-03.braze.com/users/track',
-                  endpointPath: 'users/track',
-                  headers: {
-                    'Content-Type': 'application/json',
-                    Accept: 'application/json',
-                    Authorization: authHeader1,
-                  },
-                  params: {},
-                  body: {
-                    JSON: {
-                      partner: 'RudderStack',
-                      attributes: [
-                        {
-                          first_name: 'Spencer',
-                          subscribe_once: true,
-                          pwa: true,
-                          external_id: 'braze_test_user',
-                          custom_obj_attr: { key1: 'value1', key2: 'value2', key4: 'value4' },
-                        },
-                        {
-                          last_name: 'Miranda 2',
-                          is_pickup_selected: 'true',
-                          external_id: 'braze_test_user',
-                          custom_arr: ['1', '2', 'str1'],
-                        },
-                        {
-                          city: 'Disney',
-                          country: 'USA',
-                          email: 'mickey@disney.com',
-                          external_id: 'user@50',
-                          first_name: 'Mickey',
-                        },
-                        {
-                          country: 'USA',
-                          external_id: 'user@50',
-                        },
-                      ],
-                      events: [
-                        {
-                          name: 'Sign In Completed',
-                          time: '2023-03-10T18:36:05.028Z',
-                          properties: {
-                            cause: '/redirector',
-                            method: 'GOOGLE',
-                            region: 'ON',
-                            orderId: '6179367977099',
-                            order_id: '6179367977099',
-                            webhookurl: 'https://my.test.com',
-                            countingMethod: 'standard',
-                            is_first_time_signin: false,
-                          },
-                          external_id: 'braze_test_user',
-                        },
-                        {
-                          name: 'Sign In Completed',
-                          time: '2023-03-10T18:36:05.028Z',
-                          properties: {
-                            cause: '/redirector',
-                            method: 'GOOGLE',
-                            region: 'ON',
-                            orderId: '6179367977099',
-                            order_id: '6179367977099',
-                            webhookurl: 'https://my.test.com',
-                            countingMethod: 'standard',
-                            is_first_time_signin: false,
-                          },
-                          external_id: 'braze_test_user',
-                        },
-                      ],
-                    },
-                    JSON_ARRAY: {},
-                    XML: {},
-                    FORM: {},
-                  },
-                  files: {},
+              batchedRequest: {
+                version: '1',
+                type: 'REST',
+                method: 'POST',
+                endpoint: 'https://rest.iad-03.braze.com/users/track',
+                headers: {
+                  'Content-Type': 'application/json',
+                  Accept: 'application/json',
+                  Authorization: authHeader1,
                 },
-              ],
+                params: {},
+                body: {
+                  JSON: {
+                    partner: 'RudderStack',
+                    attributes: [
+                      {
+                        first_name: 'Spencer',
+                        subscribe_once: true,
+                        pwa: true,
+                        custom_obj_attr: {
+                          key1: 'value1',
+                          key2: 'value2',
+                          key4: 'value4',
+                        },
+                        external_id: 'braze_test_user',
+                      },
+                      {
+                        last_name: 'Miranda 2',
+                        is_pickup_selected: 'true',
+                        custom_arr: ['1', '2', 'str1'],
+                        external_id: 'braze_test_user',
+                      },
+                      {
+                        email: 'mickey@disney.com',
+                        first_name: 'Mickey',
+                        city: 'Disney',
+                        country: 'USA',
+                        external_id: 'user@50',
+                      },
+                      {
+                        country: 'USA',
+                        external_id: 'user@50',
+                      },
+                    ],
+                    events: [
+                      {
+                        name: 'Sign In Completed',
+                        time: '2023-03-10T18:36:05.028Z',
+                        properties: {
+                          cause: '/redirector',
+                          method: 'GOOGLE',
+                          region: 'ON',
+                          orderId: '6179367977099',
+                          order_id: '6179367977099',
+                          webhookurl: 'https://my.test.com',
+                          countingMethod: 'standard',
+                          is_first_time_signin: false,
+                        },
+                        external_id: 'braze_test_user',
+                      },
+                      {
+                        name: 'Sign In Completed',
+                        time: '2023-03-10T18:36:05.028Z',
+                        properties: {
+                          cause: '/redirector',
+                          method: 'GOOGLE',
+                          region: 'ON',
+                          orderId: '6179367977099',
+                          order_id: '6179367977099',
+                          webhookurl: 'https://my.test.com',
+                          countingMethod: 'standard',
+                          is_first_time_signin: false,
+                        },
+                        external_id: 'braze_test_user',
+                      },
+                    ],
+                  },
+                  JSON_ARRAY: {},
+                  XML: {},
+                  FORM: {},
+                },
+                files: {},
+                endpointPath: 'users/track',
+              },
               metadata: [
-                { jobId: 1, userId: 'u1' },
-                { jobId: 2, userId: 'u1' },
-                { jobId: 3, userId: 'u1' },
-                { jobId: 4, userId: 'u1' },
+                {
+                  jobId: 1,
+                  userId: 'u1',
+                  destInfo: {
+                    braze: {
+                      attributesIndex: 0,
+                      eventsIndex: 0,
+                    },
+                  },
+                },
+                {
+                  jobId: 2,
+                  userId: 'u1',
+                  destInfo: {
+                    braze: {
+                      attributesIndex: 1,
+                      eventsIndex: 1,
+                    },
+                  },
+                },
+                {
+                  jobId: 3,
+                  userId: 'u1',
+                  destInfo: {
+                    braze: {
+                      attributesIndex: 2,
+                    },
+                  },
+                },
+                {
+                  jobId: 4,
+                  userId: 'u1',
+                  destInfo: {
+                    braze: {
+                      attributesIndex: 3,
+                    },
+                  },
+                },
               ],
               batched: true,
               statusCode: 200,
@@ -865,18 +1039,23 @@ const basicRouterTests = [
               },
             },
             {
+              metadata: [
+                {
+                  jobId: 5,
+                  userId: 'u1',
+                },
+              ],
+              batched: false,
+              statusCode: 400,
               error: '[Braze Deduplication]: Duplicate user detected, the user is dropped',
               statTags: {
-                destType: 'BRAZE',
                 errorCategory: 'dataValidation',
                 errorType: 'instrumentation',
-                feature: 'router',
-                implementation: 'native',
+                destType: 'BRAZE',
                 module: 'destination',
+                implementation: 'native',
+                feature: 'router',
               },
-              statusCode: 400,
-              batched: false,
-              metadata: [{ jobId: 5, userId: 'u1' }],
               destination: {
                 hasDynamicConfig: false,
                 ID: '2N9UakqKF0D35wfzSeofIxPdL8X',
@@ -1072,39 +1251,43 @@ const basicRouterTests = [
         body: {
           output: [
             {
-              batchedRequest: [
-                {
-                  version: '1',
-                  type: 'REST',
-                  method: 'POST',
-                  endpoint: 'https://rest.fra-01.braze.eu/v2/subscription/status/set',
-                  endpointPath: 'v2/subscription/status/set',
-                  headers: {
-                    'Content-Type': 'application/json',
-                    Accept: 'application/json',
-                    Authorization: 'Bearer secret1',
-                  },
-                  params: {},
-                  body: {
-                    JSON: {
-                      subscription_groups: [
-                        {
-                          subscription_group_id: '1234',
-                          subscription_state: 'unsubscribed',
-                          emails: ['abc@test.com', 'abc1@test.com'],
-                        },
-                      ],
-                    },
-                    JSON_ARRAY: {},
-                    XML: {},
-                    FORM: {},
-                  },
-                  files: {},
+              batchedRequest: {
+                version: '1',
+                type: 'REST',
+                method: 'POST',
+                endpoint: 'https://rest.fra-01.braze.eu/v2/subscription/status/set',
+                headers: {
+                  'Content-Type': 'application/json',
+                  Accept: 'application/json',
+                  Authorization: 'Bearer secret1',
                 },
-              ],
+                params: {},
+                body: {
+                  JSON: {
+                    subscription_groups: [
+                      {
+                        subscription_group_id: '1234',
+                        subscription_state: 'unsubscribed',
+                        emails: ['abc@test.com', 'abc1@test.com'],
+                      },
+                    ],
+                  },
+                  JSON_ARRAY: {},
+                  XML: {},
+                  FORM: {},
+                },
+                files: {},
+                endpointPath: 'v2/subscription/status/set',
+              },
               metadata: [
-                { jobId: 1, userId: 'u1' },
-                { jobId: 2, userId: 'u2' },
+                {
+                  jobId: 1,
+                  userId: 'u1',
+                },
+                {
+                  jobId: 2,
+                  userId: 'u2',
+                },
               ],
               batched: true,
               statusCode: 200,

--- a/test/integrations/destinations/braze/router/data.ts
+++ b/test/integrations/destinations/braze/router/data.ts
@@ -327,18 +327,14 @@ const basicRouterTests = [
                   jobId: 1,
                   userId: 'u1',
                   destInfo: {
-                    braze: {
-                      eventsIndex: 0,
-                    },
+                    eventsIndices: [0],
                   },
                 },
                 {
                   jobId: 2,
                   userId: 'u1',
                   destInfo: {
-                    braze: {
-                      attributesIndex: 0,
-                    },
+                    attributesIndices: [0],
                   },
                 },
               ],
@@ -978,38 +974,30 @@ const basicRouterTests = [
                   jobId: 1,
                   userId: 'u1',
                   destInfo: {
-                    braze: {
-                      attributesIndex: 0,
-                      eventsIndex: 0,
-                    },
+                    attributesIndices: [0],
+                    eventsIndices: [0],
                   },
                 },
                 {
                   jobId: 2,
                   userId: 'u1',
                   destInfo: {
-                    braze: {
-                      attributesIndex: 1,
-                      eventsIndex: 1,
-                    },
+                    attributesIndices: [1],
+                    eventsIndices: [1],
                   },
                 },
                 {
                   jobId: 3,
                   userId: 'u1',
                   destInfo: {
-                    braze: {
-                      attributesIndex: 2,
-                    },
+                    attributesIndices: [2],
                   },
                 },
                 {
                   jobId: 4,
                   userId: 'u1',
                   destInfo: {
-                    braze: {
-                      attributesIndex: 3,
-                    },
+                    attributesIndices: [3],
                   },
                 },
               ],

--- a/test/integrations/destinations/braze/router/data.ts
+++ b/test/integrations/destinations/braze/router/data.ts
@@ -1,3 +1,4 @@
+import { generateMetadata } from '../../amazon_audience/common';
 import { authHeader1, secret1 } from '../maskedSecrets';
 import { identityResolution } from './identityResolution';
 
@@ -1148,19 +1149,22 @@ const basicRouterTestsWithBatchIdentityResolutionEnabled = basicRouterTests.map(
 });
 
 // ---------------------------------------------------------------------------
-// Per-job delivery-mapping (INT-6808 + INT-6634) — ON path.
+// Per-job delivery-mapping — ON path.
 // When `BRAZE_PER_JOB_DELIVERY_MAPPING_ENABLED=true`, processBatch emits one
 // BatchRequestOutput per outgoing HTTP request (instead of one
-// MultiBatchRequestOutput with batchedRequest[]), preserves insertion-order
-// runs across endpoints, and attaches per-metadata `destInfo` positional
-// indices (populated for /users/track chunks; present-but-empty for sub/merge
-// chunks).
+// MultiBatchRequestOutput with batchedRequest[]). Items are coalesced by
+// endpoint type across the entire input — insertion-order runs are NOT
+// preserved — so a batch that mixes track, subscription, and merge jobs
+// produces exactly one output per endpoint (subject to chunk-size caps).
+// Track outputs carry per-metadata `destInfo.attributesIndices` /
+// `.eventsIndices` / `.purchasesIndices`; sub/merge outputs carry
+// `destInfo: {}` for correlation-shape uniformity.
 // ---------------------------------------------------------------------------
 const perJobDeliveryMappingOnTests = [
   {
     name: 'braze',
     description:
-      'per-job delivery mapping ON — mixed track + subscription + merge preserves insertion-order runs and emits destInfo positional maps',
+      'per-job delivery mapping ON — mixed track + subscription + merge coalesces items per endpoint into one output each',
     feature: 'router',
     module: 'destination',
     version: 'v0',
@@ -1228,7 +1232,7 @@ const perJobDeliveryMappingOnTests = [
                 Name: 'Braze',
                 Transformations: [],
               },
-              metadata: { jobId: 2, userId: 'u1' },
+              metadata: { jobId: 2, userId: 'u2' },
               message: {
                 anonymousId: 'e6ab2c5e-2cda-44a9-a962-e2f67df78bca',
                 channel: 'web',
@@ -1271,7 +1275,7 @@ const perJobDeliveryMappingOnTests = [
                 Name: 'Braze',
                 Transformations: [],
               },
-              metadata: { jobId: 3, userId: 'u1' },
+              metadata: { jobId: 3, userId: 'u3' },
               message: {
                 anonymousId: '56yrtsdfgbgxcb-22b4-401d-aae5-1b994be9a969',
                 groupId: 'c90f0fd2-2a02-4f2f-bf07-7e7d2c2ed2b1',
@@ -1300,7 +1304,7 @@ const perJobDeliveryMappingOnTests = [
                 Name: 'Braze',
                 Transformations: [],
               },
-              metadata: { jobId: 4, userId: 'u1' },
+              metadata: { jobId: 4, userId: 'u4' },
               message: {
                 anonymousId: 'dfgdfgdfg-22b4-401d-aae5-1b994be9a969',
                 groupId: '58d0a278-b55b-4f10-b7d2-98d1c5dd4c30',
@@ -1329,7 +1333,7 @@ const perJobDeliveryMappingOnTests = [
                 Name: 'Braze',
                 Transformations: [],
               },
-              metadata: { jobId: 5, userId: 'u1' },
+              metadata: { jobId: 5, userId: 'u5' },
               message: { type: 'alias', previousId: 'adsfsaf', userId: 'dsafsdf' },
             },
             {
@@ -1352,7 +1356,7 @@ const perJobDeliveryMappingOnTests = [
                 Name: 'Braze',
                 Transformations: [],
               },
-              metadata: { jobId: 6, userId: 'u1' },
+              metadata: { jobId: 6, userId: 'u6' },
               message: { type: 'alias', previousId: 'adsfsaf2', userId: 'dsafsdf2' },
             },
             {
@@ -1375,7 +1379,7 @@ const perJobDeliveryMappingOnTests = [
                 Name: 'Braze',
                 Transformations: [],
               },
-              metadata: { jobId: 7, userId: 'u1' },
+              metadata: { jobId: 7, userId: 'u7' },
               message: {
                 anonymousId: '56yrtsdfgbgxcb-22b4-401d-aae5-1b994be9afdf',
                 groupId: 'c90f0fd2-2a02-4f2f-bf07-7e7d2c2ed2b1',
@@ -1453,7 +1457,7 @@ const perJobDeliveryMappingOnTests = [
               },
               metadata: [
                 { jobId: 1, userId: 'u1', destInfo: { eventsIndices: [0] } },
-                { jobId: 2, userId: 'u1', destInfo: { attributesIndices: [0] } },
+                { jobId: 2, userId: 'u2', destInfo: { attributesIndices: [0] } },
               ],
               batched: true,
               statusCode: 200,
@@ -1476,12 +1480,12 @@ const perJobDeliveryMappingOnTests = [
                 Transformations: [],
               },
             },
-            // Output 2 — first subscription run (jobs 3, 4). One
-            // /v2/subscription/status/set HTTP request. Note that job 7
-            // (also a subscription with the same group_id as job 3) does NOT
-            // merge in here — insertion-order runs put job 7 into a
-            // SEPARATE run after the merge run. Sub metadata carries
-            // `destInfo: {}` (present-but-empty).
+            // Output 2 — subscription-groups (jobs 3, 4, 7 coalesced). Items
+            // from all subscription-shaped jobs across the batch are combined
+            // into a single output regardless of their position in the input,
+            // then `combineSubscriptionGroups` merges the two `c90f0fd2` rows
+            // (job 3's user123 + job 7's user12345) into one entry. Sub
+            // metadata carries `destInfo: {}` (present-but-empty).
             {
               batchedRequest: {
                 version: '1',
@@ -1499,7 +1503,7 @@ const perJobDeliveryMappingOnTests = [
                   JSON: {
                     subscription_groups: [
                       {
-                        external_ids: ['user123'],
+                        external_ids: ['user123', 'user12345'],
                         phones: ['5055077683'],
                         subscription_group_id: 'c90f0fd2-2a02-4f2f-bf07-7e7d2c2ed2b1',
                         subscription_state: 'subscribed',
@@ -1519,8 +1523,9 @@ const perJobDeliveryMappingOnTests = [
                 files: {},
               },
               metadata: [
-                { jobId: 3, userId: 'u1', destInfo: {} },
-                { jobId: 4, userId: 'u1', destInfo: {} },
+                { jobId: 3, userId: 'u3', destInfo: {} },
+                { jobId: 4, userId: 'u4', destInfo: {} },
+                { jobId: 7, userId: 'u7', destInfo: {} },
               ],
               batched: true,
               statusCode: 200,
@@ -1543,8 +1548,8 @@ const perJobDeliveryMappingOnTests = [
                 Transformations: [],
               },
             },
-            // Output 3 — merge run (jobs 5, 6). One /users/merge HTTP request.
-            // Merge metadata carries `destInfo: {}` (present-but-empty).
+            // Output 3 — alias-merge (jobs 5, 6 coalesced). One /users/merge
+            // HTTP request. Merge metadata carries `destInfo: {}`.
             {
               batchedRequest: {
                 version: '1',
@@ -1578,65 +1583,9 @@ const perJobDeliveryMappingOnTests = [
                 files: {},
               },
               metadata: [
-                { jobId: 5, userId: 'u1', destInfo: {} },
-                { jobId: 6, userId: 'u1', destInfo: {} },
+                { jobId: 5, userId: 'u5', destInfo: {} },
+                { jobId: 6, userId: 'u6', destInfo: {} },
               ],
-              batched: true,
-              statusCode: 200,
-              destination: {
-                hasDynamicConfig: false,
-                Config: {
-                  restApiKey: secret1,
-                  prefixProperties: true,
-                  useNativeSDK: false,
-                  dataCenter: 'eu-01',
-                },
-                DestinationDefinition: {
-                  DisplayName: 'Braze',
-                  ID: '1WhbSZ6uA3H5ChVifHpfL2H6sie',
-                  Name: 'BRAZE',
-                },
-                Enabled: true,
-                ID: '1WhcOCGgj9asZu850HvugU2C3Aq',
-                Name: 'Braze',
-                Transformations: [],
-              },
-            },
-            // Output 4 — second subscription run (job 7 alone). Because the
-            // merge run split the two subscription groups apart in insertion
-            // order, job 7 gets its OWN /v2/subscription/status/set HTTP
-            // request — this is the key run-preserving-shape guarantee.
-            {
-              batchedRequest: {
-                version: '1',
-                type: 'REST',
-                method: 'POST',
-                endpoint: 'https://rest.fra-01.braze.eu/v2/subscription/status/set',
-                endpointPath: 'v2/subscription/status/set',
-                headers: {
-                  'Content-Type': 'application/json',
-                  Accept: 'application/json',
-                  Authorization: authHeader1,
-                },
-                params: {},
-                body: {
-                  JSON: {
-                    subscription_groups: [
-                      {
-                        external_ids: ['user12345'],
-                        phones: ['5055077683'],
-                        subscription_group_id: 'c90f0fd2-2a02-4f2f-bf07-7e7d2c2ed2b1',
-                        subscription_state: 'subscribed',
-                      },
-                    ],
-                  },
-                  XML: {},
-                  JSON_ARRAY: {},
-                  FORM: {},
-                },
-                files: {},
-              },
-              metadata: [{ jobId: 7, userId: 'u1', destInfo: {} }],
               batched: true,
               statusCode: 200,
               destination: {
@@ -1735,7 +1684,7 @@ const perJobDeliveryMappingOnTests = [
                 Name: 'Braze',
                 Transformations: [],
               },
-              metadata: { jobId: 101, userId: 'u1' },
+              metadata: generateMetadata(101, 'u1'),
               message: {
                 anonymousId: 'a2',
                 channel: 'web',
@@ -1833,6 +1782,7 @@ const perJobDeliveryMappingOnTests = [
               metadata: [
                 { jobId: 100, userId: 'u1', destInfo: { attributesIndices: [0] } },
                 {
+                  ...generateMetadata(101, 'u1'),
                   jobId: 101,
                   userId: 'u1',
                   destInfo: { attributesIndices: [1], purchasesIndices: [0, 1, 2] },

--- a/test/integrations/destinations/braze/router/data.ts
+++ b/test/integrations/destinations/braze/router/data.ts
@@ -1150,7 +1150,8 @@ const basicRouterTestsWithBatchIdentityResolutionEnabled = basicRouterTests.map(
 
 // ---------------------------------------------------------------------------
 // Per-job delivery-mapping — ON path.
-// When `BRAZE_PER_JOB_DELIVERY_MAPPING_ENABLED=true`, processBatch emits one
+// When `BRAZE_PER_JOB_DELIVERY_MAPPING_WORKSPACE_IDS` enables the workspace,
+// processBatch emits one
 // BatchRequestOutput per outgoing HTTP request (instead of one
 // MultiBatchRequestOutput with batchedRequest[]). Items are coalesced by
 // endpoint type across the entire input — insertion-order runs are NOT
@@ -1612,7 +1613,7 @@ const perJobDeliveryMappingOnTests = [
       },
     },
     envOverrides: {
-      BRAZE_PER_JOB_DELIVERY_MAPPING_ENABLED: 'true',
+      BRAZE_PER_JOB_DELIVERY_MAPPING_WORKSPACE_IDS: 'ALL',
       BRAZE_BATCH_IDENTIFY_RESOLUTION: 'false',
     },
   },
@@ -1814,7 +1815,7 @@ const perJobDeliveryMappingOnTests = [
       },
     },
     envOverrides: {
-      BRAZE_PER_JOB_DELIVERY_MAPPING_ENABLED: 'true',
+      BRAZE_PER_JOB_DELIVERY_MAPPING_WORKSPACE_IDS: 'ALL',
       BRAZE_BATCH_IDENTIFY_RESOLUTION: 'false',
     },
   },

--- a/test/integrations/destinations/braze/router/data.ts
+++ b/test/integrations/destinations/braze/router/data.ts
@@ -269,269 +269,135 @@ const basicRouterTests = [
         body: {
           output: [
             {
-              batchedRequest: {
-                version: '1',
-                type: 'REST',
-                method: 'POST',
-                endpoint: 'https://rest.fra-01.braze.eu/users/track',
-                headers: {
-                  'Content-Type': 'application/json',
-                  Accept: 'application/json',
-                  Authorization: authHeader1,
-                },
-                params: {},
-                body: {
-                  JSON: {
-                    partner: 'RudderStack',
-                    attributes: [
-                      {
-                        email: 'mickey@disney.com',
-                        city: 'Disney',
-                        country: 'USA',
-                        firstname: 'Mickey',
-                        _update_existing_only: false,
-                        user_alias: {
-                          alias_name: 'e6ab2c5e-2cda-44a9-a962-e2f67df78bca',
-                          alias_label: 'rudder_id',
-                        },
-                      },
-                    ],
-                    events: [
-                      {
-                        name: 'Page Viewed',
-                        time: '2020-01-24T11:59:02.402+05:30',
-                        properties: {
-                          path: '/tests/html/index2.html',
-                          referrer: '',
-                          search: '',
-                          title: '',
-                          url: 'http://localhost/tests/html/index2.html',
-                        },
-                        _update_existing_only: false,
-                        user_alias: {
-                          alias_name: 'e6ab2c5e-2cda-44a9-a962-e2f67df78bca',
-                          alias_label: 'rudder_id',
-                        },
-                      },
-                    ],
-                  },
-                  JSON_ARRAY: {},
-                  XML: {},
-                  FORM: {},
-                },
-                files: {},
-                endpointPath: 'users/track',
-              },
-              metadata: [
+              batchedRequest: [
                 {
-                  jobId: 1,
-                  userId: 'u1',
-                  destInfo: {
-                    eventsIndices: [0],
+                  version: '1',
+                  type: 'REST',
+                  method: 'POST',
+                  endpoint: 'https://rest.fra-01.braze.eu/users/track',
+                  endpointPath: 'users/track',
+                  headers: {
+                    'Content-Type': 'application/json',
+                    Accept: 'application/json',
+                    Authorization: authHeader1,
                   },
+                  params: {},
+                  body: {
+                    JSON: {
+                      partner: 'RudderStack',
+                      events: [
+                        {
+                          name: 'Page Viewed',
+                          time: '2020-01-24T11:59:02.402+05:30',
+                          properties: {
+                            path: '/tests/html/index2.html',
+                            referrer: '',
+                            search: '',
+                            title: '',
+                            url: 'http://localhost/tests/html/index2.html',
+                          },
+                          _update_existing_only: false,
+                          user_alias: {
+                            alias_name: 'e6ab2c5e-2cda-44a9-a962-e2f67df78bca',
+                            alias_label: 'rudder_id',
+                          },
+                        },
+                      ],
+                      attributes: [
+                        {
+                          email: 'mickey@disney.com',
+                          city: 'Disney',
+                          country: 'USA',
+                          firstname: 'Mickey',
+                          _update_existing_only: false,
+                          user_alias: {
+                            alias_name: 'e6ab2c5e-2cda-44a9-a962-e2f67df78bca',
+                            alias_label: 'rudder_id',
+                          },
+                        },
+                      ],
+                    },
+                    XML: {},
+                    JSON_ARRAY: {},
+                    FORM: {},
+                  },
+                  files: {},
                 },
                 {
-                  jobId: 2,
-                  userId: 'u1',
-                  destInfo: {
-                    attributesIndices: [0],
+                  version: '1',
+                  type: 'REST',
+                  method: 'POST',
+                  endpoint: 'https://rest.fra-01.braze.eu/v2/subscription/status/set',
+                  endpointPath: 'v2/subscription/status/set',
+                  headers: {
+                    'Content-Type': 'application/json',
+                    Accept: 'application/json',
+                    Authorization: authHeader1,
                   },
+                  params: {},
+                  body: {
+                    JSON: {
+                      subscription_groups: [
+                        {
+                          external_ids: ['user123', 'user12345'],
+                          phones: ['5055077683'],
+                          subscription_group_id: 'c90f0fd2-2a02-4f2f-bf07-7e7d2c2ed2b1',
+                          subscription_state: 'subscribed',
+                        },
+                        {
+                          external_ids: ['user877'],
+                          phones: ['5055077683'],
+                          subscription_group_id: '58d0a278-b55b-4f10-b7d2-98d1c5dd4c30',
+                          subscription_state: 'subscribed',
+                        },
+                      ],
+                    },
+                    XML: {},
+                    JSON_ARRAY: {},
+                    FORM: {},
+                  },
+                  files: {},
+                },
+                {
+                  version: '1',
+                  type: 'REST',
+                  method: 'POST',
+                  endpoint: 'https://rest.fra-01.braze.eu/users/merge',
+                  endpointPath: 'users/merge',
+                  headers: {
+                    'Content-Type': 'application/json',
+                    Accept: 'application/json',
+                    Authorization: authHeader1,
+                  },
+                  params: {},
+                  body: {
+                    JSON: {
+                      merge_updates: [
+                        {
+                          identifier_to_keep: { external_id: 'dsafsdf' },
+                          identifier_to_merge: { external_id: 'adsfsaf' },
+                        },
+                        {
+                          identifier_to_keep: { external_id: 'dsafsdf2' },
+                          identifier_to_merge: { external_id: 'adsfsaf2' },
+                        },
+                      ],
+                    },
+                    XML: {},
+                    JSON_ARRAY: {},
+                    FORM: {},
+                  },
+                  files: {},
                 },
               ],
-              batched: true,
-              statusCode: 200,
-              destination: {
-                hasDynamicConfig: false,
-                Config: {
-                  restApiKey: secret1,
-                  prefixProperties: true,
-                  useNativeSDK: false,
-                  dataCenter: 'eu-01',
-                },
-                DestinationDefinition: {
-                  DisplayName: 'Braze',
-                  ID: '1WhbSZ6uA3H5ChVifHpfL2H6sie',
-                  Name: 'BRAZE',
-                },
-                Enabled: true,
-                ID: '1WhcOCGgj9asZu850HvugU2C3Aq',
-                Name: 'Braze',
-                Transformations: [],
-              },
-            },
-            {
-              batchedRequest: {
-                version: '1',
-                type: 'REST',
-                method: 'POST',
-                endpoint: 'https://rest.fra-01.braze.eu/v2/subscription/status/set',
-                headers: {
-                  'Content-Type': 'application/json',
-                  Accept: 'application/json',
-                  Authorization: authHeader1,
-                },
-                params: {},
-                body: {
-                  JSON: {
-                    subscription_groups: [
-                      {
-                        subscription_group_id: 'c90f0fd2-2a02-4f2f-bf07-7e7d2c2ed2b1',
-                        subscription_state: 'subscribed',
-                        phones: ['5055077683'],
-                        external_ids: ['user123'],
-                      },
-                      {
-                        subscription_group_id: '58d0a278-b55b-4f10-b7d2-98d1c5dd4c30',
-                        subscription_state: 'subscribed',
-                        phones: ['5055077683'],
-                        external_ids: ['user877'],
-                      },
-                    ],
-                  },
-                  JSON_ARRAY: {},
-                  XML: {},
-                  FORM: {},
-                },
-                files: {},
-                endpointPath: 'v2/subscription/status/set',
-              },
               metadata: [
-                {
-                  jobId: 3,
-                  userId: 'u1',
-                },
-                {
-                  jobId: 4,
-                  userId: 'u1',
-                },
-              ],
-              batched: true,
-              statusCode: 200,
-              destination: {
-                hasDynamicConfig: false,
-                Config: {
-                  restApiKey: secret1,
-                  prefixProperties: true,
-                  useNativeSDK: false,
-                  dataCenter: 'eu-01',
-                },
-                DestinationDefinition: {
-                  DisplayName: 'Braze',
-                  ID: '1WhbSZ6uA3H5ChVifHpfL2H6sie',
-                  Name: 'BRAZE',
-                },
-                Enabled: true,
-                ID: '1WhcOCGgj9asZu850HvugU2C3Aq',
-                Name: 'Braze',
-                Transformations: [],
-              },
-            },
-            {
-              batchedRequest: {
-                version: '1',
-                type: 'REST',
-                method: 'POST',
-                endpoint: 'https://rest.fra-01.braze.eu/users/merge',
-                headers: {
-                  'Content-Type': 'application/json',
-                  Accept: 'application/json',
-                  Authorization: authHeader1,
-                },
-                params: {},
-                body: {
-                  JSON: {
-                    merge_updates: [
-                      {
-                        identifier_to_merge: {
-                          external_id: 'adsfsaf',
-                        },
-                        identifier_to_keep: {
-                          external_id: 'dsafsdf',
-                        },
-                      },
-                      {
-                        identifier_to_merge: {
-                          external_id: 'adsfsaf2',
-                        },
-                        identifier_to_keep: {
-                          external_id: 'dsafsdf2',
-                        },
-                      },
-                    ],
-                  },
-                  JSON_ARRAY: {},
-                  XML: {},
-                  FORM: {},
-                },
-                files: {},
-                endpointPath: 'users/merge',
-              },
-              metadata: [
-                {
-                  jobId: 5,
-                  userId: 'u1',
-                },
-                {
-                  jobId: 6,
-                  userId: 'u1',
-                },
-              ],
-              batched: true,
-              statusCode: 200,
-              destination: {
-                hasDynamicConfig: false,
-                Config: {
-                  restApiKey: secret1,
-                  prefixProperties: true,
-                  useNativeSDK: false,
-                  dataCenter: 'eu-01',
-                },
-                DestinationDefinition: {
-                  DisplayName: 'Braze',
-                  ID: '1WhbSZ6uA3H5ChVifHpfL2H6sie',
-                  Name: 'BRAZE',
-                },
-                Enabled: true,
-                ID: '1WhcOCGgj9asZu850HvugU2C3Aq',
-                Name: 'Braze',
-                Transformations: [],
-              },
-            },
-            {
-              batchedRequest: {
-                version: '1',
-                type: 'REST',
-                method: 'POST',
-                endpoint: 'https://rest.fra-01.braze.eu/v2/subscription/status/set',
-                headers: {
-                  'Content-Type': 'application/json',
-                  Accept: 'application/json',
-                  Authorization: authHeader1,
-                },
-                params: {},
-                body: {
-                  JSON: {
-                    subscription_groups: [
-                      {
-                        subscription_group_id: 'c90f0fd2-2a02-4f2f-bf07-7e7d2c2ed2b1',
-                        subscription_state: 'subscribed',
-                        phones: ['5055077683'],
-                        external_ids: ['user12345'],
-                      },
-                    ],
-                  },
-                  JSON_ARRAY: {},
-                  XML: {},
-                  FORM: {},
-                },
-                files: {},
-                endpointPath: 'v2/subscription/status/set',
-              },
-              metadata: [
-                {
-                  jobId: 7,
-                  userId: 'u1',
-                },
+                { jobId: 1, userId: 'u1' },
+                { jobId: 2, userId: 'u1' },
+                { jobId: 3, userId: 'u1' },
+                { jobId: 4, userId: 'u1' },
+                { jobId: 5, userId: 'u1' },
+                { jobId: 6, userId: 'u1' },
+                { jobId: 7, userId: 'u1' },
               ],
               batched: true,
               statusCode: 200,
@@ -885,121 +751,93 @@ const basicRouterTests = [
         body: {
           output: [
             {
-              batchedRequest: {
-                version: '1',
-                type: 'REST',
-                method: 'POST',
-                endpoint: 'https://rest.iad-03.braze.com/users/track',
-                headers: {
-                  'Content-Type': 'application/json',
-                  Accept: 'application/json',
-                  Authorization: authHeader1,
-                },
-                params: {},
-                body: {
-                  JSON: {
-                    partner: 'RudderStack',
-                    attributes: [
-                      {
-                        first_name: 'Spencer',
-                        subscribe_once: true,
-                        pwa: true,
-                        custom_obj_attr: {
-                          key1: 'value1',
-                          key2: 'value2',
-                          key4: 'value4',
-                        },
-                        external_id: 'braze_test_user',
-                      },
-                      {
-                        last_name: 'Miranda 2',
-                        is_pickup_selected: 'true',
-                        custom_arr: ['1', '2', 'str1'],
-                        external_id: 'braze_test_user',
-                      },
-                      {
-                        email: 'mickey@disney.com',
-                        first_name: 'Mickey',
-                        city: 'Disney',
-                        country: 'USA',
-                        external_id: 'user@50',
-                      },
-                      {
-                        country: 'USA',
-                        external_id: 'user@50',
-                      },
-                    ],
-                    events: [
-                      {
-                        name: 'Sign In Completed',
-                        time: '2023-03-10T18:36:05.028Z',
-                        properties: {
-                          cause: '/redirector',
-                          method: 'GOOGLE',
-                          region: 'ON',
-                          orderId: '6179367977099',
-                          order_id: '6179367977099',
-                          webhookurl: 'https://my.test.com',
-                          countingMethod: 'standard',
-                          is_first_time_signin: false,
-                        },
-                        external_id: 'braze_test_user',
-                      },
-                      {
-                        name: 'Sign In Completed',
-                        time: '2023-03-10T18:36:05.028Z',
-                        properties: {
-                          cause: '/redirector',
-                          method: 'GOOGLE',
-                          region: 'ON',
-                          orderId: '6179367977099',
-                          order_id: '6179367977099',
-                          webhookurl: 'https://my.test.com',
-                          countingMethod: 'standard',
-                          is_first_time_signin: false,
-                        },
-                        external_id: 'braze_test_user',
-                      },
-                    ],
+              batchedRequest: [
+                {
+                  version: '1',
+                  type: 'REST',
+                  method: 'POST',
+                  endpoint: 'https://rest.iad-03.braze.com/users/track',
+                  endpointPath: 'users/track',
+                  headers: {
+                    'Content-Type': 'application/json',
+                    Accept: 'application/json',
+                    Authorization: authHeader1,
                   },
-                  JSON_ARRAY: {},
-                  XML: {},
-                  FORM: {},
+                  params: {},
+                  body: {
+                    JSON: {
+                      partner: 'RudderStack',
+                      attributes: [
+                        {
+                          first_name: 'Spencer',
+                          subscribe_once: true,
+                          pwa: true,
+                          external_id: 'braze_test_user',
+                          custom_obj_attr: { key1: 'value1', key2: 'value2', key4: 'value4' },
+                        },
+                        {
+                          last_name: 'Miranda 2',
+                          is_pickup_selected: 'true',
+                          external_id: 'braze_test_user',
+                          custom_arr: ['1', '2', 'str1'],
+                        },
+                        {
+                          city: 'Disney',
+                          country: 'USA',
+                          email: 'mickey@disney.com',
+                          external_id: 'user@50',
+                          first_name: 'Mickey',
+                        },
+                        {
+                          country: 'USA',
+                          external_id: 'user@50',
+                        },
+                      ],
+                      events: [
+                        {
+                          name: 'Sign In Completed',
+                          time: '2023-03-10T18:36:05.028Z',
+                          properties: {
+                            cause: '/redirector',
+                            method: 'GOOGLE',
+                            region: 'ON',
+                            orderId: '6179367977099',
+                            order_id: '6179367977099',
+                            webhookurl: 'https://my.test.com',
+                            countingMethod: 'standard',
+                            is_first_time_signin: false,
+                          },
+                          external_id: 'braze_test_user',
+                        },
+                        {
+                          name: 'Sign In Completed',
+                          time: '2023-03-10T18:36:05.028Z',
+                          properties: {
+                            cause: '/redirector',
+                            method: 'GOOGLE',
+                            region: 'ON',
+                            orderId: '6179367977099',
+                            order_id: '6179367977099',
+                            webhookurl: 'https://my.test.com',
+                            countingMethod: 'standard',
+                            is_first_time_signin: false,
+                          },
+                          external_id: 'braze_test_user',
+                        },
+                      ],
+                    },
+                    JSON_ARRAY: {},
+                    XML: {},
+                    FORM: {},
+                  },
+                  files: {},
                 },
-                files: {},
-                endpointPath: 'users/track',
-              },
+              ],
               metadata: [
-                {
-                  jobId: 1,
-                  userId: 'u1',
-                  destInfo: {
-                    attributesIndices: [0],
-                    eventsIndices: [0],
-                  },
-                },
-                {
-                  jobId: 2,
-                  userId: 'u1',
-                  destInfo: {
-                    attributesIndices: [1],
-                    eventsIndices: [1],
-                  },
-                },
-                {
-                  jobId: 3,
-                  userId: 'u1',
-                  destInfo: {
-                    attributesIndices: [2],
-                  },
-                },
-                {
-                  jobId: 4,
-                  userId: 'u1',
-                  destInfo: {
-                    attributesIndices: [3],
-                  },
-                },
+                { jobId: 1, userId: 'u1' },
+                { jobId: 2, userId: 'u1' },
+                { jobId: 3, userId: 'u1' },
+                { jobId: 4, userId: 'u1' },
               ],
               batched: true,
               statusCode: 200,
@@ -1027,23 +865,18 @@ const basicRouterTests = [
               },
             },
             {
-              metadata: [
-                {
-                  jobId: 5,
-                  userId: 'u1',
-                },
-              ],
-              batched: false,
-              statusCode: 400,
               error: '[Braze Deduplication]: Duplicate user detected, the user is dropped',
               statTags: {
+                destType: 'BRAZE',
                 errorCategory: 'dataValidation',
                 errorType: 'instrumentation',
-                destType: 'BRAZE',
-                module: 'destination',
-                implementation: 'native',
                 feature: 'router',
+                implementation: 'native',
+                module: 'destination',
               },
+              statusCode: 400,
+              batched: false,
+              metadata: [{ jobId: 5, userId: 'u1' }],
               destination: {
                 hasDynamicConfig: false,
                 ID: '2N9UakqKF0D35wfzSeofIxPdL8X',
@@ -1239,43 +1072,39 @@ const basicRouterTests = [
         body: {
           output: [
             {
-              batchedRequest: {
-                version: '1',
-                type: 'REST',
-                method: 'POST',
-                endpoint: 'https://rest.fra-01.braze.eu/v2/subscription/status/set',
-                headers: {
-                  'Content-Type': 'application/json',
-                  Accept: 'application/json',
-                  Authorization: 'Bearer secret1',
-                },
-                params: {},
-                body: {
-                  JSON: {
-                    subscription_groups: [
-                      {
-                        subscription_group_id: '1234',
-                        subscription_state: 'unsubscribed',
-                        emails: ['abc@test.com', 'abc1@test.com'],
-                      },
-                    ],
+              batchedRequest: [
+                {
+                  version: '1',
+                  type: 'REST',
+                  method: 'POST',
+                  endpoint: 'https://rest.fra-01.braze.eu/v2/subscription/status/set',
+                  endpointPath: 'v2/subscription/status/set',
+                  headers: {
+                    'Content-Type': 'application/json',
+                    Accept: 'application/json',
+                    Authorization: 'Bearer secret1',
                   },
-                  JSON_ARRAY: {},
-                  XML: {},
-                  FORM: {},
+                  params: {},
+                  body: {
+                    JSON: {
+                      subscription_groups: [
+                        {
+                          subscription_group_id: '1234',
+                          subscription_state: 'unsubscribed',
+                          emails: ['abc@test.com', 'abc1@test.com'],
+                        },
+                      ],
+                    },
+                    JSON_ARRAY: {},
+                    XML: {},
+                    FORM: {},
+                  },
+                  files: {},
                 },
-                files: {},
-                endpointPath: 'v2/subscription/status/set',
-              },
+              ],
               metadata: [
-                {
-                  jobId: 1,
-                  userId: 'u1',
-                },
-                {
-                  jobId: 2,
-                  userId: 'u2',
-                },
+                { jobId: 1, userId: 'u1' },
+                { jobId: 2, userId: 'u2' },
               ],
               batched: true,
               statusCode: 200,
@@ -1318,8 +1147,732 @@ const basicRouterTestsWithBatchIdentityResolutionEnabled = basicRouterTests.map(
   };
 });
 
+// ---------------------------------------------------------------------------
+// Per-job delivery-mapping (INT-6808 + INT-6634) — ON path.
+// When `BRAZE_PER_JOB_DELIVERY_MAPPING_ENABLED=true`, processBatch emits one
+// BatchRequestOutput per outgoing HTTP request (instead of one
+// MultiBatchRequestOutput with batchedRequest[]), preserves insertion-order
+// runs across endpoints, and attaches per-metadata `destInfo` positional
+// indices (populated for /users/track chunks; present-but-empty for sub/merge
+// chunks).
+// ---------------------------------------------------------------------------
+const perJobDeliveryMappingOnTests = [
+  {
+    name: 'braze',
+    description:
+      'per-job delivery mapping ON — mixed track + subscription + merge preserves insertion-order runs and emits destInfo positional maps',
+    feature: 'router',
+    module: 'destination',
+    version: 'v0',
+    input: {
+      request: {
+        body: {
+          input: [
+            {
+              destination: {
+                hasDynamicConfig: false,
+                Config: {
+                  restApiKey: secret1,
+                  prefixProperties: true,
+                  useNativeSDK: false,
+                  dataCenter: 'eu-01',
+                },
+                DestinationDefinition: {
+                  DisplayName: 'Braze',
+                  ID: '1WhbSZ6uA3H5ChVifHpfL2H6sie',
+                  Name: 'BRAZE',
+                },
+                Enabled: true,
+                ID: '1WhcOCGgj9asZu850HvugU2C3Aq',
+                Name: 'Braze',
+                Transformations: [],
+              },
+              metadata: { jobId: 1, userId: 'u1' },
+              message: {
+                anonymousId: 'e6ab2c5e-2cda-44a9-a962-e2f67df78bca',
+                channel: 'web',
+                context: {
+                  ip: '0.0.0.0',
+                  traits: {},
+                },
+                integrations: { All: true },
+                messageId: 'dd266c67-9199-4a52-ba32-f46ddde67312',
+                originalTimestamp: '2020-01-24T06:29:02.358Z',
+                properties: {
+                  path: '/tests/html/index2.html',
+                  url: 'http://localhost/tests/html/index2.html',
+                },
+                receivedAt: '2020-01-24T11:59:02.403+05:30',
+                sentAt: '2020-01-24T06:29:02.359Z',
+                timestamp: '2020-01-24T11:59:02.402+05:30',
+                type: 'page',
+                userId: '',
+              },
+            },
+            {
+              destination: {
+                hasDynamicConfig: false,
+                Config: {
+                  restApiKey: secret1,
+                  prefixProperties: true,
+                  useNativeSDK: false,
+                  dataCenter: 'eu-01',
+                },
+                DestinationDefinition: {
+                  DisplayName: 'Braze',
+                  ID: '1WhbSZ6uA3H5ChVifHpfL2H6sie',
+                  Name: 'BRAZE',
+                },
+                Enabled: true,
+                ID: '1WhcOCGgj9asZu850HvugU2C3Aq',
+                Name: 'Braze',
+                Transformations: [],
+              },
+              metadata: { jobId: 2, userId: 'u1' },
+              message: {
+                anonymousId: 'e6ab2c5e-2cda-44a9-a962-e2f67df78bca',
+                channel: 'web',
+                context: {
+                  ip: '0.0.0.0',
+                  traits: {
+                    city: 'Disney',
+                    country: 'USA',
+                    email: 'mickey@disney.com',
+                    firstname: 'Mickey',
+                  },
+                },
+                integrations: { All: true },
+                messageId: '2536eda4-d638-4c93-8014-8ffe3f083214',
+                originalTimestamp: '2020-01-24T06:29:02.362Z',
+                receivedAt: '2020-01-24T11:59:02.403+05:30',
+                sentAt: '2020-01-24T06:29:02.363Z',
+                timestamp: '2020-01-24T11:59:02.402+05:30',
+                type: 'identify',
+                userId: '',
+              },
+            },
+            {
+              destination: {
+                hasDynamicConfig: false,
+                Config: {
+                  restApiKey: secret1,
+                  prefixProperties: true,
+                  useNativeSDK: false,
+                  dataCenter: 'eu-01',
+                  enableSubscriptionGroupInGroupCall: true,
+                },
+                DestinationDefinition: {
+                  DisplayName: 'Braze',
+                  ID: '1WhbSZ6uA3H5ChVifHpfL2H6sie',
+                  Name: 'BRAZE',
+                },
+                Enabled: true,
+                ID: '1WhcOCGgj9asZu850HvugU2C3Aq',
+                Name: 'Braze',
+                Transformations: [],
+              },
+              metadata: { jobId: 3, userId: 'u1' },
+              message: {
+                anonymousId: '56yrtsdfgbgxcb-22b4-401d-aae5-1b994be9a969',
+                groupId: 'c90f0fd2-2a02-4f2f-bf07-7e7d2c2ed2b1',
+                traits: { phone: '5055077683', subscriptionState: 'subscribed' },
+                userId: 'user123',
+                type: 'group',
+              },
+            },
+            {
+              destination: {
+                hasDynamicConfig: false,
+                Config: {
+                  restApiKey: secret1,
+                  prefixProperties: true,
+                  useNativeSDK: false,
+                  dataCenter: 'eu-01',
+                  enableSubscriptionGroupInGroupCall: true,
+                },
+                DestinationDefinition: {
+                  DisplayName: 'Braze',
+                  ID: '1WhbSZ6uA3H5ChVifHpfL2H6sie',
+                  Name: 'BRAZE',
+                },
+                Enabled: true,
+                ID: '1WhcOCGgj9asZu850HvugU2C3Aq',
+                Name: 'Braze',
+                Transformations: [],
+              },
+              metadata: { jobId: 4, userId: 'u1' },
+              message: {
+                anonymousId: 'dfgdfgdfg-22b4-401d-aae5-1b994be9a969',
+                groupId: '58d0a278-b55b-4f10-b7d2-98d1c5dd4c30',
+                traits: { phone: '5055077683', subscriptionState: 'subscribed' },
+                userId: 'user877',
+                type: 'group',
+              },
+            },
+            {
+              destination: {
+                hasDynamicConfig: false,
+                Config: {
+                  restApiKey: secret1,
+                  prefixProperties: true,
+                  useNativeSDK: false,
+                  dataCenter: 'eu-01',
+                  enableSubscriptionGroupInGroupCall: true,
+                },
+                DestinationDefinition: {
+                  DisplayName: 'Braze',
+                  ID: '1WhbSZ6uA3H5ChVifHpfL2H6sie',
+                  Name: 'BRAZE',
+                },
+                Enabled: true,
+                ID: '1WhcOCGgj9asZu850HvugU2C3Aq',
+                Name: 'Braze',
+                Transformations: [],
+              },
+              metadata: { jobId: 5, userId: 'u1' },
+              message: { type: 'alias', previousId: 'adsfsaf', userId: 'dsafsdf' },
+            },
+            {
+              destination: {
+                hasDynamicConfig: false,
+                Config: {
+                  restApiKey: secret1,
+                  prefixProperties: true,
+                  useNativeSDK: false,
+                  dataCenter: 'eu-01',
+                  enableSubscriptionGroupInGroupCall: true,
+                },
+                DestinationDefinition: {
+                  DisplayName: 'Braze',
+                  ID: '1WhbSZ6uA3H5ChVifHpfL2H6sie',
+                  Name: 'BRAZE',
+                },
+                Enabled: true,
+                ID: '1WhcOCGgj9asZu850HvugU2C3Aq',
+                Name: 'Braze',
+                Transformations: [],
+              },
+              metadata: { jobId: 6, userId: 'u1' },
+              message: { type: 'alias', previousId: 'adsfsaf2', userId: 'dsafsdf2' },
+            },
+            {
+              destination: {
+                hasDynamicConfig: false,
+                Config: {
+                  restApiKey: secret1,
+                  prefixProperties: true,
+                  useNativeSDK: false,
+                  dataCenter: 'eu-01',
+                  enableSubscriptionGroupInGroupCall: true,
+                },
+                DestinationDefinition: {
+                  DisplayName: 'Braze',
+                  ID: '1WhbSZ6uA3H5ChVifHpfL2H6sie',
+                  Name: 'BRAZE',
+                },
+                Enabled: true,
+                ID: '1WhcOCGgj9asZu850HvugU2C3Aq',
+                Name: 'Braze',
+                Transformations: [],
+              },
+              metadata: { jobId: 7, userId: 'u1' },
+              message: {
+                anonymousId: '56yrtsdfgbgxcb-22b4-401d-aae5-1b994be9afdf',
+                groupId: 'c90f0fd2-2a02-4f2f-bf07-7e7d2c2ed2b1',
+                traits: { phone: '5055077683', subscriptionState: 'subscribed' },
+                userId: 'user12345',
+                type: 'group',
+              },
+            },
+          ],
+          destType: 'braze',
+        },
+        method: 'POST',
+      },
+    },
+    output: {
+      response: {
+        status: 200,
+        body: {
+          output: [
+            // Output 1 — track run (jobs 1, 2). One /users/track HTTP request.
+            // Job 1's page-view lands at events[0]; job 2's identify lands at
+            // attributes[0]. Per-metadata destInfo carries the positional
+            // indices the v1 networkHandler uses to correlate per-item
+            // warnings back to the originating job.
+            {
+              batchedRequest: {
+                version: '1',
+                type: 'REST',
+                method: 'POST',
+                endpoint: 'https://rest.fra-01.braze.eu/users/track',
+                endpointPath: 'users/track',
+                headers: {
+                  'Content-Type': 'application/json',
+                  Accept: 'application/json',
+                  Authorization: authHeader1,
+                },
+                params: {},
+                body: {
+                  JSON: {
+                    partner: 'RudderStack',
+                    events: [
+                      {
+                        name: 'Page Viewed',
+                        time: '2020-01-24T11:59:02.402+05:30',
+                        properties: {
+                          path: '/tests/html/index2.html',
+                          url: 'http://localhost/tests/html/index2.html',
+                        },
+                        _update_existing_only: false,
+                        user_alias: {
+                          alias_name: 'e6ab2c5e-2cda-44a9-a962-e2f67df78bca',
+                          alias_label: 'rudder_id',
+                        },
+                      },
+                    ],
+                    attributes: [
+                      {
+                        email: 'mickey@disney.com',
+                        city: 'Disney',
+                        country: 'USA',
+                        firstname: 'Mickey',
+                        _update_existing_only: false,
+                        user_alias: {
+                          alias_name: 'e6ab2c5e-2cda-44a9-a962-e2f67df78bca',
+                          alias_label: 'rudder_id',
+                        },
+                      },
+                    ],
+                  },
+                  XML: {},
+                  JSON_ARRAY: {},
+                  FORM: {},
+                },
+                files: {},
+              },
+              metadata: [
+                { jobId: 1, userId: 'u1', destInfo: { eventsIndices: [0] } },
+                { jobId: 2, userId: 'u1', destInfo: { attributesIndices: [0] } },
+              ],
+              batched: true,
+              statusCode: 200,
+              destination: {
+                hasDynamicConfig: false,
+                Config: {
+                  restApiKey: secret1,
+                  prefixProperties: true,
+                  useNativeSDK: false,
+                  dataCenter: 'eu-01',
+                },
+                DestinationDefinition: {
+                  DisplayName: 'Braze',
+                  ID: '1WhbSZ6uA3H5ChVifHpfL2H6sie',
+                  Name: 'BRAZE',
+                },
+                Enabled: true,
+                ID: '1WhcOCGgj9asZu850HvugU2C3Aq',
+                Name: 'Braze',
+                Transformations: [],
+              },
+            },
+            // Output 2 — first subscription run (jobs 3, 4). One
+            // /v2/subscription/status/set HTTP request. Note that job 7
+            // (also a subscription with the same group_id as job 3) does NOT
+            // merge in here — insertion-order runs put job 7 into a
+            // SEPARATE run after the merge run. Sub metadata carries
+            // `destInfo: {}` (present-but-empty).
+            {
+              batchedRequest: {
+                version: '1',
+                type: 'REST',
+                method: 'POST',
+                endpoint: 'https://rest.fra-01.braze.eu/v2/subscription/status/set',
+                endpointPath: 'v2/subscription/status/set',
+                headers: {
+                  'Content-Type': 'application/json',
+                  Accept: 'application/json',
+                  Authorization: authHeader1,
+                },
+                params: {},
+                body: {
+                  JSON: {
+                    subscription_groups: [
+                      {
+                        external_ids: ['user123'],
+                        phones: ['5055077683'],
+                        subscription_group_id: 'c90f0fd2-2a02-4f2f-bf07-7e7d2c2ed2b1',
+                        subscription_state: 'subscribed',
+                      },
+                      {
+                        external_ids: ['user877'],
+                        phones: ['5055077683'],
+                        subscription_group_id: '58d0a278-b55b-4f10-b7d2-98d1c5dd4c30',
+                        subscription_state: 'subscribed',
+                      },
+                    ],
+                  },
+                  XML: {},
+                  JSON_ARRAY: {},
+                  FORM: {},
+                },
+                files: {},
+              },
+              metadata: [
+                { jobId: 3, userId: 'u1', destInfo: {} },
+                { jobId: 4, userId: 'u1', destInfo: {} },
+              ],
+              batched: true,
+              statusCode: 200,
+              destination: {
+                hasDynamicConfig: false,
+                Config: {
+                  restApiKey: secret1,
+                  prefixProperties: true,
+                  useNativeSDK: false,
+                  dataCenter: 'eu-01',
+                },
+                DestinationDefinition: {
+                  DisplayName: 'Braze',
+                  ID: '1WhbSZ6uA3H5ChVifHpfL2H6sie',
+                  Name: 'BRAZE',
+                },
+                Enabled: true,
+                ID: '1WhcOCGgj9asZu850HvugU2C3Aq',
+                Name: 'Braze',
+                Transformations: [],
+              },
+            },
+            // Output 3 — merge run (jobs 5, 6). One /users/merge HTTP request.
+            // Merge metadata carries `destInfo: {}` (present-but-empty).
+            {
+              batchedRequest: {
+                version: '1',
+                type: 'REST',
+                method: 'POST',
+                endpoint: 'https://rest.fra-01.braze.eu/users/merge',
+                endpointPath: 'users/merge',
+                headers: {
+                  'Content-Type': 'application/json',
+                  Accept: 'application/json',
+                  Authorization: authHeader1,
+                },
+                params: {},
+                body: {
+                  JSON: {
+                    merge_updates: [
+                      {
+                        identifier_to_keep: { external_id: 'dsafsdf' },
+                        identifier_to_merge: { external_id: 'adsfsaf' },
+                      },
+                      {
+                        identifier_to_keep: { external_id: 'dsafsdf2' },
+                        identifier_to_merge: { external_id: 'adsfsaf2' },
+                      },
+                    ],
+                  },
+                  XML: {},
+                  JSON_ARRAY: {},
+                  FORM: {},
+                },
+                files: {},
+              },
+              metadata: [
+                { jobId: 5, userId: 'u1', destInfo: {} },
+                { jobId: 6, userId: 'u1', destInfo: {} },
+              ],
+              batched: true,
+              statusCode: 200,
+              destination: {
+                hasDynamicConfig: false,
+                Config: {
+                  restApiKey: secret1,
+                  prefixProperties: true,
+                  useNativeSDK: false,
+                  dataCenter: 'eu-01',
+                },
+                DestinationDefinition: {
+                  DisplayName: 'Braze',
+                  ID: '1WhbSZ6uA3H5ChVifHpfL2H6sie',
+                  Name: 'BRAZE',
+                },
+                Enabled: true,
+                ID: '1WhcOCGgj9asZu850HvugU2C3Aq',
+                Name: 'Braze',
+                Transformations: [],
+              },
+            },
+            // Output 4 — second subscription run (job 7 alone). Because the
+            // merge run split the two subscription groups apart in insertion
+            // order, job 7 gets its OWN /v2/subscription/status/set HTTP
+            // request — this is the key run-preserving-shape guarantee.
+            {
+              batchedRequest: {
+                version: '1',
+                type: 'REST',
+                method: 'POST',
+                endpoint: 'https://rest.fra-01.braze.eu/v2/subscription/status/set',
+                endpointPath: 'v2/subscription/status/set',
+                headers: {
+                  'Content-Type': 'application/json',
+                  Accept: 'application/json',
+                  Authorization: authHeader1,
+                },
+                params: {},
+                body: {
+                  JSON: {
+                    subscription_groups: [
+                      {
+                        external_ids: ['user12345'],
+                        phones: ['5055077683'],
+                        subscription_group_id: 'c90f0fd2-2a02-4f2f-bf07-7e7d2c2ed2b1',
+                        subscription_state: 'subscribed',
+                      },
+                    ],
+                  },
+                  XML: {},
+                  JSON_ARRAY: {},
+                  FORM: {},
+                },
+                files: {},
+              },
+              metadata: [{ jobId: 7, userId: 'u1', destInfo: {} }],
+              batched: true,
+              statusCode: 200,
+              destination: {
+                hasDynamicConfig: false,
+                Config: {
+                  restApiKey: secret1,
+                  prefixProperties: true,
+                  useNativeSDK: false,
+                  dataCenter: 'eu-01',
+                },
+                DestinationDefinition: {
+                  DisplayName: 'Braze',
+                  ID: '1WhbSZ6uA3H5ChVifHpfL2H6sie',
+                  Name: 'BRAZE',
+                },
+                Enabled: true,
+                ID: '1WhcOCGgj9asZu850HvugU2C3Aq',
+                Name: 'Braze',
+                Transformations: [],
+              },
+            },
+          ],
+        },
+      },
+    },
+    envOverrides: {
+      BRAZE_PER_JOB_DELIVERY_MAPPING_ENABLED: 'true',
+      BRAZE_BATCH_IDENTIFY_RESOLUTION: 'false',
+    },
+  },
+  {
+    name: 'braze',
+    description:
+      'per-job delivery mapping ON — order-completed with multiple products yields destInfo.purchasesIndices spanning all product indices',
+    feature: 'router',
+    module: 'destination',
+    version: 'v0',
+    input: {
+      request: {
+        body: {
+          input: [
+            // Job 100: identify → contributes 1 attribute.
+            {
+              destination: {
+                hasDynamicConfig: false,
+                Config: {
+                  restApiKey: secret1,
+                  prefixProperties: true,
+                  useNativeSDK: false,
+                  dataCenter: 'eu-01',
+                },
+                DestinationDefinition: {
+                  DisplayName: 'Braze',
+                  ID: '1WhbSZ6uA3H5ChVifHpfL2H6sie',
+                  Name: 'BRAZE',
+                },
+                Enabled: true,
+                ID: '1WhcOCGgj9asZu850HvugU2C3Aq',
+                Name: 'Braze',
+                Transformations: [],
+              },
+              metadata: { jobId: 100, userId: 'u1' },
+              message: {
+                anonymousId: 'a1',
+                channel: 'web',
+                context: { ip: '0.0.0.0', traits: { firstname: 'Alice' } },
+                integrations: { All: true },
+                messageId: 'm100',
+                originalTimestamp: '2020-01-24T06:29:02.362Z',
+                receivedAt: '2020-01-24T11:59:02.403+05:30',
+                sentAt: '2020-01-24T06:29:02.363Z',
+                timestamp: '2020-01-24T11:59:02.402+05:30',
+                type: 'identify',
+                userId: 'alice',
+              },
+            },
+            // Job 101: order completed → contributes 1 event + 1 attribute
+            // + 3 purchases (one per product). destInfo for this job must
+            // list all 3 purchase indices.
+            {
+              destination: {
+                hasDynamicConfig: false,
+                Config: {
+                  restApiKey: secret1,
+                  prefixProperties: true,
+                  useNativeSDK: false,
+                  dataCenter: 'eu-01',
+                },
+                DestinationDefinition: {
+                  DisplayName: 'Braze',
+                  ID: '1WhbSZ6uA3H5ChVifHpfL2H6sie',
+                  Name: 'BRAZE',
+                },
+                Enabled: true,
+                ID: '1WhcOCGgj9asZu850HvugU2C3Aq',
+                Name: 'Braze',
+                Transformations: [],
+              },
+              metadata: { jobId: 101, userId: 'u1' },
+              message: {
+                anonymousId: 'a2',
+                channel: 'web',
+                context: { ip: '0.0.0.0', traits: { firstname: 'Bob' } },
+                event: 'Order Completed',
+                integrations: { All: true },
+                messageId: 'm101',
+                originalTimestamp: '2020-01-24T06:29:02.362Z',
+                properties: {
+                  currency: 'USD',
+                  products: [
+                    { product_id: 'p1', price: 10, quantity: 1 },
+                    { product_id: 'p2', price: 20, quantity: 2 },
+                    { product_id: 'p3', price: 30, quantity: 1 },
+                  ],
+                },
+                receivedAt: '2020-01-24T11:59:02.403+05:30',
+                sentAt: '2020-01-24T06:29:02.363Z',
+                timestamp: '2020-01-24T11:59:02.402+05:30',
+                type: 'track',
+                userId: 'bob',
+              },
+            },
+          ],
+          destType: 'braze',
+        },
+        method: 'POST',
+      },
+    },
+    output: {
+      response: {
+        status: 200,
+        body: {
+          output: [
+            {
+              batchedRequest: {
+                version: '1',
+                type: 'REST',
+                method: 'POST',
+                endpoint: 'https://rest.fra-01.braze.eu/users/track',
+                endpointPath: 'users/track',
+                headers: {
+                  'Content-Type': 'application/json',
+                  Accept: 'application/json',
+                  Authorization: authHeader1,
+                },
+                params: {},
+                body: {
+                  JSON: {
+                    partner: 'RudderStack',
+                    attributes: [
+                      { firstname: 'Alice', external_id: 'alice' },
+                      { firstname: 'Bob', external_id: 'bob' },
+                    ],
+                    purchases: [
+                      {
+                        product_id: 'p1',
+                        price: 10,
+                        currency: 'USD',
+                        quantity: 1,
+                        time: '2020-01-24T11:59:02.402+05:30',
+                        external_id: 'bob',
+                      },
+                      {
+                        product_id: 'p2',
+                        price: 20,
+                        currency: 'USD',
+                        quantity: 2,
+                        time: '2020-01-24T11:59:02.402+05:30',
+                        external_id: 'bob',
+                      },
+                      {
+                        product_id: 'p3',
+                        price: 30,
+                        currency: 'USD',
+                        quantity: 1,
+                        time: '2020-01-24T11:59:02.402+05:30',
+                        external_id: 'bob',
+                      },
+                    ],
+                  },
+                  XML: {},
+                  JSON_ARRAY: {},
+                  FORM: {},
+                },
+                files: {},
+              },
+              // destInfo shape:
+              // - Job 100 contributes 1 attribute → attributesIndices: [0]
+              // - Job 101 (Order Completed) contributes 1 attribute + 3
+              //   purchases (Braze transformer emits per-product purchase
+              //   records instead of a track event for Order Completed) →
+              //   attributesIndices: [1], purchasesIndices: [0, 1, 2] (the
+              //   multi-index case for a single-job contribution).
+              metadata: [
+                { jobId: 100, userId: 'u1', destInfo: { attributesIndices: [0] } },
+                {
+                  jobId: 101,
+                  userId: 'u1',
+                  destInfo: { attributesIndices: [1], purchasesIndices: [0, 1, 2] },
+                },
+              ],
+              batched: true,
+              statusCode: 200,
+              destination: {
+                hasDynamicConfig: false,
+                Config: {
+                  restApiKey: secret1,
+                  prefixProperties: true,
+                  useNativeSDK: false,
+                  dataCenter: 'eu-01',
+                },
+                DestinationDefinition: {
+                  DisplayName: 'Braze',
+                  ID: '1WhbSZ6uA3H5ChVifHpfL2H6sie',
+                  Name: 'BRAZE',
+                },
+                Enabled: true,
+                ID: '1WhcOCGgj9asZu850HvugU2C3Aq',
+                Name: 'Braze',
+                Transformations: [],
+              },
+            },
+          ],
+        },
+      },
+    },
+    envOverrides: {
+      BRAZE_PER_JOB_DELIVERY_MAPPING_ENABLED: 'true',
+      BRAZE_BATCH_IDENTIFY_RESOLUTION: 'false',
+    },
+  },
+];
+
 export const data = [
   ...basicRouterTests,
   ...basicRouterTestsWithBatchIdentityResolutionEnabled,
+  ...perJobDeliveryMappingOnTests,
   ...identityResolution,
 ];

--- a/test/integrations/destinations/braze/router/identityResolution.ts
+++ b/test/integrations/destinations/braze/router/identityResolution.ts
@@ -179,18 +179,14 @@ export const identityResolution = [
                   jobId: 1,
                   userId: 'u1',
                   destInfo: {
-                    braze: {
-                      attributesIndex: 0,
-                    },
+                    attributesIndices: [0],
                   },
                 },
                 {
                   jobId: 2,
                   userId: 'u2',
                   destInfo: {
-                    braze: {
-                      attributesIndex: 1,
-                    },
+                    attributesIndices: [1],
                   },
                 },
               ],
@@ -335,9 +331,7 @@ export const identityResolution = [
                   jobId: 1,
                   userId: 'u1',
                   destInfo: {
-                    braze: {
-                      attributesIndex: 0,
-                    },
+                    attributesIndices: [0],
                   },
                 },
               ],
@@ -542,18 +536,14 @@ export const identityResolution = [
                   jobId: 1,
                   userId: 'u1',
                   destInfo: {
-                    braze: {
-                      attributesIndex: 0,
-                    },
+                    attributesIndices: [0],
                   },
                 },
                 {
                   jobId: 2,
                   userId: 'u2',
                   destInfo: {
-                    braze: {
-                      attributesIndex: 1,
-                    },
+                    attributesIndices: [1],
                   },
                 },
               ],
@@ -758,18 +748,14 @@ export const identityResolution = [
                   jobId: 1,
                   userId: 'u1',
                   destInfo: {
-                    braze: {
-                      attributesIndex: 0,
-                    },
+                    attributesIndices: [0],
                   },
                 },
                 {
                   jobId: 2,
                   userId: 'u2',
                   destInfo: {
-                    braze: {
-                      attributesIndex: 1,
-                    },
+                    attributesIndices: [1],
                   },
                 },
               ],

--- a/test/integrations/destinations/braze/router/identityResolution.ts
+++ b/test/integrations/destinations/braze/router/identityResolution.ts
@@ -138,57 +138,47 @@ export const identityResolution = [
         body: {
           output: [
             {
-              batchedRequest: {
-                version: '1',
-                type: 'REST',
-                method: 'POST',
-                endpoint: 'https://rest.fra-01.braze.eu/users/track',
-                headers: {
-                  'Content-Type': 'application/json',
-                  Accept: 'application/json',
-                  Authorization: authHeader1,
-                },
-                params: {},
-                body: {
-                  JSON: {
-                    partner: 'RudderStack',
-                    attributes: [
-                      {
-                        email: 'test@example.com',
-                        first_name: 'John',
-                        last_name: 'Doe',
-                        external_id: 'user123',
-                      },
-                      {
-                        email: 'test2@example.com',
-                        first_name: 'Jane',
-                        last_name: 'Smith',
-                        external_id: 'user456',
-                      },
-                    ],
+              batchedRequest: [
+                {
+                  version: '1',
+                  type: 'REST',
+                  method: 'POST',
+                  endpoint: 'https://rest.fra-01.braze.eu/users/track',
+                  endpointPath: 'users/track',
+                  headers: {
+                    'Content-Type': 'application/json',
+                    Accept: 'application/json',
+                    Authorization: authHeader1,
                   },
-                  JSON_ARRAY: {},
-                  XML: {},
-                  FORM: {},
+                  params: {},
+                  body: {
+                    JSON: {
+                      partner: 'RudderStack',
+                      attributes: [
+                        {
+                          external_id: 'user123',
+                          email: 'test@example.com',
+                          first_name: 'John',
+                          last_name: 'Doe',
+                        },
+                        {
+                          external_id: 'user456',
+                          email: 'test2@example.com',
+                          first_name: 'Jane',
+                          last_name: 'Smith',
+                        },
+                      ],
+                    },
+                    JSON_ARRAY: {},
+                    XML: {},
+                    FORM: {},
+                  },
+                  files: {},
                 },
-                files: {},
-                endpointPath: 'users/track',
-              },
+              ],
               metadata: [
-                {
-                  jobId: 1,
-                  userId: 'u1',
-                  destInfo: {
-                    attributesIndices: [0],
-                  },
-                },
-                {
-                  jobId: 2,
-                  userId: 'u2',
-                  destInfo: {
-                    attributesIndices: [1],
-                  },
-                },
+                { jobId: 1, userId: 'u1' },
+                { jobId: 2, userId: 'u2' },
               ],
               batched: true,
               statusCode: 200,
@@ -296,45 +286,39 @@ export const identityResolution = [
         body: {
           output: [
             {
-              batchedRequest: {
-                version: '1',
-                type: 'REST',
-                method: 'POST',
-                endpoint: 'https://rest.fra-01.braze.eu/users/track',
-                headers: {
-                  'Content-Type': 'application/json',
-                  Accept: 'application/json',
-                  Authorization: authHeader1,
-                },
-                params: {},
-                body: {
-                  JSON: {
-                    partner: 'RudderStack',
-                    attributes: [
-                      {
-                        email: 'test@example.com',
-                        first_name: 'John',
-                        last_name: 'Doe',
-                        external_id: 'user123',
-                      },
-                    ],
-                  },
-                  JSON_ARRAY: {},
-                  XML: {},
-                  FORM: {},
-                },
-                files: {},
-                endpointPath: 'users/track',
-              },
-              metadata: [
+              batchedRequest: [
                 {
-                  jobId: 1,
-                  userId: 'u1',
-                  destInfo: {
-                    attributesIndices: [0],
+                  version: '1',
+                  type: 'REST',
+                  method: 'POST',
+                  endpoint: 'https://rest.fra-01.braze.eu/users/track',
+                  endpointPath: 'users/track',
+                  headers: {
+                    'Content-Type': 'application/json',
+                    Accept: 'application/json',
+                    Authorization: authHeader1,
                   },
+                  params: {},
+                  body: {
+                    JSON: {
+                      partner: 'RudderStack',
+                      attributes: [
+                        {
+                          external_id: 'user123',
+                          email: 'test@example.com',
+                          first_name: 'John',
+                          last_name: 'Doe',
+                        },
+                      ],
+                    },
+                    JSON_ARRAY: {},
+                    XML: {},
+                    FORM: {},
+                  },
+                  files: {},
                 },
               ],
+              metadata: [{ jobId: 1, userId: 'u1' }],
               batched: true,
               statusCode: 200,
               destination: {
@@ -495,57 +479,47 @@ export const identityResolution = [
         body: {
           output: [
             {
-              batchedRequest: {
-                version: '1',
-                type: 'REST',
-                method: 'POST',
-                endpoint: 'https://rest.fra-01.braze.eu/users/track',
-                headers: {
-                  'Content-Type': 'application/json',
-                  Accept: 'application/json',
-                  Authorization: authHeader1,
-                },
-                params: {},
-                body: {
-                  JSON: {
-                    partner: 'RudderStack',
-                    attributes: [
-                      {
-                        email: 'test@example.com',
-                        first_name: 'John',
-                        last_name: 'Doe',
-                        external_id: 'user123',
-                      },
-                      {
-                        email: 'test2@example.com',
-                        first_name: 'Jane',
-                        last_name: 'Smith',
-                        external_id: 'user456',
-                      },
-                    ],
+              batchedRequest: [
+                {
+                  version: '1',
+                  type: 'REST',
+                  method: 'POST',
+                  endpoint: 'https://rest.fra-01.braze.eu/users/track',
+                  endpointPath: 'users/track',
+                  headers: {
+                    'Content-Type': 'application/json',
+                    Accept: 'application/json',
+                    Authorization: authHeader1,
                   },
-                  JSON_ARRAY: {},
-                  XML: {},
-                  FORM: {},
+                  params: {},
+                  body: {
+                    JSON: {
+                      partner: 'RudderStack',
+                      attributes: [
+                        {
+                          external_id: 'user123',
+                          email: 'test@example.com',
+                          first_name: 'John',
+                          last_name: 'Doe',
+                        },
+                        {
+                          external_id: 'user456',
+                          email: 'test2@example.com',
+                          first_name: 'Jane',
+                          last_name: 'Smith',
+                        },
+                      ],
+                    },
+                    JSON_ARRAY: {},
+                    XML: {},
+                    FORM: {},
+                  },
+                  files: {},
                 },
-                files: {},
-                endpointPath: 'users/track',
-              },
+              ],
               metadata: [
-                {
-                  jobId: 1,
-                  userId: 'u1',
-                  destInfo: {
-                    attributesIndices: [0],
-                  },
-                },
-                {
-                  jobId: 2,
-                  userId: 'u2',
-                  destInfo: {
-                    attributesIndices: [1],
-                  },
-                },
+                { jobId: 1, userId: 'u1' },
+                { jobId: 2, userId: 'u2' },
               ],
               batched: true,
               statusCode: 200,
@@ -707,57 +681,47 @@ export const identityResolution = [
         body: {
           output: [
             {
-              batchedRequest: {
-                version: '1',
-                type: 'REST',
-                method: 'POST',
-                endpoint: 'https://rest.fra-01.braze.eu/users/track',
-                headers: {
-                  'Content-Type': 'application/json',
-                  Accept: 'application/json',
-                  Authorization: authHeader1,
-                },
-                params: {},
-                body: {
-                  JSON: {
-                    partner: 'RudderStack',
-                    attributes: [
-                      {
-                        email: 'test@example.com',
-                        first_name: 'John',
-                        last_name: 'Doe',
-                        external_id: 'user123',
-                      },
-                      {
-                        email: 'test2@example.com',
-                        first_name: 'Jane',
-                        last_name: 'Smith',
-                        external_id: 'user456',
-                      },
-                    ],
+              batchedRequest: [
+                {
+                  version: '1',
+                  type: 'REST',
+                  method: 'POST',
+                  endpoint: 'https://rest.fra-01.braze.eu/users/track',
+                  endpointPath: 'users/track',
+                  headers: {
+                    'Content-Type': 'application/json',
+                    Accept: 'application/json',
+                    Authorization: authHeader1,
                   },
-                  JSON_ARRAY: {},
-                  XML: {},
-                  FORM: {},
+                  params: {},
+                  body: {
+                    JSON: {
+                      partner: 'RudderStack',
+                      attributes: [
+                        {
+                          external_id: 'user123',
+                          email: 'test@example.com',
+                          first_name: 'John',
+                          last_name: 'Doe',
+                        },
+                        {
+                          external_id: 'user456',
+                          email: 'test2@example.com',
+                          first_name: 'Jane',
+                          last_name: 'Smith',
+                        },
+                      ],
+                    },
+                    JSON_ARRAY: {},
+                    XML: {},
+                    FORM: {},
+                  },
+                  files: {},
                 },
-                files: {},
-                endpointPath: 'users/track',
-              },
+              ],
               metadata: [
-                {
-                  jobId: 1,
-                  userId: 'u1',
-                  destInfo: {
-                    attributesIndices: [0],
-                  },
-                },
-                {
-                  jobId: 2,
-                  userId: 'u2',
-                  destInfo: {
-                    attributesIndices: [1],
-                  },
-                },
+                { jobId: 1, userId: 'u1' },
+                { jobId: 2, userId: 'u2' },
               ],
               batched: true,
               statusCode: 200,

--- a/test/integrations/destinations/braze/router/identityResolution.ts
+++ b/test/integrations/destinations/braze/router/identityResolution.ts
@@ -138,47 +138,61 @@ export const identityResolution = [
         body: {
           output: [
             {
-              batchedRequest: [
-                {
-                  version: '1',
-                  type: 'REST',
-                  method: 'POST',
-                  endpoint: 'https://rest.fra-01.braze.eu/users/track',
-                  endpointPath: 'users/track',
-                  headers: {
-                    'Content-Type': 'application/json',
-                    Accept: 'application/json',
-                    Authorization: authHeader1,
-                  },
-                  params: {},
-                  body: {
-                    JSON: {
-                      partner: 'RudderStack',
-                      attributes: [
-                        {
-                          external_id: 'user123',
-                          email: 'test@example.com',
-                          first_name: 'John',
-                          last_name: 'Doe',
-                        },
-                        {
-                          external_id: 'user456',
-                          email: 'test2@example.com',
-                          first_name: 'Jane',
-                          last_name: 'Smith',
-                        },
-                      ],
-                    },
-                    JSON_ARRAY: {},
-                    XML: {},
-                    FORM: {},
-                  },
-                  files: {},
+              batchedRequest: {
+                version: '1',
+                type: 'REST',
+                method: 'POST',
+                endpoint: 'https://rest.fra-01.braze.eu/users/track',
+                headers: {
+                  'Content-Type': 'application/json',
+                  Accept: 'application/json',
+                  Authorization: authHeader1,
                 },
-              ],
+                params: {},
+                body: {
+                  JSON: {
+                    partner: 'RudderStack',
+                    attributes: [
+                      {
+                        email: 'test@example.com',
+                        first_name: 'John',
+                        last_name: 'Doe',
+                        external_id: 'user123',
+                      },
+                      {
+                        email: 'test2@example.com',
+                        first_name: 'Jane',
+                        last_name: 'Smith',
+                        external_id: 'user456',
+                      },
+                    ],
+                  },
+                  JSON_ARRAY: {},
+                  XML: {},
+                  FORM: {},
+                },
+                files: {},
+                endpointPath: 'users/track',
+              },
               metadata: [
-                { jobId: 1, userId: 'u1' },
-                { jobId: 2, userId: 'u2' },
+                {
+                  jobId: 1,
+                  userId: 'u1',
+                  destInfo: {
+                    braze: {
+                      attributesIndex: 0,
+                    },
+                  },
+                },
+                {
+                  jobId: 2,
+                  userId: 'u2',
+                  destInfo: {
+                    braze: {
+                      attributesIndex: 1,
+                    },
+                  },
+                },
               ],
               batched: true,
               statusCode: 200,
@@ -286,39 +300,47 @@ export const identityResolution = [
         body: {
           output: [
             {
-              batchedRequest: [
+              batchedRequest: {
+                version: '1',
+                type: 'REST',
+                method: 'POST',
+                endpoint: 'https://rest.fra-01.braze.eu/users/track',
+                headers: {
+                  'Content-Type': 'application/json',
+                  Accept: 'application/json',
+                  Authorization: authHeader1,
+                },
+                params: {},
+                body: {
+                  JSON: {
+                    partner: 'RudderStack',
+                    attributes: [
+                      {
+                        email: 'test@example.com',
+                        first_name: 'John',
+                        last_name: 'Doe',
+                        external_id: 'user123',
+                      },
+                    ],
+                  },
+                  JSON_ARRAY: {},
+                  XML: {},
+                  FORM: {},
+                },
+                files: {},
+                endpointPath: 'users/track',
+              },
+              metadata: [
                 {
-                  version: '1',
-                  type: 'REST',
-                  method: 'POST',
-                  endpoint: 'https://rest.fra-01.braze.eu/users/track',
-                  endpointPath: 'users/track',
-                  headers: {
-                    'Content-Type': 'application/json',
-                    Accept: 'application/json',
-                    Authorization: authHeader1,
-                  },
-                  params: {},
-                  body: {
-                    JSON: {
-                      partner: 'RudderStack',
-                      attributes: [
-                        {
-                          external_id: 'user123',
-                          email: 'test@example.com',
-                          first_name: 'John',
-                          last_name: 'Doe',
-                        },
-                      ],
+                  jobId: 1,
+                  userId: 'u1',
+                  destInfo: {
+                    braze: {
+                      attributesIndex: 0,
                     },
-                    JSON_ARRAY: {},
-                    XML: {},
-                    FORM: {},
                   },
-                  files: {},
                 },
               ],
-              metadata: [{ jobId: 1, userId: 'u1' }],
               batched: true,
               statusCode: 200,
               destination: {
@@ -479,47 +501,61 @@ export const identityResolution = [
         body: {
           output: [
             {
-              batchedRequest: [
-                {
-                  version: '1',
-                  type: 'REST',
-                  method: 'POST',
-                  endpoint: 'https://rest.fra-01.braze.eu/users/track',
-                  endpointPath: 'users/track',
-                  headers: {
-                    'Content-Type': 'application/json',
-                    Accept: 'application/json',
-                    Authorization: authHeader1,
-                  },
-                  params: {},
-                  body: {
-                    JSON: {
-                      partner: 'RudderStack',
-                      attributes: [
-                        {
-                          external_id: 'user123',
-                          email: 'test@example.com',
-                          first_name: 'John',
-                          last_name: 'Doe',
-                        },
-                        {
-                          external_id: 'user456',
-                          email: 'test2@example.com',
-                          first_name: 'Jane',
-                          last_name: 'Smith',
-                        },
-                      ],
-                    },
-                    JSON_ARRAY: {},
-                    XML: {},
-                    FORM: {},
-                  },
-                  files: {},
+              batchedRequest: {
+                version: '1',
+                type: 'REST',
+                method: 'POST',
+                endpoint: 'https://rest.fra-01.braze.eu/users/track',
+                headers: {
+                  'Content-Type': 'application/json',
+                  Accept: 'application/json',
+                  Authorization: authHeader1,
                 },
-              ],
+                params: {},
+                body: {
+                  JSON: {
+                    partner: 'RudderStack',
+                    attributes: [
+                      {
+                        email: 'test@example.com',
+                        first_name: 'John',
+                        last_name: 'Doe',
+                        external_id: 'user123',
+                      },
+                      {
+                        email: 'test2@example.com',
+                        first_name: 'Jane',
+                        last_name: 'Smith',
+                        external_id: 'user456',
+                      },
+                    ],
+                  },
+                  JSON_ARRAY: {},
+                  XML: {},
+                  FORM: {},
+                },
+                files: {},
+                endpointPath: 'users/track',
+              },
               metadata: [
-                { jobId: 1, userId: 'u1' },
-                { jobId: 2, userId: 'u2' },
+                {
+                  jobId: 1,
+                  userId: 'u1',
+                  destInfo: {
+                    braze: {
+                      attributesIndex: 0,
+                    },
+                  },
+                },
+                {
+                  jobId: 2,
+                  userId: 'u2',
+                  destInfo: {
+                    braze: {
+                      attributesIndex: 1,
+                    },
+                  },
+                },
               ],
               batched: true,
               statusCode: 200,
@@ -681,47 +717,61 @@ export const identityResolution = [
         body: {
           output: [
             {
-              batchedRequest: [
-                {
-                  version: '1',
-                  type: 'REST',
-                  method: 'POST',
-                  endpoint: 'https://rest.fra-01.braze.eu/users/track',
-                  endpointPath: 'users/track',
-                  headers: {
-                    'Content-Type': 'application/json',
-                    Accept: 'application/json',
-                    Authorization: authHeader1,
-                  },
-                  params: {},
-                  body: {
-                    JSON: {
-                      partner: 'RudderStack',
-                      attributes: [
-                        {
-                          external_id: 'user123',
-                          email: 'test@example.com',
-                          first_name: 'John',
-                          last_name: 'Doe',
-                        },
-                        {
-                          external_id: 'user456',
-                          email: 'test2@example.com',
-                          first_name: 'Jane',
-                          last_name: 'Smith',
-                        },
-                      ],
-                    },
-                    JSON_ARRAY: {},
-                    XML: {},
-                    FORM: {},
-                  },
-                  files: {},
+              batchedRequest: {
+                version: '1',
+                type: 'REST',
+                method: 'POST',
+                endpoint: 'https://rest.fra-01.braze.eu/users/track',
+                headers: {
+                  'Content-Type': 'application/json',
+                  Accept: 'application/json',
+                  Authorization: authHeader1,
                 },
-              ],
+                params: {},
+                body: {
+                  JSON: {
+                    partner: 'RudderStack',
+                    attributes: [
+                      {
+                        email: 'test@example.com',
+                        first_name: 'John',
+                        last_name: 'Doe',
+                        external_id: 'user123',
+                      },
+                      {
+                        email: 'test2@example.com',
+                        first_name: 'Jane',
+                        last_name: 'Smith',
+                        external_id: 'user456',
+                      },
+                    ],
+                  },
+                  JSON_ARRAY: {},
+                  XML: {},
+                  FORM: {},
+                },
+                files: {},
+                endpointPath: 'users/track',
+              },
               metadata: [
-                { jobId: 1, userId: 'u1' },
-                { jobId: 2, userId: 'u2' },
+                {
+                  jobId: 1,
+                  userId: 'u1',
+                  destInfo: {
+                    braze: {
+                      attributesIndex: 0,
+                    },
+                  },
+                },
+                {
+                  jobId: 2,
+                  userId: 'u2',
+                  destInfo: {
+                    braze: {
+                      attributesIndex: 1,
+                    },
+                  },
+                },
               ],
               batched: true,
               statusCode: 200,


### PR DESCRIPTION
## What are the changes introduced in this PR?

Introduces a Braze batching refactor plus a rollout gate for the new per-job delivery-mapping output shape needed by INT-6634 (296 "Delivered with Warning" support).

**Always-on improvements** (regardless of flag):
1. **Cross-chunk straddle prevention.** Track chunking now walks source-job groups instead of individual items, so a single job's `attributes` + `events` (+ purchases) contributions always land in the same chunk. Prerequisite for correct metadata↔chunk ownership.
2. **Byte-size caps at chunking time.** Enforces Braze's documented limits — 100 KB per item, 4 MB per batch. Oversized single items and oversized single jobs are rejected up-front with `InstrumentationError` instead of building a batch Braze would reject wholesale.
3. **Type-safety cleanups.** `TaggedItem` is a discriminated union on `type`; type predicates (`isTrackBody` / `isSubscriptionBody` / `isMergeBody`) + a discriminated `JobClassification` push all narrowing into the type system — no `as` casts introduced. `BrazeSubscriptionBatchPayload.subscription_groups` typed as `BrazeSubscriptionGroup[]` (was `unknown[]`). `SubscriptionRun.entries` / `MergeRun.entries` renamed to `items` for consistency across `Run` variants.

**Gated changes** (`BRAZE_PER_JOB_DELIVERY_MAPPING_ENABLED=true`, default **OFF**):
- **One `BatchRequestOutput` per outgoing HTTP request.** Each `/users/track` / subscription-groups / alias-merge chunk becomes its own `BatchRequestOutput` with its own scoped metadata slice (instead of a single `MultiBatchRequestOutput` carrying all endpoints' chunks + a flat metadata list).
- **Insertion-order runs preserved.** Outputs are emitted in the input's insertion-order runs so per-user jobIds stay monotonically ascending across the emitted list.
- **`destInfo` positional map on every metadata entry.** Track metadata carries `destInfo.attributesIndices` / `eventsIndices` / `purchasesIndices` arrays; sub/merge metadata carries `destInfo: {}` (present-but-empty) so the v1 networkHandler sees a uniform shape across every chunk. Populated per the design doc's Option 1 contract — top-level index arrays, no per-destination wrapper.
- **Per-chunk metadata scoping.** A 5xx on any single chunk of a multi-chunk delivery no longer wrongly marks jobs from *unrelated* chunks as failed — latent behavior only fixed in the ON path.

When OFF (default), the router output shape is identical to pre-INT-6808 (single `MultiBatchRequestOutput` with `batchedRequest[]` and flat `metadata`) — verified by the unchanged integration snapshots in `router/data.ts` + `router/identityResolution.ts`.

## What is the related Linear task?

Resolves [INT-6808](https://linear.app/rudderstack/issue/INT-6808)

## Please explain the objectives of your changes below

Prep for INT-6634 (296 warning correlation). The network handler needs a way to map Braze's `errors[input_array, index]` back to originating `jobId`s; that requires (a) each job's contributions to be reachable within a single proxy response and (b) each metadata to carry positional info tying it back to the outgoing payload. Both requirements demand the batching-layer changes above. Gating the new output shape behind `BRAZE_PER_JOB_DELIVERY_MAPPING_ENABLED` lets INT-6634 land + soak in production without a hard cutover.

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes?

- **Router output shape unchanged by default** (flag OFF): single `MultiBatchRequestOutput` per invocation, flat `metadata`, no `destInfo` — identical to develop.
- **Byte-size caps added (both paths)**: oversized single items (> 100 KB) and oversized single jobs (> 75 items or > 4 MB) are now rejected up-front. Previously these silently created batches Braze would reject. Motivation: fail fast at the transformer.
- **`entries` → `items` rename on internal `Run` types**: not user-visible, internal naming consistency only.

### Any new dependencies introduced with this change?

N/A

### Any new generic utility introduced or modified. Please explain the changes.

N/A — all changes are Braze-scoped.

### Any technical or performance related pointers to consider with the change?

- Group-preserving chunking may close a `/users/track` chunk one item early to keep a job's contributions together. Chunk-count impact in practice: negligible (a typical job contributes ≤ 2 items).
- When the flag is ON, insertion-order runs may produce more discrete outputs when a batch interleaves multiple endpoint types (track ↔ subscription ↔ merge). Real batches are usually dominated by one type, so extra outputs are rare in practice.
- Byte-size measurement uses `Buffer.byteLength(JSON.stringify(item))` per item at chunk time — O(N) hot-path cost but bounded by the same items already being serialized shortly after.
- `isPerJobDeliveryMappingEnabled()` is read dynamically per invocation (not module-load), so a rollout config flip takes effect without a service restart.

@coderabbitai review

<hr>

### Developer checklist

- [x] My code follows the style guidelines of this project

- [x] **No breaking changes are being introduced.** — default (flag OFF) preserves pre-INT-6808 router output shape verified via unchanged integration snapshots.

- [x] All related docs linked with the PR? — Linear ticket + design doc referenced.

- [x] All changes manually tested? — braze unit + component tests all pass locally.

- [ ] Any documentation changes needed with this change? — none required for this PR; INT-6634 will add the 296 contract docs.

- [x] Is the PR limited to 10 file changes? — 5 files.

- [x] Is the PR limited to one linear task? — INT-6808 only.

- [x] Are relevant unit and component test-cases added in **new readability format**? — unit tests cover both OFF (default assertions) and ON (env-swap describe block); integration tests added for both paths.

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.