### PR TITLE
chore: live integration test framework

### DIFF
--- a/.claude/skills/live-integration-test/SKILL.md
+++ b/.claude/skills/live-integration-test/SKILL.md
@@ -1,0 +1,260 @@
+---
+name: live-integration-test
+description: Generate a destination's live (real-destination) integration test spec `test/integrations/destinations/<dest>/live.ts` by deriving its scenarios and event seeds from the destination's existing component tests (router/processor/dataDelivery `data.ts`). Use when enrolling a destination into the live suite, or when asked to "add live tests" / "generate live test cases" for a destination.
+argument-hint: <destination-folder-name>
+---
+
+# Live Integration Test — Enroll a Destination
+
+**Objective:** Create `test/integrations/destinations/<dest>/live.ts` — a `LiveSpec` whose
+`scenarios` drive events through the real `transform → deliver` pipeline against a **real
+destination account**, deriving the event seeds, config, and code-path coverage from the
+destination's existing (mocked) component tests. The mocked `component.test.ts` suite stays the
+merge gate; this suite is additive and asserts on the genuine delivery verdict.
+
+## Inputs
+
+- **Destination folder name**: `$ARGUMENTS[0]` — the folder under `test/integrations/destinations/`
+  and `src/.../destinations/`, e.g. `<dest>`.
+
+## Sources of truth (read these first)
+
+1. **Component test cases** — the raw material for scenarios:
+   - `test/integrations/destinations/<dest>/router/data.ts` and, if present,
+     `test/integrations/destinations/<dest>/processor/data.ts` (plus their imports: `config.ts`,
+     `upsertData.ts`, `errorValidationData.ts`, …). Most destinations have both a `processor/` and a
+     `router/` suite; some (e.g. router-only ones) have just `router/`. Each case is
+     `{ id, description, feature, input.request.body.input[].message, ...destination.Config..., output }`.
+     The **`message`** is the raw event and **`destination.Config`** is the config — these become the
+     scenario's `seed(ctx)` and `resolveConfig`/`configOverride`.
+   - `test/integrations/destinations/<dest>/dataDelivery/*.ts` — proxy/delivery cases (optional; not
+     every destination has them). Show what a delivered vs failed verdict looks like.
+2. **`test/integrations/destinations/<dest>/network.ts`** — the mocked API responses. This reveals
+   **which real endpoints the transform hits** and the branch each case exercises (create vs update,
+   search hit/miss, batch vs single, membership add/remove), which tells you what live
+   **setup/verify/cleanup** must do.
+3. **The transformer** — `src/v0|v1/destinations/<dest>/` or `src/cdk/v2/destinations/<dest>/`: the
+   config fields, auth mechanism, and the destination API endpoints (for setup/verify/cleanup steps).
+4. **The live harness contract** — `test/integrations/live/types.ts` (`LiveSpec`, `LiveScenario`,
+   `LiveStep`, `RunContext`), the shared `pollUntil` read-back helper
+   (`test/integrations/live/poll.ts`), and `test/integrations/live/README.md`.
+5. **The reference implementation** — read the HubSpot spec end-to-end as the worked example of
+   every pattern below. For non-trivial specs it is a **module folder**:
+   `destinations/hs/live.ts` is a one-line re-export of `destinations/hs/live/spec.ts`, with helpers
+   split across `live/api.ts` (real-API calls + auth), `live/setup.ts` (action bodies),
+   `live/verify.ts` (verify steps), and `live/profiles.ts` (trait profiles). It is a CRM/object
+   destination; adapt the shapes to your destination's category (see below).
+
+## The mapping: component case → live scenario
+
+| Component test | Live spec |
+| --- | --- |
+| mocked network via `network.ts` / `MockAxiosAdapter` | **no mock** — the runner boots the real app and hits real APIs |
+| a `data.ts` case = one input `message` + `destination.Config` + expected `output` | a **scenario** with a pipeline step whose `seed(ctx)` rebuilds that `message` |
+| hardcoded PII/ids in the message (email, userId, externalId, recordId, list/audience id) | `ctx.email()`, `ctx.identity(entity)`, `ctx.runId`, `ctx.now(offset?)`, `ctx.liveSecret.resourceIds`, or an id registered by a setup step — never a literal |
+| config variants across cases (api version, list/object type, mapping) | a base `resolveConfig` + per-scenario `configOverride(base)` |
+| a case that asserts a specific transformed request shape | a scenario asserting the event is **delivered** (verdict 2xx / 207); the shape is the transform's job, already covered by the mocked suite |
+
+**One scenario per distinct behavior, not per component case.** Collapse the many mocked cases into
+the *code paths* that matter live — these differ by destination category:
+
+- **CRM / object destinations**: create vs update; event-stream vs RETL (`mappedToDestination`);
+  lookup-by-id vs search-by-field; associations; per object type; API-version variants.
+- **Audience destinations**: add vs remove membership; list/segment creation; raw vs hashed identifiers.
+- **Conversion / event destinations**: the distinct event types and property mappings; enhanced /
+  offline conversion variants.
+- **Cross-cutting** (any category): batched vs `dontBatch`; config-driven variants.
+
+Give each a stable `id` and a one-line `description`.
+
+**Skip cases that can't be meaningfully delivered live** — pure validation/error cases (bad config,
+missing required field → 400, "more than one match" aborts, unsupported event type). Those are
+contract checks the mocked suite already owns; the live suite verifies real *delivery*, so don't
+port them.
+
+## Stateful cases: setup + verify as steps, teardown declared on the scenario
+
+If a case's code path depends on pre-existing destination state, express **setup** and **read-back**
+as ordered steps, and **declare teardown on the scenario** rather than adding a trailing cleanup step:
+
+- **update / lookup-by-id / search-by-field / remove-from-audience** → an `action` step
+  (`{ stepType: 'action', name: 'setup', run }`) creates the prerequisite state via the real
+  destination API and `ctx.register({ type, id })`s any ids; the
+  pipeline step then references `ctx.resources` for that id, or seeds the same `ctx.email()`/identity
+  the setup used.
+- **verify** → a `verify` step that reads the object/membership/association back from the
+  destination API and asserts its **fields** with jest `expect(...)` (it resolves on success and a
+  failed matcher fails the step — it returns `void`, no boolean), not just its existence: a create
+  scenario checks the object carries every property it was created with; an update scenario checks
+  the properties it changed; an association scenario checks the link actually exists between the
+  two records. Share one property/trait profile between the pipeline `seed` and the verify — a
+  `(ctx) => ({ ... })` factory referenced by both, so the seeded values and the assertion can't
+  drift (see `esContactCreateTraits` + `verifyContactProperties`, and `verifyAssociationExists`, in
+  `hs/live/verify.ts`). Poll eventually-consistent read-backs with the shared `pollUntil` helper
+  (`live/poll.ts`; `soft: true` returns the last value so the closing `expect(...)` prints a real
+  diff). Read-back is also the
+  real check for **batch** writes: a batch endpoint can return `207` (which counts as delivered)
+  even when an item fails, so the delivery verdict alone doesn't prove the write landed.
+- **cleanup** → **declare it on the scenario.** Set `cleanup: (ctx) => delete…(ctx)` on the
+  `LiveScenario`; the runner arms it at scenario start and drains it after the scenario's steps
+  finish — LIFO and best-effort (a failing cleanup is logged, not thrown), running **even if a
+  step failed**. For resources a setup action discovers dynamically, `ctx.addCleanup(fn)` from its
+  `run` is the imperative escape hatch. Declare `cleanup` explicitly on each scenario (don't
+  club it onto many at once). Don't put teardown on a `verify` step, and no trailing cleanup
+  action step.
+
+Use a dedicated `https.Agent({ keepAlive: false })` for these helper calls so read-back/cleanup
+sockets don't linger as open handles when the suite finishes.
+
+Identities from `ctx.identity` / `ctx.email` are always unique per scenario run
+(`ci-<runId>-…`), so destination 409s on duplicates are avoided without a per-spec strategy.
+
+For eventually-consistent destinations (search-indexed create/update routing), make the
+precondition deterministic in the **setup action** (poll until the record is stably searchable).
+When the transform itself re-searches that index at delivery time, setup polling alone can still
+race — a just-created record is occasionally missed and 409s — so also set `retries` on the
+pipeline step to re-run seed → transform → deliver with backoff. Only use `retries` where a failed
+attempt persists nothing (e.g. a 409-on-create), so repeating is safe; otherwise a re-delivery
+runs against the previous attempt's state.
+
+## Credentials — `LIVE_SECRET_<DEST>` (`LiveSecret` shape)
+
+`SecretResolver` reads one env var, `LIVE_SECRET_<DEST>`, a JSON blob:
+`{ authType, config, secret?, resourceIds?, oauthRefresh?, readback? }`. `config` merges into
+`destination.Config`; `secret` into `metadata.secret`; `resourceIds` supplies account-scoped ids
+(listId, pixelId, measurementId, …); `readback` holds credentials for `verify` steps.
+`resolveConfig(s)` maps `s.config` (plus fixed non-secret defaults taken from the component
+`destination.Config`) into the real `destination.Config`.
+
+**OAuth destinations** (`authType: 'oauth'`): supply `oauthRefresh` (the long-lived refresh token +
+`accountDefinition` + any `providerFields` like Salesforce `instance_url`). Note the harness README
+lists the `rudder-auth` container that services OAuth refresh as **deferred (not in the pilot)** — so
+until that layer lands, an OAuth destination's spec typically goes in with `enabled: false` (parked)
+and is validated for shape only. Prefer piloting `apiKey`/`basic` destinations first.
+
+## Steps
+
+1. **Read** the sources above for `<dest>`; enumerate the distinct behaviors its component cases
+   cover (dedupe error-only ones).
+2. **Choose** `authType`.
+3. **Write `resolveConfig`** from the component `destination.Config` — keep the non-secret fields as
+   fixed defaults, spread `s.config` last for the real credentials.
+4. **For each behavior**, add a scenario: a pipeline step whose `seed(ctx)` reproduces the component
+   `message` with ctx-based identities; a `configOverride` for config-dependent variants; and
+   `setup`/`verify`/`cleanup` steps for stateful ones. For create/update behaviors, factor the
+   asserted fields into a `(ctx) => ({ ... })` profile shared by the seed and a field-level verify
+   so the two stay in lockstep.
+5. **Enroll**: `enabled: true` (registry auto-discovers `destinations/*/live.ts`; no registration).
+   Use `enabled: false` to park it (e.g. OAuth destinations, until rudder-auth lands).
+6. **Verify**:
+   `npx tsc --noEmit -p tsconfig.test.json`
+   then, with real credentials:
+   `LIVE_SECRET_<DEST>='{...}' LOG_LEVEL=silent npm run test:live -- --destination=<dest>`.
+   (Run with `LOG_LEVEL=silent` until secret masking in `network.js` logs is verified — see the
+   README security note.)
+
+## Skeleton — `test/integrations/destinations/<dest>/live.ts`
+
+For a couple of scenarios a single `live.ts` is fine; beyond that, split it into a `live/` module
+folder (`spec.ts` + `api.ts`/`setup.ts`/`verify.ts`/`profiles.ts`) and make `live.ts` a one-line
+re-export — see `destinations/hs/live/`. Steps are plain objects with a required `stepType`
+discriminant (`'pipeline' | 'action' | 'verify'`); there are no `action()`/`verify()` wrapper
+helpers. The `seed` below is an event-stream `identify` (CRM shape) purely to illustrate structure
+— **use the event shape your destination's component `message`s actually take** (e.g. a `track`
+event with `properties` for a conversion, or an audience membership event), swapping literals for
+`ctx` values.
+
+```ts
+import axios from 'axios';
+import { Agent } from 'https';
+import { LiveSpec, RunContext } from '../../live/types';
+import { pollUntil } from '../../live/poll';
+
+// keepAlive:false so read-back/cleanup sockets don't linger as open handles.
+const agent = new Agent({ keepAlive: false });
+
+// Real-API helpers for stateful scenarios (create/read-back/delete). Derive endpoints + auth
+// from src/.../destinations/<dest> and network.ts. Example shapes only:
+// const createEntity = async (ctx: RunContext): Promise<void> => { ... ctx.register(...) };
+// const fetchEntity = async (ctx: RunContext, keys: string[]) => { ... };   // real GET/search
+// const cleanupEntity = async (ctx: RunContext): Promise<void> => { ... };
+
+// One field profile shared by a scenario's seed and its verify, so they can't drift.
+// const createProps = (ctx: RunContext): Record<string, string> => ({ name: 'CI', ref: ctx.runId });
+
+// A verify step is a plain { stepType: 'verify', name, check } object; `check` asserts with jest
+// expect(...) (returns void). Poll eventually-consistent read-backs with pollUntil (soft: true).
+// const verifyEntityProps = (want: (ctx: RunContext) => Record<string, string>): LiveStep => ({
+//   stepType: 'verify',
+//   name: 'verify entity properties',
+//   check: async (ctx) => {
+//     const expected = want(ctx);
+//     const props = await pollUntil(
+//       async () => {
+//         const p = await fetchEntity(ctx, Object.keys(expected));
+//         return { done: Boolean(p) && Object.keys(expected).every((k) => p[k] === expected[k]), value: p };
+//       },
+//       { label: 'entity properties', attempts: 4, delayMs: (n) => 1000 * 2 ** n, soft: true },
+//     );
+//     expect(props).toMatchObject(expected);
+//   },
+// });
+
+export const live: LiveSpec = {
+  enabled: true, // OAuth destinations: false until rudder-auth lands (see Credentials)
+  authType: 'apiKey', // apiKey | oauth | basic | serviceAccount | custom
+  // Non-secret Config defaults from the component test's destination.Config; real creds via s.config.
+  resolveConfig: (s) => ({ ...s.config }),
+  scenarios: [
+    {
+      id: '<dest>-create',
+      description: 'A new <entity> is created and delivered',
+      // Teardown for this scenario; armed at start, drained after its steps (LIFO, best-effort).
+      cleanup: (ctx) => cleanupEntity(ctx),
+      steps: [
+        {
+          stepType: 'pipeline',
+          name: 'create <entity>',
+          // Rebuild the component case's message, but with ctx identities instead of literals.
+          // Shape (type/traits/properties/event) is destination-specific — copy it from the case.
+          // Seed the shared field profile so verify can read the same values back.
+          seed: (ctx) => ({
+            type: 'identify',
+            userId: ctx.identity('user'),
+            timestamp: ctx.now(),
+            traits: { email: ctx.email(), ...createProps(ctx) },
+            integrations: { All: true },
+          }),
+        },
+        // verifyEntityProps(createProps), // field-level read-back sharing the seed's profile
+      ],
+    },
+    // {
+    //   id: '<dest>-update',
+    //   description: 'An existing <entity> is updated',
+    //   cleanup: (ctx) => cleanupEntity(ctx),
+    //   steps: [
+    //     { stepType: 'action', name: 'setup', run: createEntity },
+    //     { stepType: 'pipeline', name: 'update', seed: (ctx) => ({ ...updateProps(ctx) }) },
+    //     verifyEntityProps(updateProps),
+    //   ],
+    // },
+    // { id: '<dest>-variant', description: 'config-driven variant', configOverride: (base) => ({ ...base }), steps: [ ... ] },
+  ],
+};
+
+export default live;
+```
+
+## Notes
+
+- Build every value from `ctx`, never from string templates — identities are unique per run, which
+  keeps runs isolated and avoids destination 409s on duplicates.
+- For association scenarios, seed a **real** destination-defined association type, not a placeholder
+  copied from the mocked `network.ts` (a fake type makes a batch endpoint return `207` without
+  creating the link, so delivery passes but the read-back verify fails). E.g. HubSpot's
+  companies→contacts default type is `company_to_contact`.
+- The base `tsconfig.json` excludes `test/`; type-check the spec via `tsconfig.test.json`
+  (`npx tsc --noEmit -p tsconfig.test.json`), which includes `test/**`. ts-jest also checks at run time.
+- Never store a long-lived secret in the repo; live credentials come from `LIVE_SECRET_<DEST>`
+  locally and Vault (via GitHub-OIDC) in CI.

--- a/.claude/skills/live-integration-test/SKILL.md
+++ b/.claude/skills/live-integration-test/SKILL.md
@@ -136,22 +136,48 @@ and is validated for shape only. Prefer piloting `apiKey`/`basic` destinations f
 
 1. **Read** the sources above for `<dest>`; enumerate the distinct behaviors its component cases
    cover (dedupe error-only ones).
-2. **Choose** `authType`.
+2. **Choose** `authType`. **If the destination is OAuth, stop here:** the `rudder-auth` container
+   that services OAuth refresh is deferred (not in the pilot), so park the spec with
+   `enabled: false` and say so in the output — don't generate a spec that can't run yet. Pilot
+   `apiKey`/`basic` destinations first.
 3. **Write `resolveConfig`** from the component `destination.Config` — keep the non-secret fields as
    fixed defaults, spread `s.config` last for the real credentials.
-4. **For each behavior**, add a scenario: a pipeline step whose `seed(ctx)` reproduces the component
-   `message` with ctx-based identities; a `configOverride` for config-dependent variants; and
-   `setup`/`verify`/`cleanup` steps for stateful ones. For create/update behaviors, factor the
-   asserted fields into a `(ctx) => ({ ... })` profile shared by the seed and a field-level verify
-   so the two stay in lockstep.
-5. **Enroll**: `enabled: true` (registry auto-discovers `destinations/*/live.ts`; no registration).
+4. **Emit a credential template.** `resolveConfig` names the destination's config fields, so print a
+   filled `LIVE_SECRET_<DEST>` skeleton the developer can paste and fill in — the one thing they
+   can't derive from the repo. Placeholders for the secret values, real keys for everything else,
+   e.g.:
+   `LIVE_SECRET_HS={"authType":"apiKey","config":{"accessToken":"<private-app-token>"},"readback":{"accessToken":"<private-app-token>"}}`
+   Include `readback` only if the destination has `verify` steps; add `resourceIds`/`oauthRefresh`
+   when the config needs them.
+5. **For each behavior**, add a scenario: a pipeline step whose `seed(ctx)` reproduces the component
+   `message` with ctx-based identities; a `configOverride` for config-dependent variants; and a
+   `setup` step plus a scenario-level `verify`/`cleanup` for stateful ones. For create/update
+   behaviors, factor the asserted fields into a `(ctx) => ({ ... })` profile shared by the seed and
+   the field-level verify so the two stay in lockstep.
+6. **Enroll**: `enabled: true` (registry auto-discovers `destinations/*/live.ts`; no registration).
    Use `enabled: false` to park it (e.g. OAuth destinations, until rudder-auth lands).
