### PR TITLE
docs(proxy): document networkHandler requires transformerProxy enabled

### DIFF
--- a/memory-bank/17_proxy_implementation_guide.md
+++ b/memory-bank/17_proxy_implementation_guide.md
@@ -903,6 +903,27 @@ const getResponseStrategy = (endpoint, response) => {
 };
 ```
 
+### 4. networkHandler present but transformerProxy not enabled
+
+**Problem**: A destination has a `networkHandler` (delivery proxy), but `transformerProxy` is not enabled for it in the rudder-server config. rudder-server then delivers directly and bypasses the networkHandler, so any request-building or delivery logic that lives only in the handler never executes — deliveries fail. This most often bites **open-source / self-hosted** users, who (unlike managed/SaaS deployments) are usually unaware of the `transformerProxy` flag and never set it.
+
+**Example**: GAEC (`google_adwords_enhanced_conversions`) builds the actual Google Ads API URL and performs delivery inside its networkHandler (via the Google Ads SDK) — the transform's `deliveryRequest` sets only `params`, `headers`, and `body`, and leaves `endpoint` empty on purpose. When `transformerProxy` is not enabled, rudder-server attempts direct delivery using that empty `endpoint`, producing an error like:
+
+```json
+{
+  "response": "504 Unable to make \"POST\" request for URL : \"\". Error: Post \"?accessToken=xxx&customerId=1225016906&developerToken=xxxx&event=Contact+%28Copy+Test%29&loginCustomerId=&subAccount=false\": unsupported protocol scheme \"\"",
+  "routerSubStage": "router_dest_delivery",
+  "payloadStage": "router_input"
+}
+```
+
+The tell-tale signs: an **empty URL** (everything after `?` is just the serialized `params`), `unsupported protocol scheme ""`, and `routerSubStage: "router_dest_delivery"` (direct delivery, not the proxy). The fix is to set `transformerProxy: true` for the destination so rudder-server routes delivery through the networkHandler, which then constructs the real endpoint.
+
+**Solution**:
+
+- Whenever you add or change a `networkHandler` for a destination, enable `transformerProxy: true` for that destination in the rudder-server Router config (`Router.<DEST_UPPERCASE>.transformerProxy`).
+- Call this out in the PR description and release notes so **self-hosted users know to enable the flag** on upgrade.
+
 ## Migrating from Proxy v0 to Proxy v1
 
 Migrating a destination from proxy v0 to proxy v1 involves creating a new network handler that supports the v1 response format and handles partial batch failures. Here's a step-by-step guide for migrating:


### PR DESCRIPTION
🔒 Scanned for secrets using gitleaks 8.30.1

## What are the changes introduced in this PR?

Add a Common Pitfalls entry: when a destination has a networkHandler (delivery proxy) but transformerProxy is not enabled, rudder-server delivers directly and bypasses the handler, so delivery logic living only in the handler never runs. Self-hosted users are the usual victims. Includes the GAEC empty-endpoint / "unsupported protocol scheme" error signature and the fix.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

## What is the related Linear task?

Resolves INT-XXX

## Please explain the objectives of your changes below

Put down any required details on the broader aspect of your changes. If there are any dependent changes, **mandatorily** mention them here

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

N/A

### Any new dependencies introduced with this change?

N/A

### Any new generic utility introduced or modified. Please explain the changes.

N/A

### Any technical or performance related pointers to consider with the change?

N/A

@coderabbitai review

<hr>

### Developer checklist

- [ ] My code follows the style guidelines of this project

- [ ] **No breaking changes are being introduced.**

- [ ] All related docs linked with the PR?

- [ ] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [ ] Is the PR limited to 10 file changes?

- [ ] Is the PR limited to one linear task?

- [ ] Are relevant unit and component test-cases added in **new readability format**?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.
