### PR TITLE
fix(ivm): cap concurrent evaluations per isolate and queue the excess

### DIFF
--- a/src/util/customMappings/sandboxClient.ts
+++ b/src/util/customMappings/sandboxClient.ts
@@ -28,6 +28,14 @@ const getRunner = (): IvmScriptRunner => {
       cacheName: 'custom_mappings_ivm',
       maxSize: Number.parseInt(process.env.CUSTOM_MAPPINGS_IVM_CACHE_MAX_SIZE || '20', 10),
       ttlMs: Number.parseInt(process.env.CUSTOM_MAPPINGS_IVM_CACHE_TTL_MS || '300000', 10),
+      // A workspace's evals all share one fixed-size isolate heap. Left ungated, a burst piles
+      // every in-flight eval onto that heap until V8 disposes the isolate and fails all of them
+      // at once — the amplification behind INT-6832. Excess evals queue instead; the queue is
+      // unbounded, so a burst costs latency rather than dropped events.
+      maxConcurrentExecutions: Number.parseInt(
+        process.env.CUSTOM_MAPPINGS_IVM_MAX_CONCURRENT_EXECUTIONS || '100',
+        10,
+      ),
     });
   }
   return runner;

--- a/src/util/ivm/scriptRunner.gate.test.ts
+++ b/src/util/ivm/scriptRunner.gate.test.ts
@@ -1,0 +1,345 @@
+/**
+ * Unit tests for IvmScriptRunner's per-isolate execution gate.
+ *
+ * An isolate has one fixed-size heap shared by every concurrent evaluation on it, so an
+ * ungated burst can breach `memoryLimit` and make V8 dispose the whole isolate — failing
+ * every in-flight call at once. These tests pin the gate that caps that concurrency.
+ *
+ * `isolated-vm` is mocked with an evalClosure that never settles on its own, so a test can
+ * hold executions open and observe exactly how many the gate lets run at a time.
+ *
+ * Kept separate from `scriptRunner.test.ts` (the platform-error counter suite) because the two
+ * need incompatible module mocks: that file stubs `fs` and `DisposableCache`, whereas these
+ * tests exercise the real cache so gate teardown can be observed against real eviction.
+ */
+
+interface MockPendingExecution {
+  code: string;
+  finish: (value: unknown) => void;
+  fail: (err: unknown) => void;
+}
+
+// Executions that have entered the isolate and not yet settled. Tests drain this to
+// free slots. Reset in beforeEach.
+let mockPendingExecutions: MockPendingExecution[] = [];
+let mockRunningNow = 0;
+let mockPeakRunning = 0;
+
+// --- Mocks ---
+
+// Leaf deps only — the real DisposableCache is exercised.
+jest.mock('../../logger', () => ({
+  info: jest.fn(),
+  debug: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+}));
+
+const mockStats = {
+  increment: jest.fn(),
+  // execute() seeds the platform-error counter at 0 on each isolate build; unmocked it would
+  // throw inside the gated path and turn every test here into a platform error.
+  counter: jest.fn(),
+  gauge: jest.fn(),
+  timing: jest.fn(),
+};
+jest.mock('../stats', () => mockStats);
+
+jest.mock('isolated-vm', () => {
+  class MockContext {
+    release() {}
+
+    evalClosure(code: string) {
+      mockRunningNow += 1;
+      mockPeakRunning = Math.max(mockPeakRunning, mockRunningNow);
+      return new Promise((resolve, reject) => {
+        mockPendingExecutions.push({
+          code,
+          finish: (value) => {
+            mockRunningNow -= 1;
+            resolve(value);
+          },
+          fail: (err) => {
+            mockRunningNow -= 1;
+            reject(err);
+          },
+        });
+      });
+    }
+  }
+
+  class MockScript {
+    async run() {
+      return undefined;
+    }
+  }
+
+  class MockIsolate {
+    async createContext() {
+      return new MockContext();
+    }
+
+    async compileScript() {
+      return new MockScript();
+    }
+
+    getHeapStatisticsSync() {
+      return { used_heap_size: 1024, total_heap_size: 2048 };
+    }
+
+    dispose() {}
+  }
+
+  return { __esModule: true, default: { Isolate: MockIsolate } };
+});
+
+import { IvmScriptRunner } from './scriptRunner';
+
+// The isolate is mocked, so the bundle is never executed — it only has to exist to be read.
+const BUNDLE_PATH = __filename;
+
+const buildRunner = (overrides: Partial<ConstructorParameters<typeof IvmScriptRunner>[0]> = {}) =>
+  new IvmScriptRunner({
+    bundlePath: BUNDLE_PATH,
+    memoryLimitMb: 8,
+    initTimeoutMs: 5_000,
+    execTimeoutMs: 1_000,
+    cacheName: 'test_ivm',
+    ...overrides,
+  });
+
+/**
+ * Wait until exactly `count` executions are inside the isolate. Isolate construction is
+ * async, so admitted calls reach evalClosure a few microtasks after execute() is invoked.
+ */
+const waitForRunning = async (count: number) => {
+  const deadline = Date.now() + 2_000;
+  while (mockPendingExecutions.length !== count && Date.now() < deadline) {
+    await new Promise((r) => setImmediate(r));
+  }
+  expect(mockPendingExecutions.length).toBe(count);
+};
+
+/** Settle the oldest in-flight execution, freeing its slot for a queued caller. */
+const finishOldest = (value: unknown = 'ok') => {
+  const execution = mockPendingExecutions.shift();
+  expect(execution).toBeDefined();
+  execution?.finish(value);
+};
+
+const failOldest = (err: Error) => {
+  const execution = mockPendingExecutions.shift();
+  expect(execution).toBeDefined();
+  execution?.fail(err);
+};
+
+const gatesOf = (runner: IvmScriptRunner): Map<string, unknown> =>
+  (runner as unknown as { gates: Map<string, unknown> }).gates;
+
+/** How many calls have been counted as queued so far. */
+const queuedCount = () =>
+  mockStats.increment.mock.calls.filter(([name]) => name === 'ivm_execution_queued').length;
+
+describe('IvmScriptRunner execution gate', () => {
+  beforeEach(() => {
+    mockPendingExecutions = [];
+    mockRunningNow = 0;
+    mockPeakRunning = 0;
+    mockStats.increment.mockClear();
+    mockStats.gauge.mockClear();
+    mockStats.timing.mockClear();
+  });
+
+  describe('concurrency cap', () => {
+    it('should admit only up to the cap at once and run the rest as slots free', async () => {
+      const runner = buildRunner({ maxConcurrentExecutions: 2 });
+
+      const calls = [1, 2, 3, 4, 5].map((n) => runner.execute('ws-1', `call-${n}`, []));
+
+      await waitForRunning(2);
+      // Draining one at a time proves a queued call only enters once a slot is free.
+      finishOldest();
+      await waitForRunning(2);
+      finishOldest();
+      await waitForRunning(2);
+      finishOldest();
+      await waitForRunning(2);
+      finishOldest();
+      await waitForRunning(1);
+      finishOldest();
+
+      await expect(Promise.all(calls)).resolves.toEqual(['ok', 'ok', 'ok', 'ok', 'ok']);
+      expect(mockPeakRunning).toBe(2);
+    });
+
+    it('should hold the cap when new calls arrive while the queue is draining', async () => {
+      const runner = buildRunner({ maxConcurrentExecutions: 2 });
+
+      const calls = [1, 2, 3].map((n) => runner.execute('ws-1', `first-${n}`, []));
+      await waitForRunning(2);
+
+      // Let the queued call take over the freed slot first, so any drift in the slot
+      // accounting has landed, and only then pile on fresh arrivals. If release freed the
+      // slot *and* woke a waiter, the gate would now believe it has room and over-admit.
+      finishOldest();
+      await waitForRunning(2);
+      calls.push(...[4, 5].map((n) => runner.execute('ws-1', `later-${n}`, [])));
+      await new Promise((r) => setImmediate(r));
+
+      while (mockPendingExecutions.length > 0) {
+        finishOldest();
+        await new Promise((r) => setImmediate(r));
+      }
+
+      await expect(Promise.all(calls)).resolves.toHaveLength(5);
+      expect(mockPeakRunning).toBe(2);
+    });
+
+    it('should leave execution ungated when no cap is configured', async () => {
+      const runner = buildRunner();
+
+      const calls = [1, 2, 3, 4, 5].map((n) => runner.execute('ws-1', `call-${n}`, []));
+
+      await waitForRunning(5);
+      expect(mockPeakRunning).toBe(5);
+      mockPendingExecutions.splice(0).forEach((execution) => execution.finish('ok'));
+      await expect(Promise.all(calls)).resolves.toHaveLength(5);
+    });
+
+    it('should leave execution ungated when the cap is unparseable or nonsensical', async () => {
+      // Number.parseInt on a bad env var yields NaN, and a zero/negative cap is equally
+      // nonsensical. Both must degrade to today's ungated behaviour rather than admitting
+      // nothing and wedging the sandbox.
+      for (const cap of [NaN, 0, -1]) {
+        const runner = buildRunner({ maxConcurrentExecutions: cap });
+        const calls = [1, 2, 3].map((n) => runner.execute('ws-1', `cap-${cap}-${n}`, []));
+
+        await waitForRunning(3);
+        mockPendingExecutions.splice(0).forEach((execution) => execution.finish('ok'));
+        await expect(Promise.all(calls)).resolves.toHaveLength(3);
+      }
+    });
+
+    it('should gate each isolate independently', async () => {
+      const runner = buildRunner({ maxConcurrentExecutions: 1 });
+
+      const workspace1 = [
+        runner.execute('ws-1', 'ws-1-first', []),
+        runner.execute('ws-1', 'ws-1-queued', []),
+      ];
+      const workspace2 = runner.execute('ws-2', 'ws-2-first', []);
+
+      // ws-1 is saturated, but its queue must not hold up a different workspace's isolate.
+      await waitForRunning(2);
+      expect(mockPendingExecutions.map((execution) => execution.code)).toEqual([
+        'ws-1-first',
+        'ws-2-first',
+      ]);
+
+      mockPendingExecutions.splice(0).forEach((execution) => execution.finish('ok'));
+      await waitForRunning(1);
+      expect(mockPendingExecutions[0].code).toBe('ws-1-queued');
+      finishOldest();
+
+      await expect(Promise.all([...workspace1, workspace2])).resolves.toHaveLength(3);
+    });
+
+    it('should release the slot when an execution fails so queued calls still run', async () => {
+      const runner = buildRunner({ maxConcurrentExecutions: 1 });
+
+      const failing = runner.execute('ws-1', 'boom', []);
+      const queued = runner.execute('ws-1', 'after-boom', []);
+
+      await waitForRunning(1);
+      failOldest(new Error('Isolate is disposed'));
+      await expect(failing).rejects.toThrow('Isolate is disposed');
+
+      await waitForRunning(1);
+      expect(mockPendingExecutions[0].code).toBe('after-boom');
+      finishOldest();
+      await expect(queued).resolves.toBe('ok');
+    });
+
+    it('should drop the gate once an isolate goes idle', async () => {
+      const runner = buildRunner({ maxConcurrentExecutions: 2 });
+
+      const calls = [runner.execute('ws-1', 'call-1', []), runner.execute('ws-1', 'call-2', [])];
+      await waitForRunning(2);
+      expect(gatesOf(runner).size).toBe(1);
+
+      mockPendingExecutions.splice(0).forEach((execution) => execution.finish('ok'));
+      await Promise.all(calls);
+
+      // Otherwise `gates` would grow with every workspace ever seen.
+      expect(gatesOf(runner).size).toBe(0);
+    });
+
+    it('should keep the gate while another call still holds a slot', async () => {
+      const runner = buildRunner({ maxConcurrentExecutions: 2 });
+
+      const calls = [runner.execute('ws-1', 'call-1', []), runner.execute('ws-1', 'call-2', [])];
+      await waitForRunning(2);
+
+      finishOldest();
+      await new Promise((r) => setImmediate(r));
+      // Dropping the gate here would let the next arrival build a fresh one with no slots
+      // recorded and admit past the cap while this call is still on the isolate.
+      expect(gatesOf(runner).size).toBe(1);
+
+      finishOldest();
+      await Promise.all(calls);
+      expect(gatesOf(runner).size).toBe(0);
+    });
+  });
+
+  describe('queue metrics', () => {
+    it('should count only the calls that had to queue', async () => {
+      const runner = buildRunner({ maxConcurrentExecutions: 2 });
+
+      // Two fit under the cap, so nothing is queued yet.
+      const calls = [1, 2].map((n) => runner.execute('ws-1', `call-${n}`, []));
+      await waitForRunning(2);
+      expect(queuedCount()).toBe(0);
+
+      // The next three have to wait. Counted at enqueue, so all three register immediately
+      // rather than trickling in as the queue drains.
+      calls.push(...[3, 4, 5].map((n) => runner.execute('ws-1', `call-${n}`, [])));
+      await new Promise((r) => setImmediate(r));
+      expect(queuedCount()).toBe(3);
+      expect(mockStats.increment).toHaveBeenCalledWith('ivm_execution_queued', {
+        functionName: 'call-3',
+        workspaceId: 'ws-1',
+        cache: 'test_ivm',
+      });
+
+      while (mockPendingExecutions.length > 0) {
+        finishOldest();
+        await new Promise((r) => setImmediate(r));
+      }
+      await expect(Promise.all(calls)).resolves.toHaveLength(5);
+      expect(queuedCount()).toBe(3);
+    });
+
+    it('should record how long a call waited for a slot', async () => {
+      const runner = buildRunner({ maxConcurrentExecutions: 1 });
+
+      const running = runner.execute('ws-1', 'running', []);
+      const queued = runner.execute('ws-1', 'queued', []);
+
+      await waitForRunning(1);
+      expect(mockStats.timing).not.toHaveBeenCalled();
+      finishOldest();
+      await waitForRunning(1);
+
+      // Same label set as `ivm_execution_queued`, so the counter and the wait distribution
+      // can be joined per (workspace, function).
+      expect(mockStats.timing).toHaveBeenCalledWith('ivm_execution_queue_wait', expect.any(Date), {
+        functionName: 'queued',
+        workspaceId: 'ws-1',
+        cache: 'test_ivm',
+      });
+      finishOldest();
+      await expect(Promise.all([running, queued])).resolves.toEqual(['ok', 'ok']);
+    });
+  });
+});