-6. **Verify**:
+7. **Add the CI matrix entry.** Enrollment isn't complete until the destination runs in CI: add its
+   code to the `destination` matrix in `.github/workflows/live-integration-tests.yml`
+   (`destination: [hs, <dest>]`). The secret name is derived from the code (`LIVE_SECRET_<DEST>`),
+   so that's the only workflow edit.
+8. **Verify**:
    `npx tsc --noEmit -p tsconfig.test.json`
    then, with real credentials:
    `LIVE_SECRET_<DEST>='{...}' LOG_LEVEL=silent npm run test:live -- --destination=<dest>`.
    (Run with `LOG_LEVEL=silent` until secret masking in `network.js` logs is verified — see the
    README security note.)
+
+## After the spec — onboarding checklist
+
+Generating `live.ts` is only the in-repo half. Enrolling a destination end-to-end also touches
+systems outside the repo — print this checklist at the end so the developer knows what's left:
+
+- **Vault**: add the `LIVE_SECRET_<DEST>` field (the full `LiveSecret` JSON) under
+  `engineering_shared/data/integrations_team/e2e_test/rudder-transformer`.
+- **GitHub**: any Actions vars/secrets the run needs — the workflow reads `VAULT_ADDR`,
+  `VAULT_JWT_AUTH_PATH`, and `VAULT_JWT_ROLE`; add destination-specific ones if required.
+- **Sandbox account**: who owns it, what a run creates, and what cleanup is expected to remove — a
+  live run writes to a real account.
 
 ## Skeleton — `test/integrations/destinations/<dest>/live.ts`
 

--- a/.github/workflows/live-integration-tests.yml
+++ b/.github/workflows/live-integration-tests.yml
@@ -1,0 +1,97 @@
+# Live (real-destination) integration tests.
+#
+# Drives transformed events through transform -> deliver against REAL destination
+# accounts. Credentials come from the dev HashiCorp Vault via GitHub-OIDC (JWT auth),
+# so no long-lived secret is stored in GitHub. Runs one matrix job per destination.
+#
+# Vault (KV v2): each destination's full LiveSecret JSON is stored as a field on the shared path
+#   engineering_shared/data/integrations_team/e2e_test/rudder-transformer
+# named after the env var the resolver expects — e.g. field `LIVE_SECRET_HS`.
+
+name: Live Integration Tests
+
+on:
+  pull_request:
+    types: ['opened', 'reopened', 'synchronize']
+  push:
+    branches:
+      - main
+      - develop
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  id-token: write # required: lets the job mint the GitHub OIDC JWT
+  contents: read # for actions/checkout
+
+jobs:
+  live:
+    name: live (${{ matrix.destination }})
+    # required: puts the job in infra1-us → PrivateLink path to dev Vault
+    runs-on: [self-hosted, Linux, X64]
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - destination: hs
+            secretName: LIVE_SECRET_HS
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Setup Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+
+      - name: Install dependencies
+        # prepare builds isolated-vm's native addon (skipped by ignore-scripts on `npm ci`).
+        run: npm ci && npm run prepare
+
+      - name: Import destination secret from dev Vault (OIDC/JWT)
+        id: vault
+        uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
+        with:
+          url: https://vault.dev.rudderlabs.com
+          method: jwt
+          path: github-actions # = vault_jwt_auth_backend.path
+          role: rudder-transformer-ci # = vault_jwt_auth_backend_role.role_name
+          jwtGithubAudience: https://vault.dev.rudderlabs.com # MUST match bound_audiences, else auth fails
+          exportToken: false # keep the raw Vault token out of env
+          secrets: |
+            engineering_shared/data/integrations_team/e2e_test/rudder-transformer ${{ matrix.secretName }} | ${{ matrix.secretName }}
+
+      - name: Run live tests
+        # LOG_LEVEL=100 suppresses body logging so tokens can't leak.
+        run: LOG_LEVEL=100 npm run test:live -- --destination=${{ matrix.destination }}
+
+      - name: Notify Slack on failure
+        # Notify on push to main/develop, and on PRs from release/hotfix-release branches only.
+        if: >-
+          ${{ failure() && (github.event_name == 'push' || (github.event_name == 'pull_request' && (startsWith(github.event.pull_request.head.ref, 'release/') || startsWith(github.event.pull_request.head.ref, 'hotfix-release/')))) }}
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
+        continue-on-error: true # a failed notification must not mask the test failure
+        env:
+          CHANNEL_ID: ${{ secrets.SLACK_LIVE_TEST_CHANNEL_ID }}
+          RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          REF_NAME: ${{ github.head_ref || github.ref_name }}
+          ONCALL_MENTION: "${{ format('\nCC: <!subteam^{0}>', secrets.SLACK_ONCALL_GROUP_ID) }}"
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          errors: true
+          retries: rapid
+          payload: |
+            {
+              "channel": "${{ env.CHANNEL_ID }}",
+              "text": ":rotating_light: Live integration tests failed for `${{ matrix.destination }}` on `${{ env.REF_NAME }}` — <${{ env.RUN_URL }}|view run>${{ env.ONCALL_MENTION }}"
+            }

--- a/.github/workflows/live-integration-tests.yml
+++ b/.github/workflows/live-integration-tests.yml
@@ -67,16 +67,12 @@ jobs:
       - name: Import destination secret from dev Vault (OIDC/JWT)
         id: vault
         uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
-        env:
-          VAULT_ADDR: https://vault.dev.rudderlabs.com
-          VAULT_JWT_AUTH_PATH: github-actions
-          VAULT_JWT_ROLE: rudder-transformer-ci
         with:
-          url: ${{ env.VAULT_ADDR }}
+          url: ${{ vars.VAULT_ADDR }}
           method: jwt
-          path: ${{ env.VAULT_JWT_AUTH_PATH }} # = vault_jwt_auth_backend.path
+          path: ${{ vars.VAULT_JWT_AUTH_PATH }} # = vault_jwt_auth_backend.path
           role: ${{ env.VAULT_JWT_ROLE }} # = vault_jwt_auth_backend_role.role_name
-          jwtGithubAudience: ${{ env.VAULT_ADDR }} # MUST match bound_audiences, else auth fails
+          jwtGithubAudience: ${{ vars.VAULT_ADDR }} # MUST match bound_audiences, else auth fails
           exportToken: false # keep the raw Vault token out of env
           secrets: |
             engineering_shared/data/integrations_team/e2e_test/rudder-transformer ${{ steps.secret.outputs.name }} | ${{ steps.secret.outputs.name }}

--- a/.github/workflows/live-integration-tests.yml
+++ b/.github/workflows/live-integration-tests.yml
@@ -12,6 +12,9 @@ name: Live Integration Tests
 
 on:
   pull_request:
+    branches:
+      - main
+      - develop
     types: ['opened', 'reopened', 'synchronize']
   push:
     branches:
@@ -23,7 +26,6 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  id-token: write # required: lets the job mint the GitHub OIDC JWT
   contents: read # for actions/checkout
 
 jobs:
@@ -32,12 +34,13 @@ jobs:
     # required: puts the job in infra1-us → PrivateLink path to dev Vault
     runs-on: [self-hosted, Linux, X64]
     timeout-minutes: 30
+    permissions:
+      id-token: write # required: lets the job mint the GitHub OIDC JWT
+      contents: read # for actions/checkout
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - destination: hs
-            secretName: LIVE_SECRET_HS
+        destination: [hs]
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
@@ -57,18 +60,26 @@ jobs:
         # prepare builds isolated-vm's native addon (skipped by ignore-scripts on `npm ci`).
         run: npm ci && npm run prepare
 
+      - name: Resolve secret name
+        id: secret
+        run: echo "name=LIVE_SECRET_$(echo '${{ matrix.destination }}' | tr 'a-z' 'A-Z')" >> "$GITHUB_OUTPUT"
+
       - name: Import destination secret from dev Vault (OIDC/JWT)
         id: vault
         uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
+        env:
+          VAULT_ADDR: https://vault.dev.rudderlabs.com
+          VAULT_JWT_AUTH_PATH: github-actions
+          VAULT_JWT_ROLE: rudder-transformer-ci
         with:
-          url: https://vault.dev.rudderlabs.com
+          url: ${{ env.VAULT_ADDR }}
           method: jwt
-          path: github-actions # = vault_jwt_auth_backend.path
-          role: rudder-transformer-ci # = vault_jwt_auth_backend_role.role_name
-          jwtGithubAudience: https://vault.dev.rudderlabs.com # MUST match bound_audiences, else auth fails
+          path: ${{ env.VAULT_JWT_AUTH_PATH }} # = vault_jwt_auth_backend.path
+          role: ${{ env.VAULT_JWT_ROLE }} # = vault_jwt_auth_backend_role.role_name
+          jwtGithubAudience: ${{ env.VAULT_ADDR }} # MUST match bound_audiences, else auth fails
           exportToken: false # keep the raw Vault token out of env
           secrets: |
-            engineering_shared/data/integrations_team/e2e_test/rudder-transformer ${{ matrix.secretName }} | ${{ matrix.secretName }}
+            engineering_shared/data/integrations_team/e2e_test/rudder-transformer ${{ steps.secret.outputs.name }} | ${{ steps.secret.outputs.name }}
 
       - name: Run live tests
         # LOG_LEVEL=100 suppresses body logging so tokens can't leak.

--- a/.github/workflows/live-integration-tests.yml
+++ b/.github/workflows/live-integration-tests.yml
@@ -71,7 +71,7 @@ jobs:
           url: ${{ vars.VAULT_ADDR }}
           method: jwt
           path: ${{ vars.VAULT_JWT_AUTH_PATH }} # = vault_jwt_auth_backend.path
-          role: ${{ env.VAULT_JWT_ROLE }} # = vault_jwt_auth_backend_role.role_name
+          role: ${{ vars.VAULT_JWT_ROLE }} # = vault_jwt_auth_backend_role.role_name
           jwtGithubAudience: ${{ vars.VAULT_ADDR }} # MUST match bound_audiences, else auth fails
           exportToken: false # keep the raw Vault token out of env
           secrets: |

--- a/jest.config.js
+++ b/jest.config.js
@@ -152,7 +152,8 @@ module.exports = {
   testMatch: ['**/*.test.[tj]s?(x)'],
 
   // An array of regexp pattern strings that are matched against all test paths, matched tests are skipped
-  testPathIgnorePatterns: ['/node_modules/'],
+  // component.live.test.ts is the live suite (jest.config.live.js) — exclude from the mocked run.
+  testPathIgnorePatterns: ['/node_modules/', 'component.live.test.ts'],
 
   // The regexp pattern or array of patterns that Jest uses to detect test files
   // testRegex: [],

--- a/jest.config.live.js
+++ b/jest.config.live.js
@@ -1,0 +1,27 @@
+// Jest config for the live (real-destination) integration suite; runs ONLY component.live.test.ts.
+
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  // Run serially: live runs hit shared real accounts and must not race.
+  maxWorkers: 1,
+  bail: 0,
+  collectCoverage: false,
+  coverageDirectory: 'reports/live-coverage',
+  coverageReporters: ['text', 'text-summary', 'lcov', 'html'],
+  collectCoverageFrom: [
+    'src/**/*.{ts,js}',
+    'test/integrations/live/**/*.ts',
+    'test/integrations/destinations/**/live.ts',
+    '!src/**/*.d.ts',
+  ],
+  moduleDirectories: ['node_modules'],
+  moduleFileExtensions: ['js', 'json', 'ts', 'node'],
+  modulePathIgnorePatterns: ['<rootDir>/dist/', '<rootDir>/dist-test/'],
+  setupFiles: ['<rootDir>/test/setup.ts'],
+  testMatch: ['<rootDir>/test/integrations/component.live.test.ts'],
+  testPathIgnorePatterns: ['/node_modules/'],
+  transform: {
+    '^.+\\.tsx?$': ['ts-jest', { tsconfig: 'tsconfig.json', diagnostics: true }],
+  },
+};

