### PR TITLE
fix(ivm): platform-error alert misses the first error burst on a fresh isolate

### DIFF
--- a/src/util/ivm/scriptRunner.test.ts
+++ b/src/util/ivm/scriptRunner.test.ts
@@ -1,0 +1,108 @@
+import { IvmScriptRunner } from './scriptRunner';
+import stats from '../stats';
+
+// evalClosure is the sandbox entry point; each test controls whether it resolves or throws.
+const evalClosure = jest.fn();
+
+jest.mock('../stats', () => ({
+  counter: jest.fn(),
+  increment: jest.fn(),
+  gauge: jest.fn(),
+}));
+
+// Avoid reading a real bundle from disk — the runner only feeds this into compileScript, which is mocked.
+jest.mock('fs', () => ({
+  readFileSync: jest.fn().mockReturnValue('// bundle'),
+  existsSync: jest.fn(),
+}));
+
+// Replace isolated-vm with a lightweight fake: no real isolate is built, and evalClosure is our hook.
+jest.mock('isolated-vm', () => ({
+  Isolate: jest.fn().mockImplementation(() => ({
+    createContext: jest.fn().mockResolvedValue({
+      evalClosure: (...callArgs: unknown[]) => evalClosure(...callArgs),
+      release: jest.fn(),
+    }),
+    compileScript: jest.fn().mockResolvedValue({ run: jest.fn().mockResolvedValue(undefined) }),
+    getHeapStatisticsSync: jest.fn().mockReturnValue({ total_heap_size: 0 }),
+    dispose: jest.fn(),
+  })),
+}));
+
+// A Map-backed DisposableCache stand-in — keeps the test off real TTL timers and init logging.
+jest.mock('../ivmCache/index', () =>
+  jest.fn().mockImplementation((opts: { name: string }) => {
+    const store = new Map<string, unknown>();
+    return {
+      cacheName: opts.name,
+      get: (k: string) => store.get(k),
+      set: (k: string, v: unknown) => store.set(k, v),
+      delete: (k: string) => store.delete(k),
+      values: () => store.values(),
+    };
+  }),
+);
+
+const makeRunner = () =>
+  new IvmScriptRunner({
+    bundlePath: '/tmp/bundle.js',
+    memoryLimitMb: 8,
+    initTimeoutMs: 100,
+    execTimeoutMs: 100,
+    cacheName: 'custom_mappings_ivm',
+  });
+
+const EXPRESSION = 'return evaluateCustomMappingsInSandbox($0, $1)';
+const WORKSPACE = 'ws-1';
+const EXPECTED_TAGS = {
+  functionName: EXPRESSION,
+  workspaceId: WORKSPACE,
+  cache: 'custom_mappings_ivm',
+};
+
+describe('IvmScriptRunner.execute platform-error counter', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('seeds the platform-error counter at 0 on the happy path so increase() has a baseline', async () => {
+    evalClosure.mockResolvedValue({ ok: true, value: { id: 'u1' } });
+
+    await makeRunner().execute(WORKSPACE, EXPRESSION, [{}, {}]);
+
+    // The 0-seed creates the series before any error can, giving rate()/increase() a 0 -> N edge.
+    expect(stats.counter).toHaveBeenCalledWith('ivm_platform_error', 0, EXPECTED_TAGS);
+    // A successful run must not record an error.
+    expect(stats.increment).not.toHaveBeenCalledWith('ivm_platform_error', expect.anything());
+  });
+
+  it('seeds 0 before running and increments on a platform failure, with matching label sets', async () => {
+    evalClosure.mockRejectedValue(new Error('Script execution timed out'));
+
+    await expect(makeRunner().execute(WORKSPACE, EXPRESSION, [{}, {}])).rejects.toThrow(
+      'Script execution timed out',
+    );
+
+    // Both the seed and the error increment use the identical label set, so they land on one series.
+    expect(stats.counter).toHaveBeenCalledWith('ivm_platform_error', 0, EXPECTED_TAGS);
+    expect(stats.increment).toHaveBeenCalledWith('ivm_platform_error', EXPECTED_TAGS);
+  });
+
+  it('seeds 0 even when isolate creation itself fails (build-time platform error)', async () => {
+    const ivm = require('isolated-vm');
+    ivm.Isolate.mockImplementationOnce(() => ({
+      createContext: jest
+        .fn()
+        .mockRejectedValue(new Error('Isolate was disposed during execution')),
+      compileScript: jest.fn(),
+      getHeapStatisticsSync: jest.fn(),
+      dispose: jest.fn(),
+    }));
+
+    await expect(makeRunner().execute(WORKSPACE, EXPRESSION, [{}, {}])).rejects.toThrow(
+      'Isolate was disposed during execution',
+    );
+
+    // The seed runs before getOrCreate, so build-time failures are covered too.
+    expect(stats.counter).toHaveBeenCalledWith('ivm_platform_error', 0, EXPECTED_TAGS);
+    expect(stats.increment).toHaveBeenCalledWith('ivm_platform_error', EXPECTED_TAGS);
+  });
+});

