### PR TITLE
fix(hubspot): populate endpointPath on delivery requests and normalize destType casing

### DIFF
--- a/src/v0/destinations/hs/HSTransform-v1.ts
+++ b/src/v0/destinations/hs/HSTransform-v1.ts
@@ -27,8 +27,12 @@ import {
   IDENTIFY_CREATE_UPDATE_CONTACT,
   IDENTIFY_CREATE_NEW_CONTACT,
   CRM_CREATE_UPDATE_ALL_OBJECTS,
+  OBJECT_TYPE_PLACEHOLDER,
   MAX_BATCH_SIZE_CRM_OBJECT,
   MAX_BATCH_SIZE_CRM_CONTACT,
+  CRM_CREATE_UPDATE_ALL_OBJECTS_PATH,
+  BATCH_CONTACT_ENDPOINT_PATH,
+  TRACK_ENDPOINT_PATH,
 } from './config';
 import {
   getTransformedJSON,
@@ -74,6 +78,7 @@ const processLegacyIdentify = async (
   // if mappedToDestination is set true, then add externalId to traits
   // rETL source
   let endpoint: string = '';
+  let endpointPath: string = '';
   const response = defaultRequestConfig();
   response.method = defaultPostRequestConfig.requestMethod;
   if (
@@ -88,13 +93,21 @@ const processLegacyIdentify = async (
       throw new InstrumentationError('objectType not found');
     }
     if (operation === 'createObject') {
-      endpoint = CRM_CREATE_UPDATE_ALL_OBJECTS.replace(':objectType', objectType);
+      endpoint = CRM_CREATE_UPDATE_ALL_OBJECTS.replace(OBJECT_TYPE_PLACEHOLDER, objectType);
+      endpointPath = CRM_CREATE_UPDATE_ALL_OBJECTS_PATH.replace(
+        OBJECT_TYPE_PLACEHOLDER,
+        objectType,
+      );
     } else if (operation === 'updateObject' && getHsSearchId(message)) {
       const { hsSearchId } = getHsSearchId(message);
       endpoint = `${CRM_CREATE_UPDATE_ALL_OBJECTS.replace(
-        ':objectType',
+        OBJECT_TYPE_PLACEHOLDER,
         objectType,
       )}/${hsSearchId}`;
+      endpointPath = CRM_CREATE_UPDATE_ALL_OBJECTS_PATH.replace(
+        OBJECT_TYPE_PLACEHOLDER,
+        objectType,
+      );
       response.method = defaultPatchRequestConfig.requestMethod;
     }
 
@@ -125,6 +138,7 @@ const processLegacyIdentify = async (
   }
 
   response.endpoint = endpoint;
+  response.endpointPath = endpointPath;
   response.headers = {
     'Content-Type': JSON_MIME_TYPE,
   };
@@ -222,6 +236,7 @@ const batchIdentifyForrETL = (
           ...ev.message.body.JSON,
         });
         batchEventResponse.batchedRequest.endpoint = `${ev.message.endpoint}/batch/create`;
+        batchEventResponse.batchedRequest.endpointPath = `${ev.message.endpointPath}/batch/create`;
 
         metadata.push(ev.metadata);
       });