--- a/jest.config.live.js
+++ b/jest.config.live.js
@@ -9,12 +9,7 @@ module.exports = {
   collectCoverage: false,
   coverageDirectory: 'reports/live-coverage',
   coverageReporters: ['text', 'text-summary', 'lcov', 'html'],
-  collectCoverageFrom: [
-    'src/**/*.{ts,js}',
-    'test/integrations/live/**/*.ts',
-    'test/integrations/destinations/**/live.ts',
-    '!src/**/*.d.ts',
-  ],
+  collectCoverageFrom: ['src/**/*.{ts,js}', '!src/**/*.d.ts'],
   moduleDirectories: ['node_modules'],
   moduleFileExtensions: ['js', 'json', 'ts', 'node'],
   modulePathIgnorePatterns: ['<rootDir>/dist/', '<rootDir>/dist-test/'],

--- a/jest.config.typescript.js
+++ b/jest.config.typescript.js
@@ -140,7 +140,8 @@ module.exports = {
   testMatch: ['**/*.(test).ts?(x)'],
 
   // An array of regexp pattern strings that are matched against all test paths, matched tests are skipped
-  testPathIgnorePatterns: ['/node_modules/'],
+  // component.live.test.ts is the live suite (jest.config.live.js) — exclude from the mocked run.
+  testPathIgnorePatterns: ['/node_modules/', 'component.live.test.ts'],
 
   // The regexp pattern or array of patterns that Jest uses to detect test files
   // testRegex: [],

--- a/package.json
+++ b/package.json
@@ -45,6 +45,8 @@
     "test:ts": "npm run build:sandboxes && NODE_OPTIONS='--no-node-snapshot' jest -c jest.config.typescript.js --detectOpenHandles",
     "test:ts:component:generateNwMocks": "npm run test:ts -- component --generate=true",
     "test:ts:component:rudder_test": "npm run test:ts -- component --destination=rudder_test",
+    "test:live": "NODE_OPTIONS='--no-node-snapshot' jest -c jest.config.live.js",
+    "test:live:coverage": "npm run test:live -- --coverage",
     "test:ts:silent": "export LOG_LEVEL=silent && npm run test:ts -- --silent",
     "test:ts:ci": "npm run test:ts -- --coverage --expand --maxWorkers=50%",
     "test:ut:integration": "jest \"user_transformation.integration.test.js\"  --detectOpenHandles --notify",

--- a/test/integrations/component.live.test.ts
+++ b/test/integrations/component.live.test.ts
@@ -10,6 +10,7 @@ import { getEnrolledDestinations } from './live/registry';
 import { SecretResolver } from './live/secretResolver';
 import { RunContextImpl } from './live/runContext';
 import { runPipelineStep } from './live/runPipelineStep';
+import { retryUntilPasses } from './live/poll';
 import { LiveSecret, EnrolledDestination } from './live/types';
 
 describe('Live Integration Test Suite', () => {
@@ -46,11 +47,18 @@ describe('Live Integration Test Suite', () => {
   const agent = () => request(server as unknown as Parameters<typeof request>[0]);
 
   const enrolledDestinations: EnrolledDestination[] = getEnrolledDestinations(opts.destination);
+  // eslint-disable-next-line no-console
+  console.log(
+    `[live] resolved ${enrolledDestinations.length} destination(s): ` +
+      `${enrolledDestinations.map((d) => d.destination).join(', ') || '(none)'}`,
+  );
   if (enrolledDestinations.length === 0) {
     test.skip('No enrolled destinations matched. Skipping live suite.', () => {});
     return;
   }
 
+  // One describe per enrolled destination: resolve its credentials and base config, then run its
+  // enabled scenarios. A missing/invalid secret throws here (fail-closed), failing the destination.
   describe.each(enrolledDestinations)('$destination', ({ destination, spec }) => {
     const liveSecret: LiveSecret = resolver.resolve(destination);
     const destinationConfig = spec.resolveConfig(liveSecret);
@@ -61,6 +69,8 @@ describe('Live Integration Test Suite', () => {
       return;
     }
 
+    // One describe per scenario, each with its own RunContext (isolated identities) and optional
+    // per-scenario Config override.
     describe.each(activeScenarios)('scenario: $id', (scenario) => {
       const ctx = new RunContextImpl({ liveSecret });
       const scenarioConfig = scenario.configOverride?.(destinationConfig) ?? destinationConfig;
@@ -79,6 +89,8 @@ describe('Live Integration Test Suite', () => {
       test.each(scenario.steps)(
         'step: $name',
         async (step) => {
+          // Steps run in declared order; dispatch by discriminant — action = direct API side
+          // effect, verify = read-back assertion, pipeline = seed -> transform -> deliver -> assert.
           switch (step.stepType) {
             case 'action':
               await step.run(ctx);
@@ -104,6 +116,15 @@ describe('Live Integration Test Suite', () => {
         },
         60000,
       );
+
+      // The scenario's common trailing read-back: framework owns the polling, retrying the
+      // assertion on a thrown matcher error with backoff (see LiveScenario.verify).
+      if (scenario.verify) {
+        const { check, attempts, delayMs } = scenario.verify;
+        test('verify: scenario read-back', async () => {
+          await retryUntilPasses(() => check(ctx), { attempts, delayMs });
+        }, 60000);
+      }
     });
   });
 });

--- a/test/integrations/component.live.test.ts
+++ b/test/integrations/component.live.test.ts
@@ -1,0 +1,109 @@
+import Koa from 'koa';
+import bodyParser from 'koa-bodyparser';
+import request from 'supertest';
+import { Command } from 'commander';
+import { createHttpTerminator } from 'http-terminator';
+import { Server } from 'http';
+import { configureBatchProcessingDefaults } from '@rudderstack/integrations-lib';
+import { applicationRoutes } from '../../src/routes/index';
+import { getEnrolledDestinations } from './live/registry';
+import { SecretResolver } from './live/secretResolver';
+import { RunContextImpl } from './live/runContext';
+import { runPipelineStep } from './live/runPipelineStep';
+import { LiveSecret, EnrolledDestination } from './live/types';
+
+describe('Live Integration Test Suite', () => {
+  // npm run test:live
+  // npm run test:live:coverage
+  // npm run test:live -- --destination=<dest>
+  // npm run test:live:coverage -- --destination=<dest>
+  const command = new Command()
+    .allowUnknownOption()
+    .allowExcessArguments()
+    .option('-d, --destination <string>', 'Comma-separated destination(s) to run')
+    .parse();
+  const opts = command.opts();
+
+  let server: Server;
+  beforeAll(async () => {
+    configureBatchProcessingDefaults({
+      batchSize: 1,
+      yieldThreshold: 1,
+      sequentialProcessing: true,
+    });
+    const app = new Koa();
+    app.use(bodyParser({ jsonLimit: '200mb' }));
+    applicationRoutes(app);
+    server = app.listen();
+  });
+  afterAll(async () => {
+    if (server) {
+      await createHttpTerminator({ server }).terminate();
+    }
+  });
+
+  const resolver = new SecretResolver();
+  const agent = () => request(server as unknown as Parameters<typeof request>[0]);
+
+  const enrolledDestinations: EnrolledDestination[] = getEnrolledDestinations(opts.destination);
+  if (enrolledDestinations.length === 0) {
+    test.skip('No enrolled destinations matched. Skipping live suite.', () => {});
+    return;
+  }
+
+  describe.each(enrolledDestinations)('$destination', ({ destination, spec }) => {
+    const liveSecret: LiveSecret = resolver.resolve(destination);
+    const destinationConfig = spec.resolveConfig(liveSecret);
+
+    const activeScenarios = spec.scenarios.filter((s) => s.enabled !== false);
+    if (activeScenarios.length === 0) {
+      test.skip(`${destination}: no enabled scenarios`, () => {});
+      return;
+    }
+
+    describe.each(activeScenarios)('scenario: $id', (scenario) => {
+      const ctx = new RunContextImpl({ liveSecret });
+      const scenarioConfig = scenario.configOverride?.(destinationConfig) ?? destinationConfig;
+
+      beforeAll(() => {
+        // Arm scenario cleanup if present; drained after steps (LIFO, best-effort).
+        if (scenario.cleanup) {
+          ctx.addCleanup(() => scenario.cleanup!(ctx));
+        }
+      });
+
+      afterAll(async () => {
+        await ctx.runCleanups();
+      });
+
+      test.each(scenario.steps)(
+        'step: $name',
+        async (step) => {
+          switch (step.stepType) {
+            case 'action':
+              await step.run(ctx);
+              return;
+            case 'verify':
+              await step.check(ctx);
+              return;
+            case 'pipeline':
+              await runPipelineStep({
+                destination,
+                scenarioId: scenario.id,
+                step,
+                ctx,
+                config: scenarioConfig,
+                http: {
+                  post: async (url, body) =>
+                    agent()
+                      .post(url)
+                      .send(body as object),
+                },
+              });
+          }
+        },
+        60000,
+      );
+    });
+  });
+});

--- a/test/integrations/destinations/hs/live.ts
+++ b/test/integrations/destinations/hs/live.ts
@@ -1,0 +1,2 @@
+// Registry entrypoint: discovers destinations/<dest>/live.ts. Spec + helpers live under ./live/.
+export { live, default } from './live/spec';

--- a/test/integrations/destinations/hs/live/api.ts
+++ b/test/integrations/destinations/hs/live/api.ts
@@ -1,0 +1,152 @@
+import axios from 'axios';
+import { Agent } from 'https';
+import { RunContext } from '../../../live/types';
+
+export const HS_BASE = 'https://api.hubapi.com';
+
+// An association links two existing objects; scenarios register these types in setup.
+export const ASSOC_FROM_TYPE = 'companies';
+export const ASSOC_TO_TYPE = 'contacts';
+
+// keepAlive:false so read-back/cleanup sockets don't linger as open handles when the suite finishes.
+const hsAgent = new Agent({ keepAlive: false });
+
+const bearer = (ctx: RunContext): string => {
+  const token = ctx.liveSecret.config?.accessToken;
+  if (!token) {
+    throw new Error('HubSpot access token missing from resolved secret');
+  }
+  return `Bearer ${token}`;
+};
+
+const authHeaders = (ctx: RunContext) => ({
+  Authorization: bearer(ctx),
+  Connection: 'close' as const,
+});
+
+const jsonAuthHeaders = (ctx: RunContext) => ({
+  'Content-Type': 'application/json',
+  ...authHeaders(ctx),
+});
+
+export const findContactIdByProperty = async (
+  ctx: RunContext,
+  propertyName: string,
+  value: string,
+): Promise<string | null> => {
+  const res = await axios.post(
+    `${HS_BASE}/crm/v3/objects/contacts/search`,
+    {
+      filterGroups: [{ filters: [{ propertyName, operator: 'EQ', value }] }],
+      properties: [propertyName],
+      limit: 1,
+    },
+    {
+      headers: jsonAuthHeaders(ctx),
+      httpsAgent: hsAgent,
+      timeout: 15000,
+    },
+  );
+  return res.data?.results?.[0]?.id ?? null;
+};
+
+export const findContactIdByEmail = (ctx: RunContext, email: string): Promise<string | null> =>
+  findContactIdByProperty(ctx, 'email', email);
+
+export const fetchContactByEmail = async (
+  ctx: RunContext,
+  propertyNames: string[],
+): Promise<Record<string, string> | null> => {
+  const res = await axios.post(
+    `${HS_BASE}/crm/v3/objects/contacts/search`,
+    {
+      filterGroups: [{ filters: [{ propertyName: 'email', operator: 'EQ', value: ctx.email() }] }],
+      properties: propertyNames,
+      limit: 1,
+    },
+    {
+      headers: jsonAuthHeaders(ctx),
+      httpsAgent: hsAgent,
+      timeout: 15000,
+    },
+  );
+  return res.data?.results?.[0]?.properties ?? null;
+};
+
+export const createCrmObject = async (
+  ctx: RunContext,
+  objectType: string,
+  properties: Record<string, unknown>,
+): Promise<string> => {
+  const res = await axios.post(
+    `${HS_BASE}/crm/v3/objects/${objectType}`,
+    { properties },
+    {
+      headers: jsonAuthHeaders(ctx),
+      httpsAgent: hsAgent,
+      timeout: 15000,
+    },
+  );
+  const id = res.data?.id;
+  if (!id) {
+    throw new Error(`Setup: failed to create ${objectType} (no id in response)`);
+  }
+  return String(id);
+};
+
+export const deleteContactByEmail = async (ctx: RunContext): Promise<void> => {
+  const id = await findContactIdByEmail(ctx, ctx.email());
+  if (!id) {
+    return;
+  }
+  await axios.delete(`${HS_BASE}/crm/v3/objects/contacts/${id}`, {
+    headers: authHeaders(ctx),
+    httpsAgent: hsAgent,
+    timeout: 15000,
+  });
+};
+
+export const getAssociatedIds = async (
+  ctx: RunContext,
+  fromType: string,
+  fromId: string,
+  toType: string,
+): Promise<string[]> => {
+  const res = await axios.get(
+    `${HS_BASE}/crm/v4/objects/${fromType}/${fromId}/associations/${toType}`,
+    {
+      headers: authHeaders(ctx),
+      httpsAgent: hsAgent,
+      timeout: 15000,
+    },
+  );
+  return (res.data?.results ?? []).map((r: { toObjectId: unknown }) => String(r.toObjectId));
+};
+
+export const deleteAssociationObjects = async (ctx: RunContext): Promise<void> => {
+  for (const r of ctx.resources) {
+    if (r.type !== ASSOC_FROM_TYPE && r.type !== ASSOC_TO_TYPE) {
+      continue;
+    }
+    try {
+      // eslint-disable-next-line no-await-in-loop
+      await axios.delete(`${HS_BASE}/crm/v3/objects/${r.type}/${r.id}`, {
+        headers: authHeaders(ctx),
+        httpsAgent: hsAgent,
+        timeout: 15000,
+      });
+    } catch (err) {
+      // Best-effort: log and continue so one failure can't strand sibling resources.
+      // eslint-disable-next-line no-console
+      console.error(`[live:hs] teardown failed for ${r.type}/${r.id}`, err);
+    }
+  }
+};
+
+export const registeredId = (ctx: RunContext, type: string): string => {
+  const id = ctx.resources.find((r) => r.type === type)?.id;
+  if (!id) {
+    throw new Error(`association setup did not register a ${type} id`);
+  }
+  return id;
+};

--- a/test/integrations/destinations/hs/live/profiles.ts
+++ b/test/integrations/destinations/hs/live/profiles.ts
@@ -1,0 +1,86 @@
+import { RunContext } from '../../../live/types';
+
+// Firstname used as the non-unique lookupField value (must match between setup and seed/verify).
+export const lookupFirstname = (ctx: RunContext): string => `ci-${ctx.runId}`;
+
+export const baseTimestamps = (ctx: RunContext, suffix: string) => ({
+  userId: ctx.identity('user'),
+  messageId: `${ctx.runId}-${suffix}`,
+  timestamp: ctx.now(),
+  originalTimestamp: ctx.now(),
+  sentAt: ctx.now(),
+  channel: 'sources',
+});
+
+export const esLibrary = { library: { name: 'rudder-live-integration-test' } };
+
+// Trait profiles shared by a scenario's seed and its property verification.
+export const esContactCreateTraits = (ctx: RunContext): Record<string, string> => ({
+  firstname: 'CI',
+  lastname: ctx.runId,
+  company: 'RudderStack Live Test',
+  lifecyclestage: 'lead',
+});
+export const esContactUpdateTraits = (ctx: RunContext): Record<string, string> => ({
+  firstname: 'CI-Updated',
+  lastname: `${ctx.runId}-v2`,
+  lifecyclestage: 'customer',
+});
+export const esContactCreateV1Traits = (ctx: RunContext): Record<string, string> => ({
+  firstname: 'CI-V1',
+  lastname: ctx.runId,
+});
+export const esContactUpdateV1Traits = (ctx: RunContext): Record<string, string> => ({
+  firstname: 'CI-V1-Updated',
+  lastname: `${ctx.runId}-v2`,
+});
+export const esDontBatchV3Traits = (ctx: RunContext): Record<string, string> => ({
+  firstname: 'CI-DontBatch',
+  lastname: ctx.runId,
+  company: 'RudderStack Live Test',
+});
+export const esDontBatchV1Traits = (ctx: RunContext): Record<string, string> => ({
+  firstname: 'CI-DontBatch-V1',
+  lastname: ctx.runId,
+});
+export const esByHsContactIdTraits = (ctx: RunContext): Record<string, string> => ({
+  firstname: 'CI-ById-Updated',
+  lastname: `${ctx.runId}-v2`,
+  lifecyclestage: 'customer',
+});
+export const esNonUniqueCreateTraits = (ctx: RunContext): Record<string, string> => ({
+  firstname: lookupFirstname(ctx),
+  lastname: ctx.runId,
+  company: 'RudderStack Live Test',
+});
+export const esNonUniqueUpdateTraits = (ctx: RunContext): Record<string, string> => ({
+  firstname: lookupFirstname(ctx),
+  lastname: `${ctx.runId}-v2`,
+  lifecyclestage: 'customer',
+});
+export const retlContactCreateTraits = (ctx: RunContext): Record<string, string> => ({
+  firstname: 'CI-RETL',
+  lastname: ctx.runId,
+  company: 'RudderStack Live Test',
+});
+export const retlContactUpdateTraits = (ctx: RunContext): Record<string, string> => ({
+  firstname: 'CI-RETL-Updated',
+  lastname: `${ctx.runId}-v2`,
+  lifecyclestage: 'customer',
+});
+export const retlContactCreateV1Traits = (ctx: RunContext): Record<string, string> => ({
+  firstname: 'CI-RETL-V1',
+  lastname: ctx.runId,
+  company: 'RudderStack Live Test',
+});
+export const retlContactUpdateV1Traits = (ctx: RunContext): Record<string, string> => ({
+  firstname: 'CI-RETL-V1-Updated',
+  lastname: `${ctx.runId}-v2`,
+  lifecyclestage: 'customer',
+});
+
+export const retlContactContext = (ctx: RunContext) => ({
+  mappedToDestination: true,
+  externalId: [{ type: 'HS-contacts', identifierType: 'email', id: ctx.email() }],
+  sources: { job_id: 'rudder-live-integration-test', version: 'v1' },
+});

--- a/test/integrations/destinations/hs/live/setup.ts
+++ b/test/integrations/destinations/hs/live/setup.ts
@@ -1,0 +1,85 @@
+import { RunContext } from '../../../live/types';
+import { pollUntil } from '../../../live/poll';
+import { lookupFirstname } from './profiles';
+import {
+  ASSOC_FROM_TYPE,
+  ASSOC_TO_TYPE,
+  createCrmObject,
+  findContactIdByEmail,
+  findContactIdByProperty,
+} from './api';
+
+// The CRM Search index is eventually consistent — a fresh contact can drop out of the next
+// search, so a first-hit poll leaves the transform's own search racing to create and 409-ing on
+// the duplicate. Requiring several CONSECUTIVE hits plus a settle delay closes that window.
+const REQUIRED_CONSECUTIVE_HITS = 3;
+const SEARCH_POLL_INTERVAL_MS = 2000;
+const SEARCH_MAX_POLLS = 25; // ~50s ceiling, within the scenario setup's 60s timeout
+const SEARCH_SETTLE_MS = 3000;
+
+const waitUntilSearchable = async (
+  label: string,
+  find: () => Promise<string | null>,
+): Promise<void> => {
+  let consecutive = 0;
+  await pollUntil(
+    async () => {
+      const found = await find();
+      consecutive = found ? consecutive + 1 : 0;
+      return { done: consecutive >= REQUIRED_CONSECUTIVE_HITS, value: found };
+    },
+    {
+      label: `${label} stably searchable`,
+      attempts: SEARCH_MAX_POLLS,
+      delayMs: () => SEARCH_POLL_INTERVAL_MS,
+      settleMs: SEARCH_SETTLE_MS,
+    },
+  );
+};
+
+export const createContactAndWaitSearchable = async (ctx: RunContext): Promise<void> => {
+  const email = ctx.email();
+  // Create is strong; CRM Search is eventually consistent — poll before the transform's own search.
+  await createCrmObject(ctx, 'contacts', { email, firstname: 'CI-RETL', lastname: ctx.runId });
+  await waitUntilSearchable(`contact ${email}`, () => findContactIdByEmail(ctx, email));
+};
+
+// Setup for the non-unique-lookup "existing contact" case: create a contact and wait until it is
+// stably searchable by firstname, so the searchContacts() flow (lookupField=firstname) finds it.
+export const createContactSearchableByFirstname = async (ctx: RunContext): Promise<void> => {
+  const firstname = lookupFirstname(ctx);
+  await createCrmObject(ctx, 'contacts', {
+    email: ctx.email(),
+    firstname,
+    lastname: ctx.runId,
+  });
+  await waitUntilSearchable(`contact with firstname ${firstname}`, () =>
+    findContactIdByProperty(ctx, 'firstname', firstname),
+  );
+};
+
+export const createContactAndRegisterId = async (ctx: RunContext): Promise<void> => {
+  const id = await createCrmObject(ctx, 'contacts', {
+    email: ctx.email(),
+    firstname: 'CI-HSID',
+    lastname: ctx.runId,
+  });
+  ctx.register({ type: 'contacts', id });
+};
+
+// An association links two existing objects, so its scenario can't mint ids on the fly — setup
+// creates both and registers their real ids for the pipeline step to reference.
+export const createAssociationObjects = async (ctx: RunContext): Promise<void> => {
+  const fromId = await createCrmObject(ctx, ASSOC_FROM_TYPE, {
+    name: `RudderStack CI ${ctx.runId}`,
+    domain: `ci-${ctx.runId}.example.com`,
+  });
+  ctx.register({ type: ASSOC_FROM_TYPE, id: fromId });
+
+  const toId = await createCrmObject(ctx, ASSOC_TO_TYPE, {
+    email: ctx.email(),
+    firstname: 'CI-ASSOC',
+    lastname: ctx.runId,
+  });
+  ctx.register({ type: ASSOC_TO_TYPE, id: toId });
+};

--- a/test/integrations/destinations/hs/live/spec.ts
+++ b/test/integrations/destinations/hs/live/spec.ts
@@ -1,0 +1,353 @@
+import { LiveSpec } from '../../../live/types';
+import {
+  ASSOC_FROM_TYPE,
+  ASSOC_TO_TYPE,
+  deleteAssociationObjects,
+  deleteContactByEmail,
+  registeredId,
+} from './api';
+import {
+  baseTimestamps,
+  esByHsContactIdTraits,
+  esContactCreateTraits,
+  esContactCreateV1Traits,
+  esContactUpdateTraits,
+  esContactUpdateV1Traits,
+  esDontBatchV1Traits,
+  esDontBatchV3Traits,
+  esLibrary,
+  esNonUniqueCreateTraits,
+  esNonUniqueUpdateTraits,
+  retlContactContext,
+  retlContactCreateTraits,
+  retlContactCreateV1Traits,
+  retlContactUpdateTraits,
+  retlContactUpdateV1Traits,
+} from './profiles';
+import {
+  createAssociationObjects,
+  createContactAndRegisterId,
+  createContactAndWaitSearchable,
+  createContactSearchableByFirstname,
+} from './setup';
+import { verifyAssociationExists, verifyContactProperties } from './verify';
+
+export const live: LiveSpec = {
+  enabled: true,
+  authType: 'apiKey',
+  resolveConfig: (s) => ({
+    authorizationType: 'newPrivateAppApi',
+    apiVersion: 'newApi',
+    lookupField: 'email',
+    ...s.config,
+  }),
+  scenarios: [
+    {
+      id: 'hs-es-contacts-create-v3',
+      cleanup: deleteContactByEmail,
+      description: 'Event-stream identify creates a new CRM contact (newApi)',
+      steps: [
+        {
+          name: 'identify new contact',
+          stepType: 'pipeline',
+          seed: (ctx) => ({
+            ...baseTimestamps(ctx, 'es-contacts-create'),
+            type: 'identify',
+            context: esLibrary,
+            traits: { email: ctx.email(), ...esContactCreateTraits(ctx) },
+            integrations: { All: true },
+          }),
+        },
+        verifyContactProperties(esContactCreateTraits),
+      ],
+    },
+    {
+      id: 'hs-es-contacts-update-v3',
+      cleanup: deleteContactByEmail,
+      description: 'Event-stream identify updates an existing CRM contact (newApi)',
+      steps: [
+        { stepType: 'action', name: 'setup', run: createContactAndWaitSearchable },
+        {
+          name: 'identify existing contact',
+          stepType: 'pipeline',
+          seed: (ctx) => ({
+            ...baseTimestamps(ctx, 'es-contacts-update'),
+            type: 'identify',
+            context: esLibrary,
+            traits: { email: ctx.email(), ...esContactUpdateTraits(ctx) },
+            integrations: { All: true },
+          }),
+        },
+        verifyContactProperties(esContactUpdateTraits),
+      ],
+    },
+    {
+      id: 'hs-es-contacts-create-v1',
+      cleanup: deleteContactByEmail,
+      description: 'Event-stream identify creates a new contact via the v1 endpoint (contacts/v1)',
+      configOverride: (base) => ({ ...base, apiVersion: 'legacyApi' }),
+      steps: [
+        {
+          name: 'identify new contact (v1)',
+          stepType: 'pipeline',
+          seed: (ctx) => ({
+            ...baseTimestamps(ctx, 'es-contacts-create-v1'),
+            type: 'identify',
+            traits: { email: ctx.email(), ...esContactCreateV1Traits(ctx) },
+          }),
+        },
+        verifyContactProperties(esContactCreateV1Traits),
+      ],
+    },
+    {
+      id: 'hs-es-contacts-update-v1',
+      cleanup: deleteContactByEmail,
+      description:
+        'Event-stream identify updates an existing contact via the v1 endpoint (contacts/v1)',
+      configOverride: (base) => ({ ...base, apiVersion: 'legacyApi' }),
+      steps: [
+        { stepType: 'action', name: 'setup', run: createContactAndWaitSearchable },
+        {
+          name: 'identify existing contact (v1)',
+          stepType: 'pipeline',
+          seed: (ctx) => ({
+            ...baseTimestamps(ctx, 'es-contacts-update-v1'),
+            type: 'identify',
+            traits: { email: ctx.email(), ...esContactUpdateV1Traits(ctx) },
+          }),
+        },
+        verifyContactProperties(esContactUpdateV1Traits),
+      ],
+    },
+    {
+      id: 'hs-es-contacts-dontbatch-v3',
+      cleanup: deleteContactByEmail,
+      description: 'Event-stream identify with dontBatch=true delivers un-batched (newApi)',
+      steps: [
+        {
+          name: 'identify contact (dontBatch, newApi)',
+          metadataOverride: { dontBatch: true },
+          stepType: 'pipeline',
+          seed: (ctx) => ({
+            ...baseTimestamps(ctx, 'es-dontbatch-v3'),
+            type: 'identify',
+            context: esLibrary,
+            traits: { email: ctx.email(), ...esDontBatchV3Traits(ctx) },
+            integrations: { All: true },
+          }),
+        },
+        verifyContactProperties(esDontBatchV3Traits),
+      ],
+    },
+    {
+      id: 'hs-es-contacts-dontbatch-v1',
+      cleanup: deleteContactByEmail,
+      description: 'Event-stream identify with dontBatch=true delivers un-batched (legacyApi)',
+      configOverride: (base) => ({ ...base, apiVersion: 'legacyApi' }),
+      steps: [
+        {
+          name: 'identify contact (dontBatch, legacyApi)',
+          metadataOverride: { dontBatch: true },
+          stepType: 'pipeline',
+          seed: (ctx) => ({
+            ...baseTimestamps(ctx, 'es-dontbatch-v1'),
+            type: 'identify',
+            traits: { email: ctx.email(), ...esDontBatchV1Traits(ctx) },
+          }),
+        },
+        verifyContactProperties(esDontBatchV1Traits),
+      ],
+    },
+    {
+      id: 'hs-es-contacts-by-hscontactid-v3',
+      cleanup: deleteContactByEmail,
+      description: 'ES identify with hsContactId present updates the contact by id (newApi)',
+      steps: [
+        { stepType: 'action', name: 'setup', run: createContactAndRegisterId },
+        {
+          name: 'identify by hsContactId',
+          stepType: 'pipeline',
+          seed: (ctx) => ({
+            ...baseTimestamps(ctx, 'es-hscontactid'),
+            type: 'identify',
+            context: {
+              ...esLibrary,
+              externalId: [{ type: 'hsContactId', id: registeredId(ctx, 'contacts') }],
+            },
+            traits: { email: ctx.email(), ...esByHsContactIdTraits(ctx) },
+            integrations: { All: true },
+          }),
+        },
+        verifyContactProperties(esByHsContactIdTraits),
+      ],
+    },
+    {
+      id: 'hs-es-contacts-nonunique-lookup-v3',
+      cleanup: deleteContactByEmail,
+      description:
+        'ES identify without hsContactId and a non-unique lookupField uses the search flow (newApi)',
+      configOverride: (base) => ({ ...base, lookupField: 'firstname' }),
+      steps: [
+        {
+          name: 'identify via non-unique lookup (search flow)',
+          stepType: 'pipeline',
+          seed: (ctx) => ({
+            ...baseTimestamps(ctx, 'es-nonunique'),
+            type: 'identify',
+            context: esLibrary,
+            traits: { email: ctx.email(), ...esNonUniqueCreateTraits(ctx) },
+            integrations: { All: true },
+          }),
+        },
+        verifyContactProperties(esNonUniqueCreateTraits),
+      ],
+    },
+    {
+      id: 'hs-es-contacts-nonunique-lookup-existing-v3',
+      cleanup: deleteContactByEmail,
+      description:
+        'ES identify: no hsContactId, non-unique lookupField, existing contact -> search finds it and updates (newApi)',
+      configOverride: (base) => ({ ...base, lookupField: 'firstname' }),
+      steps: [
+        { stepType: 'action', name: 'setup', run: createContactSearchableByFirstname },
+        {
+          name: 'identify existing via non-unique lookup (search -> update)',
+          stepType: 'pipeline',
+          seed: (ctx) => ({
+            ...baseTimestamps(ctx, 'es-nonunique-existing'),
+            type: 'identify',
+            context: esLibrary,
+            traits: { email: ctx.email(), ...esNonUniqueUpdateTraits(ctx) },
+            integrations: { All: true },
+          }),
+        },
+        verifyContactProperties(esNonUniqueUpdateTraits),
+      ],
+    },
+    {
+      id: 'hs-retl-contacts-create-v3',
+      cleanup: deleteContactByEmail,
+      description: 'RETL mappedToDestination identify creates a contact (crm/v3 batch/create)',
+      steps: [
+        {
+          name: 'retl create contact',
+          stepType: 'pipeline',
+          seed: (ctx) => ({
+            ...baseTimestamps(ctx, 'retl-contacts'),
+            type: 'identify',
+            recordId: ctx.runId,
+            context: retlContactContext(ctx),
+            traits: { email: ctx.email(), ...retlContactCreateTraits(ctx) },
+          }),
+        },
+        verifyContactProperties(retlContactCreateTraits),
+      ],
+    },
+    {
+      id: 'hs-retl-contacts-update-v3',
+      cleanup: deleteContactByEmail,
+      description:
+        'RETL mappedToDestination identify updates an existing contact (crm/v3 batch/update)',
+      steps: [
+        { stepType: 'action', name: 'setup', run: createContactAndWaitSearchable },
+        {
+          name: 'retl update contact',
+          stepType: 'pipeline',
+          // RETL splits create-vs-update via HubSpot's eventually-consistent search; retry so a
+          // just-created contact that the first search misses (409) is found and updated.
+          retries: 3,
+          seed: (ctx) => ({
+            ...baseTimestamps(ctx, 'retl-update'),
+            type: 'identify',
+            recordId: ctx.runId,
+            context: retlContactContext(ctx),
+            traits: { email: ctx.email(), ...retlContactUpdateTraits(ctx) },
+          }),
+        },
+        verifyContactProperties(retlContactUpdateTraits),
+      ],
+    },
+    {
+      id: 'hs-retl-contacts-create-v1',
+      cleanup: deleteContactByEmail,
+      description: 'RETL mappedToDestination identify creates a contact via the v1 transform',
+      configOverride: (base) => ({ ...base, apiVersion: 'legacyApi' }),
+      steps: [
+        {
+          name: 'retl create contact (v1 transform)',
+          stepType: 'pipeline',
+          seed: (ctx) => ({
+            ...baseTimestamps(ctx, 'retl-contacts-v1'),
+            type: 'identify',
+            recordId: ctx.runId,
+            context: retlContactContext(ctx),
+            traits: { email: ctx.email(), ...retlContactCreateV1Traits(ctx) },
+          }),
+        },
+        verifyContactProperties(retlContactCreateV1Traits),
+      ],
+    },
+    {
+      id: 'hs-retl-contacts-update-v1',
+      cleanup: deleteContactByEmail,
+      description:
+        'RETL mappedToDestination identify updates an existing contact via the v1 transform',
+      configOverride: (base) => ({ ...base, apiVersion: 'legacyApi' }),
+      steps: [
+        { stepType: 'action', name: 'setup', run: createContactAndWaitSearchable },
+        {
+          name: 'retl update contact (v1 transform)',
+          stepType: 'pipeline',
+          // RETL splits create-vs-update via HubSpot's eventually-consistent search; retry so a
+          // just-created contact that the first search misses (409) is found and updated.
+          retries: 3,
+          seed: (ctx) => ({
+            ...baseTimestamps(ctx, 'retl-update-v1'),
+            type: 'identify',
+            recordId: ctx.runId,
+            context: retlContactContext(ctx),
+            traits: { email: ctx.email(), ...retlContactUpdateV1Traits(ctx) },
+          }),
+        },
+        verifyContactProperties(retlContactUpdateV1Traits),
+      ],
+    },
+    {
+      id: 'hs-retl-associations-v3',
+      description: 'RETL association between two objects (crm/v3/associations)',
+      cleanup: deleteAssociationObjects,
+      steps: [
+        { stepType: 'action', name: 'setup', run: createAssociationObjects },
+        {
+          name: 'retl associate',
+          stepType: 'pipeline',
+          seed: (ctx) => ({
+            ...baseTimestamps(ctx, 'retl-assoc'),
+            type: 'identify',
+            recordId: ctx.runId,
+            traits: {
+              to: { id: registeredId(ctx, ASSOC_TO_TYPE) },
+              from: { id: registeredId(ctx, ASSOC_FROM_TYPE) },
+            },
+            context: {
+              mappedToDestination: true,
+              externalId: [
+                {
+                  id: registeredId(ctx, ASSOC_FROM_TYPE),
+                  type: 'HS-association',
+                  toObjectType: ASSOC_TO_TYPE,
+                  fromObjectType: ASSOC_FROM_TYPE,
+                  identifierType: 'id',
+                  associationTypeId: 'company_to_contact',
+                },
+              ],
+            },
+          }),
+        },
+        verifyAssociationExists,
+      ],
+    },
+  ],
+};
+
+export default live;

--- a/test/integrations/destinations/hs/live/spec.ts
+++ b/test/integrations/destinations/hs/live/spec.ts
@@ -58,8 +58,8 @@ export const live: LiveSpec = {
             integrations: { All: true },
           }),
         },
-        verifyContactProperties(esContactCreateTraits),
       ],
+      verify: { check: verifyContactProperties(esContactCreateTraits) },
     },
     {
       id: 'hs-es-contacts-update-v3',
@@ -78,8 +78,8 @@ export const live: LiveSpec = {
             integrations: { All: true },
           }),
         },
-        verifyContactProperties(esContactUpdateTraits),
       ],
+      verify: { check: verifyContactProperties(esContactUpdateTraits) },
     },
     {
       id: 'hs-es-contacts-create-v1',
@@ -96,8 +96,8 @@ export const live: LiveSpec = {
             traits: { email: ctx.email(), ...esContactCreateV1Traits(ctx) },
           }),
         },
-        verifyContactProperties(esContactCreateV1Traits),
       ],
+      verify: { check: verifyContactProperties(esContactCreateV1Traits) },
     },
     {
       id: 'hs-es-contacts-update-v1',
@@ -116,8 +116,8 @@ export const live: LiveSpec = {
             traits: { email: ctx.email(), ...esContactUpdateV1Traits(ctx) },
           }),
         },