--- a/src/util/ivm/scriptRunner.test.ts
+++ b/src/util/ivm/scriptRunner.test.ts
@@ -101,8 +101,22 @@ describe('IvmScriptRunner.execute platform-error counter', () => {
       'Isolate was disposed during execution',
     );
 
-    // The seed runs before getOrCreate, so build-time failures are covered too.
+    // The seed runs before the isolate is built, so build-time failures are covered too.
     expect(stats.counter).toHaveBeenCalledWith('ivm_platform_error', 0, EXPECTED_TAGS);
     expect(stats.increment).toHaveBeenCalledWith('ivm_platform_error', EXPECTED_TAGS);
+  });
+
+  it('seeds only once per isolate — warm-isolate calls do not touch the metrics registry', async () => {
+    evalClosure.mockResolvedValue({ ok: true, value: { id: 'u1' } });
+    const runner = makeRunner();
+
+    // First call builds the isolate (cache miss) and seeds; the next two reuse the warm
+    // isolate (cache hits) and must not re-seed — the hot path stays off the registry.
+    await runner.execute(WORKSPACE, EXPRESSION, [{}, {}]);
+    await runner.execute(WORKSPACE, EXPRESSION, [{}, {}]);
+    await runner.execute(WORKSPACE, EXPRESSION, [{}, {}]);
+
+    expect(stats.counter).toHaveBeenCalledTimes(1);
+    expect(stats.counter).toHaveBeenCalledWith('ivm_platform_error', 0, EXPECTED_TAGS);
   });
 });

--- a/src/util/ivm/scriptRunner.test.ts
+++ b/src/util/ivm/scriptRunner.test.ts
@@ -4,6 +4,11 @@ import stats from '../stats';
 // evalClosure is the sandbox entry point; each test controls whether it resolves or throws.
 const evalClosure = jest.fn();
 