@@ -237,6 +252,7 @@ const batchIdentifyForrETL = (
           0,
           updateEndpoint.lastIndexOf('/'),
         )}/batch/update`;
+        batchEventResponse.batchedRequest.endpointPath = `${ev.message.endpointPath}/batch/update`;
 
         metadata.push(ev.metadata);
       });
@@ -286,6 +302,7 @@ const legacyBatchEvents = (
       const batchedResponse: HubSpotBatchRequestOutput = defaultBatchRequestConfig();
       batchedResponse.batchedRequest.headers = message.headers!;
       batchedResponse.batchedRequest.endpoint = endpoint;
+      batchedResponse.batchedRequest.endpointPath = TRACK_ENDPOINT_PATH;
       batchedResponse.batchedRequest.body = message.body;
       batchedResponse.batchedRequest.params = message.params!;
       batchedResponse.batchedRequest.method = defaultGetRequestConfig.requestMethod;
@@ -365,6 +382,7 @@ const legacyBatchEvents = (
           inputs: identifyResponseList,
         };
         batchEventResponse.batchedRequest.endpoint = `${ev.message.endpoint}/batch/create`;
+        batchEventResponse.batchedRequest.endpointPath = `${ev.message.endpointPath}/batch/create`;
         metadata.push(ev.metadata);
       } else {
         const bodyJSON = ev.message.body.JSON;
@@ -392,6 +410,7 @@ const legacyBatchEvents = (
           batch: JSON.stringify(identifyResponseList),
         };
         batchEventResponse.batchedRequest.endpoint = BATCH_CONTACT_ENDPOINT;
+        batchEventResponse.batchedRequest.endpointPath = BATCH_CONTACT_ENDPOINT_PATH;
       }
     });
 

--- a/src/v0/destinations/hs/HSTransform-v1.ts
+++ b/src/v0/destinations/hs/HSTransform-v1.ts
@@ -21,16 +21,15 @@ import {
   sortBatchesByMinJobId,
 } from '../../util';
 import {
-  BATCH_CONTACT_ENDPOINT,
+  BASE_ENDPOINT,
+  TRACK_BASE_ENDPOINT,
   MAX_BATCH_SIZE,
-  TRACK_ENDPOINT,
-  IDENTIFY_CREATE_UPDATE_CONTACT,
-  IDENTIFY_CREATE_NEW_CONTACT,
-  CRM_CREATE_UPDATE_ALL_OBJECTS,
+  IDENTIFY_CREATE_UPDATE_CONTACT_ENDPOINT_PATH,
+  IDENTIFY_CREATE_NEW_CONTACT_ENDPOINT_PATH,
   OBJECT_TYPE_PLACEHOLDER,
   MAX_BATCH_SIZE_CRM_OBJECT,
   MAX_BATCH_SIZE_CRM_CONTACT,
-  CRM_CREATE_UPDATE_ALL_OBJECTS_PATH,
+  CRM_CREATE_UPDATE_ALL_OBJECTS_ENDPOINT_PATH,
   BATCH_CONTACT_ENDPOINT_PATH,
   TRACK_ENDPOINT_PATH,
 } from './config';
@@ -93,21 +92,18 @@ const processLegacyIdentify = async (
       throw new InstrumentationError('objectType not found');
     }
     if (operation === 'createObject') {
-      endpoint = CRM_CREATE_UPDATE_ALL_OBJECTS.replace(OBJECT_TYPE_PLACEHOLDER, objectType);
-      endpointPath = CRM_CREATE_UPDATE_ALL_OBJECTS_PATH.replace(
+      endpointPath = CRM_CREATE_UPDATE_ALL_OBJECTS_ENDPOINT_PATH.replace(
         OBJECT_TYPE_PLACEHOLDER,
         objectType,
       );
+      endpoint = `${BASE_ENDPOINT}${endpointPath}`;
     } else if (operation === 'updateObject' && getHsSearchId(message)) {
       const { hsSearchId } = getHsSearchId(message);
-      endpoint = `${CRM_CREATE_UPDATE_ALL_OBJECTS.replace(
-        OBJECT_TYPE_PLACEHOLDER,
-        objectType,
-      )}/${hsSearchId}`;
-      endpointPath = CRM_CREATE_UPDATE_ALL_OBJECTS_PATH.replace(
+      endpointPath = CRM_CREATE_UPDATE_ALL_OBJECTS_ENDPOINT_PATH.replace(
         OBJECT_TYPE_PLACEHOLDER,
         objectType,
       );
+      endpoint = `${BASE_ENDPOINT}${endpointPath}/${hsSearchId}`;
       response.method = defaultPatchRequestConfig.requestMethod;
     }
 
@@ -130,9 +126,12 @@ const processLegacyIdentify = async (
     };
 
     if (email) {
-      endpoint = IDENTIFY_CREATE_UPDATE_CONTACT.replace(':contact_email', email);
+      endpoint = `${BASE_ENDPOINT}${IDENTIFY_CREATE_UPDATE_CONTACT_ENDPOINT_PATH.replace(
+        ':contact_email',
+        email,
+      )}`;
     } else {
-      endpoint = IDENTIFY_CREATE_NEW_CONTACT;
+      endpoint = `${BASE_ENDPOINT}${IDENTIFY_CREATE_NEW_CONTACT_ENDPOINT_PATH}`;
     }
     response.body.JSON = removeUndefinedAndNullValues(payload);
   }
@@ -192,7 +191,7 @@ const processLegacyTrack = async (
   const params = removeUndefinedAndNullValues(payload);
 
   const response = defaultRequestConfig();
-  response.endpoint = TRACK_ENDPOINT;
+  response.endpoint = `${TRACK_BASE_ENDPOINT}${TRACK_ENDPOINT_PATH}`;
   response.method = defaultGetRequestConfig.requestMethod;
   response.headers = {
     'Content-Type': JSON_MIME_TYPE,
@@ -409,7 +408,7 @@ const legacyBatchEvents = (
         batchEventResponse.batchedRequest.body.JSON_ARRAY = {
           batch: JSON.stringify(identifyResponseList),
         };
-        batchEventResponse.batchedRequest.endpoint = BATCH_CONTACT_ENDPOINT;
+        batchEventResponse.batchedRequest.endpoint = `${BASE_ENDPOINT}${BATCH_CONTACT_ENDPOINT_PATH}`;
         batchEventResponse.batchedRequest.endpointPath = BATCH_CONTACT_ENDPOINT_PATH;
       }
     });

--- a/src/v0/destinations/hs/HSTransform-v2.ts
+++ b/src/v0/destinations/hs/HSTransform-v2.ts
@@ -36,8 +36,15 @@ import {
   CRM_CREATE_UPDATE_ALL_OBJECTS,
   MAX_BATCH_SIZE_CRM_OBJECT,
   CRM_ASSOCIATION_V3,
+  OBJECT_TYPE_PLACEHOLDER,
   RETL_CREATE_ASSOCIATION_OPERATION,
   RETL_SOURCE,
+  BATCH_IDENTIFY_CRM_CREATE_NEW_CONTACT_PATH,
+  BATCH_IDENTIFY_CRM_UPDATE_CONTACT_PATH,
+  BATCH_IDENTIFY_CRM_UPSERT_CONTACT_PATH,
+  TRACK_CRM_ENDPOINT_PATH,
+  CRM_CREATE_UPDATE_ALL_OBJECTS_PATH,
+  CRM_ASSOCIATION_V3_PATH,
 } from './config';
 import {
   getTransformedJSON,
@@ -115,6 +122,7 @@ const processUpsertIdentify = async (
   const response = defaultRequestConfig();
   response.method = defaultPostRequestConfig.requestMethod;
   response.endpoint = BATCH_IDENTIFY_CRM_UPSERT_CONTACT;
+  response.endpointPath = BATCH_IDENTIFY_CRM_UPSERT_CONTACT_PATH;
   response.headers = {
     'Content-Type': JSON_MIME_TYPE,
   };
@@ -154,6 +162,7 @@ const processIdentify = async (
   const objectType = externalIdInfo?.objectType;
   // build response
   let endpoint: string | undefined;
+  let endpointPath: string | undefined;
   const response = defaultRequestConfig();
   response.method = defaultPostRequestConfig.requestMethod;
 
@@ -170,6 +179,10 @@ const processIdentify = async (
       ':toObjectType',
       toObjectType,
     );
+    response.endpointPath = CRM_ASSOCIATION_V3_PATH.replace(
+      ':fromObjectType',
+      fromObjectType,
+    ).replace(':toObjectType', toObjectType);
     response.body.JSON = {
       ...traits,
       type: associationTypeId,
@@ -193,13 +206,21 @@ const processIdentify = async (
     }
     if (operation === 'createObject') {
       addExternalIdToHSTraits(message);
-      endpoint = CRM_CREATE_UPDATE_ALL_OBJECTS.replace(':objectType', objectType);
+      endpoint = CRM_CREATE_UPDATE_ALL_OBJECTS.replace(OBJECT_TYPE_PLACEHOLDER, objectType);
+      endpointPath = CRM_CREATE_UPDATE_ALL_OBJECTS_PATH.replace(
+        OBJECT_TYPE_PLACEHOLDER,
+        objectType,
+      );
     } else if (operation === 'updateObject' && getHsSearchId(message)) {
       const { hsSearchId } = getHsSearchId(message);
       endpoint = `${CRM_CREATE_UPDATE_ALL_OBJECTS.replace(
-        ':objectType',
+        OBJECT_TYPE_PLACEHOLDER,
         objectType,
       )}/${hsSearchId}`;
+      endpointPath = CRM_CREATE_UPDATE_ALL_OBJECTS_PATH.replace(
+        OBJECT_TYPE_PLACEHOLDER,
+        objectType,
+      );
       response.method = defaultPatchRequestConfig.requestMethod;
     }
 
@@ -249,6 +270,7 @@ const processIdentify = async (
   }
 
   response.endpoint = endpoint!;
+  response.endpointPath = endpointPath;
   response.headers = {
     'Content-Type': JSON_MIME_TYPE,
   };
@@ -337,6 +359,7 @@ const batchIdentify = (
 
     if (batchOperation === 'createObject') {
       batchEventResponse.batchedRequest.endpoint = `${message.endpoint}/batch/create`;
+      batchEventResponse.batchedRequest.endpointPath = `${message.endpointPath}/batch/create`;
 
       // create operation
       chunk.forEach((ev) => {
@@ -350,6 +373,7 @@ const batchIdentify = (
         0,
         message.endpoint.lastIndexOf('/'),
       )}/batch/update`;