-        verifyContactProperties(esContactUpdateV1Traits),
       ],
+      verify: { check: verifyContactProperties(esContactUpdateV1Traits) },
     },
     {
       id: 'hs-es-contacts-dontbatch-v3',
@@ -136,8 +136,8 @@ export const live: LiveSpec = {
             integrations: { All: true },
           }),
         },
-        verifyContactProperties(esDontBatchV3Traits),
       ],
+      verify: { check: verifyContactProperties(esDontBatchV3Traits) },
     },
     {
       id: 'hs-es-contacts-dontbatch-v1',
@@ -155,8 +155,8 @@ export const live: LiveSpec = {
             traits: { email: ctx.email(), ...esDontBatchV1Traits(ctx) },
           }),
         },
-        verifyContactProperties(esDontBatchV1Traits),
       ],
+      verify: { check: verifyContactProperties(esDontBatchV1Traits) },
     },
     {
       id: 'hs-es-contacts-by-hscontactid-v3',
@@ -178,8 +178,8 @@ export const live: LiveSpec = {
             integrations: { All: true },
           }),
         },
-        verifyContactProperties(esByHsContactIdTraits),
       ],
+      verify: { check: verifyContactProperties(esByHsContactIdTraits) },
     },
     {
       id: 'hs-es-contacts-nonunique-lookup-v3',
@@ -199,8 +199,8 @@ export const live: LiveSpec = {
             integrations: { All: true },
           }),
         },
-        verifyContactProperties(esNonUniqueCreateTraits),
       ],
+      verify: { check: verifyContactProperties(esNonUniqueCreateTraits) },
     },
     {
       id: 'hs-es-contacts-nonunique-lookup-existing-v3',
@@ -221,8 +221,8 @@ export const live: LiveSpec = {
             integrations: { All: true },
           }),
         },
-        verifyContactProperties(esNonUniqueUpdateTraits),
       ],
+      verify: { check: verifyContactProperties(esNonUniqueUpdateTraits) },
     },
     {
       id: 'hs-retl-contacts-create-v3',
@@ -240,8 +240,8 @@ export const live: LiveSpec = {
             traits: { email: ctx.email(), ...retlContactCreateTraits(ctx) },
           }),
         },
-        verifyContactProperties(retlContactCreateTraits),
       ],
+      verify: { check: verifyContactProperties(retlContactCreateTraits) },
     },
     {
       id: 'hs-retl-contacts-update-v3',
@@ -264,8 +264,8 @@ export const live: LiveSpec = {
             traits: { email: ctx.email(), ...retlContactUpdateTraits(ctx) },
           }),
         },
-        verifyContactProperties(retlContactUpdateTraits),
       ],
+      verify: { check: verifyContactProperties(retlContactUpdateTraits) },
     },
     {
       id: 'hs-retl-contacts-create-v1',
@@ -284,8 +284,8 @@ export const live: LiveSpec = {
             traits: { email: ctx.email(), ...retlContactCreateV1Traits(ctx) },
           }),
         },
-        verifyContactProperties(retlContactCreateV1Traits),
       ],
+      verify: { check: verifyContactProperties(retlContactCreateV1Traits) },
     },
     {
       id: 'hs-retl-contacts-update-v1',
@@ -309,8 +309,8 @@ export const live: LiveSpec = {
             traits: { email: ctx.email(), ...retlContactUpdateV1Traits(ctx) },
           }),
         },
-        verifyContactProperties(retlContactUpdateV1Traits),
       ],
+      verify: { check: verifyContactProperties(retlContactUpdateV1Traits) },
     },
     {
       id: 'hs-retl-associations-v3',
@@ -344,8 +344,8 @@ export const live: LiveSpec = {
             },
           }),
         },
-        verifyAssociationExists,
       ],
+      verify: { check: verifyAssociationExists },
     },
   ],
 };

