### PR TITLE
fix(custom_mappings): cache compiled template to prevent sandbox OOM under load

### DIFF
--- a/src/util/customMappings/mappingsSandbox.ts
+++ b/src/util/customMappings/mappingsSandbox.ts
@@ -16,15 +16,35 @@ export type MappingsResult = { ok: true; value: unknown } | { ok: false; error: 
 
 declare const globalThis: Record<string, unknown>;
 
+// Compiling a template (parse + codegen) dominates per-call allocation; running the compiled
+// engine via evaluate() is cheap. The mappings are fixed per destination while the event
+// varies, so memoize the compiled engine per template and only re-run evaluate() per event.
+// This isolate is long-lived and per-workspace, so the cache persists across evals on it —
+// under a concurrency burst each eval then allocates only evaluate()'s small working set
+// instead of recompiling, which is what let the shared 16 MB heap breach and dispose the isolate.
+// Bounded so a workspace with many distinct templates can't grow this cache into the very OOM
+// it exists to prevent; a workspace realistically has a handful of templates, so the cap rarely bites.
+const MAX_CACHED_ENGINES = 100;
+const engineCache = new Map<string, ReturnType<typeof JsonTemplateEngine.createAsSync>>();
+
 globalThis.evaluateCustomMappingsInSandbox = (
   mappings: TemplateInput,
   event: unknown,
 ): MappingsResult => {
   try {
-    const value = JsonTemplateEngine.createAsSync(mappings, {
-      defaultPathType: PathType.JSON,
-    }).evaluate(event);
-    return { ok: true, value };
+    // Args cross the isolate boundary via structured clone, so `mappings` is a fresh copy each
+    // call — key by content, not reference identity (which would never hit).
+    const key = JSON.stringify(mappings);
+    let engine = engineCache.get(key);
+    if (!engine) {
+      engine = JsonTemplateEngine.createAsSync(mappings, { defaultPathType: PathType.JSON });
+      // FIFO eviction: Map preserves insertion order, so the first key is the oldest.
+      if (engineCache.size >= MAX_CACHED_ENGINES) {
+        engineCache.delete(engineCache.keys().next().value as string);
+      }
+      engineCache.set(key, engine);
+    }
+    return { ok: true, value: engine.evaluate(event) };
   } catch (e: unknown) {
     return { ok: false, error: e instanceof Error ? e.message : String(e) };
   }

--- a/src/util/customMappings/sandboxClient.test.ts
+++ b/src/util/customMappings/sandboxClient.test.ts
@@ -16,6 +16,33 @@ describe('sandboxedApplyCustomMappings', () => {
     expect(out).toEqual({ id: 'u1' });
   });
 
+  it('reuses the compiled engine across events without leaking state between evaluations', async () => {
+    // The engine is compiled once per template and reused; evaluating it against different
+    // events must yield independent results (no per-event state retained on the engine).
+    const mappings = [{ from: '$.userId', to: 'id' }];
+    const first = await sandboxedApplyCustomMappings({ userId: 'u1' }, mappings, WS);
+    const second = await sandboxedApplyCustomMappings({ userId: 'u2' }, mappings, WS);
+    expect(first).toEqual({ id: 'u1' });
+    expect(second).toEqual({ id: 'u2' });
+  });
+
+  it('evaluates distinct mapping templates correctly on the same workspace isolate', async () => {
+    // Guards the content-keyed cache: a second template on the same isolate must not resolve
+    // to the first template's cached engine.
+    const byId = await sandboxedApplyCustomMappings(
+      { userId: 'u1', email: 'a@b.com' },
+      [{ from: '$.userId', to: 'id' }],
+      WS,
+    );
+    const byEmail = await sandboxedApplyCustomMappings(
+      { userId: 'u1', email: 'a@b.com' },
+      [{ from: '$.email', to: 'mail' }],
+      WS,
+    );
+    expect(byId).toEqual({ id: 'u1' });
+    expect(byEmail).toEqual({ mail: 'a@b.com' });
+  });
+
   it('does NOT leak process.env — process is undefined in the isolate, so it throws', async () => {
     process.env.RS_SANDBOX_SECRET = 'top-secret';
     // There is no `process` global inside the isolate, so referencing it throws a


### PR DESCRIPTION
## What

Custom-mapping evaluation runs inside a per-workspace `isolated-vm` sandbox. Today it recompiles the `JsonTemplateEngine` template from scratch on **every event** (`createAsSync(mappings).evaluate(event)`), even though the mapping is fixed per destination and only the event varies. This change memoizes the compiled engine per template and only runs `evaluate()` per event.

## Why

Compilation (parse + codegen) is the dominant per-eval cost. A single `isolated-vm` isolate serializes execution, so its throughput is a hard ceiling. When a workspace bursts past that ceiling, evals back up on the one shared 16 MB isolate, live argument copies accumulate, and V8 disposes the **whole** isolate on the memory limit — the one eval that tips it logs the genuine OOM while every other in-flight eval fails at once with "Isolate is disposed" (the amplified `ivm-platform-error` alerts).

Caching the compiled engine removes the dominant per-call cost, so each eval only runs `evaluate()`. That lifts the single-isolate throughput ceiling and lowers per-eval heap, so a workspace can sustain a much higher arrival rate before its isolate backs up.

## Load test results

Both variants driven through the real `isolated-vm` path (16 MB limit, 500 ms timeout, `copy:true` args — identical to `scriptRunner.ts`).

**CPU / throughput** (single warm isolate, sequential evals):

| Mapping | metric | uncached | cached | speedup |
|---|---|---|---|---|
| Simple (32 fields) | per-eval latency | 0.387 ms | 0.060 ms | **6.5×** |
| Simple | throughput | 2,583 evals/s | 16,674 evals/s | **6.5×** |
| Complex (40 expression fields) | per-eval latency | 1.785 ms | 0.210 ms | **8.5×** |
| Complex | throughput | 560 evals/s | 4,768 evals/s | **8.5×** |

**Peak heap under a concurrent burst** (complex mapping, fresh 16 MB isolate):

| Concurrency K | uncached peak heap | cached peak heap | reduction |
|---|---|---|---|
| 100 | 5.87 MB | 3.36 MB | 43% |
| 400 | 9.70 MB | 7.22 MB | 26% |
| 600 | 12.30 MB | 9.00 MB | 27% |

### Scope of the benefit (measured, not assumed)

- The win is **throughput / sustained arrival rate** (6.5–8.5×) and **lower heap at operating concurrency** (25–43%).
- A synthetic burst of K evals *pre-queued all at once* OOMs at roughly the same K for both variants (~1600 in this harness). At that extreme, the structured-clone of K argument-sets dominates the heap — a factor caching does not touch. Real load arrives over time against a serialized isolate, where the throughput ceiling is what governs OOM onset; this change lifts that ceiling.

## Notes for reviewers

- **Cache key is content, not reference.** Args cross the isolate boundary via structured clone, so `mappings` is a fresh copy each call — identity caching would never hit. Keyed by `JSON.stringify(mappings)`, whose cost is far below parse + codegen.
- **Bounded cache.** Compiled engines are retained in the same 16 MB heap, so the cache is capped (FIFO) to avoid trading a transient-allocation OOM for a retained-memory one. A workspace realistically has a handful of distinct templates, so the cap rarely bites.
- **No locking needed.** The isolate holds a single-execution lock and the cache read/compile/write path is synchronous, so concurrent evals can't race on the map.
- **Reuse-safety.** Two new tests assert that reusing a compiled engine across different events yields independent results, and that distinct templates on the same isolate don't collide on the cache.

## Testing

- `customMappings` unit tests: 8/8 pass (incl. two new reuse-safety guards)
- `http` component tests: 33/33 pass
- `ga4_v2` component tests: 23/23 pass
- lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)