### PR TITLE
fix(customerio): accept non-object traits and context in v2

### DIFF
--- a/src/v0/destinations/customerio/v2/types.ts
+++ b/src/v0/destinations/customerio/v2/types.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import get from 'get-value';
 import { makeRouterInputSchema } from '../../../../services/destination/nativeBatching/batchDestination';
 import { RECORD_IDENTIFIER_KEYS } from './config';
 import { CustomerIODestinationConfigSchema, CustomerIOConnectionConfigSchema } from '../types';
@@ -34,8 +35,6 @@ export type CustomerIOV2Payload = {
   [key: string]: unknown;
 };
 
-const emailTraitSchema = z.object({ email: z.unknown() }).passthrough().nullish();
-
 const recordMessageSchema = z
   .object({
     type: z.literal('record'),
@@ -63,18 +62,14 @@ const eventStreamMessageSchema = z
     anonymousId: z.union([z.string(), z.number()]).nullish(),
     previousId: z.union([z.string(), z.number()]).nullish(),
     groupId: z.union([z.string(), z.number()]).nullish(),
-    traits: emailTraitSchema,
-    context: z
-      .object({
-        // RETL/warehouse sources set mappedToDestination and supply the identifier
-        // via externalId. adduserIdFromExternalId (called in processV2, after this
-        // validation) hydrates userId — so these events must pass the refine even
-        // without a top-level userId/anonymousId/email.
-        mappedToDestination: z.unknown(),
-        traits: emailTraitSchema,
-      })
-      .passthrough()
-      .nullish(),
+    // traits and context are passed through untyped (not validated here): some
+    // sources send them as a non-object (e.g. an array). RETL/warehouse sources
+    // set context.mappedToDestination and supply the identifier via externalId;
+    // adduserIdFromExternalId (called in processV2, after this validation) hydrates
+    // userId — so those events must pass the refine even without a top-level
+    // userId/anonymousId/email.
+    traits: z.unknown(),
+    context: z.unknown(),
   })
   .passthrough()
   .refine(
@@ -85,8 +80,8 @@ const eventStreamMessageSchema = z
       if (msg.type === 'group') {
         return true;
       }
-      const hasEmail = !!msg.traits?.email || !!msg.context?.traits?.email;
-      const isMappedToDestination = !!msg.context?.mappedToDestination;
+      const hasEmail = !!get(msg, 'traits.email') || !!get(msg, 'context.traits.email');
+      const isMappedToDestination = !!get(msg, 'context.mappedToDestination');
       return !!msg.userId || !!msg.anonymousId || hasEmail || isMappedToDestination;
     },
     { message: 'userId, email or anonymousId is required' },

--- a/src/v0/destinations/customerio/v2/util.ts
+++ b/src/v0/destinations/customerio/v2/util.ts
@@ -7,7 +7,6 @@ import {
   constructPayload,
   getFieldValueFromMessage,
   isAppleFamily,
-  isObject,
   validateEventName,
 } from '../../../util';
 import { populateSpecedTraits } from '../util';