--- a/src/util/ivm/scriptRunner.ts
+++ b/src/util/ivm/scriptRunner.ts
@@ -36,6 +36,13 @@ export interface IvmScriptRunnerOptions {
   maxSize?: number;
   /** Idle-isolate TTL (ms). Omit to keep the DisposableCache default. */
   ttlMs?: number;
+  /**
+   * Max execute() calls in flight at once on a single isolate; further calls queue.
+   * The queue itself is unbounded — nothing is ever shed, so a burst costs latency
+   * rather than dropped events. Omit (or pass a non-positive value) to leave
+   * execution ungated.
+   */
+  maxConcurrentExecutions?: number;
 }
 
 interface CacheEntry {
@@ -43,6 +50,21 @@ interface CacheEntry {
   context: ivm.Context;
   destroy: () => Promise<void>;
 }
+
+/** One isolate's execution gate: slots in use plus the callers waiting for one. */
+interface ExecutionGate {
+  /**
+   * Slots currently spoken for — deliberately *not* "executions running". A slot handed from
+   * a departing caller to a waiter stays counted here across the microtask gap in which
+   * neither is executing, because the cap governs reservations, not work in progress.
+   */
+  slotsInUse: number;
+  /** FIFO — see the `shift()` in `acquireSlot`'s release closure. */
+  waiters: Array<() => void>;
+}
+
+/** Slot release for the ungated path — nothing was reserved, so nothing to hand back. */
+const NOOP_RELEASE = () => {};
 
 function releaseIvmResources(context?: ivm.Context, isolate?: ivm.Isolate) {
   try {
@@ -72,18 +94,38 @@ export class IvmScriptRunner {
 
   private readonly execTimeoutMs: number;
 
+  private readonly maxConcurrentExecutions: number;
+
+  /** Per-isolate execution gates, keyed like the isolate cache. Dropped once fully idle. */
+  private gates = new Map<string, ExecutionGate>();
+
   constructor(options: IvmScriptRunnerOptions) {
-    this.bundlePath = options.bundlePath;
-    this.memoryLimitMb = options.memoryLimitMb;
-    this.initTimeoutMs = options.initTimeoutMs;
-    this.execTimeoutMs = options.execTimeoutMs;
+    // An absent or nonsensical cap means "ungated" rather than "never admit anything", so a
+    // misconfigured env var leaves execution ungated instead of wedging the sandbox. Absent
+    // defaults to NaN, which — like an unparseable env var — fails the comparison below and
+    // falls through to Infinity.
+    const {
+      bundlePath,
+      memoryLimitMb,
+      initTimeoutMs,
+      execTimeoutMs,
+      cacheName,
+      maxSize,
+      ttlMs,
+      maxConcurrentExecutions = NaN,
+    } = options;
+    this.bundlePath = bundlePath;
+    this.memoryLimitMb = memoryLimitMb;
+    this.initTimeoutMs = initTimeoutMs;
+    this.execTimeoutMs = execTimeoutMs;
+    this.maxConcurrentExecutions = maxConcurrentExecutions > 0 ? maxConcurrentExecutions : Infinity;
     this.cache = new DisposableCache({
-      name: options.cacheName,
+      name: cacheName,
       ttlAutopurge: true,
       // Passed through only when provided so existing consumers keep their defaults
       // (DisposableCache falls back to IVM_CACHE_MAX_SIZE ?? 10 / IVM_CACHE_TTL_MS ?? 300000).
-      ...(options.maxSize !== undefined ? { maxSize: options.maxSize } : {}),
-      ...(options.ttlMs !== undefined ? { ttlMs: options.ttlMs } : {}),
+      ...(maxSize !== undefined ? { maxSize } : {}),
+      ...(ttlMs !== undefined ? { ttlMs } : {}),
       onChange: () => this.emitAggregateHeapStats(),
     });
   }
@@ -92,13 +134,21 @@ export class IvmScriptRunner {
    * Execute a closure inside a cached isolate, passing args via structured
    * clone. Args are scoped to the closure (referenced as $0, $1, $2, …),
    * avoiding global mutation and race conditions between concurrent calls.
+   *
+   * Admission is gated per isolate (see {@link acquireSlot}) so a burst cannot pile
+   * unbounded concurrent evaluations onto one fixed-size heap.
    */
   async execute<T>(cacheKey: string, expression: string, args: unknown[]): Promise<T> {
-    const platformErrorTags = {
+    // One label set for every metric this call can emit — the platform-error counter and both
+    // gate metrics — so they can be joined on (workspaceId, functionName, cache) in a query.
+    const metricTags = {
       functionName: expression,
       workspaceId: cacheKey,
       cache: this.cache.cacheName,
     };
+    // Outside the try so `releaseSlot` is in scope for the finally. Waiting for a slot is
+    // not a failure mode — acquireSlot never rejects, it only ever admits or queues.
+    const releaseSlot = await this.acquireSlot(cacheKey, metricTags);
     try {
       // Seed the platform-error counter at 0 when a fresh isolate is built for this label set
       // (once per isolate, not per call — warm-isolate calls never touch the registry).
@@ -110,7 +160,7 @@ export class IvmScriptRunner {
       // workspace's first call is always a cache miss, so the 0 is materialised before any
       // error can occur, giving increase() the 0 -> N edge it needs to detect the first burst.
       const entry = await this.getOrCreate(cacheKey, () =>
-        stats.counter('ivm_platform_error', 0, platformErrorTags),
+        stats.counter('ivm_platform_error', 0, metricTags),
       );
       const result = await entry.context.evalClosure(expression, args, {
         arguments: { copy: true },
@@ -123,9 +173,114 @@ export class IvmScriptRunner {
       // building the isolate. Evict so the next call gets a fresh one, and emit
       // a metric for observability before rethrowing.
       this.cache.delete(cacheKey);
-      stats.increment('ivm_platform_error', platformErrorTags);
+      stats.increment('ivm_platform_error', metricTags);
       throw err;
+    } finally {
+      releaseSlot();
     }
+  }
+
+  /**
+   * Reserve one of the isolate's concurrency slots, queueing if they are all taken.
+   *
+   * An isolate executes JS on a single thread with a fixed heap, so extra concurrency buys
+   * no throughput — it only keeps more argument copies and evaluation working sets alive on
+   * that one heap at once, which is what breaches `memoryLimit` and makes V8 dispose the
+   * whole isolate (failing every in-flight call, not just the one that tipped it). Queued
+   * callers hold their args on the Node heap instead, where they already were.
+   *
+   * The queue is unbounded: nothing is ever shed, so an overload costs latency rather than
+   * dropped events, and `ivm_execution_queued` is the signal that a pool is at its cap.
+   *
+   * Returns a release function that is safe to call once; it hands the slot straight to the
+   * next waiter so the isolate stays saturated up to the cap.
+   */
+  private acquireSlot(
+    cacheKey: string,
+    metricTags: Record<string, string>,
+  ): Promise<() => void> | (() => void) {
+    if (this.maxConcurrentExecutions === Infinity) {
+      return NOOP_RELEASE;
+    }
+
+    // Captured by reference for the lifetime of this call: the gate is only dropped from the
+    // map once fully idle, which cannot happen while this caller holds a slot or waits in the
+    // queue, so the closures below can never end up mutating a gate that has been replaced.
+    let gate: ExecutionGate;
+    const existing = this.gates.get(cacheKey);
+    if (existing) {
+      gate = existing;
+    } else {
+      gate = { slotsInUse: 0, waiters: [] };
+      this.gates.set(cacheKey, gate);
+    }
+
+    let released = false;
+    const release = () => {
+      if (released) {
+        return;
+      }
+      released = true;
+      // FIFO on purpose. Popping the newest waiter would be marginally cheaper but lets the
+      // oldest starve: under sustained saturation the stack never drains, and nothing bounds
+      // queue time here (execTimeoutMs covers evaluation only, and the queue is unbounded).
+      // Taking from the head caps the wait at queue-depth / drain-rate.
+      const next = gate.waiters.shift();
+      if (next) {
+        // Hand the slot over instead of freeing it: `slotsInUse` stays as is. Freeing it *and*
+        // waking a waiter would let the gate drift and admit past the cap.
+        next();
+        return;
+      }
+      gate.slotsInUse -= 1;
+      // Keep `gates` bounded by the live isolate set rather than every key ever seen. No waiters
+      // can exist here (shift() came back empty), so an idle gate is just one with no slots in
+      // use.
+      //
+      // Reaching 0 also implies this gate is still the one stored under `cacheKey`, so the
+      // delete can never drop another caller's gate: a gate is only ever removed at exactly 0,
+      // and once removed nothing can re-acquire it (gates are reached only via `gates.get`, and
+      // the `set` above runs only on a miss), so a removed gate counts further down from 0 and
+      // never returns to it.
+      if (gate.slotsInUse === 0) {
+        this.gates.delete(cacheKey);
+      }
+    };
+
+    if (gate.slotsInUse < this.maxConcurrentExecutions) {
+      gate.slotsInUse += 1;
+      return release;
+    }
+
+    // Counted at enqueue, not on admission: the wait timer below only samples once a caller is
+    // let in, so under sustained saturation it lags the burst by however long the queue takes
+    // to drain, while this shows the backlog forming. Emitted before the promise is built so a
+    // throwing metric cannot leave a waiter enqueued holding a slot that is never released.
+    //
+    // Carries the full label set: the gate is per isolate, i.e. per workspace, and these two
+    // metrics are the only overload signal there is — "which tenant is at its cap" is the
+    // first thing you need during an incident. Cardinality is bounded by the workspaces that
+    // actually reach the cap, which is rare by design (the cap sits far above normal traffic),
+    // not by call volume; `functionName` is a hardcoded expression literal per call site, so
+    // it adds no fan-out of its own.
+    stats.increment('ivm_execution_queued', metricTags);
+
+    const queuedAt = new Date();
+    return new Promise<() => void>((resolve) => {
+      // Resolved by a departing holder, which transfers its slot rather than freeing it —
+      // so `slotsInUse` is already accounted for by the time we run.
+      gate.waiters.push(() => {
+        // Resolve before emitting: this runs inside the departing caller's release(), so a
+        // throwing metric here would strand this waiter with a slot that is never handed back.
+        resolve(release);
+        // Same label set as the counter above, so the two join cleanly: "ws-1 queued 10k times"
+        // and "ws-1 waits p99 2s" are different facts and you want both for the same series.
+        // This one backs a histogram, so a label set costs a series per bucket plus _sum/_count
+        // rather than the counter's single series — affordable only because the labels
+        // materialise for saturating workspaces alone, which the cap makes rare.
+        stats.timing('ivm_execution_queue_wait', queuedAt, metricTags);
+      });
+    });
   }
 
   /** Sum heap across all cached isolates. Called on cache mutation only. */

--- a/src/util/prometheus.js
+++ b/src/util/prometheus.js
@@ -981,6 +981,18 @@ class Prometheus {
         labelNames: ['cache'],
       },
       {
+        name: 'ivm_execution_queue_wait',
+        help: 'Time an evaluation waited for a free isolate concurrency slot (seconds)',
+        type: 'histogram',
+        labelNames: ['functionName', 'workspaceId', 'cache'],
+        // Declared explicitly because the default bucket set starts at 5ms, and a gated
+        // isolate drains far faster than that: measured locally, 99.45% of 312k waits landed
+        // in that single first bucket, which makes histogram_quantile() interpolate inside it
+        // and report nothing useful. These start at 0.5ms so a healthy sub-millisecond wait is
+        // distinguishable from a degraded one, and run to 1s to keep a real backlog on-scale.
+        buckets: [0.0005, 0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1],
+      },
+      {
         name: 'fetchV2_call_duration',
         help: 'fetchV2_call_duration',
         type: 'histogram',

--- a/src/util/prometheus.js
+++ b/src/util/prometheus.js
@@ -989,8 +989,10 @@ class Prometheus {
         // isolate drains far faster than that: measured locally, 99.45% of 312k waits landed
         // in that single first bucket, which makes histogram_quantile() interpolate inside it
         // and report nothing useful. These start at 0.5ms so a healthy sub-millisecond wait is
-        // distinguishable from a degraded one, and run to 1s to keep a real backlog on-scale.
-        buckets: [0.0005, 0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1],
+        // distinguishable from a degraded one, and extend to 10s so a real backlog (queue depth
+        // growing behind timed-out executions) stays on-scale instead of pinning p99 at the top
+        // finite bucket.
+        buckets: [0.0005, 0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10],
       },
       {
         name: 'fetchV2_call_duration',


### PR DESCRIPTION
## What are the changes introduced in this PR?

Caps how many custom-mapping evaluations run concurrently on a single `isolated-vm` isolate and queues the excess.

`IvmScriptRunner` gains one optional knob — `maxConcurrentExecutions`. It defaults to unlimited, so `custom_audience` and every other consumer keep today's behaviour; only the `custom_mappings_ivm` pool opts in.

## What is the related Linear task?

Resolves INT-6832

## Please explain the objectives of your changes below

An isolate runs JS on one thread against one fixed heap. Extra concurrency on it buys no throughput — it only keeps more structured-clone argument copies and evaluation working sets alive on that heap at the same time. When the total breaches `memoryLimit`, V8 disposes the **whole isolate**, so every in-flight evaluation fails at once with a retryable 500, not just the one that tipped it. That amplification is what surfaced as the intermittent 500 spikes on Lovable's HTTP destination.

Nothing bounded that fan-in before this. `execute()` had promise-coalescing on isolate *creation* only; once an isolate was warm, unlimited calls could re-enter it. Callers actively fan out — the HTTP destination maps headers, query params and payload as three separate evaluations per event (`procWorkflow.yaml:39,50,59`), and `ga4_v2` `Promise.all`s over its mapping list (`customMappingsHandler.js:110`).

Bounding admission converts "the isolate dies and takes every in-flight event with it" into "the excess waits". Queued callers hold their args on the Node heap, where those args already were — the queue itself costs the isolate nothing.

This is follow-up #1 from the INT-6832 thread. Follow-up #2 (compile-caching the mapping template) is #5372; the two are independent and can merge in either order.

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

Only the `custom_mappings_ivm` pool changes behaviour, and only past the cap. **Nothing is ever shed** — the queue is unbounded by construction, so an overload costs latency rather than dropped events. `acquireSlot()` cannot reject; it only ever admits or queues.

One new tunable (falling back to unlimited — i.e. today's behaviour — if absent or unparseable, rather than wedging the sandbox):

| Env var | Default | Rationale |
|---|---|---|
| `CUSTOM_MAPPINGS_IVM_MAX_CONCURRENT_EXECUTIONS` | 100 | Sized from prod — see below. |

The cap alone is what protects the isolate heap, and a single-threaded isolate drains its queue at its own throughput either way, so an explicit queue bound would only have bought a strictly worse failure mode (a dropped event instead of a slower one).

#### Where the cap of 100 comes from

Sized against `enterprise-eu` / `rudder-eu-central-1b`, the busiest namespace for this pool by a wide margin (~380x `eu-central-1a`):

| Observation (7d) | Value |
|---|---|
| Peak single-pod eval rate | ~13.8k/s |
| Warm isolates per pod | 18 (cache max 20) |
| Observed heap per isolate | ~5.6 MB baseline |
| `ivm_platform_error`, `custom_mappings_ivm` | 879, **all in one hour, all one workspace** |

That error profile is the whole argument for this PR: 879 failures inside a single hour and zero across the rest of the week is not a steady error rate, it is one isolate dying and taking every in-flight evaluation with it.

An isolate runs on one thread, so sustaining ~13.8k evals/s implies a sub-100µs evaluation, which by Little's Law puts steady-state in-flight depth near 1. Concurrency only builds when arrivals transiently outrun the isolate — exactly the OOM regime. So 100 sits ~100x above anything normal traffic reaches (it will not throttle the hot workspace) and ~16x below the ~1600-concurrency OOM onset measured in #5372. Memory agrees: ~5.9 MB of eval working set at concurrency 100, on top of the ~5.6 MB baseline, against the 32 MB prod limit.

#### Measured under load

Verified locally against the real `http` destination path (single process, one workspace, 6s per phase). The cap was set to **8** rather than 100 for the run: by the Little's Law argument above, steady-state depth sits near 1, so a laptop cannot drive an isolate to depth 100 — lowering the cap exercises the identical code path at reachable load. 180,674 requests / 542,022 evaluations, **all HTTP 200**.

| offered concurrency | evals/s | queued/s | mean wait | in-flight depth |
|---|---|---|---|---|
| 1 | 6,900 | 0 | — | 0.39 |
| 4 | 14,803 | 0 | — | 0.84 |
| 8 | 16,518 | 0 | — | 0.94 |
| 16 | 17,003 | 0 | — | 0.97 |
| 32 | 17,551 | 13,553 | 0.39ms | **7.84** |
| 64 | 17,509 | 17,651 | 1.11ms | **20.43** |

Three things the run confirms:

- **Throughput is flat from concurrency 8 onward** (~17.5k evals/s) while offered load grows 8x. Extra concurrency bought zero throughput and became queue depth — the premise of the PR, measured. The implied ~57µs service time is consistent with the sub-100µs figure inferred from prod.
- **The gate is silent until it is genuinely saturated.** `ivm_execution_queued` stayed at exactly 0 through four phases of rising load. Past the cap, 312,295 evaluations queued and `ivm_execution_queue_wait_count` equalled that number exactly — every queued call was admitted, nothing lost or double-counted, and `ivm_platform_error` stayed at 0 across all 542k evaluations.
- **In-flight depth crosses the cap where queueing starts.** Depth above is Little's Law (throughput x residence), derived independently of the gate's own counters, and it crosses 8 at precisely the phase where the counter switches on.

### Any new dependencies introduced with this change?

N/A — no new packages; the gate is ~60 lines of plain promise plumbing.

### Any new generic utility introduced or modified. Please explain the changes.

`IvmScriptRunner` (shared by `custom_mappings` and `custom_audience`) gains the option above, opt-in per consumer.

`prometheus.js` gains a static registration for `ivm_execution_queue_wait` with explicit buckets — see the metrics bullet below for why.

### Any technical or performance related pointers to consider with the change?

- **Slot handoff, not free-and-wake.** `release()` hands its slot directly to the next waiter and leaves `slotsInUse` untouched. Decrementing *and* waking a waiter would let the accounting drift and admit past the cap. There is a regression test for exactly that — it fails with peak 3 against a cap of 2 under the buggy variant. The counter is named for slots *reserved*, not work in progress: a slot in transit between a departing caller and a waiter stays counted across the microtask gap in which neither is executing.
- **Waiters are FIFO.** `pop()` would be marginally cheaper, but it starves the oldest waiter under sustained saturation, and nothing bounds queue time here (`execTimeoutMs` covers evaluation only, and the queue is unbounded). The O(n) `shift()` is a pointer memmove on a queue that Little's Law keeps near-empty in steady state — orders of magnitude below the ~100µs evaluation it gates.
- **Gates are per isolate** (keyed like the isolate cache, i.e. per workspace) and dropped once fully idle, so the map stays bounded by the live isolate set rather than every workspace ever seen. A queued caller resolves with its own release closure and its own `cacheKey`, so it can never bind to another tenant's isolate.
- **New metrics:** `ivm_execution_queued` (counter) and `ivm_execution_queue_wait` (timer), both carrying the full `(workspaceId, functionName, cache)` label set that `ivm_platform_error` already uses, so all three join on the same series. The gate is per isolate — i.e. per workspace — and these two are the only overload signal there is, so "which tenant is at its cap" has to be answerable from them. `ivm_execution_queued` is incremented **at enqueue**, so a backlog shows up the moment it forms; the wait timer only samples on admission and so lags a burst by however long the queue takes to drain. `ivm_execution_queued` is the one to alert on. Cardinality is bounded by the workspaces that actually reach the cap — rare by design, since the cap sits far above normal traffic — not by call volume; `functionName` is a hardcoded expression literal per call site (three exist repo-wide, only one on a gated pool), so it adds no fan-out.
- **`ivm_execution_queue_wait` is declared statically with explicit buckets.** Left to `prometheus.js`'s dynamic path it inherits prom-client's default buckets, whose first boundary is 5ms — and a gated isolate drains far faster than that. In the load run above, **99.45% of 312k observations (310,578) landed in that single first bucket**, with the remaining 0.55% in the next and every higher bucket empty; `histogram_quantile()` on that series interpolates inside one bucket and cannot separate a healthy 0.4ms wait from a degraded 4ms one. The declared buckets start at 0.5ms and run to 1s; re-measured under the same load the distribution spans five buckets (p50 ~3.8ms, p99 ~19ms). Declaring it also pins the label set rather than inferring it from whichever call site observes first.
- **Metric emission ordering.** `ivm_execution_queued` is emitted before the waiter promise is constructed, and the wait timer after `resolve()`, so a throwing metric client can never strand a waiter in the queue holding a slot that was handed to it and never released.
- **Out of scope, deliberately:** the code default for `CUSTOM_MAPPINGS_IVM_MEMORY_MB` is still 16 while prod is overridden to 32 via helm — separate concern, prod already carries the bump. `custom_audience` stays ungated; enabling it there is a one-line config change if wanted.

@coderabbitai review

<hr>

### Developer checklist

- [x] My code follows the style guidelines of this project

- [x] **No breaking changes are being introduced.**

- [x] All related docs linked with the PR?

- [x] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [x] Is the PR limited to 10 file changes?

- [x] Is the PR limited to one linear task?

- [x] Are relevant unit and component test-cases added in **new readability format**?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.


