### PR TITLE
fix(customerio): stop rejecting non-object traits and context in v2 schema

### DIFF
--- a/src/v0/destinations/customerio/v2/types.ts
+++ b/src/v0/destinations/customerio/v2/types.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import get from 'get-value';
 import { makeRouterInputSchema } from '../../../../services/destination/nativeBatching/batchDestination';
 import { RECORD_IDENTIFIER_KEYS } from './config';
 import { CustomerIODestinationConfigSchema, CustomerIOConnectionConfigSchema } from '../types';
@@ -34,8 +35,6 @@ export type CustomerIOV2Payload = {
   [key: string]: unknown;
 };
 
-const emailTraitSchema = z.object({ email: z.unknown() }).passthrough().nullish();
-
 const recordMessageSchema = z
   .object({
     type: z.literal('record'),
@@ -63,18 +62,14 @@ const eventStreamMessageSchema = z
     anonymousId: z.union([z.string(), z.number()]).nullish(),
     previousId: z.union([z.string(), z.number()]).nullish(),
     groupId: z.union([z.string(), z.number()]).nullish(),
-    traits: emailTraitSchema,
-    context: z
-      .object({
-        // RETL/warehouse sources set mappedToDestination and supply the identifier
-        // via externalId. adduserIdFromExternalId (called in processV2, after this
-        // validation) hydrates userId — so these events must pass the refine even
-        // without a top-level userId/anonymousId/email.
-        mappedToDestination: z.unknown(),
-        traits: emailTraitSchema,
-      })
-      .passthrough()
-      .nullish(),
+    // traits and context are passed through untyped (not validated here): some
+    // sources send them as a non-object (e.g. an array). RETL/warehouse sources
+    // set context.mappedToDestination and supply the identifier via externalId;
+    // adduserIdFromExternalId (called in processV2, after this validation) hydrates
+    // userId — so those events must pass the refine even without a top-level
+    // userId/anonymousId/email.
+    traits: z.unknown(),
+    context: z.unknown(),
   })
   .passthrough()
   .refine(
@@ -85,8 +80,8 @@ const eventStreamMessageSchema = z
       if (msg.type === 'group') {
         return true;
       }
-      const hasEmail = !!msg.traits?.email || !!msg.context?.traits?.email;
-      const isMappedToDestination = !!msg.context?.mappedToDestination;
+      const hasEmail = !!get(msg, 'traits.email') || !!get(msg, 'context.traits.email');
+      const isMappedToDestination = !!get(msg, 'context.mappedToDestination');
       return !!msg.userId || !!msg.anonymousId || hasEmail || isMappedToDestination;
     },
     { message: 'userId, email or anonymousId is required' },


### PR DESCRIPTION
## What are the changes introduced in this PR?

The v2 event-stream schema validated `traits` and `context.traits` against an object shape, so events carrying either as a non-object — some sources send `context` as an array — were rejected with "Expected object, received array" before reaching the transform.

Drop the shape validation and pass both through as `z.unknown()`. The refine logic is unchanged; it now reads via `get-value`, which returns undefined on a non-object root instead of throwing, so email and mappedToDestination detection still work for the object case.

## What is the related Linear task?

Resolves INT-XXX

## Please explain the objectives of your changes below

Put down any required details on the broader aspect of your changes. If there are any dependent changes, **mandatorily** mention them here

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

N/A

### Any new dependencies introduced with this change?

N/A

### Any new generic utility introduced or modified. Please explain the changes.

N/A

### Any technical or performance related pointers to consider with the change?

N/A

@coderabbitai review

<hr>

### Developer checklist

- [ ] My code follows the style guidelines of this project

- [ ] **No breaking changes are being introduced.**

- [ ] All related docs linked with the PR?

- [ ] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [ ] Is the PR limited to 10 file changes?

- [ ] Is the PR limited to one linear task?

- [ ] Are relevant unit and component test-cases added in **new readability format**?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.
