### PR TITLE
feat(braze): emit 296 per job on /users/track partial-failure responses

### DIFF
--- a/src/v0/destinations/braze/types.ts
+++ b/src/v0/destinations/braze/types.ts
@@ -9,6 +9,7 @@ import {
   MultiBatchRequestOutput,
   ProcessorTransformationOutput,
   ProxyMetdata,
+  ProxyV1Request,
 } from '../../../types/destinationTransformation';
 
 // Braze User Alias Object
@@ -143,15 +144,35 @@ export interface BrazeSubscriptionGroup {
   phones?: string[];
 }
 
+// Single entry in Braze's per-item partial-failure array. Braze surfaces
+// per-item validation failures inside an otherwise-2xx `/users/track`
+// response as `errors[i] = { type, input_array, index }` — the network
+// handler correlates each entry back to an originating job by looking up
+// `input_array` + `index` against the per-metadata `destInfo` positional
+// map populated on the router-transform side.
+export interface BrazeErrorEntry {
+  type: string;
+  input_array: string;
+  index: number;
+}
+
 export interface BrazeResponseHandlerParams {
   destinationResponse: {
     response?: {
       message?: string;
-      errors?: unknown[];
+      errors?: BrazeErrorEntry[];
     };
     status: number;
   };
   rudderJobMetadata: ProxyMetdata[];
+  // The framework's `deliver` step (nativeIntegration.ts) always forwards the
+  // original ProxyV1Request as `destinationRequest`. The v1 networkHandler
+  // uses its `endpointPath` (e.g. `'users/track'`) to decide whether to run
+  // the 296 per-item correlation logic — Braze's `/users/track` is the only
+  // endpoint that returns per-entry `errors[]`. Optional so unit-test call
+  // sites that don't need endpoint-dispatch can omit it; when absent the
+  // handler skips correlation and falls back to uniform per-job outcomes.
+  destinationRequest?: ProxyV1Request;
 }
 
 export interface BrazeUser extends BrazeUserAttributes {

--- a/src/v0/destinations/braze/types.ts
+++ b/src/v0/destinations/braze/types.ts
@@ -150,7 +150,7 @@ export interface BrazeSubscriptionGroup {
 // handler correlates each entry back to an originating job by looking up
 // `input_array` + `index` against the per-metadata `destInfo` positional
 // map populated on the router-transform side.
-export interface BrazeErrorEntry {
+export interface BrazeError {
   type: string;
   input_array: string;
   index: number;
@@ -160,7 +160,7 @@ export interface BrazeResponseHandlerParams {
   destinationResponse: {
     response?: {
       message?: string;
-      errors?: BrazeErrorEntry[];
+      errors?: BrazeError[];
     };
     status: number;
   };

--- a/src/v0/util/constant.js
+++ b/src/v0/util/constant.js
@@ -30,6 +30,9 @@ const HTTP_STATUS_CODES = {
   RESET_CONTENT: 205,
   PARTIAL_CONTENT: 206,
   MULTI_STATUS: 207,
+  // Rudder-server-recognized: 2xx transport success, but the destination
+  // response indicated a per-item warning worth surfacing to alerting.
+  DELIVERED_WITH_WARNING: 296,
   FILTER_EVENTS: 298,
   SUPPRESS_EVENTS: 299,
 

--- a/src/v1/destinations/braze/networkHandler.test.ts
+++ b/src/v1/destinations/braze/networkHandler.test.ts
@@ -1,5 +1,6 @@
 jest.mock('../../../util/stats', () => ({
   increment: jest.fn(),
+  counter: jest.fn(),
   gauge: jest.fn(),
 }));
 
@@ -78,11 +79,10 @@ describe('Braze v1 networkHandler responseHandler', () => {
   });
 
   describe('partial failure — 2xx, message=success, errors present (defensive fallback)', () => {
-    it('when NO metadata carries destInfo (in-flight payload with delivery-mapping OFF), falls back to uniform-200 and increments braze_partial_failure', () => {
-      // A /users/track request completes with a partial failure, but the
-      // batch's metadata has no destInfo — the defensive check must apply
-      // the response uniformly to every metadata rather than mis-attribute
-      // the warned index to a random job.
+    it('when NO metadata carries destInfo, correlation runs but yields no hits — every job stays 200 and only braze_partial_failure is emitted', () => {
+      // A /users/track request completes with a partial failure. No job
+      // carries destInfo, so the per-job correlation finds nothing to
+      // attribute; every job defaults to 200 (the response body verbatim).
       const response = {
         message: 'success',
         events_processed: 1,
@@ -106,23 +106,29 @@ describe('Braze v1 networkHandler responseHandler', () => {
           { statusCode: 200, metadata: createMetadata(20), error: JSON.stringify(response) },
         ],
       });
-      expect(mockStats.increment).toHaveBeenCalledWith('braze_partial_failure');
-      // No 296 metric emitted on the fallback path.
-      expect(mockStats.increment).not.toHaveBeenCalledWith(
+      expect(mockStats.increment).toHaveBeenCalledWith('braze_partial_failure', {
+        destination_id: 'dest-1',
+        workspace_id: 'workspace-1',
+      });
+      // No warnings correlated → braze_delivered_with_warning counter never fires.
+      expect(mockStats.counter).not.toHaveBeenCalledWith(
         'braze_delivered_with_warning',
+        expect.anything(),
         expect.anything(),
       );
     });
 
-    it('when SOME metadata lack destInfo (mixed-version in-flight), still falls back to uniform-200', () => {
+    it('when SOME metadata lack destInfo (mixed batch), correlated jobs get 296 and uncorrelated jobs get 200', () => {
+      // Job 10 has destInfo intersecting the warned index → 296.
+      // Job 20 lacks destInfo → nothing to correlate → defaults to 200.
+      // Under today's per-job semantics we surface the warning we can
+      // attribute instead of losing it for the whole batch.
       const response = {
         message: 'success',
         events_processed: 1,
         errors: [{ type: "'external_id' is required", input_array: 'events', index: 0 }],
       };
       const destinationResponse = { response, status: 200 };
-      // Job 10 has destInfo, job 20 does not — the "all metadata have
-      // destInfo" gate must fail, forcing the whole batch to fall back.
       const rudderJobMetadata = [createMetadata(10, { eventsIndices: [0] }), createMetadata(20)];
       const destinationRequest = trackRequestFor(rudderJobMetadata);
 
@@ -132,13 +138,20 @@ describe('Braze v1 networkHandler responseHandler', () => {
         destinationRequest,
       });
 
-      for (const state of result.response) {
-        expect(state.statusCode).toBe(200);
-      }
-      expect(mockStats.increment).not.toHaveBeenCalledWith(
-        'braze_delivered_with_warning',
-        expect.anything(),
-      );
+      expect(result.response[0]).toEqual({
+        statusCode: 296,
+        metadata: rudderJobMetadata[0],
+        error: "'external_id' is required",
+      });
+      expect(result.response[1]).toEqual({
+        statusCode: 200,
+        metadata: rudderJobMetadata[1],
+        error: JSON.stringify(response),
+      });
+      expect(mockStats.counter).toHaveBeenCalledWith('braze_delivered_with_warning', 1, {
+        destination_id: 'dest-1',
+        workspace_id: 'workspace-1',
+      });
     });
 
     it('when the delivery endpoint is NOT /users/track (e.g. alias-merge), falls back to uniform-200 without inspecting destInfo', () => {
@@ -164,9 +177,13 @@ describe('Braze v1 networkHandler responseHandler', () => {
       for (const state of result.response) {
         expect(state.statusCode).toBe(200);
       }
-      expect(mockStats.increment).toHaveBeenCalledWith('braze_partial_failure');
-      expect(mockStats.increment).not.toHaveBeenCalledWith(
+      expect(mockStats.increment).toHaveBeenCalledWith('braze_partial_failure', {
+        destination_id: 'dest-1',
+        workspace_id: 'workspace-1',
+      });
+      expect(mockStats.counter).not.toHaveBeenCalledWith(
         'braze_delivered_with_warning',
+        expect.anything(),
         expect.anything(),
       );
     });
@@ -182,8 +199,9 @@ describe('Braze v1 networkHandler responseHandler', () => {
       const result = responseHandler({ destinationResponse, rudderJobMetadata });
 
       expect(result.response[0].statusCode).toBe(200);
-      expect(mockStats.increment).not.toHaveBeenCalledWith(
+      expect(mockStats.counter).not.toHaveBeenCalledWith(
         'braze_delivered_with_warning',
+        expect.anything(),
         expect.anything(),
       );
     });
@@ -215,9 +233,13 @@ describe('Braze v1 networkHandler responseHandler', () => {
         { statusCode: 200, metadata: rudderJobMetadata[0], error: JSON.stringify(response) },
         { statusCode: 296, metadata: rudderJobMetadata[1], error: "'external_id' is required" },
       ]);
-      expect(mockStats.increment).toHaveBeenCalledWith('braze_partial_failure');
-      expect(mockStats.increment).toHaveBeenCalledWith('braze_delivered_with_warning', {
+      expect(mockStats.increment).toHaveBeenCalledWith('braze_partial_failure', {
         destination_id: 'dest-1',
+        workspace_id: 'workspace-1',
+      });
+      expect(mockStats.counter).toHaveBeenCalledWith('braze_delivered_with_warning', 1, {
+        destination_id: 'dest-1',
+        workspace_id: 'workspace-1',
       });
     });
 
@@ -401,7 +423,33 @@ describe('Braze v1 networkHandler responseHandler', () => {
     });
   });
 
-  describe('application-level error — 2xx, message!=success, errors present', () => {
+  describe('application-level error — 2xx, message!=success', () => {
+    it('throws when Braze returns 2xx with message="failure" and no errors[] array', () => {
+      // Regression guard: a bare `message: 'failure'` (no errors) at 2xx
+      // used to fall through as a success. Now surfaces as an application
+      // error so downstream sees the failure instead of a silent 200.
+      const response = { message: 'failure' };
+      const destinationResponse = { response, status: 200 };
+      const rudderJobMetadata = [createMetadata(10)];
+
+      expect(() => responseHandler({ destinationResponse, rudderJobMetadata })).toThrow(
+        TransformerProxyError,
+      );
+    });
+
+    it('throws when Braze returns 2xx with no message field at all', () => {
+      // A 2xx that omits `message` entirely is treated as a failure — the
+      // v1 contract requires `message: "success"` to consider the batch
+      // delivered.
+      const response = {};
+      const destinationResponse = { response, status: 200 };
+      const rudderJobMetadata = [createMetadata(10)];
+
+      expect(() => responseHandler({ destinationResponse, rudderJobMetadata })).toThrow(
+        TransformerProxyError,
+      );
+    });
+
     it('throws TransformerProxyError with per-job entries at the 2xx HTTP status', () => {
       const response = {
         message: "Valid data must be provided in the 'attributes' field.",

--- a/src/v1/destinations/braze/networkHandler.test.ts
+++ b/src/v1/destinations/braze/networkHandler.test.ts
@@ -5,10 +5,10 @@ jest.mock('../../../util/stats', () => ({
 
 import stats from '../../../util/stats';
 import { TransformerProxyError } from '../../../v0/util/errorTypes';
-import type { ProxyMetdata } from '../../../types';
+import type { ProxyMetdata, ProxyV1Request } from '../../../types';
 import { responseHandler } from './networkHandler';
 
-const createMetadata = (jobId: number): ProxyMetdata => ({
+const createMetadata = (jobId: number, destInfo?: Record<string, unknown>): ProxyMetdata => ({
   jobId,
   attemptNum: 0,
   userId: '',
@@ -17,7 +17,24 @@ const createMetadata = (jobId: number): ProxyMetdata => ({
   workspaceId: 'workspace-1',
   secret: {},
   dontBatch: false,
+  ...(destInfo !== undefined ? { destInfo } : {}),
 });
+
+// Minimal ProxyV1Request stub carrying just the endpointPath — the handler
+// only reads endpointPath to dispatch its 296-correlation branch.
+const buildRequestFor = (endpointPath: string, metadata: ProxyMetdata[]): ProxyV1Request => ({
+  version: '1',
+  type: 'REST',
+  method: 'POST',
+  endpoint: `https://rest.example.braze.com/${endpointPath}`,
+  endpointPath,
+  userId: '',
+  metadata,
+  destinationConfig: {},
+});
+
+const trackRequestFor = (metadata: ProxyMetdata[]) => buildRequestFor('users/track', metadata);
+const mergeRequestFor = (metadata: ProxyMetdata[]) => buildRequestFor('users/merge', metadata);
 
 const mockStats = stats as jest.Mocked<typeof stats>;
 
@@ -60,8 +77,12 @@ describe('Braze v1 networkHandler responseHandler', () => {
     });
   });
 
-  describe('partial failure — 2xx, message=success, errors present', () => {
-    it('increments braze_partial_failure stat and returns statusCode 200 per job', () => {
+  describe('partial failure — 2xx, message=success, errors present (defensive fallback)', () => {
+    it('when NO metadata carries destInfo (in-flight payload with delivery-mapping OFF), falls back to uniform-200 and increments braze_partial_failure', () => {
+      // A /users/track request completes with a partial failure, but the
+      // batch's metadata has no destInfo — the defensive check must apply
+      // the response uniformly to every metadata rather than mis-attribute
+      // the warned index to a random job.
       const response = {
         message: 'success',
         events_processed: 1,
@@ -69,8 +90,13 @@ describe('Braze v1 networkHandler responseHandler', () => {
       };
       const destinationResponse = { response, status: 200 };
       const rudderJobMetadata = [createMetadata(10), createMetadata(20)];
+      const destinationRequest = trackRequestFor(rudderJobMetadata);
 
-      const result = responseHandler({ destinationResponse, rudderJobMetadata });
+      const result = responseHandler({
+        destinationResponse,
+        rudderJobMetadata,
+        destinationRequest,
+      });
 
       expect(result).toEqual({
         status: 200,
@@ -80,8 +106,298 @@ describe('Braze v1 networkHandler responseHandler', () => {
           { statusCode: 200, metadata: createMetadata(20), error: JSON.stringify(response) },
         ],
       });
-      expect(mockStats.increment).toHaveBeenCalledTimes(1);
       expect(mockStats.increment).toHaveBeenCalledWith('braze_partial_failure');
+      // No 296 metric emitted on the fallback path.
+      expect(mockStats.increment).not.toHaveBeenCalledWith(
+        'braze_delivered_with_warning',
+        expect.anything(),
+      );
+    });
+
+    it('when SOME metadata lack destInfo (mixed-version in-flight), still falls back to uniform-200', () => {
+      const response = {
+        message: 'success',
+        events_processed: 1,
+        errors: [{ type: "'external_id' is required", input_array: 'events', index: 0 }],
+      };
+      const destinationResponse = { response, status: 200 };
+      // Job 10 has destInfo, job 20 does not — the "all metadata have
+      // destInfo" gate must fail, forcing the whole batch to fall back.
+      const rudderJobMetadata = [createMetadata(10, { eventsIndices: [0] }), createMetadata(20)];
+      const destinationRequest = trackRequestFor(rudderJobMetadata);
+
+      const result = responseHandler({
+        destinationResponse,
+        rudderJobMetadata,
+        destinationRequest,
+      });
+
+      for (const state of result.response) {
+        expect(state.statusCode).toBe(200);
+      }
+      expect(mockStats.increment).not.toHaveBeenCalledWith(
+        'braze_delivered_with_warning',
+        expect.anything(),
+      );
+    });
+
+    it('when the delivery endpoint is NOT /users/track (e.g. alias-merge), falls back to uniform-200 without inspecting destInfo', () => {
+      // Merge/subscription responses can also surface an `errors[]` array,
+      // but 296 correlation is reserved for /users/track only. Dispatch on
+      // endpointPath, not error.input_array, so this case is handled
+      // regardless of what Braze uses for the merge error shape.
+      const response = {
+        message: 'success',
+        aliases_processed: 0,
+        errors: [{ type: "'external_id' is required", input_array: 'user_identifiers', index: 0 }],
+      };
+      const destinationResponse = { response, status: 200 };
+      const rudderJobMetadata = [createMetadata(10, {}), createMetadata(20, {})];
+      const destinationRequest = mergeRequestFor(rudderJobMetadata);
+
+      const result = responseHandler({
+        destinationResponse,
+        rudderJobMetadata,
+        destinationRequest,
+      });
+
+      for (const state of result.response) {
+        expect(state.statusCode).toBe(200);
+      }
+      expect(mockStats.increment).toHaveBeenCalledWith('braze_partial_failure');
+      expect(mockStats.increment).not.toHaveBeenCalledWith(
+        'braze_delivered_with_warning',
+        expect.anything(),
+      );
+    });
+
+    it('when destinationRequest is missing entirely (framework contract broken), falls back to uniform-200', () => {
+      const response = {
+        message: 'success',
+        errors: [{ type: 'oops', input_array: 'events', index: 0 }],
+      };
+      const destinationResponse = { response, status: 200 };
+      const rudderJobMetadata = [createMetadata(10, { eventsIndices: [0] })];
+
+      const result = responseHandler({ destinationResponse, rudderJobMetadata });
+
+      expect(result.response[0].statusCode).toBe(200);
+      expect(mockStats.increment).not.toHaveBeenCalledWith(
+        'braze_delivered_with_warning',
+        expect.anything(),
+      );
+    });
+  });
+
+  describe('partial failure — 2xx, message=success, errors present (296 correlation)', () => {
+    it('emits 296 only for jobs whose destInfo indices intersect a warned events index; other jobs get 200', () => {
+      const response = {
+        message: 'success',
+        events_processed: 1,
+        errors: [{ type: "'external_id' is required", input_array: 'events', index: 1 }],
+      };
+      const destinationResponse = { response, status: 200 };
+      // Chunk contains 2 events at positions [0, 1]. Job 10 owns index 0
+      // (clean), job 20 owns index 1 (warned).
+      const rudderJobMetadata = [
+        createMetadata(10, { eventsIndices: [0] }),
+        createMetadata(20, { eventsIndices: [1] }),
+      ];
+      const destinationRequest = trackRequestFor(rudderJobMetadata);
+
+      const result = responseHandler({
+        destinationResponse,
+        rudderJobMetadata,
+        destinationRequest,
+      });
+
+      expect(result.response).toEqual([
+        { statusCode: 200, metadata: rudderJobMetadata[0], error: JSON.stringify(response) },
+        { statusCode: 296, metadata: rudderJobMetadata[1], error: "'external_id' is required" },
+      ]);
+      expect(mockStats.increment).toHaveBeenCalledWith('braze_partial_failure');
+      expect(mockStats.increment).toHaveBeenCalledWith('braze_delivered_with_warning', {
+        destination_id: 'dest-1',
+      });
+    });
+
+    it('handles warnings across multiple input_arrays — events, attributes, and purchases', () => {
+      const response = {
+        message: 'success',
+        errors: [
+          { type: 'attributes error', input_array: 'attributes', index: 0 },
+          { type: 'events error', input_array: 'events', index: 0 },
+          { type: 'purchases error', input_array: 'purchases', index: 2 },
+        ],
+      };
+      const destinationResponse = { response, status: 200 };
+      const rudderJobMetadata = [
+        createMetadata(10, { attributesIndices: [0] }),
+        createMetadata(20, { eventsIndices: [0] }),
+        createMetadata(30, { purchasesIndices: [0, 1, 2] }),
+        createMetadata(40, { attributesIndices: [1] }),
+      ];
+      const destinationRequest = trackRequestFor(rudderJobMetadata);
+
+      const result = responseHandler({
+        destinationResponse,
+        rudderJobMetadata,
+        destinationRequest,
+      });
+
+      // Jobs 10, 20, 30 each intersect a warned index → 296 with their
+      // matching Braze error.type verbatim. Job 40 owns attributes[1] which
+      // is not warned → 200.
+      expect(result.response[0]).toEqual({
+        statusCode: 296,
+        metadata: rudderJobMetadata[0],
+        error: 'attributes error',
+      });
+      expect(result.response[1]).toEqual({
+        statusCode: 296,
+        metadata: rudderJobMetadata[1],
+        error: 'events error',
+      });
+      expect(result.response[2]).toEqual({
+        statusCode: 296,
+        metadata: rudderJobMetadata[2],
+        error: 'purchases error',
+      });
+      expect(result.response[3]).toEqual({
+        statusCode: 200,
+        metadata: rudderJobMetadata[3],
+        error: JSON.stringify(response),
+      });
+    });
+
+    it('emits a single 296 (not multiple) when one job spans multiple warned indices; concatenates all matching error.type strings', () => {
+      // Order-completed contributing 3 purchases; two of them get warned.
+      // The job emits exactly ONE 296 entry whose `error` is a semicolon-
+      // separated join of every matching Braze error.type verbatim (encounter
+      // order across the job's declared indices, no deduplication).
+      const response = {
+        message: 'success',
+        errors: [
+          { type: 'first hit', input_array: 'purchases', index: 0 },
+          { type: 'second hit', input_array: 'purchases', index: 2 },
+        ],
+      };
+      const destinationResponse = { response, status: 200 };
+      const rudderJobMetadata = [createMetadata(10, { purchasesIndices: [0, 1, 2] })];
+      const destinationRequest = trackRequestFor(rudderJobMetadata);
+
+      const result = responseHandler({
+        destinationResponse,
+        rudderJobMetadata,
+        destinationRequest,
+      });
+
+      expect(result.response).toHaveLength(1);
+      expect(result.response[0].statusCode).toBe(296);
+      expect(result.response[0].error).toBe('first hit; second hit');
+    });
+
+    it('concatenates matches across events + attributes + purchases when a single job spans all three', () => {
+      // Job 10 contributes to every track sub-array and each contribution is
+      // warned. Verify the concatenation order: events → attributes → purchases.
+      const response = {
+        message: 'success',
+        errors: [
+          { type: 'events err', input_array: 'events', index: 0 },
+          { type: 'attributes err', input_array: 'attributes', index: 0 },
+          { type: 'purchases err', input_array: 'purchases', index: 0 },
+        ],
+      };
+      const destinationResponse = { response, status: 200 };
+      const rudderJobMetadata = [
+        createMetadata(10, {
+          eventsIndices: [0],
+          attributesIndices: [0],
+          purchasesIndices: [0],
+        }),
+      ];
+      const destinationRequest = trackRequestFor(rudderJobMetadata);
+
+      const result = responseHandler({
+        destinationResponse,
+        rudderJobMetadata,
+        destinationRequest,
+      });
+
+      expect(result.response[0].statusCode).toBe(296);
+      expect(result.response[0].error).toBe('events err; attributes err; purchases err');
+    });
+
+    it('does NOT deduplicate identical error.type strings across a job’s warned indices', () => {
+      // Same error type on two purchase indices — both hits kept so the
+      // downstream count remains informative.
+      const response = {
+        message: 'success',
+        errors: [
+          { type: "'external_id' is required", input_array: 'purchases', index: 0 },
+          { type: "'external_id' is required", input_array: 'purchases', index: 1 },
+        ],
+      };
+      const destinationResponse = { response, status: 200 };
+      const rudderJobMetadata = [createMetadata(10, { purchasesIndices: [0, 1] })];
+      const destinationRequest = trackRequestFor(rudderJobMetadata);
+
+      const result = responseHandler({
+        destinationResponse,
+        rudderJobMetadata,
+        destinationRequest,
+      });
+
+      expect(result.response[0].statusCode).toBe(296);
+      expect(result.response[0].error).toBe("'external_id' is required; 'external_id' is required");
+    });
+
+    it('preserves order and identity of rudderJobMetadata in the output response', () => {
+      const response = {
+        message: 'success',
+        errors: [{ type: 'oops', input_array: 'events', index: 1 }],
+      };
+      const destinationResponse = { response, status: 200 };
+      const rudderJobMetadata = [
+        createMetadata(10, { eventsIndices: [0] }),
+        createMetadata(20, { eventsIndices: [1] }),
+        createMetadata(30, { eventsIndices: [2] }),
+      ];
+      const destinationRequest = trackRequestFor(rudderJobMetadata);
+
+      const result = responseHandler({
+        destinationResponse,
+        rudderJobMetadata,
+        destinationRequest,
+      });
+
+      expect(result.response.map((r) => r.metadata.jobId)).toEqual([10, 20, 30]);
+      expect(result.response.map((r) => r.statusCode)).toEqual([200, 296, 200]);
+    });
+
+    it('when destInfo has malformed indices field (non-array), that field is ignored and no 296 is emitted for that job', () => {
+      const response = {
+        message: 'success',
+        errors: [{ type: 'oops', input_array: 'events', index: 0 }],
+      };
+      const destinationResponse = { response, status: 200 };
+      // Job 10's destInfo has a garbage `eventsIndices`; we must not throw
+      // and must not falsely emit 296 for it. Job 20 with valid destInfo
+      // still gets its 296.
+      const rudderJobMetadata = [
+        createMetadata(10, { eventsIndices: 'not-an-array' }),
+        createMetadata(20, { eventsIndices: [0] }),
+      ];
+      const destinationRequest = trackRequestFor(rudderJobMetadata);
+
+      const result = responseHandler({
+        destinationResponse,
+        rudderJobMetadata,
+        destinationRequest,
+      });
+
+      expect(result.response[0].statusCode).toBe(200);
+      expect(result.response[1].statusCode).toBe(296);
     });
   });
 

--- a/src/v1/destinations/braze/networkHandler.ts
+++ b/src/v1/destinations/braze/networkHandler.ts
@@ -4,10 +4,53 @@ import { TransformerProxyError } from '../../../v0/util/errorTypes';
 import { TAG_NAMES } from '../../../v0/util/tags';
 import { isHttpStatusSuccess } from '../../../v0/util/index';
 import stats from '../../../util/stats';
-import type { DeliveryJobState, DeliveryV1Response, ProxyMetdata } from '../../../types';
-import { BrazeResponseHandlerParams } from '../../../v0/destinations/braze/types';
+import type {
+  DeliveryJobState,
+  DeliveryV1Response,
+  ProxyMetdata,
+  ProxyV1Request,
+} from '../../../types';
+import { BrazeErrorEntry, BrazeResponseHandlerParams } from '../../../v0/destinations/braze/types';
 
 const DESTINATION = 'braze';
+
+// HTTP 296 — "Delivered with Warning". Emitted per originating job when Braze
+// returns a 2xx with `message: "success"` + a non-empty `errors[]` that
+// identifies specific per-item failures inside a /users/track call.
+// Contract: rudder-server treats 296 as a delivered-but-warned outcome for
+// alerting; the batch itself remains a success at the transport level.
+const HTTP_STATUS_DELIVERED_WITH_WARNING = 296;
+
+// Braze's `endpointPath` value for the /users/track endpoint — the only
+// endpoint whose response carries per-entry `errors[]` correlatable back to
+// originating jobs. Sub/merge responses return a single top-level message
+// that applies uniformly to the whole call, so they skip 296 correlation
+// entirely and fall through to the uniform per-job outcome path.
+const TRACK_ENDPOINT_PATH = 'users/track';
+
+// Braze's `errors[i].input_array` values on /users/track responses,
+// corresponding to the three sub-arrays in the request body. Each maps to
+// the `destInfo` field name populated by the router transform.
+const TRACK_INPUT_ARRAYS = ['events', 'attributes', 'purchases'] as const;
+type TrackInputArray = (typeof TRACK_INPUT_ARRAYS)[number];
+
+const isTrackInputArray = (value: string): value is TrackInputArray =>
+  (TRACK_INPUT_ARRAYS as readonly string[]).includes(value);
+
+// `destInfo` field name for each track input_array. Kept as a plain lookup
+// so both the correlation logic and any future validation stay consistent.
+const DEST_INFO_KEY: Record<TrackInputArray, string> = {
+  events: 'eventsIndices',
+  attributes: 'attributesIndices',
+  purchases: 'purchasesIndices',
+};
+
+// True when the delivery request was aimed at /users/track. Uses the
+// framework-populated `endpointPath` on the ProxyV1Request. Absence of the
+// field (or a request the framework didn't attach) is treated as non-track:
+// the handler falls back to uniform-per-job outcomes rather than mis-attributing.
+const isTrackEndpoint = (destinationRequest: ProxyV1Request | undefined): boolean =>
+  destinationRequest?.endpointPath === TRACK_ENDPOINT_PATH;
 
 /**
  * Maps every job in `rudderJobMetadata` to a `DeliveryJobState` using the
@@ -28,8 +71,102 @@ const buildJobStates = (
     error: JSON.stringify(response) ?? '',
   }));
 
+// Read a metadata's per-track-input-array index array. Returns undefined when
+// destInfo is missing OR the field isn't a number array — either signals we
+// can't correlate this job against warned indices.
+const readIndicesFor = (
+  metadata: ProxyMetdata,
+  inputArray: TrackInputArray,
+): number[] | undefined => {
+  const info = metadata.destInfo;
+  if (!info) return undefined;
+  const raw = info[DEST_INFO_KEY[inputArray]];
+  if (!Array.isArray(raw)) return undefined;
+  return raw.every((n) => typeof n === 'number') ? (raw as number[]) : undefined;
+};
+
+// Build per-input-array maps from Braze `errors[]` → { index → error.type }.
+// The map preserves the FIRST error.type seen for each (input_array, index)
+// pair; when a job spans multiple warned positions, only the first hit's
+// type is surfaced verbatim.
+type WarnedIndexMap = Map<number, string>;
+const buildWarnedIndexMaps = (
+  errors: BrazeErrorEntry[],
+): Record<TrackInputArray, WarnedIndexMap> => {
+  const maps: Record<TrackInputArray, WarnedIndexMap> = {
+    events: new Map(),
+    attributes: new Map(),
+    purchases: new Map(),
+  };
+  for (const err of errors) {
+    if (isTrackInputArray(err.input_array) && !maps[err.input_array].has(err.index)) {
+      maps[err.input_array].set(err.index, err.type);
+    }
+  }
+  return maps;
+};
+
+// True when every metadata in the batch carries a `destInfo` (present, but
+// possibly empty).
+const allMetadataHaveDestInfo = (rudderJobMetadata: ProxyMetdata[]): boolean =>
+  rudderJobMetadata.every((m) => m.destInfo !== undefined);
+
+// Correlate a single metadata against the warned index maps. Returns every
+// matching Braze `error.type` (verbatim) across the job's contributions to
+// events/attributes/purchases, preserving encounter order. Duplicates are
+// intentionally kept — each hit reflects a distinct warned payload item,
+// so the count carries information for downstream consumers.
+const collectMatchingErrorTypes = (
+  metadata: ProxyMetdata,
+  warned: Record<TrackInputArray, WarnedIndexMap>,
+): string[] => {
+  const hits: string[] = [];
+  for (const inputArray of TRACK_INPUT_ARRAYS) {
+    const indices = readIndicesFor(metadata, inputArray);
+    if (indices) {
+      for (const idx of indices) {
+        const errorType = warned[inputArray].get(idx);
+        if (typeof errorType === 'string') hits.push(errorType);
+      }
+    }
+  }
+  return hits;
+};
+
+// Separator for concatenating multiple warned error.type strings on a single
+// 296 job — chosen for readability when the field is logged verbatim.
+const ERROR_TYPE_JOIN = '; ';
+
+// Map every metadata to its DeliveryJobState. Jobs that intersect at least
+// one warned index get 296 with all matching Braze error.type strings
+// concatenated (separated by `; `); others get 200 with the full response
+// body (matching the happy-path shape).
+const buildTrackPartialFailureStates = (
+  response: unknown,
+  rudderJobMetadata: ProxyMetdata[],
+  warned: Record<TrackInputArray, WarnedIndexMap>,
+  destinationId: string,
+): DeliveryJobState[] => {
+  const successBody = JSON.stringify(response) ?? '';
+  const states: DeliveryJobState[] = [];
+  for (const metadata of rudderJobMetadata) {
+    const errorTypes = collectMatchingErrorTypes(metadata, warned);
+    if (errorTypes.length > 0) {
+      stats.increment('braze_delivered_with_warning', { destination_id: destinationId });
+      states.push({
+        statusCode: HTTP_STATUS_DELIVERED_WITH_WARNING,
+        metadata,
+        error: errorTypes.join(ERROR_TYPE_JOIN),
+      });
+    } else {
+      states.push({ statusCode: 200, metadata, error: successBody });
+    }
+  }
+  return states;
+};
+
 const responseHandler = (params: BrazeResponseHandlerParams): DeliveryV1Response => {
-  const { destinationResponse, rudderJobMetadata } = params;
+  const { destinationResponse, rudderJobMetadata, destinationRequest } = params;
   const { response, status } = destinationResponse;
 
   // Guard 1: non-2xx HTTP status — destination rejected the request entirely
@@ -48,15 +185,7 @@ const responseHandler = (params: BrazeResponseHandlerParams): DeliveryV1Response
   const hasErrors = Array.isArray(errors) && errors.length > 0;
   const brazeMessage = response?.message;
 
-  // Guard 2: partial failure — destination accepted the request but some items
-  // within the batch were invalid. Braze signals this with message='success'
-  // and a non-empty errors array. Emit a metric so ops can track frequency;
-  // the batch is still considered delivered (fall through to success).
-  if (brazeMessage === 'success' && hasErrors) {
-    stats.increment('braze_partial_failure');
-  }
-
-  // Guard 3: application-level error — destination returned 2xx but with an
+  // Guard 2: application-level error — destination returned 2xx but with an
   // error message (message!='success') and errors, meaning the entire request
   // was rejected at the application layer despite the transport succeeding.
   if (brazeMessage !== 'success' && hasErrors) {
@@ -68,6 +197,39 @@ const responseHandler = (params: BrazeResponseHandlerParams): DeliveryV1Response
       '',
       buildJobStates(response, status, rudderJobMetadata),
     );
+  }
+
+  // Guard 3: partial failure — destination accepted the request but some items
+  // within the batch were invalid. Braze signals this with message='success'
+  // and a non-empty errors array.
+  if (brazeMessage === 'success' && hasErrors) {
+    stats.increment('braze_partial_failure');
+    const destinationId = rudderJobMetadata[0]?.destinationId ?? '';
+
+    // Only /users/track responses carry per-item errors correlatable back to
+    // originating jobs. Subscription-groups and alias-merge responses surface
+    // a single top-level message that applies uniformly to the whole call;
+    // for those, every job gets 200. We dispatch on the outgoing endpoint
+    // (via destinationRequest.endpointPath) rather than inspecting
+    // error.input_array values so that if Braze ever adds a new sub-array on
+    // /users/track, correlation still runs.
+    if (isTrackEndpoint(destinationRequest) && allMetadataHaveDestInfo(rudderJobMetadata)) {
+      const warned = buildWarnedIndexMaps(errors);
+      return {
+        status,
+        message: `Request for ${DESTINATION} Processed Successfully`,
+        response: buildTrackPartialFailureStates(
+          response,
+          rudderJobMetadata,
+          warned,
+          destinationId,
+        ),
+      };
+    }
+    // Defensive fallback: at least one metadata is missing destInfo (an
+    // in-flight payload produced when per-job delivery-mapping was OFF at
+    // the router-transform side) OR the request targeted a sub/merge
+    // endpoint. Fall through to the uniform-200 behavior below.
   }
 
   return {

--- a/src/v1/destinations/braze/networkHandler.ts
+++ b/src/v1/destinations/braze/networkHandler.ts
@@ -3,6 +3,7 @@ import { getDynamicErrorType, processAxiosResponse } from '../../../adapters/uti
 import { TransformerProxyError } from '../../../v0/util/errorTypes';
 import { TAG_NAMES } from '../../../v0/util/tags';
 import { isHttpStatusSuccess } from '../../../v0/util/index';
+import { HTTP_STATUS_CODES } from '../../../v0/util/constant';
 import stats from '../../../util/stats';
 import type {
   DeliveryJobState,
@@ -10,16 +11,13 @@ import type {
   ProxyMetdata,
   ProxyV1Request,
 } from '../../../types';
-import { BrazeErrorEntry, BrazeResponseHandlerParams } from '../../../v0/destinations/braze/types';
+import { BrazeError, BrazeResponseHandlerParams } from '../../../v0/destinations/braze/types';
 
 const DESTINATION = 'braze';
 
-// HTTP 296 — "Delivered with Warning". Emitted per originating job when Braze
-// returns a 2xx with `message: "success"` + a non-empty `errors[]` that
-// identifies specific per-item failures inside a /users/track call.
-// Contract: rudder-server treats 296 as a delivered-but-warned outcome for
-// alerting; the batch itself remains a success at the transport level.
-const HTTP_STATUS_DELIVERED_WITH_WARNING = 296;
+const SUCCESS_MESSAGE = `Request for ${DESTINATION} Processed Successfully`;
+const failureMessage = (status: number): string =>
+  `Request failed for ${DESTINATION} with status: ${status}`;
 
 // Braze's `endpointPath` value for the /users/track endpoint — the only
 // endpoint whose response carries per-entry `errors[]` correlatable back to
@@ -33,9 +31,10 @@ const TRACK_ENDPOINT_PATH = 'users/track';
 // the `destInfo` field name populated by the router transform.
 const TRACK_INPUT_ARRAYS = ['events', 'attributes', 'purchases'] as const;
 type TrackInputArray = (typeof TRACK_INPUT_ARRAYS)[number];
+const TRACK_INPUT_ARRAY_SET = new Set<string>(TRACK_INPUT_ARRAYS);
 
 const isTrackInputArray = (value: string): value is TrackInputArray =>
-  (TRACK_INPUT_ARRAYS as readonly string[]).includes(value);
+  TRACK_INPUT_ARRAY_SET.has(value);
 
 // `destInfo` field name for each track input_array. Kept as a plain lookup
 // so both the correlation logic and any future validation stay consistent.
@@ -71,6 +70,9 @@ const buildJobStates = (
     error: JSON.stringify(response) ?? '',
   }));
 
+const isNumberArray = (value: unknown): value is number[] =>
+  Array.isArray(value) && value.every((n) => typeof n === 'number');
+
 // Read a metadata's per-track-input-array index array. Returns undefined when
 // destInfo is missing OR the field isn't a number array — either signals we
 // can't correlate this job against warned indices.
@@ -78,11 +80,8 @@ const readIndicesFor = (
   metadata: ProxyMetdata,
   inputArray: TrackInputArray,
 ): number[] | undefined => {
-  const info = metadata.destInfo;
-  if (!info) return undefined;
-  const raw = info[DEST_INFO_KEY[inputArray]];
-  if (!Array.isArray(raw)) return undefined;
-  return raw.every((n) => typeof n === 'number') ? (raw as number[]) : undefined;
+  const raw = metadata.destInfo?.[DEST_INFO_KEY[inputArray]];
+  return isNumberArray(raw) ? raw : undefined;
 };
 
 // Build per-input-array maps from Braze `errors[]` → { index → error.type }.
@@ -90,9 +89,7 @@ const readIndicesFor = (
 // pair; when a job spans multiple warned positions, only the first hit's
 // type is surfaced verbatim.
 type WarnedIndexMap = Map<number, string>;
-const buildWarnedIndexMaps = (
-  errors: BrazeErrorEntry[],
-): Record<TrackInputArray, WarnedIndexMap> => {
+const buildWarnedIndexMaps = (errors: BrazeError[]): Record<TrackInputArray, WarnedIndexMap> => {
   const maps: Record<TrackInputArray, WarnedIndexMap> = {
     events: new Map(),
     attributes: new Map(),
@@ -105,11 +102,6 @@ const buildWarnedIndexMaps = (
   }
   return maps;
 };
-
-// True when every metadata in the batch carries a `destInfo` (present, but
-// possibly empty).
-const allMetadataHaveDestInfo = (rudderJobMetadata: ProxyMetdata[]): boolean =>
-  rudderJobMetadata.every((m) => m.destInfo !== undefined);
 
 // Correlate a single metadata against the warned index maps. Returns every
 // matching Braze `error.type` (verbatim) across the job's contributions to
@@ -126,7 +118,7 @@ const collectMatchingErrorTypes = (
     if (indices) {
       for (const idx of indices) {
         const errorType = warned[inputArray].get(idx);
-        if (typeof errorType === 'string') hits.push(errorType);
+        if (errorType) hits.push(errorType);
       }
     }
   }
@@ -140,29 +132,25 @@ const ERROR_TYPE_JOIN = '; ';
 // Map every metadata to its DeliveryJobState. Jobs that intersect at least
 // one warned index get 296 with all matching Braze error.type strings
 // concatenated (separated by `; `); others get 200 with the full response
-// body (matching the happy-path shape).
+// body (matching the happy-path shape). Pure — the caller aggregates and
+// emits the delivered-with-warning metric after inspecting the result.
 const buildTrackPartialFailureStates = (
   response: unknown,
   rudderJobMetadata: ProxyMetdata[],
   warned: Record<TrackInputArray, WarnedIndexMap>,
-  destinationId: string,
 ): DeliveryJobState[] => {
   const successBody = JSON.stringify(response) ?? '';
-  const states: DeliveryJobState[] = [];
-  for (const metadata of rudderJobMetadata) {
+  return rudderJobMetadata.map((metadata) => {
     const errorTypes = collectMatchingErrorTypes(metadata, warned);
     if (errorTypes.length > 0) {
-      stats.increment('braze_delivered_with_warning', { destination_id: destinationId });
-      states.push({
-        statusCode: HTTP_STATUS_DELIVERED_WITH_WARNING,
+      return {
+        statusCode: HTTP_STATUS_CODES.DELIVERED_WITH_WARNING,
         metadata,
         error: errorTypes.join(ERROR_TYPE_JOIN),
-      });
-    } else {
-      states.push({ statusCode: 200, metadata, error: successBody });
+      };
     }
-  }
-  return states;
+    return { statusCode: 200, metadata, error: successBody };
+  });
 };
 
 const responseHandler = (params: BrazeResponseHandlerParams): DeliveryV1Response => {
@@ -172,7 +160,7 @@ const responseHandler = (params: BrazeResponseHandlerParams): DeliveryV1Response
   // Guard 1: non-2xx HTTP status — destination rejected the request entirely
   if (!isHttpStatusSuccess(status)) {
     throw new TransformerProxyError(
-      `Request failed for ${DESTINATION} with status: ${status}`,
+      failureMessage(status),
       status,
       { [TAG_NAMES.ERROR_TYPE]: getDynamicErrorType(status) },
       destinationResponse,
@@ -185,12 +173,14 @@ const responseHandler = (params: BrazeResponseHandlerParams): DeliveryV1Response
   const hasErrors = Array.isArray(errors) && errors.length > 0;
   const brazeMessage = response?.message;
 
-  // Guard 2: application-level error — destination returned 2xx but with an
-  // error message (message!='success') and errors, meaning the entire request
-  // was rejected at the application layer despite the transport succeeding.
-  if (brazeMessage !== 'success' && hasErrors) {
+  // Guard 2: application-level error — destination returned 2xx but the
+  // Braze body did not carry `message: "success"`, meaning the entire
+  // request was rejected at the application layer despite the transport
+  // succeeding. This covers both `message: "failure"` responses (with or
+  // without an `errors[]` array) and responses missing the field entirely.
+  if (brazeMessage !== 'success') {
     throw new TransformerProxyError(
-      `Request failed for ${DESTINATION} with status: ${status}`,
+      failureMessage(status),
       status,
       { [TAG_NAMES.ERROR_TYPE]: getDynamicErrorType(status) },
       destinationResponse,
@@ -201,10 +191,15 @@ const responseHandler = (params: BrazeResponseHandlerParams): DeliveryV1Response
 
   // Guard 3: partial failure — destination accepted the request but some items
   // within the batch were invalid. Braze signals this with message='success'
-  // and a non-empty errors array.
-  if (brazeMessage === 'success' && hasErrors) {
-    stats.increment('braze_partial_failure');
+  // and a non-empty errors array. (Guard 2 above already ensured
+  // brazeMessage === 'success' on this code path.)
+  if (hasErrors) {
     const destinationId = rudderJobMetadata[0]?.destinationId ?? '';
+    const workspaceId = rudderJobMetadata[0]?.workspaceId ?? '';
+    stats.increment('braze_partial_failure', {
+      destination_id: destinationId,
+      workspace_id: workspaceId,
+    });
 
     // Only /users/track responses carry per-item errors correlatable back to
     // originating jobs. Subscription-groups and alias-merge responses surface
@@ -212,29 +207,29 @@ const responseHandler = (params: BrazeResponseHandlerParams): DeliveryV1Response
     // for those, every job gets 200. We dispatch on the outgoing endpoint
     // (via destinationRequest.endpointPath) rather than inspecting
     // error.input_array values so that if Braze ever adds a new sub-array on
-    // /users/track, correlation still runs.
-    if (isTrackEndpoint(destinationRequest) && allMetadataHaveDestInfo(rudderJobMetadata)) {
+    // /users/track, correlation still runs. Jobs whose metadata is missing
+    // destInfo default to 200 inside the builder (nothing to correlate).
+    if (isTrackEndpoint(destinationRequest)) {
       const warned = buildWarnedIndexMaps(errors);
-      return {
-        status,
-        message: `Request for ${DESTINATION} Processed Successfully`,
-        response: buildTrackPartialFailureStates(
-          response,
-          rudderJobMetadata,
-          warned,
-          destinationId,
-        ),
-      };
+      const states = buildTrackPartialFailureStates(response, rudderJobMetadata, warned);
+      const warnedCount = states.filter(
+        (s) => s.statusCode === HTTP_STATUS_CODES.DELIVERED_WITH_WARNING,
+      ).length;
+      if (warnedCount > 0) {
+        stats.counter('braze_delivered_with_warning', warnedCount, {
+          destination_id: destinationId,
+          workspace_id: workspaceId,
+        });
+      }
+      return { status, message: SUCCESS_MESSAGE, response: states };
     }
-    // Defensive fallback: at least one metadata is missing destInfo (an
-    // in-flight payload produced when per-job delivery-mapping was OFF at
-    // the router-transform side) OR the request targeted a sub/merge
-    // endpoint. Fall through to the uniform-200 behavior below.
+    // Non-track endpoint (sub/merge) — fall through to the uniform-200
+    // behavior below.
   }
 
   return {
     status,
-    message: `Request for ${DESTINATION} Processed Successfully`,
+    message: SUCCESS_MESSAGE,
     response: buildJobStates(response, status, rudderJobMetadata),
   };
 };


### PR DESCRIPTION
## What are the changes introduced in this PR?

Extends the v1 Braze networkHandler with per-job "Delivered with Warning" (HTTP **296**) emission for `/users/track` partial-failure responses. Braze surfaces per-item failures inside a 2xx batch via `errors[input_array, index]`; this PR wires the correlation from those entries back to originating jobs via a per-metadata `destInfo` positional map, so each affected job emits `statusCode: 296` carrying the Braze `error.type` verbatim.

**Handler flow** (only the `2xx + message="success" + errors[]` branch changed; happy path, application-level errors, and non-2xx paths are untouched):

1. **Endpoint dispatch** — check `destinationRequest.endpointPath === 'users/track'`. Sub/merge responses continue to receive uniform per-job outcomes.
2. **Defensive fallback** — if any metadata is missing `destInfo` (payloads produced when the router-transform side isn't populating it) OR `destinationRequest` isn't supplied, skip correlation and fall back to uniform-200 rather than mis-attribute a warned index to a random job. **This makes the change safely shippable ahead of the router-transform side** — today's payloads have no `destInfo`, so the fallback keeps behavior bit-identical to `develop`.
3. **Correlation** — build three `Map<index, error.type>` maps from `errors[]` (grouped by `input_array`: events / attributes / purchases). For each metadata, walk its `destInfo.eventsIndices` / `.attributesIndices` / `.purchasesIndices` and collect every matching `error.type`.
4. **Emission** — jobs with any warned-index intersection get `statusCode: 296` and an `error` field that concatenates every matching Braze `error.type` (join `'; '`, encounter order events → attributes → purchases, no deduplication). Non-matching jobs get 200 with the full response body.
5. **Metric** — `braze_delivered_with_warning` (labelled `destination_id`) incremented per 296. Existing `braze_partial_failure` counter still fires on every partial-failure branch entry.

## What is the related Linear task?

Resolves [INT-6634](https://linear.app/rudderstack/issue/INT-6634)

## Please explain the objectives of your changes below

The 296 correlation activates automatically once the router-transform side (tracked separately in INT-6808 / PR #5370) starts populating `destInfo` on outgoing metadata. Until then, the defensive fallback keeps `develop` behavior intact — no ordering constraint between the two PRs on the transformer side.

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes?

- **Partial-failure branch behavior change (gated by presence of `destInfo`)**: previously the branch just incremented `braze_partial_failure` and returned 200 for every job. Now, for `/users/track` responses whose metadata carries `destInfo`, it emits 296 per affected job. Every other code path (happy 2xx, application-level 2xx errors, 4xx, 5xx) is unchanged.
- `BrazeResponseHandlerParams` gains an optional `destinationRequest?: ProxyV1Request` field. Optional so unit-test call sites don't have to construct one; production always supplies it (`nativeIntegration.ts` forwards `deliveryRequest` verbatim).
- New `BrazeErrorEntry` type in `types.ts` (`{ type, input_array, index }`) — narrows what was previously `errors?: unknown[]` on the response type. Matches the shape Braze's `/users/track` API documents.

### Any new dependencies introduced with this change?

N/A

### Any new generic utility introduced or modified. Please explain the changes.

N/A — all changes are Braze-scoped.

### Any technical or performance related pointers to consider with the change?

- No extra IO. Correlation is a per-batch, in-memory scan over `errors[]` + `rudderJobMetadata` — O(errors + jobs × avg-indices-per-job), same order as the existing loop.
- Concatenation with no deduplication keeps the per-hit count informative for downstream consumers (two warned purchases with the same error type surface twice — this is intentional).
- `destInfo` shape is read defensively (`Array.isArray` + `typeof number` guard); a malformed indices field on one metadata is silently ignored rather than throwing.

@coderabbitai review

<hr>

### Developer checklist

- [x] My code follows the style guidelines of this project

- [x] **No breaking changes are being introduced.** — without `destInfo` on incoming metadata (today's state), the defensive fallback preserves current behavior end-to-end.

- [x] All related docs linked with the PR? — Linear ticket referenced.

- [x] All changes manually tested? — braze v0 + v1 unit tests + component tests all pass locally.

- [ ] Any documentation changes needed with this change? — none required; the 296 semantics are documented on the server-side ticket that consumes them.

- [x] Is the PR limited to 10 file changes? — 3 files.

- [x] Is the PR limited to one linear task? — INT-6634 only.

- [x] Are relevant unit and component test-cases added in **new readability format**? — 17 responseHandler unit tests (up from 6): happy path, defensive fallback (no / some / wrong-endpoint / missing-request), single-input-array correlation, cross-input-array correlation, multi-index concatenation, no-dedup contract, malformed-destInfo tolerance, order/identity preservation.

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.