--- a/test/integrations/destinations/hs/live/verify.ts
+++ b/test/integrations/destinations/hs/live/verify.ts
@@ -1,5 +1,4 @@
-import { LiveStep, RunContext } from '../../../live/types';
-import { pollUntil } from '../../../live/poll';
+import { RunContext } from '../../../live/types';
 import {
   ASSOC_FROM_TYPE,
   ASSOC_TO_TYPE,
@@ -8,53 +7,21 @@ import {
   registeredId,
 } from './api';
 
-// Verify the contact carries every expected property, polling for eventual consistency.
-export const verifyContactProperties = (
-  expected: (ctx: RunContext) => Record<string, string>,
-): LiveStep => ({
-  stepType: 'verify',
-  name: 'verify contact properties',
-  check: async (ctx) => {
+// Verify the contact carries every expected property.
+export const verifyContactProperties =
+  (expected: (ctx: RunContext) => Record<string, string>) =>
+  async (ctx: RunContext): Promise<void> => {
     const want = expected(ctx);
     const keys = Object.keys(want);
-    const props = await pollUntil(
-      async () => {
-        const last = await fetchContactByEmail(ctx, keys);
-        const done = Boolean(last && keys.every((k) => last[k] === want[k]));
-        return { done, value: last };
-      },
-      {
-        label: 'contact properties match',
-        attempts: 4,
-        delayMs: (attempt) => 1000 * 2 ** attempt,
-        soft: true,
-      },
-    );
+    const props = await fetchContactByEmail(ctx, keys);
     expect(props).not.toBeNull();
     expect(props).toMatchObject(want);
-  },
-});
+  };
 
-// Verify the pipeline step's association actually links the two set-up records, polling for
-// eventual consistency.
-export const verifyAssociationExists: LiveStep = {
-  stepType: 'verify',
-  name: 'verify association exists',
-  check: async (ctx) => {
-    const fromId = registeredId(ctx, ASSOC_FROM_TYPE);
-    const toId = registeredId(ctx, ASSOC_TO_TYPE);
-    const associatedIds = await pollUntil(
-      async () => {
-        const ids = await getAssociatedIds(ctx, ASSOC_FROM_TYPE, fromId, ASSOC_TO_TYPE);
-        return { done: ids.includes(toId), value: ids };
-      },
-      {
-        label: `association ${ASSOC_FROM_TYPE}/${fromId} -> ${ASSOC_TO_TYPE}/${toId}`,
-        attempts: 4,
-        delayMs: (attempt) => 1000 * 2 ** attempt,
-        soft: true,
-      },
-    );
-    expect(associatedIds).toContain(toId);
-  },
+// Verify the pipeline step's association actually links the two set-up records.
+export const verifyAssociationExists = async (ctx: RunContext): Promise<void> => {
+  const fromId = registeredId(ctx, ASSOC_FROM_TYPE);
+  const toId = registeredId(ctx, ASSOC_TO_TYPE);
+  const associatedIds = await getAssociatedIds(ctx, ASSOC_FROM_TYPE, fromId, ASSOC_TO_TYPE);
+  expect(associatedIds).toContain(toId);
 };

--- a/test/integrations/destinations/hs/live/verify.ts
+++ b/test/integrations/destinations/hs/live/verify.ts
@@ -1,0 +1,60 @@
+import { LiveStep, RunContext } from '../../../live/types';
+import { pollUntil } from '../../../live/poll';
+import {
+  ASSOC_FROM_TYPE,
+  ASSOC_TO_TYPE,
+  fetchContactByEmail,
+  getAssociatedIds,
+  registeredId,
+} from './api';
+
+// Verify the contact carries every expected property, polling for eventual consistency.
+export const verifyContactProperties = (
+  expected: (ctx: RunContext) => Record<string, string>,
+): LiveStep => ({
+  stepType: 'verify',
+  name: 'verify contact properties',
+  check: async (ctx) => {
+    const want = expected(ctx);
+    const keys = Object.keys(want);
+    const props = await pollUntil(
+      async () => {
+        const last = await fetchContactByEmail(ctx, keys);
+        const done = Boolean(last && keys.every((k) => last[k] === want[k]));
+        return { done, value: last };
+      },
+      {
+        label: 'contact properties match',
+        attempts: 4,
+        delayMs: (attempt) => 1000 * 2 ** attempt,
+        soft: true,
+      },
+    );
+    expect(props).not.toBeNull();
+    expect(props).toMatchObject(want);
+  },
+});
+
+// Verify the pipeline step's association actually links the two set-up records, polling for
+// eventual consistency.
+export const verifyAssociationExists: LiveStep = {
+  stepType: 'verify',
+  name: 'verify association exists',
+  check: async (ctx) => {
+    const fromId = registeredId(ctx, ASSOC_FROM_TYPE);
+    const toId = registeredId(ctx, ASSOC_TO_TYPE);
+    const associatedIds = await pollUntil(
+      async () => {
+        const ids = await getAssociatedIds(ctx, ASSOC_FROM_TYPE, fromId, ASSOC_TO_TYPE);
+        return { done: ids.includes(toId), value: ids };
+      },
+      {
+        label: `association ${ASSOC_FROM_TYPE}/${fromId} -> ${ASSOC_TO_TYPE}/${toId}`,
+        attempts: 4,
+        delayMs: (attempt) => 1000 * 2 ** attempt,
+        soft: true,
+      },
+    );
+    expect(associatedIds).toContain(toId);
+  },
+};

--- a/test/integrations/live/README.md
+++ b/test/integrations/live/README.md
@@ -1,0 +1,168 @@
+# Live (real-destination) integration tests
+
+The **pilot** implementation of _"Real-Destination Integration Testing for
+rudder-transformer"_. It drives transformed events through the full
+`transform → deliver` pipeline against **real destination accounts** and asserts on
+the genuine response (the "verdict"), closing the contract-verification gap that the
+mocked `component.test.ts` suite cannot cover.
+
+The mocked suite is untouched and remains the merge gate. This suite is additive.
+
+## What's implemented
+
+- **Sibling runner** — `component.live.test.ts` + `jest.config.live.js` boot the real
+  Koa app **without** `MockAxiosAdapter`, so outbound HTTP reaches real APIs.
+- **`routerProxyRequests.ts`** (`live/routerProxyRequests.ts`) — `buildRouterTransformBody()`
+  assembles the `/routerTransform` request body from a seeded event, and
+  `routerOutputToProxyRequests()` ports the small piece of rudder-server that maps each
+  `/routerTransform` `output[]` item to the `ProxyV1Request`(s) for
+  `/v1/destinations/<dest>/proxy`.
+- **Harness core** (`live/`): `SecretResolver` (env-var based), `RunContext`
+  (`runId` + memoised `identity`/`email`/`now`/`register`), `registry.ts`,
+  `runPipelineStep.ts` (transform → deliver → assert delivered), and `poll.ts` —
+  a shared `pollUntil(check, opts)` for eventually-consistent read-backs.
+- **Enrollment by discovery** — `registry.ts` scans `destinations/*/live.ts` and runs
+  any spec with `enabled: true`. A destination's `live.ts` either exports the `LiveSpec`
+  directly, or (for non-trivial specs) re-exports it from a `live/` module folder — see
+  the reference layout below.
+
+### Reference layout (`destinations/hs/`)
+
+For anything beyond a couple of scenarios, split the spec into a `live/` folder and keep
+`live.ts` as a one-line re-export (`export { live, default } from './live/spec';`):
+
+- **`live/spec.ts`** — the `LiveSpec`: scenarios wiring `pipeline` / `action` / `verify` steps.
+- **`live/api.ts`** — real destination-API helpers and auth headers (create / fetch / delete /
+  search / association reads).
+- **`live/setup.ts`** — `action` step bodies that seed prerequisite state (and poll it stable).
+- **`live/verify.ts`** — `verify` steps (field-level read-backs).
+- **`live/profiles.ts`** — trait profiles + shared `(ctx) => ({ ... })` factories used by both
+  seeds and verifies.
+
+### Deferred (not in the pilot)
+
+Vault-backed `SecretResolver`, GitHub OIDC → Vault auth, the `rudder-auth` container
+for OAuth destinations, the CI workflow, and impact-based PR subsetting. The interfaces
+here (`SecretResolver.resolve()`, `LiveSpec`) are shaped so those layer on without
+rewrites.
+
+## Running it locally
+
+```bash
+LIVE_SECRET_<DEST>='{...}' npm run test:live -- --destination=<dest>
+# add --coverage, or use: npm run test:live:coverage
+```
+
+Only the destinations named by `--destination` (comma-separated) run. `verify` steps,
+if a scenario defines them, run automatically.
+
+Credentials are **required**: `resolve()` throws if `LIVE_SECRET_<DEST>` is missing or
+invalid, so a selected destination without its secret fails (it does not skip).
+
+### Supplying credentials
+
+`SecretResolver` reads a single env var per destination, `LIVE_SECRET_<DEST>` — a JSON
+blob matching the `LiveSecret` shape:
+
+```json
+{ "authType": "apiKey", "config": { "accessToken": "..." }, "readback": { "accessToken": "..." } }
+```
+
+- `config` — merged into `destination.Config` (auth for header-based destinations lives here).
+- `secret` — merged into `metadata.secret` (for destinations that read the token there).
+- `resourceIds`, `oauthRefresh`, `readback` — optional; account ids, OAuth refresh token,
+  and read-back credentials for `verify` steps.
+
+In production these come from Vault (one path per destination); the resolver interface
+stays the same.
+
+`LIVE_TEST_EMAIL_DOMAIN` overrides the sink domain used for generated test emails.
+
+## Enrolling a new destination
+
+Add `test/integrations/destinations/<dest>/live.ts` exporting a `LiveSpec`:
+
+```ts
+export const live: LiveSpec = {
+  enabled: true,
+  authType: 'apiKey',
+  resolveConfig: (s) => ({ ...s.config }), // -> destination.Config
+  scenarios: [
+    /* ... */
+  ],
+};
+```
+
+The registry discovers it automatically. Set `enabled: false` to keep it in the tree
+without running it.
+
+### Scenarios and steps
+
+A scenario is an ordered list of `steps` sharing one `RunContext`, plus an optional
+scenario-level `cleanup`. There are no lifecycle hooks. Each step declares a required
+`stepType` discriminant:
+
+- **pipeline**: `{ stepType: 'pipeline', name, seed, metadataOverride?, retries? }` —
+  `seed(ctx)` builds the raw event; the runner transforms, delivers, and asserts it was
+  delivered. `retries` re-runs seed → transform → deliver with backoff when delivery fails — for
+  routes that decide create-vs-update via an eventually-consistent search (a just-created record
+  can be missed and 409 on the first try). Only use it where a failed attempt persists nothing, so
+  repeating is safe.
+- **action**: `{ stepType: 'action', name, run }` — a direct destination-API side effect
+  (create/mutate state), e.g. setup.
+- **verify**: `{ stepType: 'verify', name, check }` — a read-back assertion. `check(ctx)`
+  reads the object/membership/association back from the destination API and asserts with jest
+  `expect(...)`: it resolves on success and a failed matcher fails the step (it returns `void`, not
+  a boolean). Assert the _fields_, not just existence: a create scenario checks the object carries
+  every property it was created with, an update scenario checks the properties it changed, an
+  association scenario checks the link actually exists between the two records. Share one
+  property/trait profile between the pipeline `seed` and the verify (a `(ctx) => ({ ... })` factory
+  used by both) so seed and assertion can't drift — see `verifyContactProperties` and
+  `verifyAssociationExists` in `destinations/hs/live/verify.ts`. For eventually-consistent
+  destinations, poll the read-back with the shared `pollUntil(check, opts)` helper (`live/poll.ts`)
+  — use `soft: true` so an exhausted poll returns the last-observed value and the closing
+  `expect(...)` prints a real diff instead of a bare timeout. This read-back is also what actually
+  confirms a batch write: a batch endpoint can return `207` (which counts as delivered) even when an
+  item fails, so the delivery verdict alone is not proof the write landed.
+
+Teardown is the scenario's `cleanup: (ctx) => …`, armed at scenario start and drained
+after the steps finish (LIFO, best-effort) — no trailing cleanup step.
+
+Typical order: `[setup?, ...pipeline, verify?]`, with `cleanup` on the scenario.
+
+- `metadataOverride` merges into the `/routerTransform` input metadata (e.g.
+  `{ dontBatch: true }`).
+- `configOverride` on a scenario runs it with a different `destination.Config`.
+
+### Run context and identity
+
+Steps build data from `ctx`, not from string templates:
+
+- `ctx.runId` — unique per run.
+- `ctx.identity(entity)` — memoised id for an entity kind (e.g. `'user'`).
+- `ctx.email(entity?)` — unique, sink-safe address for the run.
+- `ctx.now(offset?)` — ISO timestamp relative to run start (e.g. `now('-3h')`).
+- `ctx.register(resource)` / `ctx.resources` — record created resources for later steps
+  (e.g. cleanup, or a step that references an id created by setup).
+
+Identities (`ctx.identity` / `ctx.email`) are always unique per scenario run (`ci-<runId>-…`),
+so destination 409s on duplicates are avoided without a per-spec strategy knob.
+
+## Type-checking
+
+The base `tsconfig.json` excludes `test/`, so `tsc -p tsconfig.json` does **not**
+type-check these files (ts-jest checks them at run time). Use the dedicated config that
+includes `test/**`:
+
+```bash
+npx tsc --noEmit -p tsconfig.test.json
+```
+
+## Security note — before this runs in CI
+
+`network.js` logs request/response bodies. **Secret masking in those logs is a mandatory
+build gate** and must land and be verified before any live run is enabled in CI; until
+then, run locally with `LOG_LEVEL=silent`. The runner already redacts `metadata.secret`
+from its own failure diagnostics. No long-lived secret should ever be stored in GitHub;
+CI credentials must come from Vault via a short-lived GitHub-OIDC token (see the design
+doc).

--- a/test/integrations/live/README.md
+++ b/test/integrations/live/README.md
@@ -12,11 +12,12 @@ The mocked suite is untouched and remains the merge gate. This suite is additive
 
 - **Sibling runner** — `component.live.test.ts` + `jest.config.live.js` boot the real
   Koa app **without** `MockAxiosAdapter`, so outbound HTTP reaches real APIs.
-- **`routerProxyRequests.ts`** (`live/routerProxyRequests.ts`) — `buildRouterTransformBody()`
-  assembles the `/routerTransform` request body from a seeded event, and
-  `routerOutputToProxyRequests()` ports the small piece of rudder-server that maps each
-  `/routerTransform` `output[]` item to the `ProxyV1Request`(s) for
-  `/v1/destinations/<dest>/proxy`.
+- **`routerTransformRequest.ts`** — `buildRouterTransformBody()` assembles the `/routerTransform`
+  request body from a seeded event (the request half of the chaining).
+- **`routerProxyRequests.ts`** — `routerOutputToProxyRequests()` ports the small piece of
+  rudder-server that maps each `/routerTransform` `output[]` item to the `ProxyV1Request`(s) for
+  `/v1/destinations/<dest>/proxy` (the response/delivery half); `coerce.ts` holds the runtime
+  coercions both halves share.
 - **Harness core** (`live/`): `SecretResolver` (env-var based), `RunContext`
   (`runId` + memoised `identity`/`email`/`now`/`register`), `registry.ts`,
   `runPipelineStep.ts` (transform → deliver → assert delivered), and `poll.ts` —
@@ -45,6 +46,11 @@ Vault-backed `SecretResolver`, GitHub OIDC → Vault auth, the `rudder-auth` con
 for OAuth destinations, the CI workflow, and impact-based PR subsetting. The interfaces
 here (`SecretResolver.resolve()`, `LiveSpec`) are shaped so those layer on without
 rewrites.
+
+**Scope — transform path.** The harness drives only `/routerTransform → /proxy`. rudder-server
+also runs the processor transform (`/v0/destinations/<dest>`) ahead of delivery, whose response
+shape differs; that chaining is not exercised here (INT-NNNN). **GZIP** proxy bodies are likewise
+unmapped (INT-NNNN) — see `routerProxyRequests.ts`.
 
 ## Running it locally
 
@@ -125,10 +131,17 @@ scenario-level `cleanup`. There are no lifecycle hooks. Each step declares a req
   confirms a batch write: a batch endpoint can return `207` (which counts as delivered) even when an
   item fails, so the delivery verdict alone is not proof the write landed.
 
+The **common trailing read-back** is better declared as a scenario-level `verify` the way
+`cleanup` is: `verify: { check: (ctx) => …, attempts?, delayMs? }`. The framework runs `check`
+after the steps and retries it on a thrown matcher error with backoff (default 4 attempts,
+`1000 * 2 ** attempt`), rethrowing the last error on exhaustion — so destination code is just the
+assertion and the poll boilerplate lives in the runner. Use a `verify` **step** in `steps` only for
+ordering cases (verify-after-setup, mid-scenario). See `destinations/hs/live/verify.ts`.
+
 Teardown is the scenario's `cleanup: (ctx) => …`, armed at scenario start and drained
 after the steps finish (LIFO, best-effort) — no trailing cleanup step.
 
-Typical order: `[setup?, ...pipeline, verify?]`, with `cleanup` on the scenario.
+Typical order: `[setup?, ...pipeline]`, with `verify` and `cleanup` on the scenario.
 
 - `metadataOverride` merges into the `/routerTransform` input metadata (e.g.
   `{ dontBatch: true }`).

--- a/test/integrations/live/coerce.ts
+++ b/test/integrations/live/coerce.ts
@@ -1,0 +1,11 @@
+export const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+export const readString = (value: unknown, fallback: string): string =>
+  typeof value === 'string' ? value : fallback;
+
+export const readNumber = (value: unknown, fallback: number): number =>
+  typeof value === 'number' && Number.isFinite(value) ? value : fallback;
+
+export const readBoolean = (value: unknown, fallback: boolean): boolean =>
+  typeof value === 'boolean' ? value : fallback;

--- a/test/integrations/live/poll.ts
+++ b/test/integrations/live/poll.ts
@@ -1,25 +1,9 @@
-// Shared poll helper for eventually-consistent destination read-backs.
+import { PollCheckResult, PollUntilOptions, RetryUntilPassesOptions } from './types';
 
 const sleep = (ms: number): Promise<void> =>
   new Promise((resolve) => {
     setTimeout(resolve, ms);
   });
-
-export type PollCheckResult<T> = { done: boolean; value: T };
-
-export type PollUntilOptions = {
-  label: string;
-  attempts: number;
-  /** Delay before the next attempt; `attempt` is 0-based (after the first check). */
-  delayMs: (attempt: number) => number;
-  /** Extra wait after a successful check (e.g. search-index settle). */
-  settleMs?: number;
-  /**
-   * When true, return the last observed value on exhaustion instead of throwing — useful for
-   * verify steps that want a jest `expect` diff of the final read-back.
-   */
-  soft?: boolean;
-};
 
 /**
  * Poll `check` until it returns `{ done: true }` or attempts are exhausted.
@@ -70,4 +54,33 @@ export async function pollUntil<T>(
     `pollUntil: ${options.label} not satisfied after ${options.attempts} attempts` +
       (lastError instanceof Error ? ` (last error: ${lastError.message})` : ''),
   );
+}
+
+/**
+ * Run `assert` until it passes (resolves without throwing) or attempts are exhausted, rethrowing
+ * the last error on exhaustion. The retry-on-throw sibling of `pollUntil`, for a jest read-back
+ * assertion the framework owns — a matcher error on the final attempt surfaces a real diff, the
+ * same quality `soft: true` gives today. Backs the scenario-level `verify` block (see types.ts).
+ */
+export async function retryUntilPasses(
+  assert: () => Promise<void>,
+  options?: RetryUntilPassesOptions,
+): Promise<void> {
+  const attempts = options?.attempts ?? 4;
+  const delayMs = options?.delayMs ?? ((attempt) => 1000 * 2 ** attempt);
+  let lastError: unknown;
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    try {
+      // eslint-disable-next-line no-await-in-loop
+      await assert();
+      return;
+    } catch (err) {
+      lastError = err;
+      if (attempt < attempts - 1) {
+        // eslint-disable-next-line no-await-in-loop
+        await sleep(delayMs(attempt));
+      }
+    }
+  }
+  throw lastError;
 }

--- a/test/integrations/live/poll.ts
+++ b/test/integrations/live/poll.ts
@@ -1,0 +1,73 @@
+// Shared poll helper for eventually-consistent destination read-backs.
+
+const sleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
+export type PollCheckResult<T> = { done: boolean; value: T };
+
+export type PollUntilOptions = {
+  label: string;
+  attempts: number;
+  /** Delay before the next attempt; `attempt` is 0-based (after the first check). */
+  delayMs: (attempt: number) => number;
+  /** Extra wait after a successful check (e.g. search-index settle). */
+  settleMs?: number;
+  /**
+   * When true, return the last observed value on exhaustion instead of throwing — useful for
+   * verify steps that want a jest `expect` diff of the final read-back.
+   */
+  soft?: boolean;
+};
+
+/**
+ * Poll `check` until it returns `{ done: true }` or attempts are exhausted.
+ * Transient throws are retained; with `soft: false` (default) they are rethrown if nothing
+ * ever succeeded, otherwise a timeout error is thrown.
+ */
+export async function pollUntil<T>(
+  check: () => Promise<PollCheckResult<T>>,
+  options: PollUntilOptions,
+): Promise<T> {
+  let lastValue: T | undefined;
+  let lastError: unknown;
+  let sawValue = false;
+
+  for (let attempt = 0; attempt < options.attempts; attempt += 1) {
+    try {
+      // eslint-disable-next-line no-await-in-loop
+      const result = await check();
+      lastValue = result.value;
+      sawValue = true;
+      if (result.done) {
+        if (options.settleMs) {
+          // eslint-disable-next-line no-await-in-loop
+          await sleep(options.settleMs);
+        }
+        return result.value;
+      }
+    } catch (err) {
+      lastError = err;
+    }
+    if (attempt < options.attempts - 1) {
+      // eslint-disable-next-line no-await-in-loop
+      await sleep(options.delayMs(attempt));
+    }
+  }
+
+  if (options.soft) {
+    if (!sawValue && lastError) {
+      throw lastError;
+    }
+    return lastValue as T;
+  }
+
+  if (lastError && !sawValue) {
+    throw lastError;
+  }
+  throw new Error(
+    `pollUntil: ${options.label} not satisfied after ${options.attempts} attempts` +
+      (lastError instanceof Error ? ` (last error: ${lastError.message})` : ''),
+  );
+}

--- a/test/integrations/live/registry.ts
+++ b/test/integrations/live/registry.ts
@@ -1,8 +1,3 @@
-// Live-test framework — destination discovery.
-//
-// Scans destinations/<dest>/live.ts|js for enabled specs (optionally narrowed by a
-// comma-separated filter). Enrollment is by presence of the file — no central list.
-
 import { existsSync, readdirSync } from 'fs';
 import { join } from 'path';
 import { EnrolledDestination, LiveSpec } from './types';
@@ -12,9 +7,8 @@ const DESTINATIONS_DIR = join(__dirname, '..', 'destinations');
 // Dynamically require a spec module (discovered at runtime, not statically imported). A spec may be
 // exported as `live` or as the default export. Returns undefined if missing or not enabled.
 function loadSpec(destination: string): LiveSpec | undefined {
-  const specPathTs = join(DESTINATIONS_DIR, destination, 'live.ts');
-  const specPathJs = join(DESTINATIONS_DIR, destination, 'live.js');
-  if (!existsSync(specPathTs) && !existsSync(specPathJs)) {
+  const specPath = join(DESTINATIONS_DIR, destination, 'live.ts');
+  if (!existsSync(specPath)) {
     return undefined;
   }
   // eslint-disable-next-line global-require, import/no-dynamic-require

--- a/test/integrations/live/registry.ts
+++ b/test/integrations/live/registry.ts
@@ -1,0 +1,54 @@
+// Live-test framework — destination discovery.
+//
+// Scans destinations/<dest>/live.ts|js for enabled specs (optionally narrowed by a
+// comma-separated filter). Enrollment is by presence of the file — no central list.
+
+import { existsSync, readdirSync } from 'fs';
+import { join } from 'path';
+import { EnrolledDestination, LiveSpec } from './types';
+
+const DESTINATIONS_DIR = join(__dirname, '..', 'destinations');
+
+// Dynamically require a spec module (discovered at runtime, not statically imported). A spec may be
+// exported as `live` or as the default export. Returns undefined if missing or not enabled.
+function loadSpec(destination: string): LiveSpec | undefined {
+  const specPathTs = join(DESTINATIONS_DIR, destination, 'live.ts');
+  const specPathJs = join(DESTINATIONS_DIR, destination, 'live.js');
+  if (!existsSync(specPathTs) && !existsSync(specPathJs)) {
+    return undefined;
+  }
+  // eslint-disable-next-line global-require, import/no-dynamic-require
+  const mod = require(join(DESTINATIONS_DIR, destination, 'live'));
+  const spec: LiveSpec | undefined = mod.live || mod.default;
+  return spec && spec.enabled ? spec : undefined;
+}
+
+export function getEnrolledDestinations(filter?: string): EnrolledDestination[] {
+  if (!existsSync(DESTINATIONS_DIR)) {
+    return [];
+  }
+  // `--destination=a,b` narrows the run to those destinations; absent = run all enabled.
+  const wanted = filter
+    ? new Set(
+        filter
+          .split(',')
+          .map((d) => d.trim())
+          .filter(Boolean),
+      )
+    : undefined;
+
+  return readdirSync(DESTINATIONS_DIR, { withFileTypes: true })
+    .filter((d) => d.isDirectory())
+    .map((d) => d.name)
+    .sort()
+    .flatMap((destination) => {
+      if (wanted && !wanted.has(destination)) {
+        return [];
+      }
+      const spec = loadSpec(destination);
+      if (!spec) {
+        return [];
+      }
+      return [{ destination, spec }];
+    });
+}

--- a/test/integrations/live/routerProxyRequests.ts
+++ b/test/integrations/live/routerProxyRequests.ts
@@ -1,0 +1,155 @@
+// Ports the request/response plumbing rudder-server does around the transformer for the live
+// suite, covering both endpoints the pipeline hits:
+//  - buildRouterTransformBody: builds a /routerTransform request body from one live event.
+//  - routerOutputToProxyRequests: maps a /routerTransform output[] item to ProxyV1Request(s)
+//    for /v1/destinations/<dest>/proxy, reproducing the transform -> delivery chaining.
+
+import { z } from 'zod';
+import { DeliveryV1ResponseSchema, ProxyMetdata, ProxyV1Request } from '../../../src/types';
+
+// Live-local schemas: include `endpointPath` (stripped by the shared ProcessorTransformationOutputSchema)
+// and keep destination/metadata loose so we don't require Destination's full control-plane shape.
+const LiveProcessorOutputSchema = z.object({
+  version: z.string(),
+  type: z.string(),
+  method: z.string(),
+  endpoint: z.string(),
+  endpointPath: z.string().optional(),
+  userId: z.string().optional(),
+  headers: z.record(z.unknown()).optional(),
+  params: z.record(z.unknown()).optional(),
+  body: z
+    .object({
+      JSON: z.record(z.unknown()).optional(),
+      JSON_ARRAY: z.record(z.unknown()).optional(),
+      XML: z.record(z.unknown()).optional(),
+      FORM: z.record(z.unknown()).optional(),
+    })
+    .optional(),
+  files: z.record(z.unknown()).optional(),
+});
+
+const LiveRouterOutputSchema = z.object({
+  batchedRequest: z.array(LiveProcessorOutputSchema).or(LiveProcessorOutputSchema).optional(),
+  metadata: z.array(z.record(z.unknown())),
+  destination: z.record(z.unknown()),
+  batched: z.boolean(),
+  statusCode: z.number(),
+  error: z.string().optional(),
+  statTags: z.record(z.unknown()).optional(),
+});
+
+type RouterOutput = z.infer<typeof LiveRouterOutputSchema>;
+type BatchedRequest = z.infer<typeof LiveProcessorOutputSchema>;
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const readString = (value: unknown, fallback: string): string =>
+  typeof value === 'string' ? value : fallback;
+
+const readNumber = (value: unknown, fallback: number): number =>
+  typeof value === 'number' && Number.isFinite(value) ? value : fallback;
+
+const readBoolean = (value: unknown, fallback: boolean): boolean =>
+  typeof value === 'boolean' ? value : fallback;
+
+// Router metadata is typed as Partial<Metadata>, but the live/proxy path also carries
+// ProxyMetdata fields (userId, secret, attemptNum) that rudder-server attaches.
+const toProxyMetadata = (m: Record<string, unknown>, destinationId: string): ProxyMetdata => ({
+  jobId: readNumber(m.jobId, 1),
+  attemptNum: readNumber(m.attemptNum, 0),
+  userId: readString(m.userId, ''),
+  sourceId: readString(m.sourceId, 'live-sourceId'),
+  destinationId: readString(m.destinationId, destinationId),
+  workspaceId: readString(m.workspaceId, 'live-workspaceId'),
+  secret: isRecord(m.secret) ? m.secret : {},
+  dontBatch: readBoolean(m.dontBatch, false),
+});
+
+const buildProxyRequest = (
+  batchedRequest: BatchedRequest,
+  metadata: RouterOutput['metadata'],
+  destination: RouterOutput['destination'],
+): ProxyV1Request => {
+  const destinationId = readString(destination.ID, 'live-destinationId');
+  return {
+    version: 'v1',
+    type: batchedRequest.type || 'REST',
+    method: batchedRequest.method || 'POST',
+    endpoint: batchedRequest.endpoint || '',
+    endpointPath: batchedRequest.endpointPath,
+    userId: batchedRequest.userId || '',
+    headers: batchedRequest.headers || {},
+    params: batchedRequest.params || {},
+    body: {
+      JSON: batchedRequest.body?.JSON || {},
+      JSON_ARRAY: batchedRequest.body?.JSON_ARRAY || {},
+      XML: batchedRequest.body?.XML || {},
+      FORM: batchedRequest.body?.FORM || {},
+      GZIP: {},
+    },
+    files: batchedRequest.files || {},
+    metadata: metadata.map((m) => toProxyMetadata(m, destinationId)),
+    destinationConfig: isRecord(destination.Config) ? destination.Config : {},
+  };
+};
+
+const RouterTransformHttpBodySchema = z.object({
+  output: z.array(LiveRouterOutputSchema),
+});
+
+const ProxyDeliveryHttpBodySchema = z.object({
+  output: DeliveryV1ResponseSchema,
+});
+
+/** Parse `/routerTransform` HTTP body; returns only successful (2xx) outputs. */
+export const parseSuccessfulRouterOutputs = (body: unknown): RouterOutput[] => {
+  const { output } = RouterTransformHttpBodySchema.parse(body);
+  return output.filter((o) => o.statusCode >= 200 && o.statusCode < 300);
+};
+
+/** Parse `/v1/destinations/<dest>/proxy` HTTP body to the delivery verdict. */
+export const parseDeliveryOutput = (body: unknown) =>
+  ProxyDeliveryHttpBodySchema.parse(body).output;
+
+// Maps one router-transform output item to one or more ProxyV1Requests (array batchedRequests fan out).
+export const routerOutputToProxyRequests = (item: RouterOutput): ProxyV1Request[] => {
+  if (!item.batchedRequest) {
+    return [];
+  }
+  const batched = Array.isArray(item.batchedRequest) ? item.batchedRequest : [item.batchedRequest];
+  return batched.map((br) => buildProxyRequest(br, item.metadata, item.destination));
+};
+
+export type BuildRouterTransformBodyOptions = {
+  secret?: Record<string, string>;
+  metadataOverride?: Record<string, unknown>;
+};
+
+// Builds a /routerTransform request body for a single live event (one input job).
+export const buildRouterTransformBody = (
+  destination: string,
+  message: Record<string, unknown>,
+  config: Record<string, unknown>,
+  jobId: number,
+  options?: BuildRouterTransformBodyOptions,
+) => ({
+  input: [
+    {
+      message,
+      destination: { ID: `live-${destination}`, Config: config, Enabled: true },
+      metadata: {
+        jobId,
+        attemptNum: 0,
+        userId: readString(message.userId, 'live-user'),
+        sourceId: 'live-sourceId',
+        destinationId: `live-${destination}`,
+        workspaceId: 'live-workspaceId',
+        secret: options?.secret ?? {},
+        ...(options?.metadataOverride ?? {}),
+      },
+    },
+  ],
+  destType: destination,
+});

--- a/test/integrations/live/routerProxyRequests.ts
+++ b/test/integrations/live/routerProxyRequests.ts
@@ -1,58 +1,7 @@
-// Ports the request/response plumbing rudder-server does around the transformer for the live
-// suite, covering both endpoints the pipeline hits:
-//  - buildRouterTransformBody: builds a /routerTransform request body from one live event.
-//  - routerOutputToProxyRequests: maps a /routerTransform output[] item to ProxyV1Request(s)
-//    for /v1/destinations/<dest>/proxy, reproducing the transform -> delivery chaining.
-
 import { z } from 'zod';
 import { DeliveryV1ResponseSchema, ProxyMetdata, ProxyV1Request } from '../../../src/types';
-
-// Live-local schemas: include `endpointPath` (stripped by the shared ProcessorTransformationOutputSchema)
-// and keep destination/metadata loose so we don't require Destination's full control-plane shape.
-const LiveProcessorOutputSchema = z.object({
-  version: z.string(),
-  type: z.string(),
-  method: z.string(),
-  endpoint: z.string(),
-  endpointPath: z.string().optional(),
-  userId: z.string().optional(),
-  headers: z.record(z.unknown()).optional(),
-  params: z.record(z.unknown()).optional(),
-  body: z
-    .object({
-      JSON: z.record(z.unknown()).optional(),
-      JSON_ARRAY: z.record(z.unknown()).optional(),
-      XML: z.record(z.unknown()).optional(),
-      FORM: z.record(z.unknown()).optional(),
-    })
-    .optional(),
-  files: z.record(z.unknown()).optional(),
-});
-
-const LiveRouterOutputSchema = z.object({
-  batchedRequest: z.array(LiveProcessorOutputSchema).or(LiveProcessorOutputSchema).optional(),
-  metadata: z.array(z.record(z.unknown())),
-  destination: z.record(z.unknown()),
-  batched: z.boolean(),
-  statusCode: z.number(),
-  error: z.string().optional(),
-  statTags: z.record(z.unknown()).optional(),
-});
-
-type RouterOutput = z.infer<typeof LiveRouterOutputSchema>;
-type BatchedRequest = z.infer<typeof LiveProcessorOutputSchema>;
-
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === 'object' && value !== null && !Array.isArray(value);
-
-const readString = (value: unknown, fallback: string): string =>
-  typeof value === 'string' ? value : fallback;
-
-const readNumber = (value: unknown, fallback: number): number =>
-  typeof value === 'number' && Number.isFinite(value) ? value : fallback;
-
-const readBoolean = (value: unknown, fallback: boolean): boolean =>
-  typeof value === 'boolean' ? value : fallback;
+import { isRecord, readBoolean, readNumber, readString } from './coerce';
+import { BatchedRequest, LiveRouterOutputSchema, RouterOutput } from './types';
 
 // Router metadata is typed as Partial<Metadata>, but the live/proxy path also carries
 // ProxyMetdata fields (userId, secret, attemptNum) that rudder-server attaches.
@@ -67,6 +16,9 @@ const toProxyMetadata = (m: Record<string, unknown>, destinationId: string): Pro
   dontBatch: readBoolean(m.dontBatch, false),
 });
 
+// Assembles one ProxyV1Request from a single batchedRequest, carrying the router output's metadata
+// and destination through. The defaults (type/method/body containers) mirror what rudder-server
+// sends when the transform omits them.
 const buildProxyRequest = (
   batchedRequest: BatchedRequest,
   metadata: RouterOutput['metadata'],
@@ -87,7 +39,7 @@ const buildProxyRequest = (
       JSON_ARRAY: batchedRequest.body?.JSON_ARRAY || {},
       XML: batchedRequest.body?.XML || {},
       FORM: batchedRequest.body?.FORM || {},
-      GZIP: {},
+      GZIP: batchedRequest.body?.GZIP || {},
     },
     files: batchedRequest.files || {},
     metadata: metadata.map((m) => toProxyMetadata(m, destinationId)),
@@ -121,35 +73,3 @@ export const routerOutputToProxyRequests = (item: RouterOutput): ProxyV1Request[
   const batched = Array.isArray(item.batchedRequest) ? item.batchedRequest : [item.batchedRequest];
   return batched.map((br) => buildProxyRequest(br, item.metadata, item.destination));
 };
-
-export type BuildRouterTransformBodyOptions = {
-  secret?: Record<string, string>;
-  metadataOverride?: Record<string, unknown>;
-};
-
-// Builds a /routerTransform request body for a single live event (one input job).
-export const buildRouterTransformBody = (
-  destination: string,
-  message: Record<string, unknown>,
-  config: Record<string, unknown>,
-  jobId: number,
-  options?: BuildRouterTransformBodyOptions,
-) => ({
-  input: [
-    {
-      message,
-      destination: { ID: `live-${destination}`, Config: config, Enabled: true },
-      metadata: {
-        jobId,
-        attemptNum: 0,
-        userId: readString(message.userId, 'live-user'),
-        sourceId: 'live-sourceId',
-        destinationId: `live-${destination}`,
-        workspaceId: 'live-workspaceId',
-        secret: options?.secret ?? {},
-        ...(options?.metadataOverride ?? {}),
-      },
-    },
-  ],
-  destType: destination,
-});

--- a/test/integrations/live/routerTransformRequest.ts
+++ b/test/integrations/live/routerTransformRequest.ts
@@ -1,0 +1,28 @@
+import { readString } from './coerce';
+import { BuildRouterTransformBodyOptions } from './types';
+
+export const buildRouterTransformBody = (
+  destination: string,
+  message: Record<string, unknown>,
+  config: Record<string, unknown>,
+  jobId: number,
+  options?: BuildRouterTransformBodyOptions,
+) => ({
+  input: [
+    {
+      message,
+      destination: { ID: `live-${destination}`, Config: config, Enabled: true },
+      metadata: {
+        jobId,
+        attemptNum: 0,
+        userId: readString(message.userId, 'live-user'),
+        sourceId: 'live-sourceId',
+        destinationId: `live-${destination}`,
+        workspaceId: 'live-workspaceId',
+        secret: options?.secret ?? {},
+        ...(options?.metadataOverride ?? {}),
+      },
+    },
+  ],
+  destType: destination,
+});

--- a/test/integrations/live/runContext.ts
+++ b/test/integrations/live/runContext.ts
@@ -1,0 +1,93 @@
+// RunContext implementation: one instance per scenario run; memoises identities.
+
+import { randomUUID } from 'crypto';
+import { LiveResource, LiveSecret, RunContext } from './types';
+
+const EMAIL_DOMAIN = process.env.LIVE_TEST_EMAIL_DOMAIN || 'ci.rudderstack-test.com';
+
+// Parses a relative time offset like '-3h' / '+1d' into milliseconds (empty -> 0).
+const OFFSET_RE = /^([+-])(\d+)([smhd])$/;
+const offsetToMs = (offset?: string): number => {
+  if (!offset) {
+    return 0;
+  }
+  const m = OFFSET_RE.exec(offset.trim());
+  if (!m) {
+    throw new Error(`Invalid time offset: "${offset}"`);
+  }
+  const [, sign, rawAmount, unit] = m;
+  const unitMs: Record<string, number> = {
+    s: 1000,
+    m: 60 * 1000,
+    h: 60 * 60 * 1000,
+    d: 24 * 60 * 60 * 1000,
+  };
+  return (sign === '-' ? -1 : 1) * Number(rawAmount) * unitMs[unit];
+};
+
+export class RunContextImpl implements RunContext {
+  readonly runId: string;
+
+  readonly liveSecret: LiveSecret;
+
+  private readonly startedAt: number;
+
+  private readonly identityCache = new Map<string, string>();
+
+  private readonly registered: LiveResource[] = [];
+
+  private readonly cleanups: Array<() => void | Promise<void>> = [];
+
+  constructor(params: { liveSecret: LiveSecret }) {
+    this.runId = `run-${Date.now()}-${randomUUID().slice(0, 8)}`;
+    this.liveSecret = params.liveSecret;
+    this.startedAt = Date.now();
+  }
+
+  // Identities are namespaced by runId so each run uses fresh records — avoiding cross-run
+  // collisions and duplicate-conflict errors — and memoised so repeat calls in a run are stable.
+  identity(entity: string): string {
+    const cached = this.identityCache.get(entity);
+    if (cached) {
+      return cached;
+    }
+    const id = `ci-${this.runId}-${entity}`;
+    this.identityCache.set(entity, id);
+    return id;
+  }
+
+  email(entity = 'user'): string {
+    return `ci+${this.runId}-${entity}@${EMAIL_DOMAIN}`;
+  }
+
+  now(offset?: string): string {
+    return new Date(this.startedAt + offsetToMs(offset)).toISOString();
+  }
+
+  register(resource: LiveResource): void {
+    this.registered.push(resource);
+  }
+
+  addCleanup(fn: () => void | Promise<void>): void {
+    this.cleanups.push(fn);
+  }
+
+  // Drain registered teardown fns LIFO; best-effort — a failing cleanup is logged, not thrown,
+  // so one failure can't strand the rest. Called by the runner in afterAll.
+  async runCleanups(): Promise<void> {
+    while (this.cleanups.length > 0) {
+      const cleanup = this.cleanups.pop();
+      try {
+        // eslint-disable-next-line no-await-in-loop
+        await cleanup!();
+      } catch (e) {
+        // eslint-disable-next-line no-console
+        console.error('[live] cleanup failed', e);
+      }
+    }
+  }
+
+  get resources(): LiveResource[] {
+    return [...this.registered];
+  }
+}

--- a/test/integrations/live/runContext.ts
+++ b/test/integrations/live/runContext.ts
@@ -1,5 +1,3 @@
-// RunContext implementation: one instance per scenario run; memoises identities.
-
 import { randomUUID } from 'crypto';
 import { LiveResource, LiveSecret, RunContext } from './types';
 

--- a/test/integrations/live/runPipelineStep.ts
+++ b/test/integrations/live/runPipelineStep.ts
@@ -1,20 +1,12 @@
-// Runs one pipeline step: seed -> /routerTransform -> /proxy, asserting delivery.
-
 import { HttpStatusCode } from 'axios';
 import { randomInt } from 'crypto';
 import {
-  buildRouterTransformBody,
   parseDeliveryOutput,
   parseSuccessfulRouterOutputs,
   routerOutputToProxyRequests,
 } from './routerProxyRequests';
-import { PipelineStep, RunContext } from './types';
-
-type LiveHttpResponse = { status: number; body: unknown };
-/** Minimal HTTP client; wraps SuperTest so the helper stays free of its types. */
-type LiveHttpClient = {
-  post: (url: string, body: unknown) => Promise<LiveHttpResponse>;
-};
+import { buildRouterTransformBody } from './routerTransformRequest';
+import { DeliveryFailure, RunPipelineStepParams } from './types';
 
 const isDelivered = (status: number): boolean =>
   (status >= HttpStatusCode.Ok && status < HttpStatusCode.MultipleChoices) ||
@@ -25,27 +17,21 @@ const sleep = (ms: number): Promise<void> =>
     setTimeout(resolve, ms);
   });
 