@@ -51,11 +50,7 @@ const buildTraitAttributes = (message): Record<string, unknown> => {
   populateSpecedTraits(attributes, message);
 
   const pathToTraits = message.traits ? 'traits' : 'context.traits';
-  const rawTraits = getFieldValueFromMessage(message, 'traits');
-  // Only plain objects yield named attributes. Arrays/primitives would otherwise
-  // produce index-keyed junk (e.g. ['a','b'] -> { '0': 'a', '1': 'b' }), so they
-  // contribute no free-form attributes instead.
-  const traits = isObject(rawTraits) ? rawTraits : {};
+  const traits = getFieldValueFromMessage(message, 'traits') || {};
   Object.keys(traits)
     .filter(
       (trait) =>

--- a/src/v0/destinations/customerio/v2/util.ts
+++ b/src/v0/destinations/customerio/v2/util.ts
@@ -7,6 +7,7 @@ import {
   constructPayload,
   getFieldValueFromMessage,
   isAppleFamily,
+  isObject,
   validateEventName,
 } from '../../../util';
 import { populateSpecedTraits } from '../util';
@@ -50,7 +51,11 @@ const buildTraitAttributes = (message): Record<string, unknown> => {
   populateSpecedTraits(attributes, message);
 
   const pathToTraits = message.traits ? 'traits' : 'context.traits';
-  const traits = getFieldValueFromMessage(message, 'traits') || {};
+  const rawTraits = getFieldValueFromMessage(message, 'traits');
+  // Only plain objects yield named attributes. Arrays/primitives would otherwise
+  // produce index-keyed junk (e.g. ['a','b'] -> { '0': 'a', '1': 'b' }), so they
+  // contribute no free-form attributes instead.
+  const traits = isObject(rawTraits) ? rawTraits : {};
   Object.keys(traits)
     .filter(
       (trait) =>

--- a/test/integrations/destinations/customerio/router/dataV2.ts
+++ b/test/integrations/destinations/customerio/router/dataV2.ts
@@ -2936,7 +2936,7 @@ export const dataV2 = [
   {
     name: 'customerio',
     description:
-      'v2: non-object traits (array, string, number) are accepted and contribute no free-form attributes (regression)',
+      'v2: track events with non-object traits and context.traits are accepted (schema no longer enforces an object shape)',
     feature: 'router',
     module: 'destination',
     version: 'v0',
@@ -2950,11 +2950,15 @@ export const dataV2 = [
             {
               message: {
                 channel: 'web',
-                type: 'identify',
-                userId: 'cio_array_traits_user',
-                // Object.keys() over an array would otherwise yield index keys
-                // ({ '0': 'a', '1': 'b' }) instead of named attributes.
+                type: 'track',
+                event: 'Clicked Button',
+                userId: 'cio_track_array_traits_user',
+                // traits/context.traits are no longer validated against an object
+                // shape, so non-object values must pass through without error.
                 traits: ['a', 'b'],
+                properties: {
+                  plan: 'enterprise',
+                },
                 sentAt: '2024-01-15T10:00:00.000Z',
               },
               metadata: {
@@ -2973,34 +2977,19 @@ export const dataV2 = [
             {
               message: {
                 channel: 'web',
-                type: 'identify',
-                userId: 'cio_string_traits_user',
-                traits: 'hello',
+                type: 'track',
+                event: 'Clicked Button',
+                userId: 'cio_track_ctx_traits_user',
+                context: {
+                  traits: ['a', 'b'],
+                },
+                properties: {
+                  plan: 'pro',
+                },
                 sentAt: '2024-01-15T10:00:00.000Z',
               },
               metadata: {
                 jobId: 61,
-                userId: 'u1',
-                workspaceId: 'ws-cio-v2',
-              },
-              destination: {
-                Config: {
-                  datacenter: 'US',
-                  siteID: secret1,
-                  apiKey: secret2,
-                },
-              },
-            },
-            {
-              message: {
-                channel: 'web',
-                type: 'identify',
-                userId: 'cio_number_traits_user',
-                traits: 42,
-                sentAt: '2024-01-15T10:00:00.000Z',
-              },
-              metadata: {
-                jobId: 62,
                 userId: 'u1',
                 workspaceId: 'ws-cio-v2',
               },
@@ -3040,27 +3029,25 @@ export const dataV2 = [
                     batch: [
                       {
                         type: 'person',
-                        action: 'identify',
+                        action: 'event',
                         identifiers: {
-                          id: 'cio_array_traits_user',
+                          id: 'cio_track_array_traits_user',
                         },
-                        attributes: {},
+                        name: 'Clicked Button',
+                        attributes: {
+                          plan: 'enterprise',
+                        },
                       },
                       {
                         type: 'person',
-                        action: 'identify',
+                        action: 'event',
                         identifiers: {
-                          id: 'cio_string_traits_user',
+                          id: 'cio_track_ctx_traits_user',
                         },
-                        attributes: {},
-                      },
-                      {
-                        type: 'person',
-                        action: 'identify',
-                        identifiers: {
-                          id: 'cio_number_traits_user',
+                        name: 'Clicked Button',
+                        attributes: {
+                          plan: 'pro',
                         },
-                        attributes: {},
                       },
                     ],
                   },
@@ -3078,226 +3065,6 @@ export const dataV2 = [
                 },
                 {
                   jobId: 61,
-                  userId: 'u1',
-                  workspaceId: 'ws-cio-v2',
-                },
-                {
-                  jobId: 62,
-                  userId: 'u1',
-                  workspaceId: 'ws-cio-v2',
-                },
-              ],
-              destination: {
-                Config: {
-                  datacenter: 'US',
-                  siteID: secret1,
-                  apiKey: secret2,
-                },
-              },
-              batched: true,
-              statusCode: 200,
-            },
-          ],
-        },
-      },
-    },
-  },
-  {
-    name: 'customerio',
-    description:
-      'v2: non-object context (array) with a top-level userId passes schema validation (regression)',
-    feature: 'router',
-    module: 'destination',
-    version: 'v0',
-    envOverrides: {
-      CUSTOMERIO_BATCHING_FRAMEWORK_ENABLED_WORKSPACE_IDS: 'ALL',
-    },
-    input: {
-      request: {
-        body: {
-          input: [
-            {
-              message: {
-                channel: 'web',
-                type: 'identify',
-                userId: 'cio_array_context_user',
-                // context as an array previously failed zod with
-                // "Expected object, received array" before reaching the transform.
-                context: ['a', 'b'],
-                traits: {
-                  plan: 'enterprise',
-                },
-                sentAt: '2024-01-15T10:00:00.000Z',
-              },
-              metadata: {
-                jobId: 63,
-                userId: 'u1',
-                workspaceId: 'ws-cio-v2',
-              },
-              destination: {
-                Config: {
-                  datacenter: 'US',
-                  siteID: secret1,
-                  apiKey: secret2,
-                },
-              },
-            },
-          ],
-          destType: 'customerio',
-        },
-        method: 'POST',
-      },
-    },
-    output: {
-      response: {
-        status: 200,
-        body: {
-          output: [
-            {
-              batchedRequest: {
-                version: '1',
-                type: 'REST',
-                method: 'POST',
-                endpoint: 'https://track.customer.io/api/v2/batch',
-                endpointPath: 'v2/batch',
-                headers: {
-                  Authorization: authHeader1,
-                  'Content-Type': 'application/json',
-                },
-                params: {},
-                body: {
-                  JSON: {
-                    batch: [
-                      {
-                        type: 'person',
-                        action: 'identify',
-                        identifiers: {
-                          id: 'cio_array_context_user',
-                        },
-                        attributes: {
-                          plan: 'enterprise',
-                        },
-                      },
-                    ],
-                  },
-                  JSON_ARRAY: {},
-                  XML: {},
-                  FORM: {},
-                },
-                files: {},
-              },
-              metadata: [
-                {
-                  jobId: 63,
-                  userId: 'u1',
-                  workspaceId: 'ws-cio-v2',
-                },
-              ],
-              destination: {
-                Config: {
-                  datacenter: 'US',
-                  siteID: secret1,
-                  apiKey: secret2,
-                },
-              },
-              batched: true,
-              statusCode: 200,
-            },
-          ],
-        },
-      },
-    },
-  },
-  {
-    name: 'customerio',
-    description:
-      'v2: RETL identify with non-object traits still resolves userId from externalId (regression)',
-    feature: 'router',
-    module: 'destination',
-    version: 'v0',
-    envOverrides: {
-      CUSTOMERIO_BATCHING_FRAMEWORK_ENABLED_WORKSPACE_IDS: 'ALL',
-    },
-    input: {
-      request: {
-        body: {
-          input: [
-            {
-              message: {
-                channel: 'web',
-                type: 'identify',
-                context: {
-                  mappedToDestination: true,
-                  externalId: [
-                    {
-                      type: 'CUSTOMERIO-userId',
-                      identifierType: 'userId',
-                      id: 'cio_retl_array_traits_user',
-                    },
-                  ],
-                  traits: ['a', 'b'],
-                },
-                traits: ['a', 'b'],
-                sentAt: '2024-01-15T10:00:00.000Z',
-              },
-              metadata: {
-                jobId: 64,
-                userId: 'u1',
-                workspaceId: 'ws-cio-v2',
-              },
-              destination: {
-                Config: {
-                  datacenter: 'US',
-                  siteID: secret1,
-                  apiKey: secret2,
-                },
-              },
-            },
-          ],
-          destType: 'customerio',
-        },
-        method: 'POST',
-      },
-    },
-    output: {
-      response: {
-        status: 200,
-        body: {
-          output: [
-            {
-              batchedRequest: {
-                version: '1',
-                type: 'REST',
-                method: 'POST',
-                endpoint: 'https://track.customer.io/api/v2/batch',
-                endpointPath: 'v2/batch',
-                headers: {
-                  Authorization: authHeader1,
-                  'Content-Type': 'application/json',
-                },
-                params: {},
-                body: {
-                  JSON: {
-                    batch: [
-                      {
-                        type: 'person',
-                        action: 'identify',
-                        identifiers: {
-                          id: 'cio_retl_array_traits_user',
-                        },
-                        attributes: {},
-                      },
-                    ],
-                  },
-                  JSON_ARRAY: {},
-                  XML: {},
-                  FORM: {},
-                },
-                files: {},
-              },
-              metadata: [
-                {
-                  jobId: 64,
                   userId: 'u1',
                   workspaceId: 'ws-cio-v2',
                 },

--- a/test/integrations/destinations/customerio/router/dataV2.ts
+++ b/test/integrations/destinations/customerio/router/dataV2.ts
@@ -2933,4 +2933,388 @@ export const dataV2 = [
       },
     },
   },
+  {
+    name: 'customerio',
+    description:
+      'v2: non-object traits (array, string, number) are accepted and contribute no free-form attributes (regression)',
+    feature: 'router',
+    module: 'destination',
+    version: 'v0',
+    envOverrides: {
+      CUSTOMERIO_BATCHING_FRAMEWORK_ENABLED_WORKSPACE_IDS: 'ALL',
+    },
+    input: {
+      request: {
+        body: {
+          input: [
+            {
+              message: {
+                channel: 'web',
+                type: 'identify',
+                userId: 'cio_array_traits_user',
+                // Object.keys() over an array would otherwise yield index keys
+                // ({ '0': 'a', '1': 'b' }) instead of named attributes.
+                traits: ['a', 'b'],
+                sentAt: '2024-01-15T10:00:00.000Z',
+              },
+              metadata: {
+                jobId: 60,
+                userId: 'u1',
+                workspaceId: 'ws-cio-v2',
+              },
+              destination: {
+                Config: {
+                  datacenter: 'US',
+                  siteID: secret1,
+                  apiKey: secret2,
+                },
+              },
+            },
+            {
+              message: {
+                channel: 'web',
+                type: 'identify',
+                userId: 'cio_string_traits_user',
+                traits: 'hello',
+                sentAt: '2024-01-15T10:00:00.000Z',
+              },
+              metadata: {
+                jobId: 61,
+                userId: 'u1',
+                workspaceId: 'ws-cio-v2',
+              },
+              destination: {
+                Config: {
+                  datacenter: 'US',
+                  siteID: secret1,
+                  apiKey: secret2,
+                },
+              },
+            },
+            {
+              message: {
+                channel: 'web',
+                type: 'identify',
+                userId: 'cio_number_traits_user',
+                traits: 42,
+                sentAt: '2024-01-15T10:00:00.000Z',
+              },
+              metadata: {
+                jobId: 62,
+                userId: 'u1',
+                workspaceId: 'ws-cio-v2',
+              },
+              destination: {
+                Config: {
+                  datacenter: 'US',
+                  siteID: secret1,
+                  apiKey: secret2,
+                },
+              },
+            },
+          ],
+          destType: 'customerio',
+        },
+        method: 'POST',
+      },
+    },
+    output: {
+      response: {
+        status: 200,
+        body: {
+          output: [
+            {
+              batchedRequest: {
+                version: '1',
+                type: 'REST',
+                method: 'POST',
+                endpoint: 'https://track.customer.io/api/v2/batch',
+                endpointPath: 'v2/batch',
+                headers: {
+                  Authorization: authHeader1,
+                  'Content-Type': 'application/json',
+                },
+                params: {},
+                body: {
+                  JSON: {
+                    batch: [
+                      {
+                        type: 'person',
+                        action: 'identify',
+                        identifiers: {
+                          id: 'cio_array_traits_user',
+                        },
+                        attributes: {},
+                      },
+                      {
+                        type: 'person',
+                        action: 'identify',
+                        identifiers: {
+                          id: 'cio_string_traits_user',
+                        },
+                        attributes: {},
+                      },
+                      {
+                        type: 'person',
+                        action: 'identify',
+                        identifiers: {
+                          id: 'cio_number_traits_user',
+                        },
+                        attributes: {},
+                      },
+                    ],
+                  },
+                  JSON_ARRAY: {},
+                  XML: {},
+                  FORM: {},
+                },
+                files: {},
+              },
+              metadata: [
+                {
+                  jobId: 60,
+                  userId: 'u1',
+                  workspaceId: 'ws-cio-v2',
+                },
+                {
+                  jobId: 61,
+                  userId: 'u1',
+                  workspaceId: 'ws-cio-v2',
+                },
+                {
+                  jobId: 62,
+                  userId: 'u1',
+                  workspaceId: 'ws-cio-v2',
+                },
+              ],
+              destination: {
+                Config: {
+                  datacenter: 'US',
+                  siteID: secret1,
+                  apiKey: secret2,
+                },
+              },
+              batched: true,
+              statusCode: 200,
+            },
+          ],
+        },
+      },
+    },
+  },
+  {
+    name: 'customerio',
+    description:
+      'v2: non-object context (array) with a top-level userId passes schema validation (regression)',
+    feature: 'router',
+    module: 'destination',
+    version: 'v0',
+    envOverrides: {
+      CUSTOMERIO_BATCHING_FRAMEWORK_ENABLED_WORKSPACE_IDS: 'ALL',
+    },
+    input: {
+      request: {
+        body: {
+          input: [
+            {
+              message: {
+                channel: 'web',
+                type: 'identify',
+                userId: 'cio_array_context_user',
+                // context as an array previously failed zod with
+                // "Expected object, received array" before reaching the transform.
+                context: ['a', 'b'],
+                traits: {
+                  plan: 'enterprise',
+                },
+                sentAt: '2024-01-15T10:00:00.000Z',
+              },
+              metadata: {
+                jobId: 63,
+                userId: 'u1',
+                workspaceId: 'ws-cio-v2',
+              },
+              destination: {
+                Config: {
+                  datacenter: 'US',
+                  siteID: secret1,
+                  apiKey: secret2,
+                },
+              },
+            },
+          ],
+          destType: 'customerio',
+        },
+        method: 'POST',
+      },
+    },
+    output: {
+      response: {
+        status: 200,
+        body: {
+          output: [
+            {
+              batchedRequest: {
+                version: '1',
+                type: 'REST',
+                method: 'POST',
+                endpoint: 'https://track.customer.io/api/v2/batch',
+                endpointPath: 'v2/batch',
+                headers: {
+                  Authorization: authHeader1,
+                  'Content-Type': 'application/json',
+                },
+                params: {},
+                body: {
+                  JSON: {
+                    batch: [
+                      {
+                        type: 'person',
+                        action: 'identify',
+                        identifiers: {
+                          id: 'cio_array_context_user',
+                        },
+                        attributes: {
+                          plan: 'enterprise',
+                        },
+                      },
+                    ],
+                  },
+                  JSON_ARRAY: {},
+                  XML: {},
+                  FORM: {},
+                },
+                files: {},
+              },
+              metadata: [
+                {
+                  jobId: 63,
+                  userId: 'u1',
+                  workspaceId: 'ws-cio-v2',
+                },
+              ],
+              destination: {
+                Config: {
+                  datacenter: 'US',
+                  siteID: secret1,
+                  apiKey: secret2,
+                },
+              },
+              batched: true,
+              statusCode: 200,
+            },
+          ],
+        },
+      },
+    },
+  },
+  {
+    name: 'customerio',
+    description:
+      'v2: RETL identify with non-object traits still resolves userId from externalId (regression)',
+    feature: 'router',
+    module: 'destination',
+    version: 'v0',
+    envOverrides: {
+      CUSTOMERIO_BATCHING_FRAMEWORK_ENABLED_WORKSPACE_IDS: 'ALL',
+    },
+    input: {
+      request: {
+        body: {
+          input: [
+            {
+              message: {
+                channel: 'web',
+                type: 'identify',
+                context: {
+                  mappedToDestination: true,
+                  externalId: [
+                    {
+                      type: 'CUSTOMERIO-userId',
+                      identifierType: 'userId',
+                      id: 'cio_retl_array_traits_user',
+                    },
+                  ],
+                  traits: ['a', 'b'],
+                },
+                traits: ['a', 'b'],
+                sentAt: '2024-01-15T10:00:00.000Z',
+              },
+              metadata: {
+                jobId: 64,
+                userId: 'u1',
+                workspaceId: 'ws-cio-v2',
+              },
+              destination: {
+                Config: {
+                  datacenter: 'US',
+                  siteID: secret1,
+                  apiKey: secret2,
+                },
+              },
+            },
+          ],
+          destType: 'customerio',
+        },
+        method: 'POST',
+      },
+    },
+    output: {
+      response: {
+        status: 200,
+        body: {
+          output: [
+            {
+              batchedRequest: {
+                version: '1',
+                type: 'REST',
+                method: 'POST',
+                endpoint: 'https://track.customer.io/api/v2/batch',
+                endpointPath: 'v2/batch',
+                headers: {
+                  Authorization: authHeader1,
+                  'Content-Type': 'application/json',
+                },
+                params: {},
+                body: {
+                  JSON: {
+                    batch: [
+                      {
+                        type: 'person',
+                        action: 'identify',
+                        identifiers: {
+                          id: 'cio_retl_array_traits_user',
+                        },
+                        attributes: {},
+                      },
+                    ],
+                  },
+                  JSON_ARRAY: {},
+                  XML: {},
+                  FORM: {},
+                },
+                files: {},
+              },
+              metadata: [
+                {
+                  jobId: 64,
+                  userId: 'u1',
+                  workspaceId: 'ws-cio-v2',
+                },
+              ],
+              destination: {
+                Config: {
+                  datacenter: 'US',
+                  siteID: secret1,
+                  apiKey: secret2,
+                },
+              },
+              batched: true,
+              statusCode: 200,
+            },
+          ],
+        },
+      },
+    },
+  },
 ];


### PR DESCRIPTION
## What are the changes introduced in this PR?

The v2 event-stream schema validated `traits` and `context.traits` against an object shape, so events carrying either as a non-object — some sources send `context` as an array — were rejected with "Expected object, received array" before reaching the transform.

Relax both to `z.unknown()` so they pass through, and read them in the refine via `get-value`, which returns undefined on a non-object root instead of throwing. Email and mappedToDestination detection are unchanged.

## What is the related Linear task?

Resolves INT-XXX

## Please explain the objectives of your changes below

Put down any required details on the broader aspect of your changes. If there are any dependent changes, **mandatorily** mention them here

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

N/A

### Any new dependencies introduced with this change?

N/A

### Any new generic utility introduced or modified. Please explain the changes.

N/A

### Any technical or performance related pointers to consider with the change?

N/A

@coderabbitai review

<hr>

### Developer checklist

- [ ] My code follows the style guidelines of this project

- [ ] **No breaking changes are being introduced.**

- [ ] All related docs linked with the PR?

- [ ] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [ ] Is the PR limited to 10 file changes?

- [ ] Is the PR limited to one linear task?

- [ ] Are relevant unit and component test-cases added in **new readability format**?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.