+      batchEventResponse.batchedRequest.endpointPath = `${message.endpointPath}/batch/update`;
       // update operation
       chunk.forEach((ev) => {
         const updateEndpoint = ev.message.endpoint;
@@ -414,6 +438,7 @@ const batchIdentify = (
     } else if (batchOperation === 'createAssociations') {
       chunk.forEach((ev) => {
         batchEventResponse.batchedRequest.endpoint = ev.message.endpoint;
+        batchEventResponse.batchedRequest.endpointPath = ev.message.endpointPath;
         if (!hasAssociationShape(ev.message.body.JSON)) {
           throw new TransformationError('rETL - Invalid payload for createAssociations batch');
         }
@@ -451,6 +476,7 @@ const batchIdentify = (
         metadata.push(ev.metadata);
       });
       batchEventResponse.batchedRequest.endpoint = chunk[0].message.endpoint;
+      batchEventResponse.batchedRequest.endpointPath = chunk[0].message.endpointPath;
     } else {
       throw new TransformationError('Unknown hubspot operation', 400);
     }
@@ -461,8 +487,10 @@ const batchIdentify = (
 
     if (batchOperation === 'createContacts') {
       batchEventResponse.batchedRequest.endpoint = BATCH_IDENTIFY_CRM_CREATE_NEW_CONTACT;
+      batchEventResponse.batchedRequest.endpointPath = BATCH_IDENTIFY_CRM_CREATE_NEW_CONTACT_PATH;
     } else if (batchOperation === 'updateContacts') {
       batchEventResponse.batchedRequest.endpoint = BATCH_IDENTIFY_CRM_UPDATE_CONTACT;
+      batchEventResponse.batchedRequest.endpointPath = BATCH_IDENTIFY_CRM_UPDATE_CONTACT_PATH;
     }
 
     batchEventResponse.batchedRequest.headers = message.headers!;
@@ -513,6 +541,7 @@ const batchEvents = (
       const batchedResponse: HubSpotBatchRequestOutput = defaultBatchRequestConfig();
       batchedResponse.batchedRequest.headers = message.headers!;
       batchedResponse.batchedRequest.endpoint = endpoint;
+      batchedResponse.batchedRequest.endpointPath = TRACK_CRM_ENDPOINT_PATH;
       batchedResponse.batchedRequest.body = message.body;
       batchedResponse.batchedRequest.params = message.params!;
       batchedResponse.batchedRequest.method = defaultPostRequestConfig.requestMethod;

--- a/src/v0/destinations/hs/HSTransform-v2.ts
+++ b/src/v0/destinations/hs/HSTransform-v2.ts
@@ -24,27 +24,22 @@ import {
 } from '../../util';
 import stats from '../../../util/stats';
 import {
-  IDENTIFY_CRM_UPDATE_CONTACT,
-  IDENTIFY_CRM_CREATE_NEW_CONTACT,
+  BASE_ENDPOINT,
+  IDENTIFY_CRM_UPDATE_CONTACT_ENDPOINT_PATH,
+  IDENTIFY_CRM_CREATE_NEW_CONTACT_ENDPOINT_PATH,
   MAX_BATCH_SIZE_CRM_CONTACT,
-  BATCH_IDENTIFY_CRM_CREATE_NEW_CONTACT,
-  BATCH_IDENTIFY_CRM_UPDATE_CONTACT,
-  BATCH_IDENTIFY_CRM_UPSERT_CONTACT,
   mappingConfig,
   ConfigCategory,
-  TRACK_CRM_ENDPOINT,
-  CRM_CREATE_UPDATE_ALL_OBJECTS,
   MAX_BATCH_SIZE_CRM_OBJECT,
-  CRM_ASSOCIATION_V3,
   OBJECT_TYPE_PLACEHOLDER,
   RETL_CREATE_ASSOCIATION_OPERATION,
   RETL_SOURCE,
-  BATCH_IDENTIFY_CRM_CREATE_NEW_CONTACT_PATH,
-  BATCH_IDENTIFY_CRM_UPDATE_CONTACT_PATH,
-  BATCH_IDENTIFY_CRM_UPSERT_CONTACT_PATH,
+  BATCH_IDENTIFY_CRM_CREATE_NEW_CONTACT_ENDPOINT_PATH,
+  BATCH_IDENTIFY_CRM_UPDATE_CONTACT_ENDPOINT_PATH,
+  BATCH_IDENTIFY_CRM_UPSERT_CONTACT_ENDPOINT_PATH,
   TRACK_CRM_ENDPOINT_PATH,
-  CRM_CREATE_UPDATE_ALL_OBJECTS_PATH,
-  CRM_ASSOCIATION_V3_PATH,
+  CRM_CREATE_UPDATE_ALL_OBJECTS_ENDPOINT_PATH,
+  CRM_ASSOCIATION_V3_ENDPOINT_PATH,
 } from './config';
 import {
   getTransformedJSON,
@@ -121,8 +116,8 @@ const processUpsertIdentify = async (
   // Build response
   const response = defaultRequestConfig();
   response.method = defaultPostRequestConfig.requestMethod;
-  response.endpoint = BATCH_IDENTIFY_CRM_UPSERT_CONTACT;
-  response.endpointPath = BATCH_IDENTIFY_CRM_UPSERT_CONTACT_PATH;
+  response.endpoint = `${BASE_ENDPOINT}${BATCH_IDENTIFY_CRM_UPSERT_CONTACT_ENDPOINT_PATH}`;
+  response.endpointPath = BATCH_IDENTIFY_CRM_UPSERT_CONTACT_ENDPOINT_PATH;
   response.headers = {
     'Content-Type': JSON_MIME_TYPE,
   };
@@ -175,14 +170,12 @@ const processIdentify = async (
     externalIdObj
   ) {
     const { associationTypeId, fromObjectType, toObjectType } = externalIdObj;
-    response.endpoint = CRM_ASSOCIATION_V3.replace(':fromObjectType', fromObjectType).replace(
-      ':toObjectType',
-      toObjectType,
-    );
-    response.endpointPath = CRM_ASSOCIATION_V3_PATH.replace(
+    const associationEndpointPath = CRM_ASSOCIATION_V3_ENDPOINT_PATH.replace(
       ':fromObjectType',
       fromObjectType,
     ).replace(':toObjectType', toObjectType);
+    response.endpoint = `${BASE_ENDPOINT}${associationEndpointPath}`;
+    response.endpointPath = associationEndpointPath;
     response.body.JSON = {
       ...traits,
       type: associationTypeId,
@@ -206,21 +199,18 @@ const processIdentify = async (
     }
     if (operation === 'createObject') {
       addExternalIdToHSTraits(message);
-      endpoint = CRM_CREATE_UPDATE_ALL_OBJECTS.replace(OBJECT_TYPE_PLACEHOLDER, objectType);
-      endpointPath = CRM_CREATE_UPDATE_ALL_OBJECTS_PATH.replace(
+      endpointPath = CRM_CREATE_UPDATE_ALL_OBJECTS_ENDPOINT_PATH.replace(
         OBJECT_TYPE_PLACEHOLDER,
         objectType,
       );
+      endpoint = `${BASE_ENDPOINT}${endpointPath}`;
     } else if (operation === 'updateObject' && getHsSearchId(message)) {
       const { hsSearchId } = getHsSearchId(message);
-      endpoint = `${CRM_CREATE_UPDATE_ALL_OBJECTS.replace(
-        OBJECT_TYPE_PLACEHOLDER,
-        objectType,
-      )}/${hsSearchId}`;
-      endpointPath = CRM_CREATE_UPDATE_ALL_OBJECTS_PATH.replace(
+      endpointPath = CRM_CREATE_UPDATE_ALL_OBJECTS_ENDPOINT_PATH.replace(
         OBJECT_TYPE_PLACEHOLDER,
         objectType,
       );
+      endpoint = `${BASE_ENDPOINT}${endpointPath}/${hsSearchId}`;
       response.method = defaultPatchRequestConfig.requestMethod;
     }
 
@@ -257,13 +247,16 @@ const processIdentify = async (
     if (contactId) {
       // contact exists
       // update
-      endpoint = IDENTIFY_CRM_UPDATE_CONTACT.replace(':contactId', contactId);
+      endpoint = `${BASE_ENDPOINT}${IDENTIFY_CRM_UPDATE_CONTACT_ENDPOINT_PATH.replace(
+        ':contactId',
+        contactId,
+      )}`;
       response.operation = 'updateContacts';
       response.method = defaultPatchRequestConfig.requestMethod;
     } else {
       // contact do not exist
       // create
-      endpoint = IDENTIFY_CRM_CREATE_NEW_CONTACT;
+      endpoint = `${BASE_ENDPOINT}${IDENTIFY_CRM_CREATE_NEW_CONTACT_ENDPOINT_PATH}`;
       response.operation = 'createContacts';
     }
     response.body.JSON = removeUndefinedAndNullValues(payload);
@@ -313,7 +306,7 @@ const processTrack = async ({
   }
 
   const response = defaultRequestConfig();
-  response.endpoint = TRACK_CRM_ENDPOINT;
+  response.endpoint = `${BASE_ENDPOINT}${TRACK_CRM_ENDPOINT_PATH}`;
   response.method = defaultPostRequestConfig.requestMethod;
   response.headers = {
     'Content-Type': JSON_MIME_TYPE,
@@ -331,7 +324,7 @@ const processTrack = async ({
     };
   } else {
     // using legacyApiKey
-    response.endpoint = `${TRACK_CRM_ENDPOINT}?hapikey=${Config.apiKey}`;
+    response.endpoint = `${BASE_ENDPOINT}${TRACK_CRM_ENDPOINT_PATH}?hapikey=${Config.apiKey}`;
   }
 
   return response;
@@ -486,11 +479,13 @@ const batchIdentify = (
     };
 
     if (batchOperation === 'createContacts') {
-      batchEventResponse.batchedRequest.endpoint = BATCH_IDENTIFY_CRM_CREATE_NEW_CONTACT;
-      batchEventResponse.batchedRequest.endpointPath = BATCH_IDENTIFY_CRM_CREATE_NEW_CONTACT_PATH;
+      batchEventResponse.batchedRequest.endpoint = `${BASE_ENDPOINT}${BATCH_IDENTIFY_CRM_CREATE_NEW_CONTACT_ENDPOINT_PATH}`;
+      batchEventResponse.batchedRequest.endpointPath =
+        BATCH_IDENTIFY_CRM_CREATE_NEW_CONTACT_ENDPOINT_PATH;
     } else if (batchOperation === 'updateContacts') {
-      batchEventResponse.batchedRequest.endpoint = BATCH_IDENTIFY_CRM_UPDATE_CONTACT;
-      batchEventResponse.batchedRequest.endpointPath = BATCH_IDENTIFY_CRM_UPDATE_CONTACT_PATH;
+      batchEventResponse.batchedRequest.endpoint = `${BASE_ENDPOINT}${BATCH_IDENTIFY_CRM_UPDATE_CONTACT_ENDPOINT_PATH}`;
+      batchEventResponse.batchedRequest.endpointPath =
+        BATCH_IDENTIFY_CRM_UPDATE_CONTACT_ENDPOINT_PATH;
     }
 
     batchEventResponse.batchedRequest.headers = message.headers!;

--- a/src/v0/destinations/hs/config.ts
+++ b/src/v0/destinations/hs/config.ts
@@ -1,6 +1,8 @@
 import { getMappingConfig } from '../../util';
 
 const BASE_ENDPOINT = 'https://api.hubapi.com';
+// Placeholder replaced with the real object type when building object endpoints/paths.
+const OBJECT_TYPE_PLACEHOLDER = ':objectType';
 
 // For fetching properties from HubSpot
 const CONTACT_PROPERTY_MAP_ENDPOINT = `${BASE_ENDPOINT}/properties/v1/contacts/properties`;
@@ -19,11 +21,13 @@ const IDENTIFY_CREATE_UPDATE_CONTACT = `${BASE_ENDPOINT}/contacts/v1/contact/cre
 // Identify Batch
 // Ref - https://legacydocs.hubspot.com/docs/methods/contacts/batch_create_or_update
 const BATCH_CONTACT_ENDPOINT = `${BASE_ENDPOINT}/contacts/v1/contact/batch/`;
+const BATCH_CONTACT_ENDPOINT_PATH = '/contacts/v1/contact/batch/';
 const MAX_BATCH_SIZE = 1000;
 
 // Track
 // Ref - https://legacydocs.hubspot.com/docs/methods/enterprise_events/http_api
 const TRACK_ENDPOINT = 'https://track.hubspot.com/v1/event';
+const TRACK_ENDPOINT_PATH = '/v1/event';
 
 /*
  * NEW API
@@ -37,18 +41,23 @@ const IDENTIFY_CRM_UPDATE_CONTACT = `${BASE_ENDPOINT}/crm/v3/objects/contacts/:c
 
 // Identify Batch
 const BATCH_IDENTIFY_CRM_CREATE_NEW_CONTACT = `${BASE_ENDPOINT}/crm/v3/objects/contacts/batch/create`;
+const BATCH_IDENTIFY_CRM_CREATE_NEW_CONTACT_PATH = '/crm/v3/objects/contacts/batch/create';
 const BATCH_IDENTIFY_CRM_UPDATE_CONTACT = `${BASE_ENDPOINT}/crm/v3/objects/contacts/batch/update`;
+const BATCH_IDENTIFY_CRM_UPDATE_CONTACT_PATH = '/crm/v3/objects/contacts/batch/update';
 // Ref - https://developers.hubspot.com/docs/api/crm/contacts#create-or-update-contacts-upsert
 const BATCH_IDENTIFY_CRM_UPSERT_CONTACT = `${BASE_ENDPOINT}/crm/v3/objects/contacts/batch/upsert`;
+const BATCH_IDENTIFY_CRM_UPSERT_CONTACT_PATH = '/crm/v3/objects/contacts/batch/upsert';
 // Ref - https://developers.hubspot.com/docs/api/crm/contacts#endpoint?spec=GET-/crm/v3/objects/contacts
 const MAX_BATCH_SIZE_CRM_CONTACT = 100;
 
 // Track
 // Ref - https://developers.hubspot.com/docs/api/analytics/events
 const TRACK_CRM_ENDPOINT = `${BASE_ENDPOINT}/events/v3/send`;
+const TRACK_CRM_ENDPOINT_PATH = '/events/v3/send';
 
 /* CRM ALL Objects */
 const CRM_CREATE_UPDATE_ALL_OBJECTS = `${BASE_ENDPOINT}/crm/v3/objects/:objectType`;
+const CRM_CREATE_UPDATE_ALL_OBJECTS_PATH = '/crm/v3/objects/:objectType';
 
 // Batch for custom Objects
 // Ref - https://developers.hubspot.com/docs/api/crm/crm-custom-objects
@@ -57,6 +66,7 @@ const BATCH_CREATE_CUSTOM_OBJECTS = `${BASE_ENDPOINT}/crm/v3/objects/:objectType
 /* CRM Association v3 */
 // Ref - https://developers.hubspot.com/docs/api/crm/associations
 const CRM_ASSOCIATION_V3 = `${BASE_ENDPOINT}/crm/v3/associations/:fromObjectType/:toObjectType/batch/create`;
+const CRM_ASSOCIATION_V3_PATH = '/crm/v3/associations/:fromObjectType/:toObjectType/batch/create';
 
 // Ref - https://developers.hubspot.com/docs/api/crm/understanding-the-crm
 const MAX_BATCH_SIZE_CRM_OBJECT = 100;
@@ -132,4 +142,13 @@ export {
   DESTINATION,
   HUBSPOT_SYSTEM_FIELDS,
   CONTACT_PROPERTIES_CACHE_TTL,
+  OBJECT_TYPE_PLACEHOLDER,
+  BATCH_CONTACT_ENDPOINT_PATH,
+  TRACK_ENDPOINT_PATH,
+  BATCH_IDENTIFY_CRM_CREATE_NEW_CONTACT_PATH,
+  BATCH_IDENTIFY_CRM_UPDATE_CONTACT_PATH,
+  BATCH_IDENTIFY_CRM_UPSERT_CONTACT_PATH,
+  TRACK_CRM_ENDPOINT_PATH,
+  CRM_CREATE_UPDATE_ALL_OBJECTS_PATH,
+  CRM_ASSOCIATION_V3_PATH,
 };

--- a/src/v0/destinations/hs/config.ts
+++ b/src/v0/destinations/hs/config.ts
@@ -1,32 +1,33 @@
 import { getMappingConfig } from '../../util';
 
 const BASE_ENDPOINT = 'https://api.hubapi.com';
+// Legacy analytics events are sent to a different host than the rest of the HubSpot APIs.
+const TRACK_BASE_ENDPOINT = 'https://track.hubspot.com';
 // Placeholder replaced with the real object type when building object endpoints/paths.
 const OBJECT_TYPE_PLACEHOLDER = ':objectType';
 
 // For fetching properties from HubSpot
-const CONTACT_PROPERTY_MAP_ENDPOINT = `${BASE_ENDPOINT}/properties/v1/contacts/properties`;
+const CONTACT_PROPERTY_MAP_ENDPOINT_PATH = '/properties/v1/contacts/properties';
 // Ref - https://developers.hubspot.com/docs/api-reference/crm-properties-v3/core/get-crm-v3-properties-objectType
-const CRM_V3_CONTACT_PROPERTIES_ENDPOINT = `${BASE_ENDPOINT}/crm/v3/properties/contacts`;
+const CRM_V3_CONTACT_PROPERTIES_ENDPOINT_PATH = '/crm/v3/properties/contacts';
 
 /*
  * Legacy API
  */
 // Identify
 // Ref - https://legacydocs.hubspot.com/docs/methods/contacts/create_contact
-const IDENTIFY_CREATE_NEW_CONTACT = `${BASE_ENDPOINT}/contacts/v1/contact`;
+const IDENTIFY_CREATE_NEW_CONTACT_ENDPOINT_PATH = '/contacts/v1/contact';
 // Ref - https://legacydocs.hubspot.com/docs/methods/contacts/create_or_update
-const IDENTIFY_CREATE_UPDATE_CONTACT = `${BASE_ENDPOINT}/contacts/v1/contact/createOrUpdate/email/:contact_email`;
+const IDENTIFY_CREATE_UPDATE_CONTACT_ENDPOINT_PATH =
+  '/contacts/v1/contact/createOrUpdate/email/:contact_email';
 
 // Identify Batch
 // Ref - https://legacydocs.hubspot.com/docs/methods/contacts/batch_create_or_update
-const BATCH_CONTACT_ENDPOINT = `${BASE_ENDPOINT}/contacts/v1/contact/batch/`;
 const BATCH_CONTACT_ENDPOINT_PATH = '/contacts/v1/contact/batch/';
 const MAX_BATCH_SIZE = 1000;
 
 // Track
 // Ref - https://legacydocs.hubspot.com/docs/methods/enterprise_events/http_api
-const TRACK_ENDPOINT = 'https://track.hubspot.com/v1/event';
 const TRACK_ENDPOINT_PATH = '/v1/event';
 
 /*
@@ -34,39 +35,30 @@ const TRACK_ENDPOINT_PATH = '/v1/event';
  */
 // Identify
 // Ref - https://developers.hubspot.com/docs/api/crm/contacts#endpoint?spec=GET-/crm/v3/objects/contacts
-const IDENTIFY_CRM_SEARCH_CONTACT = `${BASE_ENDPOINT}/crm/v3/objects/contacts/search`;
-const IDENTIFY_CRM_SEARCH_ALL_OBJECTS = `${BASE_ENDPOINT}/crm/v3/objects/:objectType/search`;
-const IDENTIFY_CRM_CREATE_NEW_CONTACT = `${BASE_ENDPOINT}/crm/v3/objects/contacts`;
-const IDENTIFY_CRM_UPDATE_CONTACT = `${BASE_ENDPOINT}/crm/v3/objects/contacts/:contactId`;
+const IDENTIFY_CRM_SEARCH_CONTACT_ENDPOINT_PATH = '/crm/v3/objects/contacts/search';
+const IDENTIFY_CRM_SEARCH_ALL_OBJECTS_ENDPOINT_PATH = '/crm/v3/objects/:objectType/search';
+const IDENTIFY_CRM_CREATE_NEW_CONTACT_ENDPOINT_PATH = '/crm/v3/objects/contacts';
+const IDENTIFY_CRM_UPDATE_CONTACT_ENDPOINT_PATH = '/crm/v3/objects/contacts/:contactId';
 
 // Identify Batch
-const BATCH_IDENTIFY_CRM_CREATE_NEW_CONTACT = `${BASE_ENDPOINT}/crm/v3/objects/contacts/batch/create`;
-const BATCH_IDENTIFY_CRM_CREATE_NEW_CONTACT_PATH = '/crm/v3/objects/contacts/batch/create';
-const BATCH_IDENTIFY_CRM_UPDATE_CONTACT = `${BASE_ENDPOINT}/crm/v3/objects/contacts/batch/update`;
-const BATCH_IDENTIFY_CRM_UPDATE_CONTACT_PATH = '/crm/v3/objects/contacts/batch/update';
+const BATCH_IDENTIFY_CRM_CREATE_NEW_CONTACT_ENDPOINT_PATH = '/crm/v3/objects/contacts/batch/create';
+const BATCH_IDENTIFY_CRM_UPDATE_CONTACT_ENDPOINT_PATH = '/crm/v3/objects/contacts/batch/update';
 // Ref - https://developers.hubspot.com/docs/api/crm/contacts#create-or-update-contacts-upsert
-const BATCH_IDENTIFY_CRM_UPSERT_CONTACT = `${BASE_ENDPOINT}/crm/v3/objects/contacts/batch/upsert`;
-const BATCH_IDENTIFY_CRM_UPSERT_CONTACT_PATH = '/crm/v3/objects/contacts/batch/upsert';
+const BATCH_IDENTIFY_CRM_UPSERT_CONTACT_ENDPOINT_PATH = '/crm/v3/objects/contacts/batch/upsert';
 // Ref - https://developers.hubspot.com/docs/api/crm/contacts#endpoint?spec=GET-/crm/v3/objects/contacts
 const MAX_BATCH_SIZE_CRM_CONTACT = 100;
 
 // Track
 // Ref - https://developers.hubspot.com/docs/api/analytics/events
-const TRACK_CRM_ENDPOINT = `${BASE_ENDPOINT}/events/v3/send`;
 const TRACK_CRM_ENDPOINT_PATH = '/events/v3/send';
 
 /* CRM ALL Objects */
-const CRM_CREATE_UPDATE_ALL_OBJECTS = `${BASE_ENDPOINT}/crm/v3/objects/:objectType`;
-const CRM_CREATE_UPDATE_ALL_OBJECTS_PATH = '/crm/v3/objects/:objectType';
-
-// Batch for custom Objects
-// Ref - https://developers.hubspot.com/docs/api/crm/crm-custom-objects
-const BATCH_CREATE_CUSTOM_OBJECTS = `${BASE_ENDPOINT}/crm/v3/objects/:objectType/batch/create`;
+const CRM_CREATE_UPDATE_ALL_OBJECTS_ENDPOINT_PATH = '/crm/v3/objects/:objectType';
 
 /* CRM Association v3 */
 // Ref - https://developers.hubspot.com/docs/api/crm/associations
-const CRM_ASSOCIATION_V3 = `${BASE_ENDPOINT}/crm/v3/associations/:fromObjectType/:toObjectType/batch/create`;
-const CRM_ASSOCIATION_V3_PATH = '/crm/v3/associations/:fromObjectType/:toObjectType/batch/create';
+const CRM_ASSOCIATION_V3_ENDPOINT_PATH =
+  '/crm/v3/associations/:fromObjectType/:toObjectType/batch/create';
 
 // Ref - https://developers.hubspot.com/docs/api/crm/understanding-the-crm
 const MAX_BATCH_SIZE_CRM_OBJECT = 100;
@@ -110,25 +102,26 @@ const CONTACT_PROPERTIES_CACHE_TTL = 60 * 60 * 24; // 24 hours
 
 export {
   BASE_ENDPOINT,
-  CONTACT_PROPERTY_MAP_ENDPOINT,
-  CRM_V3_CONTACT_PROPERTIES_ENDPOINT,
-  TRACK_ENDPOINT,
-  IDENTIFY_CREATE_UPDATE_CONTACT,
-  IDENTIFY_CREATE_NEW_CONTACT,
-  BATCH_CONTACT_ENDPOINT,
+  TRACK_BASE_ENDPOINT,
+  OBJECT_TYPE_PLACEHOLDER,
+  CONTACT_PROPERTY_MAP_ENDPOINT_PATH,
+  CRM_V3_CONTACT_PROPERTIES_ENDPOINT_PATH,
+  IDENTIFY_CREATE_NEW_CONTACT_ENDPOINT_PATH,
+  IDENTIFY_CREATE_UPDATE_CONTACT_ENDPOINT_PATH,
+  BATCH_CONTACT_ENDPOINT_PATH,
   MAX_BATCH_SIZE,
-  IDENTIFY_CRM_SEARCH_CONTACT,
-  IDENTIFY_CRM_SEARCH_ALL_OBJECTS,
-  IDENTIFY_CRM_CREATE_NEW_CONTACT,
-  IDENTIFY_CRM_UPDATE_CONTACT,
-  BATCH_IDENTIFY_CRM_CREATE_NEW_CONTACT,
-  BATCH_IDENTIFY_CRM_UPDATE_CONTACT,
-  BATCH_IDENTIFY_CRM_UPSERT_CONTACT,
+  TRACK_ENDPOINT_PATH,
+  IDENTIFY_CRM_SEARCH_CONTACT_ENDPOINT_PATH,
+  IDENTIFY_CRM_SEARCH_ALL_OBJECTS_ENDPOINT_PATH,
+  IDENTIFY_CRM_CREATE_NEW_CONTACT_ENDPOINT_PATH,
+  IDENTIFY_CRM_UPDATE_CONTACT_ENDPOINT_PATH,
+  BATCH_IDENTIFY_CRM_CREATE_NEW_CONTACT_ENDPOINT_PATH,
+  BATCH_IDENTIFY_CRM_UPDATE_CONTACT_ENDPOINT_PATH,
+  BATCH_IDENTIFY_CRM_UPSERT_CONTACT_ENDPOINT_PATH,
   MAX_BATCH_SIZE_CRM_CONTACT,
-  TRACK_CRM_ENDPOINT,
-  CRM_CREATE_UPDATE_ALL_OBJECTS,
-  BATCH_CREATE_CUSTOM_OBJECTS,
-  CRM_ASSOCIATION_V3,
+  TRACK_CRM_ENDPOINT_PATH,
+  CRM_CREATE_UPDATE_ALL_OBJECTS_ENDPOINT_PATH,
+  CRM_ASSOCIATION_V3_ENDPOINT_PATH,
   MAX_BATCH_SIZE_CRM_OBJECT,
   API_VERSION,
   ConfigCategory,
@@ -142,13 +135,4 @@ export {
   DESTINATION,
   HUBSPOT_SYSTEM_FIELDS,
   CONTACT_PROPERTIES_CACHE_TTL,
-  OBJECT_TYPE_PLACEHOLDER,
-  BATCH_CONTACT_ENDPOINT_PATH,
-  TRACK_ENDPOINT_PATH,
-  BATCH_IDENTIFY_CRM_CREATE_NEW_CONTACT_PATH,
-  BATCH_IDENTIFY_CRM_UPDATE_CONTACT_PATH,
-  BATCH_IDENTIFY_CRM_UPSERT_CONTACT_PATH,
-  TRACK_CRM_ENDPOINT_PATH,
-  CRM_CREATE_UPDATE_ALL_OBJECTS_PATH,
-  CRM_ASSOCIATION_V3_PATH,
 };

--- a/src/v0/destinations/hs/util.ts
+++ b/src/v0/destinations/hs/util.ts
@@ -25,10 +25,11 @@ import {
   isHttpStatusSuccess,
 } from '../../util';
 import {
-  CONTACT_PROPERTY_MAP_ENDPOINT,
-  CRM_V3_CONTACT_PROPERTIES_ENDPOINT,
-  IDENTIFY_CRM_SEARCH_CONTACT,
-  IDENTIFY_CRM_SEARCH_ALL_OBJECTS,
+  BASE_ENDPOINT,
+  CONTACT_PROPERTY_MAP_ENDPOINT_PATH,
+  CRM_V3_CONTACT_PROPERTIES_ENDPOINT_PATH,
+  IDENTIFY_CRM_SEARCH_CONTACT_ENDPOINT_PATH,
+  IDENTIFY_CRM_SEARCH_ALL_OBJECTS_ENDPOINT_PATH,
   SEARCH_LIMIT_VALUE,
   hsCommonConfigJson,
   primaryToSecondaryFields,
@@ -159,18 +160,22 @@ const getProperties = async (
         Authorization: `Bearer ${Config.accessToken}`,
       },
     };
-    hubspotPropertyMapResponse = await httpGET(CONTACT_PROPERTY_MAP_ENDPOINT, requestOptions, {
-      destType: DESTINATION,
-      feature: 'transformation',
-      endpointPath: `/properties/v1/contacts/properties`,
-      requestMethod: 'GET',
-      module: 'router',
-      metadata,
-    });
+    hubspotPropertyMapResponse = await httpGET(
+      `${BASE_ENDPOINT}${CONTACT_PROPERTY_MAP_ENDPOINT_PATH}`,
+      requestOptions,
+      {
+        destType: DESTINATION,
+        feature: 'transformation',
+        endpointPath: CONTACT_PROPERTY_MAP_ENDPOINT_PATH,
+        requestMethod: 'GET',
+        module: 'router',
+        metadata,
+      },
+    );
     hubspotPropertyMapResponse = processAxiosResponse(hubspotPropertyMapResponse);
   } else {
     // API Key (hapikey)
-    const url = `${CONTACT_PROPERTY_MAP_ENDPOINT}?hapikey=${Config.apiKey}`;
+    const url = `${BASE_ENDPOINT}${CONTACT_PROPERTY_MAP_ENDPOINT_PATH}?hapikey=${Config.apiKey}`;
     hubspotPropertyMapResponse = await httpGET(
       url,
       {},
@@ -463,7 +468,7 @@ const searchContacts = async (
       },
     };
     searchContactsResponse = await httpPOST(
-      IDENTIFY_CRM_SEARCH_CONTACT,
+      `${BASE_ENDPOINT}${IDENTIFY_CRM_SEARCH_CONTACT_ENDPOINT_PATH}`,
       requestData,
       requestOptions,
       {
@@ -478,7 +483,7 @@ const searchContacts = async (
     searchContactsResponse = processAxiosResponse(searchContactsResponse);
   } else {
     // API Key
-    const url = `${IDENTIFY_CRM_SEARCH_CONTACT}?hapikey=${Config.apiKey}`;
+    const url = `${BASE_ENDPOINT}${IDENTIFY_CRM_SEARCH_CONTACT_ENDPOINT_PATH}?hapikey=${Config.apiKey}`;
     searchContactsResponse = await httpPOST(url, requestData, {
       destType: DESTINATION,
       feature: 'transformation',
@@ -642,7 +647,10 @@ const performHubSpotSearch = async (
   const requestData = reqdata;
   const { Config } = destination;
 
-  const endpoint = IDENTIFY_CRM_SEARCH_ALL_OBJECTS.replace(':objectType', objectType);
+  const endpoint = `${BASE_ENDPOINT}${IDENTIFY_CRM_SEARCH_ALL_OBJECTS_ENDPOINT_PATH.replace(
+    ':objectType',
+    objectType,
+  )}`;
   const endpointPath = `objects/:objectType/search`;
 
   const url =
@@ -1012,7 +1020,11 @@ const fetchContactPropertiesV3 = async (
     metadata,
   };
   const authenticationInfo = addHsAuthentication({}, Config);
-  const response = await httpGET(CRM_V3_CONTACT_PROPERTIES_ENDPOINT, authenticationInfo, statTags);
+  const response = await httpGET(
+    `${BASE_ENDPOINT}${CRM_V3_CONTACT_PROPERTIES_ENDPOINT_PATH}`,
+    authenticationInfo,
+    statTags,
+  );
 
   const processedResponse = processAxiosResponse(response);
   if (processedResponse.status !== 200) {

--- a/src/v0/destinations/hs/util.ts
+++ b/src/v0/destinations/hs/util.ts
@@ -160,7 +160,7 @@ const getProperties = async (
       },
     };
     hubspotPropertyMapResponse = await httpGET(CONTACT_PROPERTY_MAP_ENDPOINT, requestOptions, {
-      destType: 'hs',
+      destType: DESTINATION,
       feature: 'transformation',
       endpointPath: `/properties/v1/contacts/properties`,
       requestMethod: 'GET',
@@ -175,7 +175,7 @@ const getProperties = async (
       url,
       {},
       {
-        destType: 'hs',
+        destType: DESTINATION,
         feature: 'transformation',
         endpointPath: `/properties/v1/contacts/properties?hapikey`,
         requestMethod: 'GET',
@@ -467,7 +467,7 @@ const searchContacts = async (
       requestData,
       requestOptions,
       {
-        destType: 'hs',
+        destType: DESTINATION,
         feature: 'transformation',
         endpointPath,
         requestMethod: 'POST',
@@ -480,7 +480,7 @@ const searchContacts = async (
     // API Key
     const url = `${IDENTIFY_CRM_SEARCH_CONTACT}?hapikey=${Config.apiKey}`;
     searchContactsResponse = await httpPOST(url, requestData, {
-      destType: 'hs',
+      destType: DESTINATION,
       feature: 'transformation',
       endpointPath,
       requestMethod: 'POST',
@@ -659,7 +659,7 @@ const performHubSpotSearch = async (
 
   while (checkAfter) {
     const httpResponse = await httpPOST(url, requestData, requestOptions, {
-      destType: 'hs',
+      destType: DESTINATION,
       feature: 'transformation',
       endpointPath,
       requestMethod: 'POST',

--- a/test/integrations/destinations/hs/router/data.ts
+++ b/test/integrations/destinations/hs/router/data.ts
@@ -221,6 +221,7 @@ export const data = [
                 method: 'POST',
                 endpoint:
                   'https://api.hubapi.com/crm/v3/associations/companies/contacts/batch/create',
+                endpointPath: '/crm/v3/associations/companies/contacts/batch/create',
                 headers: { 'Content-Type': 'application/json', Authorization: authHeader1 },
                 params: {},
                 body: {
@@ -373,6 +374,7 @@ export const data = [
                 type: 'REST',
                 method: 'POST',
                 endpoint: 'https://api.hubapi.com/crm/v3/objects/lead/batch/update',
+                endpointPath: '/crm/v3/objects/lead/batch/update',
                 headers: { 'Content-Type': 'application/json' },
                 params: { hapikey: 'dummy-apikey' },
                 body: {
@@ -426,6 +428,7 @@ export const data = [
                 type: 'REST',
                 method: 'POST',
                 endpoint: 'https://api.hubapi.com/crm/v3/objects/lead/batch/create',
+                endpointPath: '/crm/v3/objects/lead/batch/create',
                 headers: { 'Content-Type': 'application/json' },
                 params: { hapikey: 'dummy-apikey' },
                 body: {
@@ -668,6 +671,7 @@ export const data = [
                 type: 'REST',
                 method: 'POST',
                 endpoint: 'https://api.hubapi.com/contacts/v1/contact/batch/',
+                endpointPath: '/contacts/v1/contact/batch/',
                 headers: { 'Content-Type': 'application/json' },
                 params: { hapikey: 'dummy-apikey' },
                 body: {
@@ -716,6 +720,7 @@ export const data = [
                 type: 'REST',
                 method: 'GET',
                 endpoint: 'https://track.hubspot.com/v1/event',
+                endpointPath: '/v1/event',
                 headers: { 'Content-Type': 'application/json' },
                 params: {
                   _a: 'dummy-hubId',
@@ -757,6 +762,7 @@ export const data = [
                 type: 'REST',
                 method: 'POST',
                 endpoint: 'https://api.hubapi.com/contacts/v1/contact/batch/',
+                endpointPath: '/contacts/v1/contact/batch/',
                 headers: { 'Content-Type': 'application/json' },
                 params: { hapikey: 'dummy-apikey' },
                 body: {
@@ -1078,6 +1084,7 @@ export const data = [
                 type: 'REST',
                 method: 'POST',
                 endpoint: 'https://api.hubapi.com/crm/v3/objects/lead/batch/update',
+                endpointPath: '/crm/v3/objects/lead/batch/update',
                 headers: {
                   'Content-Type': 'application/json',
                   Authorization: authHeader1,
@@ -1161,6 +1168,7 @@ export const data = [
                 type: 'REST',
                 method: 'POST',
                 endpoint: 'https://api.hubapi.com/crm/v3/objects/lead/batch/create',
+                endpointPath: '/crm/v3/objects/lead/batch/create',
                 headers: {
                   'Content-Type': 'application/json',
                   Authorization: authHeader1,
@@ -1684,6 +1692,7 @@ export const data = [
                 type: 'REST',
                 method: 'POST',
                 endpoint: 'https://api.hubapi.com/crm/v3/objects/contacts/batch/upsert',
+                endpointPath: '/crm/v3/objects/contacts/batch/upsert',
                 headers: {
                   'Content-Type': 'application/json',
                   Authorization: 'Bearer hs1',
@@ -1797,6 +1806,7 @@ export const data = [
                 type: 'REST',
                 method: 'POST',
                 endpoint: 'https://api.hubapi.com/events/v3/send',
+                endpointPath: '/events/v3/send',
                 headers: {
                   'Content-Type': 'application/json',
                   Authorization: 'Bearer hs1',
@@ -1900,6 +1910,7 @@ export const data = [
                 type: 'REST',
                 method: 'POST',
                 endpoint: 'https://api.hubapi.com/crm/v3/objects/contacts/batch/upsert',
+                endpointPath: '/crm/v3/objects/contacts/batch/upsert',
                 headers: {
                   'Content-Type': 'application/json',
                   Authorization: 'Bearer hs1',
@@ -2095,6 +2106,7 @@ export const data = [
                 type: 'REST',
                 method: 'POST',
                 endpoint: 'https://api.hubapi.com/crm/v3/objects/contacts/batch/update',
+                endpointPath: '/crm/v3/objects/contacts/batch/update',
                 headers: {
                   'Content-Type': 'application/json',
                   Authorization: authHeader3,
@@ -2513,6 +2525,7 @@ export const data = [
                   XML: {},
                 },
                 endpoint: 'https://api.hubapi.com/crm/v3/objects/contacts/batch/upsert',
+                endpointPath: '/crm/v3/objects/contacts/batch/upsert',
                 files: {},
                 headers: {
                   Authorization: authHeader1,
@@ -2609,6 +2622,7 @@ export const data = [
                   XML: {},
                 },
                 endpoint: 'https://api.hubapi.com/crm/v3/objects/contacts/batch/upsert',
+                endpointPath: '/crm/v3/objects/contacts/batch/upsert',
                 files: {},
                 headers: {
                   Authorization: authHeader1,
@@ -2696,6 +2710,7 @@ export const data = [
                   XML: {},
                 },
                 endpoint: 'https://api.hubapi.com/crm/v3/objects/contacts/batch/upsert',
+                endpointPath: '/crm/v3/objects/contacts/batch/upsert',
                 files: {},
                 headers: {
                   Authorization: authHeader1,
@@ -2974,6 +2989,7 @@ export const data = [
                   XML: {},
                 },
                 endpoint: 'https://api.hubapi.com/crm/v3/objects/contacts/batch/upsert',
+                endpointPath: '/crm/v3/objects/contacts/batch/upsert',
                 files: {},
                 headers: {
                   Authorization: authHeader1,
@@ -3322,6 +3338,7 @@ export const data = [
                 type: 'REST',
                 method: 'POST',
                 endpoint: 'https://api.hubapi.com/crm/v3/objects/contacts/batch/upsert',
+                endpointPath: '/crm/v3/objects/contacts/batch/upsert',
                 headers: {
                   'Content-Type': 'application/json',
                   Authorization: authHeader1,
@@ -3376,6 +3393,7 @@ export const data = [
                 type: 'REST',
                 method: 'POST',
                 endpoint: 'https://api.hubapi.com/events/v3/send',
+                endpointPath: '/events/v3/send',
                 headers: {
                   'Content-Type': 'application/json',
                   Authorization: authHeader1,
@@ -3412,6 +3430,7 @@ export const data = [
                 type: 'REST',
                 method: 'POST',
                 endpoint: 'https://api.hubapi.com/events/v3/send',
+                endpointPath: '/events/v3/send',
                 headers: {
                   'Content-Type': 'application/json',
                   Authorization: authHeader1,
@@ -3445,6 +3464,7 @@ export const data = [
                 type: 'REST',
                 method: 'POST',
                 endpoint: 'https://api.hubapi.com/events/v3/send',
+                endpointPath: '/events/v3/send',
                 headers: {
                   'Content-Type': 'application/json',
                   Authorization: authHeader1,
@@ -3478,6 +3498,7 @@ export const data = [
                 type: 'REST',
                 method: 'POST',
                 endpoint: 'https://api.hubapi.com/events/v3/send',
+                endpointPath: '/events/v3/send',
                 headers: {
                   'Content-Type': 'application/json',
                   Authorization: authHeader1,
@@ -3511,6 +3532,7 @@ export const data = [
                 type: 'REST',
                 method: 'POST',
                 endpoint: 'https://api.hubapi.com/events/v3/send',
+                endpointPath: '/events/v3/send',
                 headers: {
                   'Content-Type': 'application/json',
                   Authorization: authHeader1,
@@ -3544,6 +3566,7 @@ export const data = [
                 type: 'REST',
                 method: 'POST',
                 endpoint: 'https://api.hubapi.com/crm/v3/objects/contacts/batch/upsert',
+                endpointPath: '/crm/v3/objects/contacts/batch/upsert',
                 headers: {
                   'Content-Type': 'application/json',
                   Authorization: authHeader1,
@@ -4123,6 +4146,7 @@ export const data = [
                   XML: {},
                 },
                 endpoint: 'https://api.hubapi.com/crm/v3/objects/contacts/batch/upsert',
+                endpointPath: '/crm/v3/objects/contacts/batch/upsert',
                 files: {},
                 headers: {
                   Authorization: authHeader2,
@@ -4335,6 +4359,7 @@ export const data = [
                 type: 'REST',
                 method: 'POST',
                 endpoint: 'https://api.hubapi.com/crm/v3/objects/lead/batch/create',
+                endpointPath: '/crm/v3/objects/lead/batch/create',
                 headers: { 'Content-Type': 'application/json' },
                 params: { hapikey: 'dummy-apikey' },
                 body: {
@@ -4393,6 +4418,7 @@ export const data = [
                 type: 'REST',
                 method: 'POST',
                 endpoint: 'https://api.hubapi.com/crm/v3/objects/lead/batch/update',
+                endpointPath: '/crm/v3/objects/lead/batch/update',
                 headers: { 'Content-Type': 'application/json' },
                 params: { hapikey: 'dummy-apikey' },
                 body: {
@@ -4505,6 +4531,7 @@ export const data = [
                 type: 'REST',
                 method: 'POST',
                 endpoint: 'https://api.hubapi.com/events/v3/send',
+                endpointPath: '/events/v3/send',
                 headers: {
                   'Content-Type': 'application/json',
                   Authorization: authHeader1,
@@ -4556,6 +4583,7 @@ export const data = [
       type: 'REST',
       method: 'POST',
       endpoint: 'https://api.hubapi.com/crm/v3/objects/contacts/batch/create',
+      endpointPath: '/crm/v3/objects/contacts/batch/create',
       headers: { 'Content-Type': 'application/json', Authorization: authHeader1 },
       params: {},
       body: {
@@ -4580,6 +4608,7 @@ export const data = [
       type: 'REST',
       method: 'POST',
       endpoint: 'https://api.hubapi.com/crm/v3/objects/contacts/batch/update',
+      endpointPath: '/crm/v3/objects/contacts/batch/update',
       headers: { 'Content-Type': 'application/json', Authorization: authHeader2 },
       params: {},
       body: {
@@ -4732,6 +4761,7 @@ export const data = [
       type: 'REST',
       method: 'POST',
       endpoint: 'https://api.hubapi.com/crm/v3/objects/contacts/batch/create',
+      endpointPath: '/crm/v3/objects/contacts/batch/create',
       headers: { 'Content-Type': 'application/json' },
       params: { hapikey: 'dummy-apikeysuccess' },
       body: {
@@ -4764,6 +4794,7 @@ export const data = [
       type: 'REST',
       method: 'POST',
       endpoint: 'https://api.hubapi.com/contacts/v1/contact/batch/',
+      endpointPath: '/contacts/v1/contact/batch/',
       headers: { 'Content-Type': 'application/json', Authorization: authHeader1 },
       params: {},
       body: {
@@ -4794,6 +4825,7 @@ export const data = [
       type: 'REST',
       method: 'GET',
       endpoint: 'https://track.hubspot.com/v1/event',
+      endpointPath: '/v1/event',
       headers: { 'Content-Type': 'application/json', Authorization: authHeader1 },
       params: { _a: '123', _n: 'Purchase', email: 'v1@e.com' },
       body: { JSON: {}, JSON_ARRAY: {}, XML: {}, FORM: {} },

--- a/test/integrations/destinations/hs/router/upsertData.ts
+++ b/test/integrations/destinations/hs/router/upsertData.ts
@@ -76,6 +76,7 @@ export const upsertData = [
                 type: 'REST',
                 method: 'POST',
                 endpoint: 'https://api.hubapi.com/crm/v3/objects/contacts/batch/upsert',
+                endpointPath: '/crm/v3/objects/contacts/batch/upsert',
                 headers: {
                   'Content-Type': 'application/json',
                   Authorization: authHeader1,
@@ -187,6 +188,7 @@ export const upsertData = [
                 type: 'REST',
                 method: 'POST',
                 endpoint: 'https://api.hubapi.com/crm/v3/objects/contacts/batch/upsert',
+                endpointPath: '/crm/v3/objects/contacts/batch/upsert',
                 headers: {
                   'Content-Type': 'application/json',
                   Authorization: authHeader1,
@@ -358,6 +360,7 @@ export const upsertData = [
                 type: 'REST',
                 method: 'POST',
                 endpoint: 'https://api.hubapi.com/crm/v3/objects/contacts/batch/upsert',
+                endpointPath: '/crm/v3/objects/contacts/batch/upsert',
                 headers: {
                   'Content-Type': 'application/json',
                   Authorization: authHeader1,
@@ -497,6 +500,7 @@ export const upsertData = [
                 type: 'REST',
                 method: 'POST',
                 endpoint: 'https://api.hubapi.com/crm/v3/objects/contacts/batch/upsert',
+                endpointPath: '/crm/v3/objects/contacts/batch/upsert',
                 headers: {
                   'Content-Type': 'application/json',
                   Authorization: authHeader1,
@@ -637,6 +641,7 @@ export const upsertData = [
                 type: 'REST',
                 method: 'POST',
                 endpoint: 'https://api.hubapi.com/crm/v3/objects/contacts/batch/upsert',
+                endpointPath: '/crm/v3/objects/contacts/batch/upsert',
                 headers: {
                   'Content-Type': 'application/json',
                   Authorization: authHeader1,


### PR DESCRIPTION
## What & why

Two problems with `transformer_outgoing_request_count` for HubSpot:

1. **Every endpoint collapsed into `endpointPath="default"`.** HubSpot delivery requests never set the `endpointPath` field, so rudder-server substituted the literal `"default"` (`router/worker.go`) for all of them. Upsert, create, update, search, and track were indistinguishable on dashboards, and per-endpoint delivery throttling couldn't discriminate either.
2. **`destType` split across `hs` and `HS`.** rudder-server emits `destType` from `DestinationDefinition.Name` (`HS`), while the transformer's own HubSpot API calls hard-coded the lowercase literal `'hs'` — so the same destination showed up under two labels.
3. Resolves INT-6784.

## Changes

- **Populate `endpointPath` on each delivered request**, built the same way as `endpoint`: the processor sets the single-object path from a `_PATH` constant co-located with each endpoint constant in `config.ts`, and the batch step appends the `/batch/*` suffix (or, for fixed endpoints like contacts/track, sets the sibling `_PATH` constant directly). Object/association types are templated via a shared `:objectType` placeholder, and record IDs (`hsSearchId`, `contactId`) never enter the tag, so label cardinality stays bounded. Dashboards now get real, per-endpoint labels, e.g. `/crm/v3/objects/contacts/batch/upsert`, `/crm/v3/objects/lead/batch/create`, `/crm/v3/associations/:fromObjectType/:toObjectType/batch/create`, `/events/v3/send`.
- ** Normalise `destType`** from `'hs'` to the `DESTINATION` constant (`'HS'`) at the five `util.ts` stat-tag call sites, matching what rudder-server emits (`DestinationDefinition.Name`) and the cache tags.
- **Update the hs router component fixtures** with the new `endpointPath` values.