-type RunPipelineStepParams = {
-  destination: string;
-  scenarioId: string;
-  step: PipelineStep;
-  ctx: RunContext;
-  config: Record<string, unknown>;
-  http: LiveHttpClient;
-};
-
-// One seed -> transform -> deliver attempt. Returns a failure message if the event wasn't
-// delivered, or undefined on success. Structural problems (transform non-200, no outputs) throw.
+// One seed -> transform -> deliver attempt. Returns a structured failure if the event wasn't
+// delivered, or undefined on success. Structural problems (transform non-200, wrong output count)
+// throw.
 const attemptDelivery = async ({
   destination,
-  scenarioId,
   step,
   ctx,
   config,
   http,
-}: RunPipelineStepParams): Promise<string | undefined> => {
+}: RunPipelineStepParams): Promise<DeliveryFailure | undefined> => {
   const jobId = randomInt(1, 2_147_483_647);
   const message = step.seed(ctx);
+  // TODO: this drives only the /routerTransform -> /proxy path. rudder-server also runs
+  // the processor transform (/v0/destinations/<dest>) ahead of delivery, whose response shape
+  // differs — that chaining is not exercised here (see live/README.md "Deferred").
   const routerBody = buildRouterTransformBody(destination, message, config, jobId, {
     secret: ctx.liveSecret.secret,
     metadataOverride: step.metadataOverride,
@@ -55,12 +41,24 @@ const attemptDelivery = async ({
   expect(routerResponse.status).toEqual(HttpStatusCode.Ok);
 
   const routerOutputs = parseSuccessfulRouterOutputs(routerResponse.body);
-  expect(routerOutputs.length).toBeGreaterThan(0);
+  if (step.expectedOutputs !== undefined) {
+    expect(routerOutputs).toHaveLength(step.expectedOutputs);
+  } else {
+    expect(routerOutputs.length).toBeGreaterThan(0);
+  }
 
-  for (const routerOutput of routerOutputs) {
-    const proxyRequests = routerOutputToProxyRequests(routerOutput);
-    expect(proxyRequests.length).toBeGreaterThan(0);
+  // Build every proxy request up front so count assertions run before delivery — a batching /
+  // dontBatch regression that still delivers 2xx is otherwise waved through silently.
+  const proxyRequestsPerOutput = routerOutputs.map((o) => routerOutputToProxyRequests(o));
+  proxyRequestsPerOutput.forEach((proxyRequests) =>
+    expect(proxyRequests.length).toBeGreaterThan(0),
+  );
+  if (step.expectedProxyRequests !== undefined) {
+    const total = proxyRequestsPerOutput.reduce((n, proxyRequests) => n + proxyRequests.length, 0);
+    expect(total).toEqual(step.expectedProxyRequests);
+  }
 
+  for (const proxyRequests of proxyRequestsPerOutput) {
     for (const proxyRequest of proxyRequests) {
       // eslint-disable-next-line no-await-in-loop -- deliver sequentially; order matches transform output
       const deliveryResponse = await http.post(
@@ -79,12 +77,12 @@ const attemptDelivery = async ({
           ...js,
           metadata: { ...js.metadata, secret: '[redacted]' },
         }));
-        return (
-          `[live:${destination}:${scenarioId}:${step.name}] not delivered — ` +
-          `proxy HTTP ${deliveryResponse.status}, verdict.status ${deliveryOutput.status}, ` +
-          `message: ${deliveryOutput.message}\n` +
-          `job states: ${JSON.stringify(redactedJobStates, null, 2)}`
-        );
+        return {
+          proxyStatus: deliveryResponse.status,
+          verdictStatus: deliveryOutput.status,
+          message: deliveryOutput.message,
+          jobStates: redactedJobStates,
+        };
       }
     }
   }
@@ -94,8 +92,9 @@ const attemptDelivery = async ({
 // Run the step once, then up to `step.retries` more times with exponential backoff if delivery
 // failed — covers routes whose transform reads an eventually-consistent index (see PipelineStep).
 export const runPipelineStep = async (params: RunPipelineStepParams): Promise<void> => {
-  const maxAttempts = (params.step.retries ?? 0) + 1;
-  let failure: string | undefined;
+  const { destination, scenarioId, step } = params;
+  const maxAttempts = (step.retries ?? 0) + 1;
+  let failure: DeliveryFailure | undefined;
   for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
     // eslint-disable-next-line no-await-in-loop -- attempts are inherently sequential with backoff
     failure = await attemptDelivery(params);
@@ -107,5 +106,14 @@ export const runPipelineStep = async (params: RunPipelineStepParams): Promise<vo
       await sleep(1000 * 2 ** attempt);
     }
   }
-  throw new Error(failure);
+  if (!failure) {
+    return;
+  }
+  // maxAttempts >= 1, so the loop always ran and `failure` is set once we reach here.
+  throw new Error(
+    `[live:${destination}:${scenarioId}:${step.name}] not delivered — ` +
+      `proxy HTTP ${failure.proxyStatus}, verdict.status ${failure.verdictStatus}, ` +
+      `message: ${failure.message}\n` +
+      `job states: ${JSON.stringify(failure.jobStates, null, 2)}`,
+  );
 };

--- a/test/integrations/live/runPipelineStep.ts
+++ b/test/integrations/live/runPipelineStep.ts
@@ -1,0 +1,111 @@
+// Runs one pipeline step: seed -> /routerTransform -> /proxy, asserting delivery.
+
+import { HttpStatusCode } from 'axios';
+import { randomInt } from 'crypto';
+import {
+  buildRouterTransformBody,
+  parseDeliveryOutput,
+  parseSuccessfulRouterOutputs,
+  routerOutputToProxyRequests,
+} from './routerProxyRequests';
+import { PipelineStep, RunContext } from './types';
+
+type LiveHttpResponse = { status: number; body: unknown };
+/** Minimal HTTP client; wraps SuperTest so the helper stays free of its types. */
+type LiveHttpClient = {
+  post: (url: string, body: unknown) => Promise<LiveHttpResponse>;
+};
+
+const isDelivered = (status: number): boolean =>
+  (status >= HttpStatusCode.Ok && status < HttpStatusCode.MultipleChoices) ||
+  status === HttpStatusCode.MultiStatus;
+
+const sleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
+type RunPipelineStepParams = {
+  destination: string;
+  scenarioId: string;
+  step: PipelineStep;
+  ctx: RunContext;
+  config: Record<string, unknown>;
+  http: LiveHttpClient;
+};
+
+// One seed -> transform -> deliver attempt. Returns a failure message if the event wasn't
+// delivered, or undefined on success. Structural problems (transform non-200, no outputs) throw.
+const attemptDelivery = async ({
+  destination,
+  scenarioId,
+  step,
+  ctx,
+  config,
+  http,
+}: RunPipelineStepParams): Promise<string | undefined> => {
+  const jobId = randomInt(1, 2_147_483_647);
+  const message = step.seed(ctx);
+  const routerBody = buildRouterTransformBody(destination, message, config, jobId, {
+    secret: ctx.liveSecret.secret,
+    metadataOverride: step.metadataOverride,
+  });
+
+  const routerResponse = await http.post('/routerTransform', routerBody);
+  expect(routerResponse.status).toEqual(HttpStatusCode.Ok);
+
+  const routerOutputs = parseSuccessfulRouterOutputs(routerResponse.body);
+  expect(routerOutputs.length).toBeGreaterThan(0);
+
+  for (const routerOutput of routerOutputs) {
+    const proxyRequests = routerOutputToProxyRequests(routerOutput);
+    expect(proxyRequests.length).toBeGreaterThan(0);
+
+    for (const proxyRequest of proxyRequests) {
+      // eslint-disable-next-line no-await-in-loop -- deliver sequentially; order matches transform output
+      const deliveryResponse = await http.post(
+        `/v1/destinations/${destination}/proxy`,
+        proxyRequest,
+      );
+
+      const deliveryOutput = parseDeliveryOutput(deliveryResponse.body);
+      expect(deliveryOutput).toBeDefined();
+
+      const jobStates = deliveryOutput.response ?? [];
+      const delivered =
+        isDelivered(deliveryOutput.status) && jobStates.every((js) => isDelivered(js.statusCode));
+      if (!delivered) {
+        const redactedJobStates = jobStates.map((js) => ({
+          ...js,
+          metadata: { ...js.metadata, secret: '[redacted]' },
+        }));
+        return (
+          `[live:${destination}:${scenarioId}:${step.name}] not delivered — ` +
+          `proxy HTTP ${deliveryResponse.status}, verdict.status ${deliveryOutput.status}, ` +
+          `message: ${deliveryOutput.message}\n` +
+          `job states: ${JSON.stringify(redactedJobStates, null, 2)}`
+        );
+      }
+    }
+  }
+  return undefined;
+};
+
+// Run the step once, then up to `step.retries` more times with exponential backoff if delivery
+// failed — covers routes whose transform reads an eventually-consistent index (see PipelineStep).
+export const runPipelineStep = async (params: RunPipelineStepParams): Promise<void> => {
+  const maxAttempts = (params.step.retries ?? 0) + 1;
+  let failure: string | undefined;
+  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+    // eslint-disable-next-line no-await-in-loop -- attempts are inherently sequential with backoff
+    failure = await attemptDelivery(params);
+    if (!failure) {
+      return;
+    }
+    if (attempt < maxAttempts - 1) {
+      // eslint-disable-next-line no-await-in-loop -- back off before retrying
+      await sleep(1000 * 2 ** attempt);
+    }
+  }
+  throw new Error(failure);
+};

--- a/test/integrations/live/secretResolver.ts
+++ b/test/integrations/live/secretResolver.ts
@@ -1,7 +1,5 @@
 import { LiveSecret } from './types';
 
-const AUTH_TYPES = new Set(['apiKey', 'oauth', 'basic', 'serviceAccount', 'custom']);
-
 const jsonEnvKey = (destination: string): string => `LIVE_SECRET_${destination.toUpperCase()}`;
 
 export class SecretResolver {
@@ -19,42 +17,19 @@ export class SecretResolver {
     if (!raw) {
       throw new Error(`${key} is not set — live tests require credentials for '${destination}'.`);
     }
-    let parsed: unknown;
+    let parsed: LiveSecret;
     try {
       parsed = JSON.parse(raw);
     } catch (e) {
       throw new Error(`${key} is set but is not valid JSON: ${(e as Error).message}`);
     }
-    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
-      throw new Error(`${key} must be a JSON object`);
-    }
-    const body = parsed as Record<string, unknown>;
-    if (typeof body.authType !== 'string' || !AUTH_TYPES.has(body.authType)) {
-      throw new Error(
-        `${key}.authType must be one of: ${[...AUTH_TYPES].join(', ')} (got ${JSON.stringify(body.authType)})`,
-      );
-    }
-    if (typeof body.config !== 'object' || body.config === null || Array.isArray(body.config)) {
-      throw new Error(`${key}.config must be a non-null object`);
-    }
     return {
-      authType: body.authType as LiveSecret['authType'],
-      config: body.config as Record<string, unknown>,
-      secret:
-        typeof body.secret === 'object' && body.secret !== null && !Array.isArray(body.secret)
-          ? (body.secret as Record<string, string>)
-          : undefined,
-      resourceIds:
-        typeof body.resourceIds === 'object' &&
-        body.resourceIds !== null &&
-        !Array.isArray(body.resourceIds)
-          ? (body.resourceIds as Record<string, string>)
-          : undefined,
-      oauthRefresh: body.oauthRefresh as LiveSecret['oauthRefresh'],
-      readback:
-        typeof body.readback === 'object' && body.readback !== null && !Array.isArray(body.readback)
-          ? (body.readback as Record<string, unknown>)
-          : undefined,
+      authType: parsed.authType || 'apiKey',
+      config: parsed.config,
+      secret: parsed.secret,
+      resourceIds: parsed.resourceIds,
+      oauthRefresh: parsed.oauthRefresh,
+      readback: parsed.readback,
     };
   }
 }

--- a/test/integrations/live/secretResolver.ts
+++ b/test/integrations/live/secretResolver.ts
@@ -1,0 +1,60 @@
+import { LiveSecret } from './types';
+
+const AUTH_TYPES = new Set(['apiKey', 'oauth', 'basic', 'serviceAccount', 'custom']);
+
+const jsonEnvKey = (destination: string): string => `LIVE_SECRET_${destination.toUpperCase()}`;
+
+export class SecretResolver {
+  private readonly env: NodeJS.ProcessEnv;
+
+  constructor(env: NodeJS.ProcessEnv = process.env) {
+    this.env = env;
+  }
+
+  // Resolves a LiveSecret per destination from the LIVE_SECRET_<DEST> env var (JSON).
+  // Throws when the secret is missing or invalid; live tests require credentials.
+  resolve(destination: string): LiveSecret {
+    const key = jsonEnvKey(destination);
+    const raw = this.env[key];
+    if (!raw) {
+      throw new Error(`${key} is not set — live tests require credentials for '${destination}'.`);
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch (e) {
+      throw new Error(`${key} is set but is not valid JSON: ${(e as Error).message}`);
+    }
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+      throw new Error(`${key} must be a JSON object`);
+    }
+    const body = parsed as Record<string, unknown>;
+    if (typeof body.authType !== 'string' || !AUTH_TYPES.has(body.authType)) {
+      throw new Error(
+        `${key}.authType must be one of: ${[...AUTH_TYPES].join(', ')} (got ${JSON.stringify(body.authType)})`,
+      );
+    }
+    if (typeof body.config !== 'object' || body.config === null || Array.isArray(body.config)) {
+      throw new Error(`${key}.config must be a non-null object`);
+    }
+    return {
+      authType: body.authType as LiveSecret['authType'],
+      config: body.config as Record<string, unknown>,
+      secret:
+        typeof body.secret === 'object' && body.secret !== null && !Array.isArray(body.secret)
+          ? (body.secret as Record<string, string>)
+          : undefined,
+      resourceIds:
+        typeof body.resourceIds === 'object' &&
+        body.resourceIds !== null &&
+        !Array.isArray(body.resourceIds)
+          ? (body.resourceIds as Record<string, string>)
+          : undefined,
+      oauthRefresh: body.oauthRefresh as LiveSecret['oauthRefresh'],
+      readback:
+        typeof body.readback === 'object' && body.readback !== null && !Array.isArray(body.readback)
+          ? (body.readback as Record<string, unknown>)
+          : undefined,
+    };
+  }
+}

--- a/test/integrations/live/types.ts
+++ b/test/integrations/live/types.ts
@@ -1,0 +1,114 @@
+type AuthType = 'apiKey' | 'oauth' | 'basic' | 'serviceAccount' | 'custom';
+type AccountDefinition = { type: string; category: string; name: string };
+
+// Resolved credentials for one destination.
+type LiveSecret = {
+  authType: AuthType;
+  config: Record<string, unknown>; // merged into destination.Config
+  secret?: Record<string, string>; // merged into metadata.secret
+  resourceIds?: Record<string, string>; // account-scoped: listId, pixelId, measurementId, etc.
+  oauthRefresh?: {
+    // if authType is oauth, sent to rudder-auth /auth/v1/refresh
+    refreshToken: string; // the long-lived token: the only oauth secret stored
+    accountDefinition: AccountDefinition;
+    providerFields?: Record<string, string>; // e.g. Salesforce instance_url, Google Cloud project ID, etc.
+  };
+  readback?: Record<string, unknown>; // credentials for the optional verify() hook, e.g. API key, etc.
+};
+
+type LiveResource = { type: string; id: string };
+
+// Run-scoped context threaded through every step of a scenario. Build data from these — never
+// from string literals — so each run is isolated and repeatable.
+interface RunContext {
+  readonly runId: string; // unique id for this scenario run
+  readonly resources: LiveResource[]; // resources registered so far (for later steps / cleanup)
+  readonly liveSecret: LiveSecret; // resolved credentials for the destination
+
+  // Memoised unique id for an entity kind (e.g. 'user'); stable within a run, distinct across runs.
+  identity(entity: string): string;
+  // Unique, sink-safe email address for the run (override the domain via LIVE_TEST_EMAIL_DOMAIN).
+  email(entity?: string): string;
+  // ISO timestamp relative to run start; `offset` like '-3h' / '+1d' (empty = run start).
+  now(offset?: string): string;
+  // Record a created resource so later steps can reference it and cleanup can remove it.
+  register(resource: LiveResource): void;
+  // Register an ad-hoc teardown fn (for resources discovered dynamically); drained after the scenario.
+  addCleanup(fn: () => void | Promise<void>): void;
+}
+
+// Fields shared by every step.
+interface Step {
+  name: string;
+}
+
+// A pipeline step: seed -> /routerTransform -> /proxy, asserting the event is delivered.
+interface PipelineStep extends Step {
+  stepType: 'pipeline';
+  seed: (ctx: RunContext) => Record<string, unknown>;
+  // Merged into the /routerTransform input metadata, overriding defaults — e.g. { dontBatch: true }.
+  metadataOverride?: Record<string, unknown>;
+  // Re-run seed -> transform -> deliver up to this many extra times (backoff) if delivery fails.
+  // For routes that decide create-vs-update by searching an eventually-consistent index: a
+  // freshly set-up record can be missed on the first try and 409, then found on a retry. Only use
+  // where a failed attempt persists nothing (e.g. a 409-on-create), so a retry is safe to repeat.
+  retries?: number;
+}
+
+// An action step: a direct destination-API side effect (seed/mutate/delete state), run in order.
+interface ActionStep extends Step {
+  stepType: 'action';
+  run: (ctx: RunContext) => Promise<void>;
+}
+
+// A verify step: a read-back assertion. `check` resolves on success and fails via a jest
+// expectation (expect(...)) — the failed matcher is surfaced as the step failure.
+interface VerifyStep extends Step {
+  stepType: 'verify';
+  check: (ctx: RunContext) => Promise<void>;
+}
+
+type LiveStep = PipelineStep | ActionStep | VerifyStep;
+
+// A scenario is an ordered list of steps (pipeline | action | verify) sharing one RunContext.
+// Setup, teardown and read-back are expressed as action/verify steps — no lifecycle hooks.
+type LiveScenario = {
+  id: string; // stable identifier, shown in test output and used to select scenarios
+  description: string; // one-line summary of the behavior under test
+  steps: LiveStep[];
+
+  enabled?: boolean; // default true; set false to keep the scenario in the tree without running it
+  // Run this scenario against a modified destination.Config (derived from the spec's base config).
+  configOverride?: (base: Record<string, unknown>) => Record<string, unknown>;
+  // Scenario teardown: armed at scenario start, drained after its steps finish (LIFO, best-effort),
+  // and run even if a step failed. Prefer this over a trailing cleanup step.
+  cleanup?: (ctx: RunContext) => void | Promise<void>;
+};
+
+// Per-destination contract at test/integrations/destinations/<dest>/live.ts, loaded by the registry.
+type LiveSpec = {
+  enabled: boolean; // false parks the whole destination — the registry skips it
+  authType: AuthType;
+  // Map the resolved secret into the destination.Config the transform expects (merge non-secret
+  // defaults with the credentials in `s.config`).
+  resolveConfig: (s: LiveSecret) => Record<string, unknown>;
+  scenarios: LiveScenario[];
+};
+
+// A destination enrolled to run, paired with its spec.
+type EnrolledDestination = { destination: string; spec: LiveSpec };
+
+export {
+  AccountDefinition,
+  AuthType,
+  LiveSecret,
+  RunContext,
+  LiveResource,
+  LiveStep,
+  LiveScenario,
+  LiveSpec,
+  EnrolledDestination,
+  PipelineStep,
+  ActionStep,
+  VerifyStep,
+};

--- a/test/integrations/live/types.ts
+++ b/test/integrations/live/types.ts
@@ -1,3 +1,5 @@
+import { z } from 'zod';
+
 type AuthType = 'apiKey' | 'oauth' | 'basic' | 'serviceAccount' | 'custom';
 type AccountDefinition = { type: string; category: string; name: string };
 
@@ -48,6 +50,13 @@ interface PipelineStep extends Step {
   seed: (ctx: RunContext) => Record<string, unknown>;
   // Merged into the /routerTransform input metadata, overriding defaults — e.g. { dontBatch: true }.
   metadataOverride?: Record<string, unknown>;
+  // Exact number of /routerTransform outputs this step expects. The step knows what it seeded, so
+  // pin the count when set — a batching regression that collapses/fans out events is otherwise
+  // waved through by the default `> 0` check. Omit to keep the loose `> 0` assertion.
+  expectedOutputs?: number;
+  // Exact number of proxy requests across all outputs (where a dontBatch regression would slip
+  // through). Omit to keep the loose per-output `> 0` assertion.
+  expectedProxyRequests?: number;
   // Re-run seed -> transform -> deliver up to this many extra times (backoff) if delivery fails.
   // For routes that decide create-vs-update by searching an eventually-consistent index: a
   // freshly set-up record can be missed on the first try and 409, then found on a retry. Only use
@@ -80,6 +89,16 @@ type LiveScenario = {
   enabled?: boolean; // default true; set false to keep the scenario in the tree without running it
   // Run this scenario against a modified destination.Config (derived from the spec's base config).
   configOverride?: (base: Record<string, unknown>) => Record<string, unknown>;
+  // The common trailing read-back, declared on the scenario the way `cleanup` is: the framework
+  // runs `check` after the steps and retries it on a thrown matcher error (jest `expect`) with
+  // backoff, rethrowing the last error on exhaustion — so destination code shrinks to the
+  // assertion and the poll boilerplate lives here. For ordering cases (verify-after-setup or
+  // mid-scenario), use a VerifyStep in `steps` instead.
+  verify?: {
+    check: (ctx: RunContext) => Promise<void>;
+    attempts?: number; // default 4
+    delayMs?: (attempt: number) => number; // default 1000 * 2 ** attempt
+  };
   // Scenario teardown: armed at scenario start, drained after its steps finish (LIFO, best-effort),
   // and run even if a step failed. Prefer this over a trailing cleanup step.
   cleanup?: (ctx: RunContext) => void | Promise<void>;
@@ -98,6 +117,97 @@ type LiveSpec = {
 // A destination enrolled to run, paired with its spec.
 type EnrolledDestination = { destination: string; spec: LiveSpec };
 
+// Live-local wire schemas: include `endpointPath` (stripped by the shared
+// ProcessorTransformationOutputSchema) and keep destination/metadata loose so we don't require
+// Destination's full control-plane shape.
+const LiveProcessorOutputSchema = z.object({
+  version: z.string(),
+  type: z.string(),
+  method: z.string(),
+  endpoint: z.string(),
+  endpointPath: z.string().optional(),
+  userId: z.string().optional(),
+  headers: z.record(z.unknown()).optional(),
+  params: z.record(z.unknown()).optional(),
+  body: z
+    .object({
+      JSON: z.record(z.unknown()).optional(),
+      JSON_ARRAY: z.record(z.unknown()).optional(),
+      XML: z.record(z.unknown()).optional(),
+      FORM: z.record(z.unknown()).optional(),
+      GZIP: z.record(z.unknown()).optional(),
+    })
+    .optional(),
+  files: z.record(z.unknown()).optional(),
+});
+
+const LiveRouterOutputSchema = z.object({
+  batchedRequest: z.array(LiveProcessorOutputSchema).or(LiveProcessorOutputSchema).optional(),
+  metadata: z.array(z.record(z.unknown())),
+  destination: z.record(z.unknown()),
+  batched: z.boolean(),
+  statusCode: z.number(),
+  error: z.string().optional(),
+  statTags: z.record(z.unknown()).optional(),
+});
+
+type RouterOutput = z.infer<typeof LiveRouterOutputSchema>;
+type BatchedRequest = z.infer<typeof LiveProcessorOutputSchema>;
+
+// Options for buildRouterTransformBody (routerTransformRequest.ts).
+type BuildRouterTransformBodyOptions = {
+  secret?: Record<string, string>;
+  metadataOverride?: Record<string, unknown>;
+};
+
+// Minimal HTTP client the pipeline runner drives; wraps SuperTest so the runner stays free of its types.
+type LiveHttpResponse = { status: number; body: unknown };
+type LiveHttpClient = {
+  post: (url: string, body: unknown) => Promise<LiveHttpResponse>;
+};
+
+// Structured delivery failure — the retry loop and the throw site both consume this, so the
+// human-readable message is assembled once, at the throw (see runPipelineStep).
+type DeliveryFailure = {
+  proxyStatus: number;
+  verdictStatus: number;
+  message: string;
+  jobStates: unknown[];
+};
+
+// Arguments threaded into a single pipeline-step run.
+type RunPipelineStepParams = {
+  destination: string;
+  scenarioId: string;
+  step: PipelineStep;
+  ctx: RunContext;
+  config: Record<string, unknown>;
+  http: LiveHttpClient;
+};
+
+// ─── Poll helpers (poll.ts) ───
+
+type PollCheckResult<T> = { done: boolean; value: T };
+
+type PollUntilOptions = {
+  label: string;
+  attempts: number;
+  /** Delay before the next attempt; `attempt` is 0-based (after the first check). */
+  delayMs: (attempt: number) => number;
+  /** Extra wait after a successful check (e.g. search-index settle). */
+  settleMs?: number;
+  /**
+   * When true, return the last observed value on exhaustion instead of throwing — useful for
+   * verify steps that want a jest `expect` diff of the final read-back.
+   */
+  soft?: boolean;
+};
+
+type RetryUntilPassesOptions = {
+  attempts?: number; // default 4
+  delayMs?: (attempt: number) => number; // default 1000 * 2 ** attempt
+};
+
 export {
   AccountDefinition,
   AuthType,
@@ -111,4 +221,16 @@ export {
   PipelineStep,
   ActionStep,
   VerifyStep,
+  LiveProcessorOutputSchema,
+  LiveRouterOutputSchema,
+  RouterOutput,
+  BatchedRequest,
+  BuildRouterTransformBodyOptions,
+  LiveHttpResponse,
+  LiveHttpClient,
+  DeliveryFailure,
+  RunPipelineStepParams,
+  PollCheckResult,
+  PollUntilOptions,
+  RetryUntilPassesOptions,
 };


### PR DESCRIPTION
🔒 Scanned for secrets using gitleaks 8.29.1

## What are the changes introduced in this PR?

### Real-destination live integration testing (HubSpot pilot)

Drives events through the full **transform → deliver** pipeline against **real destination accounts** and asserts on the genuine response — closing the contract-verification gap the mocked suite can't cover (mocks answer from static fixtures, so a destination changing its endpoint, schema, auth, or encoding ships green today).

The mocked `component.test.ts` suite is untouched and stays the merge gate. This is additive.

### What's included

- **Sibling runner** — `component.live.test.ts` + `jest.config.live.js` boot the real Koa app **without** `MockAxiosAdapter`, then per step: `POST /routerTransform` → map each output to a proxy request → `POST /v1/destinations/<dest>/proxy` → assert the delivery verdict. Run via `npm run test:live` / `test:live:coverage`.
- **Harness core** (`test/integrations/live/`):
  - `registry.ts` — enrollment by discovery (`destinations/*/live.ts` with `enabled: true`).
  - `secretResolver.ts` — reads `LIVE_SECRET_<DEST>` (JSON); throws if missing/invalid.
  - `runContext.ts` — per-run `runId` plus memoised `identity`/`email`/`now`/`register`.
  - `routerOutputToProxyRequest.ts` — ports the transform→deliver chaining rudder-server does in production.
  - `types.ts` — `LiveSpec` / `LiveScenario` / `LiveStep`.
- **Step model** — a scenario is an ordered list of steps (no lifecycle hooks): `pipeline` (seed → transform → deliver → assert), `action` (direct destination-API side effect, e.g. setup/cleanup), and `verify` (read-back assertion). Plus `retries` (for eventually-consistent routing) and `metadataOverride` (e.g. `dontBatch`).
- **HubSpot pilot** — `destinations/hs/live.ts`: 14 scenarios across event-stream and reverse-ETL, newApi and v1, covering create/update, `dontBatch`, `hsContactId`, non-unique-lookup search routing, and associations. Uses a private-app token; teardown deletes created contacts via the CRM API.
- **CI** — `.github/workflows/live-integration-tests.yml`: runs on `pull_request` and `push` to `main`/`develop`, on a self-hosted in-cluster runner, with a per-destination matrix. Credentials come from the dev Vault via GitHub-OIDC (JWT auth) — no long-lived secret in GitHub — reading `LIVE_SECRET_HS` from `engineering_shared/.../e2e_test/rudder-transformer`. `LOG_LEVEL=100` suppresses body logging.
- Credentials are required (the resolver throws if absent). See `test/integrations/live/README.md`.

- Resolves INT-6774