### PR TITLE
fix(customerio): include field and message in 207 partial-failure errors

### DIFF
--- a/src/v1/destinations/customerio/networkHandler.test.ts
+++ b/src/v1/destinations/customerio/networkHandler.test.ts
@@ -65,6 +65,48 @@ describe('CustomerIO networkHandler', () => {
       expect(result.response[2].statusCode).toBe(200);
     });
 
+    it('combines reason, field and message into the error string', () => {
+      const h = buildHandler();
+      const metadata = [makeMetadata(1), makeMetadata(2), makeMetadata(3)];
+      const response = {
+        errors: [
+          {
+            batch_index: 2,
+            reason: 'invalid',
+            field: 'attributes.delivery_suburb',
+            message: 'property value cannot be longer than 1000 bytes',
+          },
+        ],
+      };
+      const result = h.responseHandler({
+        rudderJobMetadata: metadata,
+        destinationResponse: { response, status: 207 },
+        destinationRequest: {
+          endpoint: 'https://track.customer.io/api/v2/batch',
+          body: { JSON: { batch: makeBatch(3) } },
+        },
+      });
+      expect(result.response[2].statusCode).toBe(400);
+      expect(result.response[2].error).toBe(
+        'reason: invalid, field: attributes.delivery_suburb, message: property value cannot be longer than 1000 bytes',
+      );
+    });
+
+    it('falls back to a default message when the error has no descriptive fields', () => {
+      const h = buildHandler();
+      const metadata = [makeMetadata(1), makeMetadata(2)];
+      const result = h.responseHandler({
+        rudderJobMetadata: metadata,
+        destinationResponse: { response: { errors: [{ batch_index: 0 }] }, status: 207 },
+        destinationRequest: {
+          endpoint: 'https://track.customer.io/api/v2/batch',
+          body: { JSON: { batch: makeBatch(2) } },
+        },
+      });
+      expect(result.response[0].statusCode).toBe(400);
+      expect(result.response[0].error).toBe('Unknown error from CustomerIO');
+    });
+
     it('marks all as 200 when errors array is empty', () => {
       const h = buildHandler();
       const metadata = [makeMetadata(1), makeMetadata(2)];

--- a/src/v1/destinations/customerio/networkHandler.ts
+++ b/src/v1/destinations/customerio/networkHandler.ts
@@ -13,10 +13,22 @@ import tags from '../../../v0/util/tags';
 type CustomerIOError = {
   batch_index: number;
   reason?: string;
+  field?: string;
+  message?: string;
 };
 
 type CustomerIO207Response = {
   errors?: CustomerIOError[];
+};
+
+const buildErrorMessage = (error: CustomerIOError): string => {
+  const parts = [
+    error.reason ? `reason: ${error.reason}` : undefined,
+    error.field ? `field: ${error.field}` : undefined,
+    error.message ? `message: ${error.message}` : undefined,
+  ].filter(Boolean);
+
+  return parts.length > 0 ? parts.join(', ') : 'Unknown error from CustomerIO';
 };
 
 const handle207MultiStatus = (
@@ -26,7 +38,7 @@ const handle207MultiStatus = (
   const errors = Array.isArray(response.errors) ? response.errors : [];
   const failedByIndex = new Map<number, string>();
   errors.forEach((e) => {
-    failedByIndex.set(e.batch_index, e.reason ?? 'Unknown error from CustomerIO');
+    failedByIndex.set(e.batch_index, buildErrorMessage(e));
   });
 
   const responseWithIndividualEvents: DeliveryJobState[] = rudderJobMetadata.map(

--- a/test/integrations/destinations/customerio/dataDelivery/data.ts
+++ b/test/integrations/destinations/customerio/dataDelivery/data.ts
@@ -104,7 +104,12 @@ export const v1BusinessTestScenarios: ProxyV1TestData[] = [
             message: '[CustomerIO Response Handler] - Batch completed with partial failures',
             response: [
               { statusCode: 200, metadata: generateMetadata(1), error: 'success' },
-              { statusCode: 400, metadata: generateMetadata(2), error: 'invalid attribute' },
+              {
+                statusCode: 400,
+                metadata: generateMetadata(2),
+                error:
+                  'reason: invalid, field: attributes.plan, message: property value cannot be longer than 1000 bytes',
+              },
             ],
           },
         },

--- a/test/integrations/destinations/customerio/network.ts
+++ b/test/integrations/destinations/customerio/network.ts
@@ -21,7 +21,16 @@ export const networkCallsData = [
       },
     },
     httpRes: {
-      data: { errors: [{ batch_index: 1, reason: 'invalid attribute' }] },
+      data: {
+        errors: [
+          {
+            batch_index: 1,
+            reason: 'invalid',
+            field: 'attributes.plan',
+            message: 'property value cannot be longer than 1000 bytes',
+          },
+        ],
+      },
       status: 207,
     },
   },


### PR DESCRIPTION
## What are the changes introduced in this PR?

The 207 multi-status handler only surfaced CustomerIO's `reason`, dropping the `field` and `message` details that explain why an event failed. Combine all present fields into a single "reason: ..., field: ..., message: ..." string so per-event errors are actionable.

## What is the related Linear task?

Resolves INT-XXX

## Please explain the objectives of your changes below

Put down any required details on the broader aspect of your changes. If there are any dependent changes, **mandatorily** mention them here

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

N/A

### Any new dependencies introduced with this change?

N/A

### Any new generic utility introduced or modified. Please explain the changes.

N/A

### Any technical or performance related pointers to consider with the change?

N/A

@coderabbitai review

<hr>

### Developer checklist

- [ ] My code follows the style guidelines of this project

- [ ] **No breaking changes are being introduced.**

- [ ] All related docs linked with the PR?

- [ ] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [ ] Is the PR limited to 10 file changes?

- [ ] Is the PR limited to one linear task?

- [ ] Are relevant unit and component test-cases added in **new readability format**?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.