+// Fidelity note: these mocks are independent jest.fn()s, but in production `stats.increment`
+// delegates to `stats.counter(name, 1)` (see stats.js). So do NOT assert a total `stats.counter`
+// call count across a path that also errors — the real client would count the increment as a
+// counter call too. Assert seed calls via `('ivm_platform_error', 0, ...)` and error calls via
+// `stats.increment` instead. The 0-seed's non-reset semantics are covered in prometheus.test.js.
 jest.mock('../stats', () => ({
   counter: jest.fn(),
   increment: jest.fn(),
@@ -118,5 +123,48 @@ describe('IvmScriptRunner.execute platform-error counter', () => {
 
     expect(stats.counter).toHaveBeenCalledTimes(1);
     expect(stats.counter).toHaveBeenCalledWith('ivm_platform_error', 0, EXPECTED_TAGS);
+  });
+
+  it('coalesces concurrent first-callers — one 0-seed and one isolate build for the same key', async () => {
+    evalClosure.mockResolvedValue({ ok: true, value: { id: 'u1' } });
+    const ivm = require('isolated-vm');
+    const runner = makeRunner();
+
+    // Fire two calls for the same key before the first isolate finishes building. getOrCreate
+    // sets pendingCreations synchronously (no await before it returns), so the second caller must
+    // join the in-flight creation rather than seed/build a second time.
+    await Promise.all([
+      runner.execute(WORKSPACE, EXPRESSION, [{}, {}]),
+      runner.execute(WORKSPACE, EXPRESSION, [{}, {}]),
+    ]);
+
+    expect(ivm.Isolate).toHaveBeenCalledTimes(1);
+    expect(stats.counter).toHaveBeenCalledTimes(1);
+    expect(stats.counter).toHaveBeenCalledWith('ivm_platform_error', 0, EXPECTED_TAGS);
+  });
+
+  it('re-seeds 0 and rebuilds after an error evicts the isolate', async () => {
+    const ivm = require('isolated-vm');
+    const runner = makeRunner();
+
+    // First call fails at execution time; the catch path evicts the isolate from the cache.
+    evalClosure.mockRejectedValueOnce(new Error('Script execution timed out'));
+    await expect(runner.execute(WORKSPACE, EXPRESSION, [{}, {}])).rejects.toThrow(
+      'Script execution timed out',
+    );
+
+    // Next call is a fresh cache miss: it must build a new isolate AND re-seed the 0 baseline.
+    evalClosure.mockResolvedValueOnce({ ok: true, value: { id: 'u1' } });
+    await runner.execute(WORKSPACE, EXPRESSION, [{}, {}]);
+
+    // Two build cycles → two 0-seeds. The re-seed is inc(0), which is add-only and never resets
+    // the accumulated count (proven against the real registry in prometheus.test.js).
+    expect(ivm.Isolate).toHaveBeenCalledTimes(2);
+    expect(stats.counter).toHaveBeenCalledTimes(2);
+    expect(stats.counter).toHaveBeenNthCalledWith(1, 'ivm_platform_error', 0, EXPECTED_TAGS);
+    expect(stats.counter).toHaveBeenNthCalledWith(2, 'ivm_platform_error', 0, EXPECTED_TAGS);
+    // The single error from the first call was still recorded, with the matching label set.
+    expect(stats.increment).toHaveBeenCalledTimes(1);
+    expect(stats.increment).toHaveBeenCalledWith('ivm_platform_error', EXPECTED_TAGS);
   });
 });

--- a/src/util/ivm/scriptRunner.ts
+++ b/src/util/ivm/scriptRunner.ts
@@ -99,17 +99,19 @@ export class IvmScriptRunner {
       workspaceId: cacheKey,
       cache: this.cache.cacheName,
     };
-    // Seed the platform-error counter at 0 for this label set before running anything.
-    // Prometheus only exports a counter after its first increment, and rate()/increase()
-    // anchor on the first sample within their window — so without a 0 baseline, an error
-    // burst that lands on a freshly-seen (workspaceId, functionName, cache) series is
-    // invisible to the ivm-platform-errors alert: increase() can only catch the *second*
-    // increment of an already-established series, missing the first burst entirely. Seeding
-    // 0 on the happy path gives increase() the 0 -> N edge it needs to detect the very first
-    // burst on any workspace that is actively processing.
-    stats.counter('ivm_platform_error', 0, platformErrorTags);
     try {
-      const entry = await this.getOrCreate(cacheKey);
+      // Seed the platform-error counter at 0 when a fresh isolate is built for this label set
+      // (once per isolate, not per call — warm-isolate calls never touch the registry).
+      // Prometheus only exports a counter after its first increment, and rate()/increase()
+      // anchor on the first sample within their window — so without a 0 baseline, an error
+      // burst that lands on a freshly-seen (workspaceId, functionName, cache) series is
+      // invisible to the ivm-platform-errors alert: increase() can only catch the *second*
+      // increment of an already-established series, missing the first burst entirely. A
+      // workspace's first call is always a cache miss, so the 0 is materialised before any
+      // error can occur, giving increase() the 0 -> N edge it needs to detect the first burst.
+      const entry = await this.getOrCreate(cacheKey, () =>
+        stats.counter('ivm_platform_error', 0, platformErrorTags),
+      );
       const result = await entry.context.evalClosure(expression, args, {
         arguments: { copy: true },
         result: { copy: true, promise: true },
@@ -164,7 +166,7 @@ export class IvmScriptRunner {
     }
   }
 
-  private async getOrCreate(cacheKey: string) {
+  private async getOrCreate(cacheKey: string, onCreate: () => void) {
     const cached = this.cache.get(cacheKey);
     if (cached) {
       return cached;
@@ -180,6 +182,10 @@ export class IvmScriptRunner {
     // the map empty and re-opening the race window.
     let pending = this.pendingCreations.get(cacheKey);
     if (!pending) {
+      // First build for this key — seed the error counter's 0 baseline before the isolate
+      // (and any error it could raise) exists. Concurrent first callers coalesce below, so
+      // this runs once per isolate creation.
+      onCreate();
       pending = this.createEntry()
         .then((entry) => {
           this.cache.set(cacheKey, entry);

--- a/src/util/ivm/scriptRunner.ts
+++ b/src/util/ivm/scriptRunner.ts
@@ -94,6 +94,20 @@ export class IvmScriptRunner {
    * avoiding global mutation and race conditions between concurrent calls.
    */
   async execute<T>(cacheKey: string, expression: string, args: unknown[]): Promise<T> {
+    const platformErrorTags = {
+      functionName: expression,
+      workspaceId: cacheKey,
+      cache: this.cache.cacheName,
+    };
+    // Seed the platform-error counter at 0 for this label set before running anything.
+    // Prometheus only exports a counter after its first increment, and rate()/increase()
+    // anchor on the first sample within their window — so without a 0 baseline, an error
+    // burst that lands on a freshly-seen (workspaceId, functionName, cache) series is
+    // invisible to the ivm-platform-errors alert: increase() can only catch the *second*
+    // increment of an already-established series, missing the first burst entirely. Seeding
+    // 0 on the happy path gives increase() the 0 -> N edge it needs to detect the very first
+    // burst on any workspace that is actively processing.
+    stats.counter('ivm_platform_error', 0, platformErrorTags);
     try {
       const entry = await this.getOrCreate(cacheKey);
       const result = await entry.context.evalClosure(expression, args, {
@@ -107,11 +121,7 @@ export class IvmScriptRunner {
       // building the isolate. Evict so the next call gets a fresh one, and emit
       // a metric for observability before rethrowing.
       this.cache.delete(cacheKey);
-      stats.increment('ivm_platform_error', {
-        functionName: expression,
-        workspaceId: cacheKey,
-        cache: this.cache.cacheName,
-      });
+      stats.increment('ivm_platform_error', platformErrorTags);
       throw err;
     }
   }

--- a/src/util/prometheus.test.js
+++ b/src/util/prometheus.test.js
@@ -1,0 +1,40 @@
+const { Prometheus } = require('./prometheus');
+
+// These tests pin the semantics the ivm platform-error 0-seed relies on: `counter(name, 0)` must
+// materialise a series at 0 (so increase()/rate() get a 0 -> N edge) and must NOT reset an already
+// incremented series when it runs again after an isolate is evicted and rebuilt.
+//
+// A single Prometheus instance is shared: constructing it twice would re-register the predefined
+// metrics on prom-client's global registry and throw. Distinct workspaceIds keep each test's series
+// independent on the shared, lazily-created `ivm_platform_error` counter.
+describe('Prometheus platform-error zero-seed semantics', () => {
+  const client = new Prometheus(false);
+
+  const valueFor = async (labels) => {
+    const metrics = await client.prometheusRegistry.getMetricsAsJSON();
+    const metric = metrics.find((m) => m.name === 'transformer_ivm_platform_error');
+    const series = metric?.values.find((v) =>
+      Object.entries(labels).every(([k, val]) => v.labels[k] === val),
+    );
+    return series?.value;
+  };
+
+  it('counter(name, 0) materialises the series at 0 before any increment', async () => {
+    const tags = { functionName: 'fn', workspaceId: 'ws-seed', cache: 'custom_mappings_ivm' };
+
+    client.counter('ivm_platform_error', 0, tags);
+
+    expect(await valueFor(tags)).toBe(0);
+  });
+
+  it('re-seeding with 0 after an increment does not reset the accumulated count', async () => {
+    const tags = { functionName: 'fn', workspaceId: 'ws-reset', cache: 'custom_mappings_ivm' };
+
+    client.counter('ivm_platform_error', 0, tags); // seed on first isolate build
+    client.increment('ivm_platform_error', tags); // one platform error -> 1
+    client.counter('ivm_platform_error', 0, tags); // re-seed after eviction/rebuild
+
+    // inc(0) is add-only, so the second seed must leave the series at 1, not reset it to 0.
+    expect(await valueFor(tags)).toBe(1);
+  });
+});

--- a/src/v0/destinations/custom_audience/template/ivmScriptRunner.test.ts
+++ b/src/v0/destinations/custom_audience/template/ivmScriptRunner.test.ts
@@ -30,6 +30,7 @@ jest.mock('../../../../logger', () => ({
 }));
 
 const mockStats = {
+  counter: jest.fn(),
   increment: jest.fn(),
   gauge: jest.fn(),
 };


### PR DESCRIPTION
## What

The `ivm-platform-errors` alert can silently miss the **first** burst of isolated-vm platform errors on a workspace/isolate that hasn't errored before — the exact failure mode we hit in a recent enterprise-eu incident, where a burst of ~2.7k errors on a freshly-seen isolate never showed up and only a later, smaller burst tripped the alert.

## Why it happens

`transformer_ivm_platform_error` is created lazily on its first increment, so its series springs into existence *already at a non-zero value*. `rate()`/`increase()` anchor on the first sample within their window and cannot measure the jump that **creates** a series — there is no earlier sample to diff against. As a result:

- the alert (`sum by (cluster, namespace, functionName) (increase(transformer_ivm_platform_error[1m])) > 0`) only trips on the **second** increment of an already-established series;
- a single burst that then goes quiet is **never** alerted;
- `increase()`-based dashboard panels undercount the same bursts.

Replaying the alert expression over the incident confirmed it: the first burst's window evaluated to `0` throughout, and only the second increment produced a non-zero value.

## Fix

Materialise the counter at `0` for a label set **when its isolate is first built** (the cache-miss path of `IvmScriptRunner.execute`), using the same labels the error path increments. Because a workspace's first call is always a cache miss, the `0` baseline exists *before* any error can occur, so `increase()` sees a clean `0 → N` edge and catches the very first burst.

Seeding on isolate build (rather than on every call) keeps the warm-isolate hot path off the metrics registry entirely — the `0` is written once per isolate lifecycle, not per event. This is the same zero-initialisation approach already used elsewhere in the transformer for counters that feed alerts.

## Tradeoffs & scope

- **Cardinality:** the counter now gets a (zero-valued) series for every actively-processing `(workspaceId, functionName, cache)`, not only erroring ones. It is bounded by the active workspaces per pod. `workspaceId` was already a label on this metric, so no new label dimension is introduced.
- **Residual gap:** if a workspace's very first call errors within a single scrape interval (before the `0` is ever scraped), that one burst can still be missed. This is far narrower than the previous behaviour (every freshly-seen series was blind) and is inherent to lazily-created counters.
- No change to the alert definition is required — the existing expression becomes correct once the baseline exists.

## Testing

New `scriptRunner.test.ts` covers:
- happy path seeds `0` and records no error;
- a platform failure seeds `0` **and** increments with a matching label set;
- an isolate build-time failure is covered (seed runs before the isolate exists);
- warm-isolate calls do **not** re-seed — only one registry write per isolate.

The existing `sandboxClient` integration suite exercises the seeded build path.