### PR TITLE
feat(nativeBatching): fold NetworkHandler into the BatchDestination class

### DIFF
--- a/.claude/skills/batching-framework-delivery/SKILL.md
+++ b/.claude/skills/batching-framework-delivery/SKILL.md
@@ -101,6 +101,12 @@ So: if your destination's errors are worth reading, write the extractor in your 
 
 `gaec` originally indexed off the response's `results` and hit exactly this: whenever Google omitted `results`, an abort became a batch retry that could never converge, since re-uploading accepted adjustments returns duplicate-enhancement failures on every attempt.
 
+**`ctx.request.body?.JSON` only holds the batch on `BodyFormat.JSON`.** `mapSuccessPayloadToServerFormat` writes the batch to `body[strategy.bodyFormat]` and hard-sets the other three to `{}` (`processBatchedDestination.ts`), so a destination on `JSON_ARRAY`, `FORM` or `XML` reading `body.JSON` gets nothing on every response — success included — and the mismatch guard answers each one with an N-job 500. Read the key your `getBatchStrategy` actually returns. All six spec'd destinations are on `JSON` today, which is why no test catches this for you.
+
+**Decide what an unreadable posted array should mean before you write the loop.** `perItem([])` is a length mismatch, so the bridge retries the whole batch — and that retry reposts the same body and mismatches again, which never converges. `braze_audience` avoids it by falling back to `ctx.jobs`, which the framework builds 1:1 with the posted array. Taking the `fallback` parameter and returning a whole-batch verdict is the other option.
+
+**A delivery spec and an array-returning `transformEvent` are mutually exclusive.** `ctx.jobs` carries one entry per job, so a job contributing two body items puts the two lengths permanently out of step and the batch retries forever. `batchDestination.ts` and the VDM V2 dispatch table both permit `transformEvent` to return an array; a destination that does must not call `perItem`.
+
 ### Never infer auth from a status code
 
 A 401 from an API-key destination is a bad key, not a refreshable token, and guessing costs a real control-plane token refresh. Derive the category from the **response body** — `gaec` does, via `getAuthErrCategory` — or leave it alone. `getAuthErrCategoryFromStCode`'s unconditional 401→`REFRESH_TOKEN` is the anti-pattern this replaces.

--- a/.claude/skills/batching-framework-delivery/SKILL.md
+++ b/.claude/skills/batching-framework-delivery/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: batching-framework-delivery
+description: Delivery (response handling) for batching-framework destinations. Declare a static delivery spec on the BatchDestination class instead of writing a networkHandler responseHandler — the framework derives status codes, statTags and the response shape.
+---
+
+# Batching Framework — Delivery
+
+**Objective:** Handle a destination's delivery response by declaring what should happen to the batch, and let the framework turn that into the delivery API response. Integrations never build a `DeliveryV1Response`, choose a status code, or throw.
+
+For the router-transform half of the framework, see `.claude/skills/batching-framework/SKILL.md`.
+
+## When you need this
+
+**Most destinations need nothing.** The framework default reproduces `genericNetworkHandler`: 2xx is a success, 429 is throttled, other retryable statuses retry, everything else aborts. `posthog` and `custom_audience` declare no overrides at all.
+
+Add a `delivery.ts` only when the destination's response handling genuinely differs:
+
+- a **partial-failure body** — some records rejected inside an otherwise-successful response
+- a **2xx that isn't a success** — the failure is in the body, not the status
+- **identity-keyed failures** — the response names *which* records failed rather than indexing them
+- a **real auth signal** in the body that should drive token refresh
+
+## Reference
+
+- `src/services/destination/nativeBatching/delivery.ts` — verdicts, `DeliverySpec`, the bridge
+- `src/v0/destinations/customerio/v2/delivery.ts` — 207 multi-status, positional index
+- `src/v0/destinations/braze_audience/delivery.ts` — partial failure on a 2xx, positional index
+- `src/v0/destinations/iterable_audience/delivery.ts` — failures keyed by identity, not index
+- `src/v0/destinations/google_adwords_enhanced_conversions/delivery.ts` — partial failure + body-derived OAuth
+- `docs/superpowers/specs/2026-07-30-network-handler-abstraction-design.md` — design, evidence, per-destination parity tables
+
+## Declaring the delivery spec
+
+Everything an integration says about delivery lives in **one object**, exported from its
+`delivery.ts` and attached to the class as `static readonly delivery`. Grouping it is the point: a
+`BatchDestination`'s other members are all about transforming an event, and a bare `statusOverrides`
+or `failureReason` beside them reads as more of the same.
+
+```typescript
+// delivery.ts
+import {
+  abort, perItem, success, retry, throttled, authExpired, authRevoked,
+  type DeliverySpec, type StatusOverrideMap,
+} from '../../../services/destination/nativeBatching/batchDestination';
+
+const myStatusOverrides: StatusOverrideMap = {
+  207: (ctx) => perItem(items.map((item, i) => (failed(i) ? abort(reason) : success()))),
+  '4xx': (ctx, fallback) => (isAuthBody(ctx.response) ? authRevoked('grant gone') : fallback()),
+};
+
+export const myDelivery: DeliverySpec = {
+  statusOverrides: myStatusOverrides,
+  // Optional: the reason on a failure verdict. Default is status-only and never reads the body.
+  failureReason: (ctx) => extractMyErrorMessage(ctx.response),
+};
+
+// routerTransform.ts
+class MyIntegration extends BatchDestination<TBody> {
+  static readonly delivery = myDelivery;
+}
+```
+
+- Both members are **optional**. A destination needing neither declares no `delivery` at all.
+- Status keys are an **exact status** or a class (`'2xx'` / `'4xx'` / `'5xx'`); exact wins.
+- The spec is **resolved down the prototype chain**: `statusOverrides` merges key-by-key (child
+  winning) and `failureReason` takes the nearest declaration. Declaring a spec in a subclass
+  therefore does not drop what a parent declared — static properties are shadowed, not merged, and
+  that failure would otherwise be invisible.
+- `fallback()` gives you the framework's own classification. Call it for the responses your override
+  does not own, rather than re-deriving a verdict — the return type stays total, with no sentinel.
+- Applying the spec is **framework-owned**: `handleDeliveryResponse(Class, ctx)` is a free function
+  in `delivery.ts`, so there is nothing to override and no `super` to call.
+
+`DeliveryContext` carries `status`, `response` (parsed body), `jobs` (one `ProxyMetdata` per job, in order), `request` (what was sent) and `destinationConfig`.
+
+## Error messages belong to the integration
+
+`failureReason`'s default is status-only — `[Generic Response Handler] Request failed with status: <n>` — and **never inspects the response body**. That mirrors `genericNetworkHandler`, the fallback every unmigrated destination already gets, which likewise leaves the body to travel in `destinationResponse`.
+
+Do not add body-parsing to the framework. There is no shared convention to generalise: on the legacy path every destination extracts its message itself, against the shape its own API returns (`buildErrorMessage` joining `reason`/`field`/`message` for customerio, `error.message` for gaec, `params ?? msg ?? message` for iterable_audience). A generic "look for `message`, then `msg`, then `error`" helper looks like it unifies them but does not — it just imposes one destination's field order on every other, and any quirk added for one leaks into all of them.
+
+So: if your destination's errors are worth reading, write the extractor in your own `delivery.ts` and point `delivery.failureReason` at it. Return the string **bare** — the per-job `error` is what live events display and what error reporting groups on, so `Invalid API key` beats `"Invalid API key"`.
+
+## Verdicts
+
+| Builder | Meaning | Result |
+| --- | --- | --- |
+| `success()` | delivered | per-job `200` |
+| `abort(reason)` | permanent failure | per-job `400` |
+| `retry(reason, { dontBatch })` | transient failure | per-job `500` |
+| `throttled(reason)` | rate limited | per-job `429` |
+| `authExpired(reason)` | token stale but recoverable | `REFRESH_TOKEN` → refresh + retry |
+| `authRevoked(reason)` | grant gone | `AUTH_STATUS_INACTIVE` → abort |
+| `perItem([...])` | one verdict per request-body item | per-job, positionally |
+
+`ItemVerdict` (what `perItem` accepts) deliberately excludes the two auth refinements: rudder-server overwrites the status code of *every* job in a batch when an `authErrorCategory` is present, so a per-item auth verdict cannot be represented.
+
+### `perItem` is positional and 1:1
+
+**Index it off the posted request body (`ctx.request.body?.JSON`), not off the response.** The posted array is the one guaranteed to be the same length as the job list; a response array can be truncated or omitted entirely. A length mismatch makes the framework retry the whole batch rather than misattribute — correct, but a worse outcome than reading the body you sent.
+
+`gaec` originally indexed off the response's `results` and hit exactly this: whenever Google omitted `results`, an abort became a batch retry that could never converge, since re-uploading accepted adjustments returns duplicate-enhancement failures on every attempt.
+
+### Never infer auth from a status code
+
+A 401 from an API-key destination is a bad key, not a refreshable token, and guessing costs a real control-plane token refresh. Derive the category from the **response body** — `gaec` does, via `getAuthErrCategory` — or leave it alone. `getAuthErrCategoryFromStCode`'s unconditional 401→`REFRESH_TOKEN` is the anti-pattern this replaces.
+
+## What the framework derives
+
+Don't set these yourself:
+
+- **per-job `statusCode`** — from the verdict kind
+- **top-level `status`** — `ctx.status`, passed through
+- **`message`** — the shared failure reason when every failure agrees on one, otherwise a count
+- **`statTags`** — the whole tag set, when every job failed the same way
+- **`authErrorCategory`** — from the auth refinements only
+
+## Transport stays in `networkHandler.ts`
+
+Only *response handling* moves. A destination that builds its HTTP request at delivery time (SDK call, URL derived from `params`, custom `processAxiosResponse`) keeps `proxy` / `prepareProxy` / `processAxiosResponse` in its handler.
+
+**Keep the legacy `networkHandler.ts` until GA.** Workspaces not yet enrolled still transform through `processRouterDest` and are delivered by that handler; both are deleted together at GA.
+
+## Enabling it
+
+`{DEST_NAME_UPPER}_BATCHING_FRAMEWORK_DELIVERY_ENABLED_WORKSPACE_IDS` — comma-separated workspace IDs or `ALL`. Two things to know:
+
+- There is **no GA map** for it — being in `batchedDestinationsMap` does not enable framework delivery. It stays on the legacy handler everywhere until a workspace is named.
+- It **requires the transform flag** for the same workspace and returns false without it. The delivery path interprets a payload built by the matching transform path; an unenrolled workspace's events are still built by `processRouterDest`, and pairing those with framework response handling would misread them.
+
+Set both in your `dataDelivery` component tests via `envOverrides` (and in `live.ts` via the `envOverrides` field on `LiveSpec`), or CI keeps exercising the legacy handler.
+
+## Testing
+
+Drive **both** paths over the same responses and compare, rather than asserting the new one in isolation — that is what makes it a parity test:
+
+```typescript
+const viaFramework = (ctx) =>
+  toDeliveryV1Response(handleDeliveryResponse(Integration, ctx), ctx, DEST);
+const viaLegacy = (ctx) => legacyResponseHandler({ ... });
+// compare per-job statusCodes and errors for each response shape
+```
+
+**Reference:** `src/v0/destinations/braze_audience/delivery.test.ts` — also compares `stats.increment` call lists, so counters are held to parity too.

--- a/.claude/skills/batching-framework/SKILL.md
+++ b/.claude/skills/batching-framework/SKILL.md
@@ -12,6 +12,7 @@ description: Native batching framework for destination transformations. Extend B
 - `src/v0/destinations/posthog/routerTransform.ts` — `ChunkBatchStrategy` with `maxPayloadSize`
 - `src/v0/destinations/custom_audience/routerTransform.ts` — `CustomBatchStrategy` with template evaluation
 - `src/services/destination/nativeBatching/` — Framework source code
+- `.claude/skills/batching-framework-delivery/SKILL.md` — Delivery (response handling) contract
 
 ## Architecture
 
@@ -32,6 +33,21 @@ BatchStrategy.batch()                [chunking/wrapping]
 RouterTransformationResponse[]
 ```
 
+Delivery is a separate service call, over the same class:
+
+```
+deliver()                            [nativeIntegration, behind the delivery flag]
+    |
+handleDeliveryResponse(Class, ctx)   [framework-owned]
+    |--- delivery.statusOverrides[status] ?? [class] ?? classify by status
+    |
+Verdict | perItem(ItemVerdict[])     [what should happen to the batch]
+    |
+toDeliveryV1Response()               [derives per-job codes, statTags, message]
+    |
+DeliveryV1Response
+```
+
 ## File Structure
 
 ```
@@ -40,6 +56,9 @@ src/v0/destinations/<dest_name>/
 ├── types.ts                  # Zod schemas, TypeScript types
 ├── config.ts                 # Constants, endpoints, action maps
 ├── utils.ts                  # (Optional) Field processing, API helpers
+├── delivery.ts               # (Optional) the `delivery` spec — only if response handling
+│                             #            differs from the framework default
+├── delivery.test.ts          # (Optional) Parity test vs the legacy handler
 └── routerTransform.test.ts   # Unit tests
 ```
 
@@ -209,25 +228,38 @@ When enabled, the platform routes events through `processBatchedDestination()` i
 For gradual rollout before GA, use the env var pattern:
 `{DEST_NAME_UPPER}_BATCHING_FRAMEWORK_ENABLED_WORKSPACE_IDS` (comma-separated workspace IDs or `ALL`).
 
-## Proxy / networkHandler destinations
+Delivery is gated **separately** by `{DEST_NAME_UPPER}_BATCHING_FRAMEWORK_DELIVERY_ENABLED_WORKSPACE_IDS`
+— see `.claude/skills/batching-framework-delivery/SKILL.md`.
 
-Some destinations deliver through a custom `networkHandler` that builds the actual HTTP request
-(URL, SDK call) at delivery time rather than from the transformed payload. When that's the case,
-`transformEvent`'s `endpoint` is typically left empty/placeholder and unused — the handler derives
-the real URL from `params` (and sometimes details unknown at transform time, e.g. the API version).
-If instead the handler reads the endpoint from the payload, set it normally. Two things to watch
-when the handler owns delivery:
+## Delivery (response handling)
 
-- **Audit the network handler for single-item assumptions.** Pre-batching it received one item per
-  request and often hard-codes index `0` (e.g. `set(body.JSON, 'items[0].field', ...)`). Once
-  batched, `items` is an array of N — change it to iterate the whole array. The single-item case
-  collapses to an array of one, so legacy traffic is unaffected (a safe, ungated change).
+The framework owns delivery too, over the same class: an integration declares a static
+`delivery` spec — `statusOverrides` and `failureReason`, grouped so they read as delivery rather
+than as more transform surface — and never builds a `DeliveryV1Response`, picks a status code, or
+throws.
+
+**Most destinations need nothing** — the default reproduces `genericNetworkHandler`. `posthog` and
+`custom_audience` declare no overrides at all.
+
+**See `.claude/skills/batching-framework-delivery/SKILL.md`** for the contract, the verdict builders,
+the `perItem` rules and the delivery flag.
+
+### If you just batched a destination that had a network handler
+
+Only *response handling* moves onto the class; transport (`proxy` / `prepareProxy` /
+`processAxiosResponse`) stays in `networkHandler.ts`. When the handler builds the request at delivery
+time, `transformEvent`'s `endpoint` is typically an unused placeholder — the handler derives the real
+URL from `params`. If instead it reads the endpoint from the payload, set it normally.
+
+- **Audit the transport for single-item assumptions.** Pre-batching it received one item per request
+  and often hard-codes index `0` (e.g. `set(body.JSON, 'items[0].field', ...)`). Once batched,
+  `items` is an array of N — iterate the whole array. The single-item case collapses to an array of
+  one, so legacy traffic is unaffected (a safe, ungated change).
 - The proxy layer runs in a later service call than the transform and **does not see the workspace
-  batching flag**, so don't try to gate network-handler changes on it; make them
-  unconditionally-correct for both 1 and N items instead.
+  batching flag**, so don't gate transport changes on it; make them correct for both 1 and N items.
 
-Cover this with a focused unit test that mocks the delivery SDK/client and asserts the per-item
-field is set on **every** item (cheaper and more direct than a full dataDelivery mock).
+Cover this with a focused unit test that mocks the delivery SDK/client and asserts the per-item field
+is set on **every** item (cheaper and more direct than a full dataDelivery mock).
 
 ## Partners that reject the whole batch
 

--- a/.claude/skills/live-integration-test/SKILL.md
+++ b/.claude/skills/live-integration-test/SKILL.md
@@ -161,7 +161,11 @@ spec.
    behaviors, factor the asserted fields into a `(ctx) => ({ ... })` profile shared by the seed and
    the field-level verify so the two stay in lockstep.
 6. **Enroll**: `enabled: true` (registry auto-discovers `destinations/*/live.ts`; no registration).
-   Use `enabled: false` to park a spec in the tree without running it.
+   Use `enabled: false` to park a spec in the tree without running it. If the destination sits
+   behind a rollout flag, name it in `envOverrides` — a live run exercises the real transform and
+   delivery paths, so without it the suite tests the legacy path and proves nothing about the one
+   the destination is moving to. See `.claude/skills/batching-framework-delivery/SKILL.md` for the
+   batching-framework flags.
 7. **CI is automatic.** The `discover` job builds the workflow matrix from `destinations/*/live.ts`,
    so a new spec runs in CI with no workflow edit. `LIVE_SECRET_<DEST>` is derived from the
    destination code; an **OAuth** spec (`authType: 'oauth'`) additionally wildcard-imports the whole
@@ -243,6 +247,9 @@ const agent = new Agent({ keepAlive: false });
 export const live = {
   enabled: true,
   authType: 'apiKey', // apiKey | oauth | basic | serviceAccount | custom
+  // Optional: env applied around this destination's scenarios and restored after. Name any rollout
+  // flag the destination is behind, or the run silently exercises the legacy path instead.
+  envOverrides: { <DEST>_BATCHING_FRAMEWORK_DELIVERY_ENABLED_WORKSPACE_IDS: 'ALL' },
   // Non-secret Config defaults from the component test's destination.Config; real creds via s.config.
   resolveConfig: (s) => ({ ...s.config }),
   scenarios: [

--- a/.claude/skills/vdm-next-audience-integration/SKILL.md
+++ b/.claude/skills/vdm-next-audience-integration/SKILL.md
@@ -26,7 +26,9 @@ src/v0/destinations/<dest_name>/
 ├── types.ts                  # Zod schemas + TypeScript types for record events
 ├── config.ts                 # Constants: endpoints, action maps, batch sizes, identifier configs
 ├── utils.ts                  # (Optional) Normalization, hashing, field processing, API helpers
-├── networkHandler.ts         # (Optional) Custom network/delivery handler
+├── delivery.ts               # (Optional) the `delivery` spec — only if response handling
+│                             #            differs from the framework default
+├── networkHandler.ts         # (Optional) Transport only (SDK/proxy/processAxiosResponse)
 ├── routerTransform.test.ts   # Unit tests for router transform
 └── utils.test.ts             # (Optional) Unit tests for utilities
 ```
@@ -472,17 +474,31 @@ headers: { 'x-api-key': apiKey };
 
 ---
 
-## networkHandler.ts — Custom Network Handler (Optional)
+## Delivery — response handling (Optional)
 
-Some audience destinations need custom network/delivery handling. If the destination API returns errors in a non-standard format, create a custom network handler:
+Response handling lives on your `BatchDestination` class as a static `delivery` spec, not in a
+`networkHandler.ts`. **Most audience destinations need nothing** — the framework default reproduces
+`genericNetworkHandler`.
+
+**See `.claude/skills/batching-framework-delivery/SKILL.md`** for the contract, verdicts and flag.
+
+What is audience-specific: these APIs commonly report failures by **identity** rather than index —
+a `failedUpdates` object naming the emails/userIds that failed, with no positional information.
+`iterable_audience` is the reference for that shape. It matches each posted subscriber against the
+returned identity sets, and keeps two deliberate successes: a GDPR-forgotten user is accepted rather
+than aborted, and `notFound` on an unsubscribe is a no-op success. Reproduce that kind of
+destination-specific semantics in `delivery.statusOverrides`, or the default will abort them as
+plain failures.
+
+`networkHandler.ts` remains the place for **transport** — a shared platform proxy, custom
+`processAxiosResponse`, SDK-based delivery:
 
 ```typescript
 export { networkHandler, errorResponseHandler } from '../../util/<platform>Utils/networkHandler';
 ```
 
-For destinations with standard REST error responses, no custom network handler is needed.
-
-**Reference:** `src/v0/destinations/fb_custom_audience/networkHandler.ts` — Re-exports shared Facebook network handler
+**Reference:** `src/v0/destinations/iterable_audience/delivery.ts` (identity-keyed),
+`src/v0/destinations/fb_custom_audience/networkHandler.ts` (transport re-export)
 
 ---
 
@@ -525,14 +541,10 @@ Errors thrown in `transformEvent()` are automatically caught by the framework an
 | Batch strategy error (wrapBody failure)        | Caught in batch strategy | Fails all events in group |
 | Hashing consistency violation (strict mode)    | `InstrumentationError`   | Fails single event        |
 
-For destinations with custom network handlers at delivery time:
-
-| Scenario                          | Error Type                   | Effect                          |
-| --------------------------------- | ---------------------------- | ------------------------------- |
-| Token expired / invalid (401/190) | Retryable with token refresh | Triggers OAuth re-authorization |
-| Rate limited (429)                | Network error with backoff   | Retries                         |
-| Permission denied (294/403)       | Abortable error              | Permanent failure               |
-| Server error (5xx)                | Network error                | Retries                         |
+At delivery time, failures are expressed as verdicts (`authExpired`, `throttled`, `authRevoked`,
+`retry`, `perItem`) rather than hand-built responses — see
+`.claude/skills/batching-framework-delivery/SKILL.md`. The framework default already covers plain
+4xx/5xx/429; declare an override only for signals that have to be read out of the response body.
 
 ---
 
@@ -759,7 +771,7 @@ export const data = [
    - `getInputSchema()` — return the Zod schema for input validation
    - Export the class as `Integration`
 5. Register in `src/constants/batchedDestinationsMap.ts` — add `<DEST_NAME_UPPER>: true`
-6. Create `networkHandler.ts` (optional) — only if the destination API returns errors in a non-standard format requiring custom parsing
+6. Create `delivery.ts` (optional) — only if the API reports failures the framework default cannot read (partial failures, identity-keyed errors); `networkHandler.ts` only if transport itself is custom
 7. Create `routerTransform.test.ts` — unit tests using `processBatchedDestination(inputs, Integration, {})` covering: valid insert/update/delete, invalid identifiers, null identifiers, hashing on/off, batch overflow, mixed actions, missing auth
 8. Create `test/integrations/destinations/<dest_name>/router/data.ts` — integration test cases covering: successful operations, validation errors, unsupported types, batching, audience subtypes, pre-hashed values
 9. Run verification:

--- a/.claude/skills/vdm-v2-object-destination/SKILL.md
+++ b/.claude/skills/vdm-v2-object-destination/SKILL.md
@@ -29,7 +29,10 @@ Read these files before implementing:
   - `types.ts` -- Zod schemas for connection config (with `object` field), destination config, router request type
   - `v2/recordTransform.ts` -- record payload builder (no action validation)
   - `v2/types.ts` -- Zod schemas for record and event-stream messages, input schema factory
+  - `v2/delivery.ts` -- the `delivery` spec: a `statusOverrides` entry for the 207 multi-status batch response
+  - `v2/delivery.test.ts` -- parity test driving both the framework and the legacy handler
 - **Batching framework** -- `.claude/skills/batching-framework/SKILL.md`
+- **Delivery contract** -- `.claude/skills/batching-framework-delivery/SKILL.md`
 
 ## File Structure
 
@@ -38,6 +41,8 @@ src/v0/destinations/<dest_name>/
   routerTransform.ts        # VDMV2ObjectDestination subclass (exported as Integration)
   routerTransform.test.ts   # Unit tests for the Integration class
   types.ts                  # Zod schemas, TypeScript types, connection config
+  delivery.ts               # (Optional) the `delivery` spec — only if response handling
+                            #            differs from the framework default
 ```
 
 Additional files (config, payload builders, utils) depend on the destination's complexity. See the CustomerIO reference for one way to organize them.
@@ -63,6 +68,10 @@ Framework groups by composite key, chunks, wraps
     |
 RouterTransformationResponse[]
 ```
+
+Delivery runs as a separate service call over the same class. Most destinations need no overrides;
+add them when the API reports per-record failures, as CustomerIO does with its 207 multi-status body
+(`v2/delivery.ts`). See `.claude/skills/batching-framework-delivery/SKILL.md`.
 
 ## Key Conventions
 
@@ -102,6 +111,8 @@ Object destinations declare both `recordSchema` and `eventStreamSchema`. Overrid
 
 Register in `src/constants/batchedDestinationsMap.ts` and update `src/features.ts` under `defaultFeaturesConfig` with the destination definition name.
 
+Delivery is gated separately -- see `.claude/skills/batching-framework-delivery/SKILL.md`.
+
 ## Steps
 
 1. Read the reference files listed above
@@ -113,9 +124,11 @@ Register in `src/constants/batchedDestinationsMap.ts` and update `src/features.t
    - (Optional) `transformEventStream(input)` -- handle non-record events
    - Export as `Integration`
 4. Register in `src/constants/batchedDestinationsMap.ts` and `src/features.ts`
-5. Create `src/v0/destinations/<dest_name>/routerTransform.test.ts` -- unit tests
-6. Create `test/integrations/destinations/<dest_name>/router/` -- integration test cases
-7. Verify:
+5. (Optional) Create `delivery.ts` -- the `delivery` spec, only if the API reports failures the
+   framework default cannot read; add a `delivery.test.ts` that compares it against the legacy handler
+6. Create `src/v0/destinations/<dest_name>/routerTransform.test.ts` -- unit tests
+7. Create `test/integrations/destinations/<dest_name>/router/` -- integration test cases
+8. Verify:
    ```bash
    npm run lint
    npm test -- --testPathPattern="<dest_name>" --no-coverage

--- a/docs/superpowers/specs/2026-07-30-network-handler-abstraction-design.md
+++ b/docs/superpowers/specs/2026-07-30-network-handler-abstraction-design.md
@@ -1,0 +1,793 @@
+# Design: fold NetworkHandler into the BatchDestination class
+
+Date: 2026-07-30
+Status: ready to plan
+Scope: framework + migrate every batching-framework destination that has its own network handler —
+`customerio`, `iterable_audience`, `google_adwords_enhanced_conversions`, `braze_audience`,
+`test_destination` (§4.0)
+
+---
+
+## 1. Problem
+
+Two concrete problems with the current `NetworkHandler` abstraction.
+
+### 1.1 Delivery lives in a different file, directory, and registry than the transform
+
+For a batching destination the transform and the delivery logic are maximally far apart. Take `iterable_audience`:
+
+|             | transform                                                                   | delivery                                                                                  |
+| ----------- | --------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| file        | `src/v0/destinations/iterable_audience/routerTransform.ts`                  | `src/v1/destinations/iterable_audience/networkHandler.ts` → `strategies/audience-list.ts` |
+| version dir | `v0`                                                                        | `v1`                                                                                      |
+| registry    | `MiscService.getBatchDestinationHandler` (`src/services/misc.ts:30`)        | `networkHandlerFactory.getNetworkHandler` (`src/adapters/networkHandlerFactory.js:39`)    |
+| typing      | `BatchDestination<IterableAudiencePayload, …>` (`routerTransform.ts:29-32`) | body shape re-derived as `IterableSubscriber[]` (`audience-list.ts:68`)                   |
+
+The `networkHandler.ts` file is 18 lines of pure indirection — it assigns the four transport defaults and delegates `responseHandler` to `AudienceListStrategy`. So the delivery logic is three files away from the transform, and it imports its input types from a _different destination_ (`../../iterable/types`, `audience-list.ts:3`).
+
+The type disconnect is real, not hypothetical. The transform class is generic over `IterableAudiencePayload`, but the handler reaches back into the serialised request and re-declares the shape:
+
+```ts
+const subscribers: IterableSubscriber[] = requestBody?.subscribers ?? []; // audience-list.ts:68
+```
+
+Nothing links `IterableSubscriber` to `IterableAudiencePayload`, so changing the payload shape produces no type error in the handler.
+
+### 1.2 The return contract is API-shaped, not intent-shaped
+
+To write a `responseHandler` today an implementer must know all of:
+
+- whether to **throw** or **return** (throw = whole-batch failure, return = per-job outcomes) — nothing in the signature says this
+- that raw HTTP status codes double as **retry semantics** (`500` retry vs `400` drop vs `429` throttle)
+- how to build `statTags` with the right `ERROR_TYPE`
+- when to set `authErrorCategory`, and to which of two magic strings
+- to echo `destinationResponse` back so the platform can log it
+- whether the destination is wired as v0 or v1, because the response shape differs
+- how to correlate the destination's per-item errors back to `rudderJobMetadata`
+
+Only the last item is genuinely destination-specific. Everything else is platform mechanics that every handler re-derives, and gets subtly wrong in different ways (§2).
+
+---
+
+## 2. Survey: how the 31 existing handlers correlate jobs to outcomes
+
+This drove the design, so it is recorded here.
+
+**Pattern A — all-jobs-same (large majority).** One whole-batch verdict fanned across every job: `am`, `clicksend`, `emarsys`, `hs`, `linkedin_ads`, `reddit`, `bloomreach`, `bloomreach_catalog`, `algolia`, `campaign_manager`, `monday`, `zoho`, `postscript`, `marketo_static_list`. Also every _error_ path, including `iterable_audience`'s (`audience-list.ts:127-131`).
+
+**Pattern B — positional, destination returns explicit indices.** `customerio` (`batch_index`, `src/v1/destinations/customerio/networkHandler.ts:41`). Assumes 1:1 job↔item.
+
+**Pattern C — positional against a parallel results array.** `google_adwords_offline_conversions` walks `results?.[i]` against `metaDataArray.map((metadata, i) => …)` (`networkHandler.js:349-350`); `google_adwords_enhanced_conversions` does the same on a **2xx** response carrying `partialFailureError`, treating an empty `results[i]` as a failed event (`src/v1/destinations/google_adwords_enhanced_conversions/networkHandler.ts:67-80`). `mp` does the same but **defensively**: `const event = index < events.length ? events[index] : null` (`src/v1/destinations/mp/utils.ts:229-230`).
+
+**Pattern D — content-keyed, no indices exist.** `iterable` and `iterable_audience`. The API returns failing _identities_ (`invalidEmails`, `invalidUserIds`, `disallowedEventNames`, `forgottenEmails`, `notFoundUserIds`), so `createBatchErrorChecker` (`src/v1/destinations/iterable/utils.ts:32-77`) builds identity→failure maps and tests each **request body item**. Both loops are driven from the body, then attributed to jobs positionally:
+
+```ts
+const response = subscribers.map((subscriber, idx) => {
+  const metadata = rudderJobMetadata[idx];        // audience-list.ts:80-81
+```
+
+— which yields a job state with `metadata: undefined` if body items outnumber jobs. `iterable`'s `strategies/track-identify.ts:15-34` has the identical shape.
+
+**Pattern E — `destInfo` side channel.** Two unrelated uses of the same field:
+
+- `braze` stamps per-job item-index maps at transform time (`src/v0/destinations/braze/util.ts:1196`, `buildDestInfoByJob`) and reads them back in delivery (`readIndicesFor`, `src/v1/destinations/braze/networkHandler.ts:79-85`). The only destination that genuinely multiplexes and solved it properly — at the cost of ~80 hand-rolled lines.
+- `salesforce` (`src/v0/destinations/salesforce/networkHandler.js:13`) and `marketo` (`src/v0/destinations/marketo/util.js:218-220`) stamp an `authKey` so the handler can **evict a stale token cache** on invalid/expired-token errors.
+
+### 2.1 What rudder-server does with `authErrorCategory`
+
+Traced on `rudder-server@origin/master`. This is what shapes the verdict vocabulary in §3.1.
+
+The OAuth transport bypasses itself entirely for non-OAuth destinations — `if (!isOauthDestination) { return t.Transport.RoundTrip(req) }` (`services/oauth/v2/http/transport.go:255-257`). So **`authErrorCategory` is inert for API-key destinations, customerio included.** Both values are read in `postRoundTrip` (`transport.go:158`) and dispatched by a two-case switch (`:175`):
+
+| category               | rudder-server behaviour                                                                                                                                                                                             | net effect                     |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------ |
+| `REFRESH_TOKEN`        | calls `oauthHandler.RefreshToken` against the control plane (circuit-breakered, `oauth_breaker.go:82`); on success forces the status to **500** (`transport.go:204`, _"so we return a 500 to the caller to retry"_) | `jobsdb.Failed` → **retried**  |
+| `AUTH_STATUS_INACTIVE` | sets the status to **400** (`transport.go:205-206`). That is the whole branch — no control-plane call                                                                                                               | `jobsdb.Aborted` → **dropped** |
+
+`isJobTerminated` (`router/misc.go:23-28`) makes 400 terminal and 500 retryable; the branch is taken at `router/worker.go:1045-1046`. Note it also exempts 429 and 408, which is what makes the `throttled`→429 mapping in §3.7 retry correctly.
+
+Two findings worth recording:
+
+- **`AUTH_STATUS_INACTIVE` no longer disables the destination.** Commit `45e5dba66` (_"chore: remove oauth status toggling (#6492)"_) deleted the `AuthStatusToggle` control-plane call — 99 lines out of `oauth_handler.go`; the `OAuthHandler` interface now exposes only `FetchToken` and `RefreshToken`. The doc comment at `transport.go:48` still claims the transport updates authStatus to `inactive`, and `oauth_stats.go:19,25,28` still reference an `auth_status_inactive` action; both are stale. So the only signal a re-auth is needed is the aborted jobs' reason string.
+- **An auth category overwrites every job's status code.** `router/transformer/transformer.go:621-633` loops over all metadata and assigns the single `InterceptorResponse.StatusCode` to each job:
+
+  ```go
+  for _, metadata := range proxyReqParams.ResponseData.Metadata {
+      if transportResponse.InterceptorResponse.StatusCode > 0 {
+          transResp.routerJobResponseCodes[metadata.JobID] = transportResponse.InterceptorResponse.StatusCode
+      }
+  ```
+
+  The top-level code is overwritten too (`transformer.go:555-556`), and a second site does the same over `destinationJobs[i]` (`:332-336`). So per-job codes computed by the transformer are discarded whenever an `authErrorCategory` is present — which is why §3.2 forbids auth refinements inside `perItem`, and why the `authExpired`/`authRevoked` rows are absent from §3.7's per-job status table.
+
+### Three conclusions that shape the contract
+
+1. **`dontBatch` is not a one-off.** `algolia`, `hs`, `reddit`, and `am` all set `metadata.dontBatch = true` on a returned job state to force an unbatched retry. It belongs in the vocabulary.
+2. **Response handling cannot be pure.** Marketo's cache eviction, and `iterable_audience` emitting a GDPR metric mid-loop (`stats.counter('iterable_forgotten_user_violations', …)`, `audience-list.ts:90-96`), are real side effects inside today's response handlers. The contract must permit them rather than imply purity and have implementers fight it.
+3. **The 1:1 assumption is pervasive and already strained.** `mp` guards against it, `iterable` and `iterable_audience` both carry a live `undefined`-metadata bug from it, `braze` outgrew it. Only Pattern D cannot be expressed positionally.
+
+---
+
+## 3. Design
+
+### 3.1 Vocabulary: `Verdict`
+
+New file `src/services/destination/nativeBatching/delivery.ts`.
+
+There are exactly **three** outcomes the platform can act on — retry the job, drop it, or accept it. Throttling and auth failures are not peers of those; they are _refinements_ of them. So the type has three kinds, and everything else is a modifier:
+
+```ts
+export type Verdict =
+  | { kind: 'success' }
+  | { kind: 'abort'; reason: string; auth?: 'revoked' }
+  | { kind: 'retry'; reason: string; as?: 'throttled' | 'authExpired'; dontBatch?: boolean };
+```
+
+This matches what rudder-server does (§2.1). `REFRESH_TOKEN` ends as a **500 → retry**; `AUTH_STATUS_INACTIVE` ends as a **400 → abort**. Separate top-level kinds would invent a distinction the platform does not have, and leave the implementer to guess which ones retry.
+
+Six builders construct them, so the vocabulary an implementer writes stays familiar:
+
+```ts
+export const success = (): Verdict;
+export const abort = (reason: string): Verdict;
+export const retry = (reason: string, opts?: { dontBatch?: boolean }): Verdict;
+export const throttled = (reason: string): Verdict; // retry, as: 'throttled'
+export const authExpired = (reason: string): Verdict; // retry, as: 'authExpired'  -> REFRESH_TOKEN
+export const authRevoked = (reason: string): Verdict; // abort, auth: 'revoked'    -> AUTH_STATUS_INACTIVE
+```
+
+Because the two auth refinements sit on different kinds, the type enforces the semantics: you cannot write an `authExpired` that aborts, or an `authRevoked` that retries.
+
+#### Overrides are a status-keyed map, inside a `delivery` spec
+
+Integrations do not implement the response-handling entry point; it is framework-owned. What an integration declares is a map from status code to the behaviour for that status, and it declares it **inside a single `delivery` object**:
+
+```ts
+export type StatusOverride = (
+  ctx: DeliveryContext,
+  fallback: () => Verdict,
+) => HandleResponseResult;
+
+/** An exact status, or a whole class of them. */
+export type StatusKey = number | '2xx' | '4xx' | '5xx';
+
+export type DeliverySpec = {
+  statusOverrides?: Readonly<Partial<Record<StatusKey, StatusOverride>>>;
+  failureReason?: (ctx: DeliveryContext) => string;
+};
+
+abstract class BatchDestination<TBody, TInputSchema> {
+  /** Everything this destination declares about delivery. */
+  static readonly delivery: DeliverySpec = {};
+}
+```
+
+**Why one object rather than two statics.** Everything else on a `BatchDestination` — `transformEvent`, `getBatchStrategy`, `getInputSchema`, `transformEvents` — is about turning an event into a request. `statusOverrides` and `failureReason` are about reading the response that comes back, which is a different phase, gated by a different flag, exercised by different tests. Declared as bare statics they sit at the same level as the transform members and read as more of the same; behind `static readonly delivery` the scope is stated where it is declared. It also gives each destination's `delivery.ts` a single export to be the whole delivery contract, and keeps the class's line count for delivery at one regardless of how much that contract grows.
+
+The framework prefers an exact-status entry, falls back to the class entry, and otherwise classifies the status itself:
+
+```ts
+export function handleDeliveryResponse(klass: unknown, ctx: DeliveryContext): HandleResponseResult {
+  const { statusOverrides, failureReason } = resolveDeliverySpec(klass);
+  const fallback = () => classifyByStatus(ctx.status, failureReason(ctx));
+  const override = statusOverrides[ctx.status] ?? statusOverrides[statusClassOf(ctx.status)];
+  return override ? override(ctx, fallback) : fallback();
+}
+
+/** Framework-internal classification. Not an extension point. */
+const classifyByStatus = (status: number, reason: string): Verdict => {
+  if (isHttpStatusSuccess(status)) return success();
+  if (status === 429) return throttled(reason);
+  if (isHttpStatusRetryable(status)) return retry(reason);
+  return abort(reason);
+};
+```
+
+**Why a free function rather than a static.** `handleDeliveryResponse` takes the class instead of living on it, so there is no member for an integration to override and no `super` to call — the rule "never override this" is enforced by shape rather than by comment. Resolution order is the contract; a destination that wants different behaviour declares an entry for the status it cares about.
+
+**Why `fallback` is a parameter.** A handler usually owns only _some_ of the responses carrying its status. Mixpanel's `400` handler applies to the `/import` endpoint but not to `/engage`, and cannot decode every body it is handed (§4). Those branches still have to produce a verdict, and making the handler re-derive one would mean reimplementing the framework's classification at every call site. Passing it in keeps the return type total — `HandleResponseResult`, never optional — so there is no sentinel whose meaning has to be learned and no branch that can fall off the end. It is not inheritance either: nothing to name, no prototype chain, no way to delegate to the wrong place.
+
+`classifyByStatus` reproduces today's behaviour, mirroring `getDynamicErrorType` (`src/adapters/utils/networkUtils.js:87-95`). `isHttpStatusRetryable` is `status >= 500 && status < 600` (`src/v0/util/index.js:1638-1640`), so **422 aborts by default**. A destination whose API returns 422 for transient backpressure reclassifies it:
+
+```ts
+static readonly delivery: DeliverySpec = {
+  statusOverrides: { 422: (ctx, fallback) => retry(reasonOf(fallback())) },
+};
+```
+
+**The framework never infers an auth verdict from a status code.** 401 and 403 classify as plain `abort`; `authExpired` / `authRevoked` come only from the integration, in most cases after parsing the error body, because that is the only place the information exists.
+
+This departs from `getAuthErrCategoryFromStCode` (`src/v0/util/index.js:2175-2185`), which maps 401→`REFRESH_TOKEN` and 403→`AUTH_STATUS_INACTIVE` unconditionally. That mapping is wrong more often than right: a 401 from an API-key destination means a bad key, not a refreshable OAuth token, and a 403 is as likely to be a missing scope or a suspended account as a revoked grant. Guessing is not cosmetic — per §2.1, `REFRESH_TOKEN` makes rudder-server burn a control-plane token refresh and retry, `AUTH_STATUS_INACTIVE` aborts the batch. Neither should follow from a status code alone. An OAuth destination states it explicitly instead:
+
+```ts
+static readonly delivery: DeliverySpec = {
+  statusOverrides: {
+    401: (ctx, fallback) => {
+      const msg = extractMyErrorMessage(ctx.response);
+      return /token (expired|invalid)/i.test(msg) ? authExpired(msg) : fallback();
+    },
+  },
+};
+```
+
+**Why class keys exist.** Existing handlers overwhelmingly branch on `isHttpStatusSuccess(status)` rather than on a specific code — `iterable_audience` reaches its per-subscriber logic through `BaseStrategy.handleResponse`, which dispatches on `!isHttpStatusSuccess(status)` (`src/v1/destinations/iterable/strategies/base.ts:10`); `gaec` inspects `partialFailureError` on any 2xx (`src/v1/destinations/google_adwords_enhanced_conversions/networkHandler.ts:46`). Both return only `200` in practice, so an exact `200` key would pass today's tests while silently narrowing the contract the code was written to. `'2xx'` states the real intent. Exact keys stay available for the case that genuinely is one status — customerio's `207` (§4.1) — and take precedence over the class key. `'4xx'` / `'5xx'` also cover range policy such as "every 4xx is retryable for this destination".
+
+**The framework resolves the spec down the prototype chain.** Static properties are inherited, and lookup does walk the chain — but it resolves to a single object, the nearest one, and never merges across levels. So a subclass declaring `delivery` would otherwise silently drop everything an ancestor declared, with no type error and no runtime error. `resolveDeliverySpec` therefore collects each own-`delivery` up the chain and folds them: `statusOverrides` merges key-by-key child-over-parent, so a family-level map on `VDMV2ObjectDestination` keeps working when a concrete destination adds an entry of its own, and `failureReason` takes the nearest declaration, which is what a plain static override would have done. The cost is that an inherited status entry cannot be _removed_, only replaced — no destination in the migration set has reason to, and losing an entry silently is much worse than being unable to delete one.
+
+#### Locating the error message: `failureReason`
+
+A verdict class is not enough on its own — the useful text is inside the destination's response body, and every destination buries it somewhere different. Today handlers dig it out by hand: `response?.params ?? response?.msg ?? response?.message` (`iterable_audience/strategies/audience-list.ts:124`), or fall back to `JSON.stringify` of the whole body (`postTransformation.ts:212`).
+
+Rather than have the classification path overridden purely to supply better wording, the reason is its own overridable member:
+
+```ts
+/** The reason carried by a failure verdict. Default is status-only. */
+failureReason?: (ctx: DeliveryContext) => string;
+```
+
+It is the second member of the same `DeliverySpec`, resolved to the nearest declaration up the chain — so a destination whose only special need is error-text extraction declares **one line in its spec** and no `statusOverrides` at all.
+
+**The default does not read the response body.** It returns `[Generic Response Handler] Request failed with status: <n>`, which is what `genericNetworkHandler` — the fallback every unmigrated destination already gets — produces today; the body travels separately in `destinationResponse`.
+
+> **Amended after review.** The original design had this member as `extractErrorMessage(response)`, defaulting to a shared `messageFromResponse` helper that searched the body for `message`, then `msg`, then `error`, then `description`. That was withdrawn. Surveying the legacy path shows **there is no shared body-parsing convention to generalise**: customerio joins `reason`/`field`/`message` from its own `errors[]` (`v1/customerio/networkHandler.ts:24-31`), gaec reads `error.message` (`:103`), braze_audience does `JSON.stringify(response?.message ?? response)` (`:56`), iterable_audience uses the `??` chain above, and `genericNetworkHandler` reads nothing at all. A generic key-ordered search looks like it unifies those four but does not — it imposes one destination's field order on every other, and any quirk added for one leaks into all of them. Concretely, Iterable's `params`-before-`msg` precedence, encoded as a key list, meant an object-valued early key silently masked a good message on a later key **for every destination on the default list**. So body parsing moved into each integration's own `delivery.ts`, and the framework kept only the status-only default.
+
+No HTTP codes, no `statTags`, no `authErrorCategory`, no `destinationResponse` echo, no throwing, no v0-vs-v1 branching. That is problem 1.2 addressed.
+
+### 3.2 The list form is **per item**, not per job
+
+The obvious choice is "one verdict per job", but the survey argues against it. Every destination API that reports partial failure indexes into **the request body it received** — `batch_index` for customerio, `results[i]` for gaoc, `events[index]` for mp, identities-of-body-items for iterable and iterable_audience. None of them index jobs. A per-job list would force each implementer to convert, which is exactly the correlation work that §2 shows being done four different ways and getting it wrong twice.
+
+So the list form is one verdict per **request body item**, and mapping items→jobs is the framework's job:
+
+```ts
+export type PerItemVerdicts = { kind: 'perItem'; verdicts: Verdict[] };
+export const perItem = (verdicts: Verdict[]): PerItemVerdicts;
+
+export type HandleResponseResult = Verdict | PerItemVerdicts;
+```
+
+For a 1:1 destination items and jobs coincide, so `customerio` is unaffected by this choice. Naming it `perItem` rather than `perJob` keeps the implementer indexing the thing the API handed them, and leaves room for a real item→job map later (§3.5) without changing the implementer-facing contract.
+
+**Mapping is positional and requires 1:1.** `verdicts[i]` applies to `jobs[i]`. Per §3.5 the framework carries no item→job map, so `perItem` is only correct for destinations where each job contributes exactly one body item.
+
+**The framework bounds-checks it.** If `verdicts.length !== ctx.jobs.length`, the framework must **not** index past the end — that is precisely the bug live in `iterable` and `iterable_audience`, which emit job states with `metadata: undefined`. Instead it discards the per-item detail, **retries the whole batch**, and emits a stat so the mismatch is visible rather than silently producing malformed job states. Degraded but never malformed.
+
+**Retry, not a fold of what is present.** The obvious rule — collapse to the most severe verdict present, on `retry > abort > success` — is wrong in the direction that costs data. A list of two successes against three jobs folds to `success`, so the job with no verdict at all is reported delivered on no evidence; an _empty_ list folds to `success` for every job, and an empty list is only ever produced by a handler that had already decided there were failures. A job whose verdict cannot be attributed has an unknown outcome, and the only honest reading of an unknown outcome is that it must be redelivered. Re-sending items that already succeeded is the accepted cost under the platform's at-least-once contract; reporting an event delivered when nothing said so is not recoverable.
+
+**Auth refinements are whole-batch only, enforced by the type.** `perItem` accepts `ItemVerdict[]`, a narrowing of `Verdict` without the `auth` / `as: 'authExpired'` refinements, so `perItem([authExpired(msg)])` does not compile. Reason in §2.1: rudder-server overwrites the status code of **every job in the batch** with a single interceptor value whenever an `authErrorCategory` is present, so a per-item auth verdict is not expressible — one `authExpired` item among 49 successes would retry all 50 jobs.
+
+### 3.3 Context: `DeliveryContext`
+
+```ts
+export type DeliveryContext = {
+  /** HTTP status from the destination, after processAxiosResponse. */
+  status: number;
+  /** Parsed destination response body. */
+  response: unknown;
+  /** One entry per job in this batch, in the order the framework built them. */
+  jobs: ProxyMetdata[];
+  /** The request that was sent — for content-keyed correlation (Pattern D). */
+  request: ProxyV1Request;
+  destinationConfig: Record<string, unknown>;
+};
+```
+
+`request` covers Pattern D; `jobs[i].destInfo` (already on `ProxyMetdata`, `src/types/destinationTransformation.ts:151-162`) covers Pattern E.
+
+`status` and `response` **are** the processed proxy response, not a summary of it: `processAxiosResponse` returns exactly `{ response, status }` (`src/adapters/utils/networkUtils.js:134-165`, plus a `headers` key on the non-2xx axios branch that no response handler in the repo reads). Today's handlers all begin by destructuring it — `const { response, status } = destinationResponse` — so the context exposes the two fields directly and carries no separate `destinationResponse`. The bridge reassembles `{ status, response }` when it needs to hand `TransformerProxyError` its 4th argument (§3.7).
+
+### 3.4 Placement: statics on the destination class
+
+**They must be static.** `src/types/zodTypes.ts:125-167` shows the proxy request carries `destinationConfig` and `metadata` but **no `destination` object and no `connection`**. An instance therefore cannot be constructed on the delivery path — and for some destinations must not be. Both audience destinations hard-fail without a connection:
+
+```ts
+if (!this.connection) {
+  throw new InstrumentationError('Connection config is required for iterable_audience');
+}
+```
+
+(`src/v0/destinations/iterable_audience/routerTransform.ts:38-40`; `custom_audience/routerTransform.ts:48-50` is identical.) Any instance-method design would throw on every delivery for these destinations.
+
+TypeScript has no `abstract static`, and statics cannot reference class type parameters, so these are conventions on the class rather than enforced abstract members.
+
+#### `BatchDestination` provides a default
+
+The legacy path already has a fallback handler — `src/adapters/networkhandler/genericNetworkHandler.js`, used whenever a destination has no handler of its own (`networkHandlerFactory.js:41`). The batching framework has the same property: a destination that needs no special delivery logic writes nothing.
+
+The framework's `handleDeliveryResponse` and `classifyByStatus` are given in §3.1. The only other default is the failure reason:
+
+```ts
+const defaultFailureReason = (status: number): string =>
+  `[Generic Response Handler] Request failed with status: ${status}`;
+```
+
+`classifyByStatus` mirrors `genericNetworkHandler`'s `responseHandler` one-for-one: success passes the status through, failure classifies by status, and the reason is the same status-only string the generic handler builds — neither reads the response body. The only difference is that the generic handler throws `NetworkError` while the bridge (§3.7) throws `TransformerProxyError` — both reach the same `generateErrorObject` path in `postTransformation.ts`.
+
+That leaves a destination exactly two things it can declare:
+
+| declare              | when                                                                   | cost             |
+| -------------------- | ---------------------------------------------------------------------- | ---------------- |
+| `failureReason`      | the error text is buried somewhere specific in the body                | a few lines      |
+| `statusOverrides[s]` | that status needs the response body read, or a different verdict class | a small function |
+
+Only `statusOverrides` needs the builders, and only it cannot be defaulted — there is nothing sensible to default when parsing a `batch_index` array. Specs are resolved up the chain, so `VDMV2ObjectDestination` and the audience base classes can supply a family-level `failureReason` or status entries and a concrete destination can add to them (§3.1).
+
+### 3.5 Item→job mapping: explicitly out of scope
+
+**Nothing about the router output payload changes.** No new `destInfo`, no change to `PayloadChunk` / `BatchGroup` / `chunkPayloads`, no change to what rudder-server receives. This design touches the delivery path only.
+
+The mechanism is available if it is ever needed. `chunkPayloads.ts:47-48` already has `payload.jobId` sitting next to each body item:
+
+```ts
+currentBodies.push(payload.body); // one entry per ITEM
+currentJobIds.add(payload.jobId); // Set — dedupes
+```
+
+so a future change could carry an item→job map through `BatchGroup` and stamp it into `metadata.destInfo`, generalising what `braze` hand-rolls (§2, Pattern E). Deferred until a destination actually needs it, because the cost is real and immediate — a new metadata field on router output for **every** batching destination, hence snapshot churn across all of them — while the benefit only materialises for a multiplexing destination, and none of the batching-framework destinations multiplex today.
+
+Two hazards for whoever picks that up:
+
+- **Shared `Metadata` references.** `resolveMetadata` (`processBatchedDestination.ts:84-95`) returns the _same_ object references out of `metadataMap` for every batch a job appears in, so an in-place `destInfo` write would clobber across batches for multiplexed jobs. Any stamp must write to a shallow clone.
+- **`combineBatchRequestsWithSameJobIds`** (`src/v0/util/index.js:2299-2339`) merges responses sharing jobIds into one response holding an _array_ of `batchedRequest`s with a concatenated, de-duplicated metadata array. Whether rudder-server pairs each `batchedRequest` with only its own jobs or with the merged union is unverified, so any stamp must be per-`batchedRequest`, not per-response.
+
+Consequence for this design: `perItem` is positional and 1:1-only, bounds-checked as described in §3.2.
+
+### 3.6 Wiring into `deliver()`
+
+`src/services/destination/nativeIntegration.ts:203-273` gains a branch before the existing flow:
+
+```ts
+if (
+  isProxyV1Request(deliveryRequest) &&
+  isBatchingFrameworkDeliveryEnabled(destinationType, deliveryRequest.metadata[0]?.workspaceId)
+) {
+  const IntegrationClass = FetchHandler.getBatchDestinationHandler(destinationType);
+  return toDeliveryV1Response(
+    handleDeliveryResponse(IntegrationClass, ctx),
+    ctx,
+    destinationType.toUpperCase(),
+  );
+}
+// otherwise: existing networkHandlerFactory responseHandler path, untouched
+```
+
+**Why the guard is a shape predicate, not `version === 'v1'`.** `version` is a literal passed by the
+two controller entry points (`controllers/delivery.ts:33` passes `'v0'`, `:66` passes `'v1'`) — it
+records which proxy route rudder-server called, not anything about the destination. What this branch
+actually depends on is that `metadata` is an **array**: it indexes it, hands it to `handleDeliveryResponse`
+as the job list, and shapes a `DeliveryV1Response` around it. `isProxyV1Request` is a one-line type
+predicate on exactly that field, so the narrowing both proves the precondition and removes the
+`deliveryRequest as ProxyV1Request` casts the branch would otherwise need. The two are equivalent in
+practice — the v0 route body is a `ProxyV0Request` whose `metadata` is a single object — but the
+shape check is the one the code can be wrong about.
+
+`ProxyV1RequestSchema` (`types/zodTypes.ts:147`) was considered and rejected for this: it is
+currently unused anywhere, and it marks `secret` and `dontBatch` **required** on every metadata
+entry, so a real payload omitting either would fail validation and fall through to the legacy
+handler silently — a worse failure than the cast it replaces.
+
+**Resolution is gated on `isBatchingFrameworkDeliveryEnabled`** — its own flag, separate from the transform's, defaulting to **off** for every destination and workspace:
+
+- Per-destination env var `{DEST}_BATCHING_FRAMEWORK_DELIVERY_ENABLED_WORKSPACE_IDS`, comma-separated workspace IDs or `ALL`.
+- **No GA map.** The transform flag force-enables itself for destinations listed in `features.ts` with `batching: true`; the delivery flag deliberately has no equivalent, so a GA destination like `iterable_audience` keeps the legacy handler until a workspace is named explicitly. That is what makes it safe to land the wiring before any rollout.
+- **It requires the transform flag** (`isBatchingFrameworkEnabled`) and returns false without it, because **the delivery path must interpret a payload built by the matching transform path.** `doRouterTransformation` branches on that flag at `nativeIntegration.ts:119`: an enrolled workspace's events go through `processBatchedDestination`, an unenrolled workspace's through the legacy `destHandler.processRouterDest`. Enabling delivery for a workspace not on the framework transform would pair the two halves incorrectly, so the flag refuses.
+
+Both predicates live in `src/constants/batchedDestinationsMap.ts` — `isBatchingFrameworkEnabled` at `:34`, `isBatchingFrameworkDeliveryEnabled` at `:66`.
+
+The `v1` guard matters too: the bridge produces a `DeliveryV1Response`, so a v0 proxy request stays on the legacy path regardless of the flag.
+
+Consequences, all of which follow from that:
+
+1. **Every destination keeps its legacy `networkHandler.ts`** until the delivery flag is fully rolled out for it, since any workspace not named in the flag is still delivered by that handler. It is removed once the flag reads `ALL` for the destination and its legacy transform is retired.
+
+### 3.7 Bridge: `Verdict` → `DeliveryV1Response`
+
+Framework-owned, in `delivery.ts`.
+
+**Uniform non-success batch on a non-2xx status** → construct and throw `TransformerProxyError` exactly as handlers do today, letting the existing `handlevV1DeliveriesFailureEvents` (`src/services/destination/postTransformation.ts:198-232`) build the response. The non-2xx qualifier is essential: throwing with a 2xx status would have `postTransformation.ts:215` echo that 2xx into every job's `statusCode`, and rudder-server's `isSuccessStatus` (`router/misc.go:19-21`) would then treat failed events as delivered. This preserves `statTags`, the `destinationResponse` echo, `authErrorCategory`, and — importantly — keeps `ErrorReportingService.reportError` firing (line 230). Arguments:
+
+| arg                   | value                                                                                                            |
+| --------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `message`             | the verdict's `reason`                                                                                           |
+| `status`              | `ctx.status`                                                                                                     |
+| `statTags`            | `{ ERROR_TYPE: … }` — `retry`→`RETRYABLE`, `retry as 'throttled'`→`THROTTLED`, `abort` (incl. revoked)→`ABORTED` |
+| `destinationResponse` | `{ status: ctx.status, response: ctx.response }`                                                                 |
+| `authErrorCategory`   | `retry as 'authExpired'`→`REFRESH_TOKEN`; `abort auth:'revoked'`→`AUTH_STATUS_INACTIVE`; otherwise `''`          |
+
+`ERROR_TYPE` for `authExpired` is `RETRYABLE` and for `authRevoked` is `ABORTED`, which falls straight out of the three-kind model — and matches rudder-server, where the former ends as a 500 and the latter as a 400 (§2.1).
+
+Those two rows are reachable **only** when an integration explicitly returns an auth verdict; the framework never produces one from a status code (§3.1). For a 401 left to the default classifier the result is a plain `abort` with `ERROR_TYPE: ABORTED`, which is exactly what `getDynamicErrorType(401)` returns today — so the default path is unchanged, and only a destination that has actually parsed its error body can move a job onto the refresh-and-retry path.
+
+**Two further exclusions from the throw**, both cases where it would lose or contradict something the per-job path carries correctly:
+
+- **A lost-attribution retry** (§3.2). The throw carries `ctx.status`, not a status derived from the verdict, so on a 4xx rudder-server's `isJobTerminated` (`router/misc.go:23-28`) would abort the very batch the mismatch guard just decided to retry. The per-job path derives `500` from the verdict and is therefore the only one that can express it.
+- **A `dontBatch` retry.** That flag exists only as a stamp on a job state's `metadata`; `handlevV1DeliveriesFailureEvents` rebuilds job states from the _request_ metadata (`postTransformation.ts:209-219`), so the throw has nothing to stamp. Without this exclusion `retry(reason, { dontBatch: true })` would be silently inert on exactly the whole-batch failure a destination would use it for.
+
+The general shape of both, and of the per-item exclusion above: the throw is a lossy channel, so anything the verdict says that it cannot carry forces the per-job path. The cost is `statTags`, the `destinationResponse` echo and `ErrorReportingService.reportError` for those batches.
+
+**Otherwise** (all-success, or mixed) → return a `DeliveryV1Response` directly.
+
+Status derivation:
+
+- **Top-level `status`** — `ctx.status`, always. `ProxyResponseV1` has no `status` field (`router/transformer/transformer_proxy_adapter.go:40-44`), so rudder-server takes disposition from each job state and never reads this; substituting `207` for a status the destination did not send would invent a difference from the legacy handler that nothing benefits from. 207 is one convention among several — customerio and hs use it, braze answers `201`, iterable and gaec `200`.
+- **Top-level `message`** — `[DEST] <reason>` when every failure agrees on one reason, `[DEST] <n> of <m> events failed; see per-event errors` when they do not, `[DEST] Request processed successfully` when there are none. Quoting the first of several differing reasons would present one job's error as the batch's; the per-job entries carry every reason keyed to its job either way. This is the only place the batch-level reason survives now that `destinationResponse` is not echoed, which is why a fixed "partial failures" string was not enough — it discarded gaec's `partialFailureError.message` (§5.3).
+- **Top-level `statTags`** — the whole-response tag set when every job failed and failed the same way; absent otherwise. The bridge sets the error-describing half (`errorCategory`, `errorType`), exactly what the throw path hands `TransformerProxyError`; `deliver()` merges the identifying half (`destType`, `destinationId`, `workspaceId`, `module`, `implementation`, `feature`) from the same `getTags` metadata that `postTransformation.ts:223` merges for a thrown error, so a returned failure and a thrown one carry one tag set from one source. A counter carrying only `errorType` could not be attributed to a destination or workspace. This field drives rudder-server's `integration.failure_detailed` counter (`processor/integrations/integrations.go:29-37`), which tags the response as a whole, so it is only honest when the response as a whole is one failure. A partially-succeeded batch has no single `errorType`; gaec's legacy handler emitted `aborted` for one anyway, counting a batch that partly delivered as a whole-batch abort. Emitting it for a uniform failure also means the returned path still carries an `errorType` whenever `status` is a non-2xx, which is what the response schema expects (`types/zodTypes.ts:220-231`).
+
+  Surveyed against every v1 handler that can produce a per-job response array — `am`, `bloomreach`, `bloomreach_catalog`, `braze`, `braze_audience`, `campaign_manager`, `clicksend`, `customerio`, `emarsys`, `gaec`, `gaoc`, `hs`, `iterable` (2 strategies), `iterable_audience`, `linkedin_ads`, `monday`, `mp`, `reddit`, `zoho`. **Two of the twenty set `statTags` on a returned response: `gaec` and `gaoc`**, with the same hand-rolled block copied between them (`google_adwords_enhanced_conversions/networkHandler.ts:87-95`, `google_adwords_offline_conversions/networkHandler.js:186-194`), both hardcoding `errorType: 'aborted'` and `status: 400` on a _partial_ failure. The other eighteen set none and let the thrown path supply them.
+
+  So omitting them for a mixed batch follows the overwhelming convention, and drops only the two hardcoded `aborted` labels that described a partly-delivered batch as a whole-batch abort. Emitting them for a _uniform_ whole-response failure goes slightly beyond what fifteen of the eighteen do — they emit nothing when the failure arrives on a 2xx — but it is the same tag set those destinations already emit when the identical failure arrives on a non-2xx and takes the throw path, so it removes an inconsistency rather than inventing a rule. `am/networkHandler.ts:75` records the related fact about the sibling field in a comment: _"this status is not used by server, server uses the status of response"_.
+
+- **Per-job `statusCode`** — fixed by verdict kind: `success`→200, `abort`→400, `retry`→500, `retry as 'throttled'`→429. The one case where `ctx.status` is echoed instead is the throw path above, where `postTransformation.ts:215` sets per-job `statusCode` to the same `errObj.status` as the top level — which is why that path is restricted to non-2xx statuses.
+
+  The `ctx.status` non-2xx condition is load-bearing, not defensive. A destination can return **HTTP 200 with a failure in the body** — mixpanel's Engage and Groups APIs do exactly that (`src/v1/destinations/mp/utils.ts:154-165`: success status, `response.error` present, all jobs marked 400). Without the condition, a uniform `abort` on a 200 would echo `200` into every job's `statusCode`, and `isSuccessStatus(200)` in rudder-server (`router/misc.go:19-21`) would mark genuinely failed events as delivered — silent data loss. The condition costs nothing for customerio, whose failure branches always carry a non-2xx status (§5 rows 2–3 are unaffected).
+
+- **Per-job `error`** — uniform failure → the verdict `reason`, which is `delivery.failureReason(ctx)` unless a `statusOverride` supplied its own. Mixed → that item's verdict `reason`, or `'success'`.
+- **`dontBatch`** — `retry(reason, { dontBatch: true })` sets `metadata.dontBatch = true` on that job state.
+
+The "uniform failure echoes `ctx.status` per job" rule is not an artifact of customerio. `iterable_audience` does the same by hand — `rudderJobMetadata.map((metadata) => ({ statusCode: status, … }))` (`audience-list.ts:127-131`) — so the rule generalises to the next destination migrated.
+
+The uniform-vs-mixed asymmetry is not elegant, but it is what parity demands; a cleaner uniform rule would silently change delivery behaviour for every destination migrated later. It is verified against all five of customerio's current branches in §5.
+
+**`destinationResponse` is echoed on failures and omitted on successes.** Today's handlers disagree — customerio's success path omits it (`networkHandler.ts:77-85`), `iterable_audience`'s includes it (`audience-list.ts:113-118`) — so this needed deciding rather than copying.
+
+Checked against rudder-server: `destinationResponse` has exactly **one** consumer, the error-message extractor at `enterprise/reporting/error_extractor.go:326-327`, which digs into it to find human-readable error text. That path is failure-gated — `shouldReport` admits a metric only when `StatusDetail.StatusCode >= http.StatusBadRequest` (or the filter/suppress codes) at `enterprise/reporting/error_reporting.go:246`, and `extractErrorDetails` is reached only through it (`:295`).
+
+So the field is load-bearing on failures and dead weight on successes:
+
+- **Failure** → echo it. The bridge does, via `TransformerProxyError`'s 4th argument, which `postTransformation.ts` places on the response. Without it, error reporting loses its best source of message text.
+- **Success** → omit it. Nothing reads it, and omitting matches customerio's current behaviour.
+
+---
+
+## 4. Migration
+
+### 4.0 The migration set
+
+§3.6 gates delivery on its own flag, `isBatchingFrameworkDeliveryEnabled`, which defaults to off — so the wiring is safe to land before any rollout. That does not change which destinations need migrating, though: **every destination that is on the batching framework _and_ has its own network handler**, because the flag can only be turned on for a destination whose class knows how to answer. One left unmigrated would fall back to the framework classification and lose its response handling the moment someone enabled it.
+
+Intersecting the two sets — classes extending the `BatchDestination` family, against destinations with a `networkHandler` file:
+
+| destination                           | `batching: true`            | handler                                                        | response-handler work         |
+| ------------------------------------- | --------------------------- | -------------------------------------------------------------- | ----------------------------- |
+| `iterable_audience`                   | **yes** (`features.ts:110`) | `networkHandler.ts` (18) → `strategies/audience-list.ts` (146) | content-keyed, Pattern D      |
+| `braze_audience`                      | **yes** (`features.ts:111`) | `v1/networkHandler.ts` (137)                                   | indexed partials on a 2xx     |
+| `test_destination`                    | **yes** (`features.ts:113`) | `v0/networkHandler.ts` (29)                                    | small; dev-only fixture       |
+| `customerio`                          | no — env var                | `v1/networkHandler.ts` (105)                                   | 207 multi-status, Pattern B   |
+| `google_adwords_enhanced_conversions` | no — env var                | `v1/networkHandler.ts` (122)                                   | positional results, Pattern C |
+| `custom_audience`                     | yes (`features.ts:109`)     | none                                                           | none — nothing to do          |
+| `posthog`                             | yes (`features.ts:108`)     | none                                                           | none — nothing to do          |
+
+**The three GA destinations would have been the risky ones**, and the separate delivery flag is why they are not. `iterable_audience`, `braze_audience` and `test_destination` have `batching: true`, so `isBatchingFrameworkEnabled` returns `true` unconditionally (`batchedDestinationsMap.ts:38-40`); had delivery been gated on that same flag, the wiring would have switched them for _every_ workspace the instant it shipped, with nothing to stage behind. The delivery flag has no GA map, so all five stage per workspace identically.
+
+`iterable_audience` carries the most behavioural risk. Its handler resolves failures by identity, not status: GDPR-forgotten users are deliberately returned as **200 plus a metric** rather than 400 (`audience-list.ts:88-98`), and `notFound` on an unsubscribe is a no-op success (`:100-103`). Falling back to the framework classification would abort those as plain failures, so its `statusOverrides` must reproduce all three branches. Migrating it also fixes its `metadata: undefined` bug for free, since the framework bounds-checks `perItem` (§3.2).
+
+**`gaec` is smaller than its line count suggests.** Its `v0/networkHandler.ts` is 262 lines but is almost entirely _transport_ — an SDK-based `gaecProxyRequest`, a `conversionActionId` cache, and `gaecProcessAxiosResponse` — which §3.6 rule 2 leaves in place. Only `gaecResponseHandler` in the v1 file migrates. Two things to carry over: it reports partial failure on a **2xx** status with `partialFailureError` set, which is the case §3.7's non-2xx condition exists for; and it derives auth categories from the response via `getAuthErrCategory` (`v0/util/googleUtils`), so as a genuine OAuth destination it must declare those explicitly under §3.1 rather than relying on inference.
+
+**`braze_audience` landed on develop after this design was written** (#5408) and is migrated on the same terms. It is the second destination whose partial failures arrive on a 2xx (like gaec) and the second whose response indexes the request body positionally (like customerio) — no new mechanism, which is the useful thing about it: a destination added after the contract existed fits it without extending it.
+
+The five share one framework change, so they land together; the delivery flag then decides, per destination and per workspace, when each actually switches.
+
+### 4.1 `customerio`
+
+`customerio` is genuinely 1:1 — **every** branch of `transformObjectRecord` (`src/v0/destinations/customerio/routerTransform.ts:56-63`) and `transformEventStream` (lines 71-94) returns exactly one `TransformedEvent`, and `getBatchStrategy` uses `wrapBody: (bodies) => ({ batch: bodies })` (line 99). So `batch_index` ↔ `jobs[i]` alignment holds, which is what makes `perItem` safe here under §3.2's 1:1 requirement.
+
+**`src/v1/destinations/customerio/networkHandler.ts` is kept, not deleted.** Per §3.6 rule 1, workspaces not enrolled in the batching framework still transform through the legacy `processRouterDest` (`src/v0/destinations/customerio/transform.ts:181`) and still need that handler. It is deleted when customerio reaches GA and the legacy transform is retired.
+
+The duplication is a copy rather than a divergence, because **both paths produce the same request**: the legacy transform sets `request.body.JSON = { batch: chunk.data }` (`transform.ts:173`) against `${BASE_ENDPOINT_V2}/batch` (`config.ts:33`), and the framework path produces `{ batch: bodies }` against `v2/batch` (`v2/config.ts:10`). Same endpoint, same wrapper, so the same 207 / `batch_index` contract holds on both. The parity table in §5 therefore describes both handlers.
+
+Add to `CustomerIOIntegration`:
+
+```ts
+// 207 is 2xx, so without this the framework would read it as a plain success.
+const customerIOStatusOverrides: StatusOverrideMap = {
+  207: (ctx) => {
+    const items = (ctx.request.body.JSON as { batch?: unknown[] })?.batch ?? [];
+    const failed = new Map<number, string>();
+    for (const e of asErrors(ctx.response)) {
+      failed.set(e.batch_index, buildErrorMessage(e));
+    }
+    return perItem(items.map((_, i) => (failed.has(i) ? abort(failed.get(i)!) : success())));
+  },
+};
+
+export const customerIODelivery: DeliverySpec = { statusOverrides: customerIOStatusOverrides };
+```
+
+`buildErrorMessage` and the `CustomerIOError` type move alongside it (or into `./v2/`). Three things to note:
+
+- **That is customerio's entire delivery contract** — one status entry, and no `failureReason`. Plain success and every failure status are handled by the framework, so there is no entry-point override, no `super` call, no `isHttpStatusSuccess` check, and no hardcoded reason string. Compare the 105-line `networkHandler.ts` it replaces.
+- The 207 loop is driven from the **request body**, not `ctx.jobs` — reading `batch_index` against the array it actually indexes. For customerio the two have equal length; this is simply the correct reading of the API.
+- **customerio declares no other override and no `failureReason`.** Its per-job `error` on a whole-batch failure is produced by `postTransformation.ts:212` from the thrown error's `destinationResponse`, not by `failureReason`, so it stays byte-identical and §5's parity table holds unchanged. Only the batch-level `message` moves — see behaviour change 1.
+
+#### Behaviour change 1: the top-level `message` text
+
+The framework generates the top-level `message`, so the three current strings change:
+
+| branch    | today                                                                                                  | after                                 |
+| --------- | ------------------------------------------------------------------------------------------------------ | ------------------------------------- |
+| success   | `[CustomerIO Response Handler] - Request Processed Successfully`                                       | framework success template            |
+| 207 mixed | `[CustomerIO Response Handler] - Batch completed with partial failures`                                | `[CUSTOMERIO] <first failure reason>` |
+| failure   | `[CustomerIO Response Handler] - Error in transformer proxy during CustomerIO response transformation` | the verdict `reason`                  |
+
+`message` is human-facing diagnostic text, not part of the delivery contract — no per-job field derives from it. Adding a `message` override to every builder to preserve three strings would put API noise into exactly the surface this design exists to simplify. So: accept the drift and update the expectations in `test/integrations/destinations/customerio/dataDelivery/data.ts` and `src/v1/destinations/customerio/networkHandler.test.ts`.
+
+The governing rule is that framework-generated text may change while destination-specific error text may not — which is why customerio inherits the default `failureReason` and per-job `error` stays byte-identical.
+
+#### Behaviour change 2: customerio stops emitting `authErrorCategory`
+
+Today the handler passes `getAuthErrCategoryFromStCode(status)` as `TransformerProxyError`'s 5th argument (`networkHandler.ts:93`), so a 401 emits `authErrorCategory: 'REFRESH_TOKEN'` and a 403 emits `'AUTH_STATUS_INACTIVE'`. Under §3.1 the framework does not infer auth from a status, and customerio does not declare a replacement, so the field is absent.
+
+**The field is unreachable for customerio, and the evidence is conclusive.** It is not an OAuth destination — its README states _"OAuth Support: **Supported**: No — Customer.io destination uses API Key authentication (Basic Auth) only"_ (`src/v0/destinations/customerio/README.md:125-128`), and the request is built with `Authorization: Basic ${btoa(siteID:apiKey)}` (`src/v0/destinations/customerio/v2/util.ts:254`). `OAuthTransport.RoundTrip` returns via `if !isOauthDestination { return t.Transport.RoundTrip(req) }` (`services/oauth/v2/http/transport.go`), so `postRoundTrip` never runs and neither the token refresh nor the `401`→`500` status rewrite that `REFRESH_TOKEN` normally triggers is reachable. A 401 was terminal before and is terminal now.
+
+So this is a **correction, not a regression**: customerio was labelling a bad-API-key 401 as a refreshable OAuth token, and the only reason it was harmless is that the label was unreachable. Declaring `authExpired`/`authRevoked` to preserve the string was considered and dropped — it would have kept a field nothing reads while forcing `errorType` to `retryable` on a job that is in fact aborted, which is strictly less accurate than the legacy `aborted`.
+
+Two consequences to record:
+
+- `test/integrations/destinations/customerio/dataDelivery/data.ts` no longer asserts `authErrorCategory: 'REFRESH_TOKEN'`, and `src/v1/destinations/customerio/networkHandler.test.ts:159` keeps the old assertion for the retained legacy handler.
+- The **transformer's own HTTP status** for that response moves `401`→`200`, because `controllers/delivery.ts:84-87` propagates the delivery status to the HTTP response only when `authErrorCategory` is set. The per-job `statusCode` stays `401`, which is what rudder-server reads.
+
+Everything else — per-job `error`, per-job `statusCode`, top-level `status`, `statTags.errorType` — is unchanged.
+
+### 4.2 `iterable_audience`
+
+The largest of the five and the only Pattern D case. Implemented in `src/v0/destinations/iterable_audience/delivery.ts`.
+
+Iterable's bulk list APIs answer a partially-failed request with HTTP 200 and a `failedUpdates`
+object naming the _identities_ that failed — no indices anywhere — so correlation is content-keyed:
+each subscriber in the request body is tested against those identity sets.
+
+```ts
+// delivery.ts
+export const iterableAudienceDelivery: DeliverySpec = {
+  statusOverrides: { '2xx': handleSuccessStatus },
+  // params ?? msg ?? message
+  failureReason: (ctx) => extractIterableAudienceErrorMessage(ctx.response),
+};
+
+// routerTransform.ts
+static readonly delivery = iterableAudienceDelivery;
+```
+
+Four things to note:
+
+- **`'2xx'`, not `200`.** Its dispatch today is `!isHttpStatusSuccess(status)` (`src/v1/destinations/iterable/strategies/base.ts:10`), so the class key is what preserves the contract.
+- Two branches deliberately report **success** where a naive reading would abort, and both carry over verbatim: a GDPR-forgotten user is counted and accepted rather than aborted (`audience-list.ts:88-98`), and `notFound` on an unsubscribe is a no-op success (`:100-103`). The `stats.counter` call sits inside the handler, which the contract permits (§2, conclusion 2), and the constraint on never tagging the identifier value carries over as a comment.
+- `failureReason` carries over `handleError`'s `response?.params ?? response?.msg ?? response?.message` chain (`audience-list.ts:124-125`), which is exactly what that declaration point exists for. `params` beating `msg` when both are present is that chain's behaviour, kept deliberately and pinned by a test.
+- The non-2xx path needs **no override**. The framework classification already aborts a 401 and retries a 500 with no auth inference (§3.1), which is what the legacy handler's empty `authErrorCategory` was expressing — Iterable list APIs are Api-Key authenticated, not OAuth (`audience-list.ts:138-140`).
+
+`BaseStrategy`, `AudienceListStrategy` and the 18-line `networkHandler.ts` are deleted once the framework owns delivery for this destination.
+
+### 4.3 `google_adwords_enhanced_conversions`
+
+Only `gaecResponseHandler` migrates. The 262-line `v0/networkHandler.ts` is transport — an SDK-based `gaecProxyRequest`, a `conversionActionId` cache, and `gaecProcessAxiosResponse` — which §3.6 rule 2 keeps in place.
+
+```ts
+const gaecStatusOverrides: StatusOverrideMap = {
+  // Partial failure arrives on a 2xx with partialFailureError set; results[] is positional.
+  '2xx': (ctx, fallback) => {
+    const { partialFailureError, results } = (ctx.response as any) ?? {};
+    if (!partialFailureError || partialFailureError.code === 0) return fallback(); // clean success
+    const reason: string = partialFailureError.message || 'unknown error format';
+    return perItem(
+      (results ?? []).map((r: unknown) => (isEmptyObject(r ?? {}) ? abort(reason) : success())),
+    );
+  },
+
+  // Google Ads is a genuine OAuth destination: auth category comes from the body.
+  '4xx': (ctx, fallback) => {
+    const category = getAuthErrCategory({ response: ctx.response, status: ctx.status });
+    const msg = extractGaecErrorMessage(ctx.response);
+    if (category === REFRESH_TOKEN) return authExpired(msg);
+    if (category === AUTH_STATUS_INACTIVE) return authRevoked(msg);
+    return fallback();
+  },
+};
+
+export const extractGaecErrorMessage = (response: unknown): string =>
+  (response as any)?.error?.message || 'unknown error';
+
+export const gaecDelivery: DeliverySpec = {
+  statusOverrides: gaecStatusOverrides,
+  failureReason: (ctx) => extractGaecErrorMessage(ctx.response),
+};
+```
+
+This is the first destination for which the §3.1 auth rule does real work. gaec **is** OAuth-backed, so its `authErrorCategory` is live — dropping it would break token refresh, where customerio's (§4.1) is declared for parity rather than because anything reads it. `getAuthErrCategory` (`src/v0/util/googleUtils`) already derives it from the response rather than the status, so the migration is a direct translation — and the `'4xx'` class key means 401 and 403 are both covered without enumerating.
+
+The `perItem` list is built from `results`, not from `ctx.jobs`, for the §3.2 reason: `results[]` is the array the API indexed.
+
+### 4.4 `braze_audience`
+
+Implemented in `src/v0/destinations/braze_audience/delivery.ts`.
+
+Braze answers `/users/track/bulk` with a **2xx** even when individual records were rejected, listing them in `errors[]` with an `index` into the posted `attributes` array (`src/v1/destinations/braze_audience/networkHandler.ts:55-80`). So it combines the two properties already handled separately: partial failure on a success status (gaec, §4.3) and a positional index into the request body (customerio, §4.1).
+
+```ts
+// delivery.ts
+export const brazeAudienceDelivery: DeliverySpec = {
+  statusOverrides: { '2xx': handlePartialFailure },
+  // message ?? response, unquoted
+  failureReason: (ctx) => extractBrazeAudienceErrorMessage(ctx.response),
+};
+
+// routerTransform.ts
+static readonly delivery = brazeAudienceDelivery;
+```
+
+Four things to note:
+
+- **`'2xx'`, not `201`.** Its dispatch today is `!isHttpStatusSuccess(status)` (`networkHandler.ts:35`), and Braze returns `201` on the bulk endpoint but the handler was never written to that specific code.
+- **Unindexed errors are the interesting branch.** Braze sometimes reports a failure with no `index`, which cannot be attributed to a record. The legacy handler marks every record the indexed errors did _not_ name as retryable (`:87-93`) rather than reporting them delivered, and that carries over verbatim — a success report for a batch Braze flagged as partially failed would silently drop data.
+- **Abortability is shared, not copied.** `isIdentityAborted` — the enum set plus the live-message regexes that #5408 added after observing real Braze responses — moves to `braze_audience/utils.ts` and is imported by both the legacy handler and `delivery.ts`. Copying it as customerio's `batch_index` parsing was copied (§4.1) would leave two definitions of which failures are permanent, and the regexes exist precisely because that judgement was hard to get right.
+- The non-2xx path needs **no override**, for the same reason as `iterable_audience`: the framework classification aborts a 400 and retries a 500, and the legacy handler already passed an empty `authErrorCategory` (`:50`) because Braze is REST-API-key authenticated. Unlike customerio (§4.1) there is nothing to declare here — the legacy handler inferred nothing to begin with.
+
+One guard is destination-specific. The `perItem` loop is driven from `attributes`, the array Braze indexes, but falls back to `ctx.jobs` when that body cannot be read, so that per-record verdicts survive: without it the bridge sees a length mismatch and retries the whole batch (§3.2), which would keep redelivering an identity failure that can never succeed instead of aborting it. The framework builds the two 1:1, so the fallback is exact whenever it is reached.
+
+### 4.5 `test_destination`
+
+**No `statusOverrides`, and no work beyond deleting a file.** Its handler composes the generic one and replaces only `proxy`:
+
+```ts
+function networkHandler(this: Record<string, unknown>) {
+  genericNetworkHandler.call(this); // responseHandler / processAxiosResponse / prepareProxy
+  this.proxy = proxy; // integration-major dispatch
+}
+```
+
+(`src/v0/destinations/test_destination/networkHandler.ts:24-27`.) Since `classifyByStatus` reproduces `genericNetworkHandler`'s `responseHandler` (§3.4), the framework default already is its behaviour. The `proxy` override is transport and stays; the file keeps only that.
+
+That equivalence is asserted rather than assumed: `delivery.test.ts` drives both the framework and `genericNetworkHandler` over 200/201/400/429/500/502 and compares status and `errorType`, so the day it stops holding is the day a test fails rather than the day delivery quietly changes.
+
+### 4.6 A harder case, out of scope: `mixpanel`
+
+customerio only exercises one map entry on a 2xx status. `mixpanel` is a useful second reference point — it dispatches on **endpoint** as well as status, and its per-item failures are content-keyed rather than positional. It is **not** being migrated here (`MP: { routerTransform: true, regulations: true }` in `src/features.ts:71` has no `batching: true`, and `src/v0/destinations/mp/` has only the legacy `transform.js`), but it shows the contract holding under more pressure:
+
+```ts
+const mixpanelStatusOverrides: StatusOverrideMap = {
+  // Import API: a 400 carries per-record failures keyed by $insert_id.
+  400: (ctx, fallback) => {
+    if (!ctx.request.endpoint?.includes('/import')) return fallback(); // not our endpoint
+    const events = decodeBatch(ctx.request);
+    if (!events) return fallback(); // undecodable body
+    const failed = new Map<string, string>();
+    for (const r of asFailedRecords(ctx.response)) {
+      if (r.$insert_id) failed.set(r.$insert_id, `Field: ${r.field}, Message: ${r.message}`);
+    }
+    return perItem(
+      events.map((e) => {
+        const reason = failed.get(e.properties?.$insert_id ?? '');
+        return reason ? abort(reason) : success();
+      }),
+    );
+  },
+
+  // Engage/Groups signal batch-level failure as a 2xx with `error` in the body.
+  '2xx': (ctx, fallback) => {
+    const error = get(ctx.response, 'error');
+    return error ? abort(`API error: ${error}`) : fallback();
+  },
+};
+```
+
+Three things this demonstrates that customerio does not:
+
+- **Endpoint dispatch needs no new mechanism.** The batching framework groups payloads by endpoint (`groupPayloadsByCompositeKey`), so every batch is single-endpoint; a handler reads `ctx.request.endpoint` and declines if it is not the one it handles. Today's `handleEndpointSpecificResponses` if-chain (`mp/utils.ts:283-297`) becomes the two `return fallback()` lines above.
+- **Declining composes.** The 400 handler declines twice — wrong endpoint, undecodable body — and in both cases the framework's own classification takes over, with no delegation for the author to get right.
+- **Driving `perItem` from the request body removes a bounds guard entirely.** Today mixpanel walks `metadata.map((m, index) => (index < events.length ? events[index] : null))` (`mp/utils.ts:229-230`) — positional job→event, then content-keyed event→failure by `$insert_id`. Iterating `events` instead means there is no index to run off the end. That guard exists only because the loop is driven from the wrong array.
+
+Roughly 300 lines of `mp/utils.ts` — `createResponsesForAllEvents`, `createSuccessResponse`, `handleNonSuccessResponse`, `handleStandardApiResponse`, `handleEndpointSpecificResponses`, and four copies of `Array.isArray(rudderJobMetadata) ? … : [ … ]` — would collapse into the map above plus the body decoder.
+
+Two prerequisites for whenever mixpanel is actually migrated: `BodyFormat` has no `GZIP` member (`nativeBatching/types.ts:55-60`), which its import path needs; and the top-level status on the import partial-failure path stays `200`, since §3.7 passes `ctx.status` through.
+
+---
+
+## 5. Parity check
+
+### 5.1 `customerio`
+
+| #   | branch                      | today                                                                      | under the rule                                                      |
+| --- | --------------------------- | -------------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| 1   | non-207 success, status 200 | top `200`, per-job `200`/`'success'`                                       | uniform success → top `ctx.status`=200 ✓, per-job fixed 200 ✓       |
+| 2   | non-207 failure, status 400 | throw → top `400`, per-job `400`                                           | uniform `abort` → throw path, top 400 ✓, per-job `ctx.status`=400 ✓ |
+| 3   | non-207 failure, status 500 | throw → top `500`, per-job `500`                                           | uniform `retry` → top 500 ✓, per-job 500 ✓                          |
+| 4   | 207 with errors             | top `207`, per-job `400`/`200`                                             | mixed → top 207 ✓, per-job fixed 400/200 ✓                          |
+| 5   | 207, empty `errors`         | top `207`, all per-job `200`                                               | uniform success → top `ctx.status`=207 ✓, per-job fixed 200 ✓       |
+| 6   | 401                         | throw, `authErrorCategory: 'REFRESH_TOKEN'`, `errorType: 'aborted'`        | `abort` → category dropped ✗, `errorType` ✓, per-job 401 ✓          |
+| 7   | 403                         | throw, `authErrorCategory: 'AUTH_STATUS_INACTIVE'`, `errorType: 'aborted'` | `abort` → category dropped ✗, `errorType` ✓, per-job 403 ✓          |
+
+Branch 5 is the one that rules out naive "class-preserving" per-job codes: a 2xx-preserving rule would emit `207` per job where today emits `200`.
+
+Branches 6–7 are the dropped status-inferred auth categories of §4.1 — unreachable for a Basic-auth destination. Job disposition and `errorType` are unchanged; the transformer's own HTTP status for those two responses moves `401`/`403`→`200`, since the controller propagates it only when `authErrorCategory` is set.
+
+### 5.2 `iterable_audience`
+
+| branch                         | today                                  | after                                      |
+| ------------------------------ | -------------------------------------- | ------------------------------------------ |
+| non-2xx (401, 500)             | throw → top `status`, per-job `status` | uniform `abort`/`retry` → same ✓           |
+| 2xx, all clean                 | top `200`, per-job `200`/`'success'`   | uniform success → top 200 ✓, per-job 200 ✓ |
+| 2xx, GDPR-forgotten            | top `200`, per-job `200` + metric      | `success()` + metric → same ✓              |
+| 2xx, `notFound` on unsubscribe | top `200`, per-job `200`               | `success()` → same ✓                       |
+| 2xx, some abortable            | top **`200`**, per-job `400`/`200`     | same ✓, per-job 400/200 ✓                  |
+| 2xx success shape              | includes `destinationResponse`         | omitted (§3.7) ✗                           |
+
+One response-shape change: `destinationResponse` is no longer echoed on success (§3.7). The top-level status and the per-job codes and error text are unchanged; the top-level `message` now carries the first failure reason rather than a fixed success string.
+
+### 5.3 `google_adwords_enhanced_conversions`
+
+| branch                                                   | today                                                   | after                                             |
+| -------------------------------------------------------- | ------------------------------------------------------- | ------------------------------------------------- |
+| 2xx, no `partialFailureError`                            | top `status`, per-job `status`, `'success'`             | uniform success → top 200 ✓, per-job 200 ✓        |
+| 2xx, `partialFailureError` set                           | top **`400`**, per-job `400`/`200`, explicit `statTags` | top **`200`** (`ctx.status`) ✗, per-job 400/200 ✓ |
+| non-2xx, auth (401/403)                                  | throw, `authErrorCategory` from `getAuthErrCategory`    | `authExpired`/`authRevoked` → same ✓              |
+| non-2xx, other                                           | throw, `getDynamicErrorType(status)`                    | `abort`/`retry` → same ✓                          |
+| 2xx, `partialFailureError` but `results` absent or short | per-job `400`, unmatched tail aborted                   | same ✓                                            |
+
+One change: the top-level status on partial failure moves `400`→`200`, because §3.7 passes `ctx.status` through and Google answered 200 — a `400` label on a batch in which some adjustments succeeded was misleading, and nothing reads it. The top-level `message` keeps Google's `partialFailureError.message`. `statTags` survives when every adjustment failed, which is the case the hand-rolled block was really for; it is dropped only for a genuinely mixed batch, where there is no single `errorType` to report and the legacy `aborted` described a batch that partly delivered. Auth behaviour is preserved exactly, and unlike customerio's it is live — gaec is OAuth-backed.
+
+**The last row is where the per-item list is indexed from.** An earlier revision drove it off `results`, the array the API indexes. That is wrong whenever `results` is absent or truncated — which the existing component fixture `gaec_v1_scenario_2` exercises, sending `partialFailureError` with no `results` at all — because the list then has a different length from the job list, §3.2's attribution guard fires, and the batch is retried where the legacy handler aborted it. Retrying re-uploads adjustments Google has already accepted, which come back as duplicate-enhancement failures on **every** attempt, so the retry never converges.
+
+The list is instead indexed off the **posted `conversionAdjustments`**, matching what customerio (§4.1) and braze_audience (§4.4) already do with their own request bodies. gaec is strictly 1:1 (`routerTransform.ts:44` emits one adjustment per event), so the posted array is the one array guaranteed to match the job list — which keeps §3.2's guard out of the picture entirely rather than relying on it. Reading a missing `results[i]` as failed then reproduces the legacy `results?.[i] ?? {}` exactly.
+
+§3.2 still governs the case it was written for: if the posted body cannot be read at all, there is nothing job-aligned to index and the batch is retried rather than reported delivered.
+
+### 5.4 `braze_audience`
+
+| branch                         | today                                   | after                                        |
+| ------------------------------ | --------------------------------------- | -------------------------------------------- |
+| non-2xx (400, 401, 429, 500)   | throw → top `status`, per-job `status`  | uniform `abort`/`throttled`/`retry` → same ✓ |
+| 2xx, no `errors`               | top `status`, per-job `200`/`'success'` | uniform success → top `ctx.status` ✓         |
+| 2xx, indexed identity failure  | top **`201`**, per-job `400` + metric   | same ✓, per-job 400 ✓                        |
+| 2xx, indexed other failure     | top **`201`**, per-job `500` + metric   | same ✓, per-job 500 ✓                        |
+| 2xx, unindexed error           | all unmapped jobs `500` + metric        | `retry()` per unmapped item → same ✓         |
+| 2xx, indexed abort + unindexed | per-job `400` / `500` / `500`           | same ✓                                       |
+| 2xx success shape              | includes `destinationResponse`          | omitted (§3.7) ✗                             |
+
+Same single response-shape change as `iterable_audience`: `destinationResponse` stops being echoed on success. The top-level status stays `201`. Per-job codes, error text and all three counters (`braze_audience_partial_failure`, `_aborted`, `_retryable`) are unchanged — the last is asserted directly, by comparing `stats.increment` call lists between the two paths.
+
+`authErrorCategory` needs no row: the legacy handler passes `''` unconditionally, so unlike customerio (§4.1) there is nothing to declare.
+
+### 5.5 `test_destination`
+
+| branch  | today                                                                        | after                              |
+| ------- | ---------------------------------------------------------------------------- | ---------------------------------- |
+| 2xx     | v0 shape adapted to v1: per-job `status`, error = `JSON.stringify(response)` | per-job `200`, error `'success'` ✗ |
+| non-2xx | throw `NetworkError` → v1 failure events                                     | `abort`/`retry` → same ✓           |
+
+The success-path per-job `error` changes because §3.6 rule 3 stops running the v0→v1 adaptation (`nativeIntegration.ts:235-246`), which was stringifying the whole response into every job. Dev-only fixture (`src/v0/destinations/test_destination/config.ts`), so the only impact is its own component expectations.
+
+---
+
+## 6. Scope
+
+**In:** `delivery.ts` (the `Verdict` type, builders, `DeliveryContext`, the bridge); the framework-owned `handleDeliveryResponse` / `resolveDeliverySpec` plus the single declaration point on `BatchDestination`, the `delivery` spec carrying `statusOverrides` and `failureReason`; the `isBatchingFrameworkDeliveryEnabled` flag and the branch it gates in `deliver()`; **`statusOverrides` for the four destinations that need them (§4.1-4.4); `test_destination` needs none (§4.5)**; unit tests for the bridge, override precedence and `fallback`, the status derivation, and the `perItem` bounds guard; **enabling `{DEST}_BATCHING_FRAMEWORK_DELIVERY_ENABLED_WORKSPACE_IDS` via `envOverrides` on all five destinations' `dataDelivery` component tests, and regenerating their expectations** so the framework path is what CI actually exercises rather than dead code behind an off flag.
+
+**Out, and deliberately so:**
+
+- **Any change to router output.** No `destInfo` stamp, no `BatchGroup` / `chunkPayloads` / `processBatchedDestination` change, no snapshot churn for other batching destinations (§3.5).
+- **Deleting the migrated destinations' `networkHandler.ts` files** — each is retained until that destination reaches GA and its legacy transform is retired (§3.6 rule 1). For the three already-GA destinations the legacy handler can go once the migration is verified.
+- The other ~46 network handlers and `networkHandlerFactory`, which remain the path for every unenrolled workspace and non-batching destination.
+- `proxy` / `prepareProxy` / `processAxiosResponse` overrides; the v0 delivery response shape.
+- The `iterable` / `iterable_audience` `undefined`-metadata bug — recorded below, not fixed here.
+
+---
+
+## 7. Decisions and deferrals
+
+1. **Delivery has its own flag, off by default** (§3.6). Wiring `deliver()` therefore changes nothing until a workspace is named in `{DEST}_BATCHING_FRAMEWORK_DELIVERY_ENABLED_WORKSPACE_IDS`, and the flag refuses unless that workspace is also on the batching-framework transform. All five destinations are still migrated together (§4.0), because the flag can only be enabled for a destination whose class can answer.
+2. **Two behaviour changes for customerio, both in §4.1** — the top-level `message` text, and dropping the status-inferred `authErrorCategory`, which is provably unreachable for a Basic-auth destination and takes the transformer's own HTTP status for those responses from `401`/`403` to `200`. Per-job `error`, per-job `statusCode`, top-level `status` and `statTags` are otherwise unchanged. All five destinations have worked migrations (§4.1-4.5) and parity tables (§5.1-5.5).
+3. **`destinationResponse`** is echoed on failures and omitted on successes (§3.7), on the evidence that its only consumer is failure-gated. Note `iterable_audience` currently echoes it on success (`audience-list.ts:113-118`), so that is a further response-shape change once its flag is enabled.
+4. **Item→job mapping is deferred** (§3.5) until a multiplexing batching destination needs it. The two hazards to handle are recorded there so the work does not have to be re-derived.
+
+### Follow-ups this survey surfaced but does not fix
+
+**`iterable` / `iterable_audience` can emit `metadata: undefined` job states** (`strategies/track-identify.ts:15-34`, `audience-list.ts:80-81`) when request body items outnumber jobs. What rudder-server does with it sets the severity:
+
+1. Go unmarshals the missing `metadata` to its zero value, so `resp.Metadata.JobID == 0`. `v1Adapter.getResponse` then writes `routerJobResponseCodes[0] = statusCode` (`router/transformer/transformer_proxy_adapter.go:151-153`) — a bogus entry for a job that does not exist, and no entry for the real job.
+2. **It is detected.** `transformer.go:606-618` compares the request's jobID set against the response's map keys and fires `emitBreach(reasonInOutMismatch, "[TransformerProxy] JobIDs in out mismatch", …)`. The comment there is explicit that this is _"Non-fatal: the results were applied, but may be attached to the wrong jobs."_
+3. **The real job is not lost.** `hydrateRespStatusCodes` (`router/worker.go:815-822`) backfills any job in `JobMetadataArray` with no response entry as `500` + `"Response for this job is expected but not found"`, so it is retried rather than stranded.
+
+Net: no data loss and no stuck jobs, but the delivery outcome the destination actually reported is **discarded**, so a successfully-delivered event gets redelivered — duplicates plus alert noise. That is why §3.2 has the framework bounds-check `perItem` and degrade to a whole-batch verdict instead of indexing past the end. Worth its own issue for the two iterable destinations.
+
+Also note `transformer.go:611` flags `responseEntriesCount > len(routerJobResponseCodes)` as a breach — two response entries collapsing onto one jobID silently drops a status. Another reason `perItem` must stay 1:1.
+
+**`TransformerProxyError`'s 6th argument is dead and safe to drop.** The constructor stores it as `this.response` (`src/v0/util/errorTypes/transformerProxyError.js:24`) and nothing ever reads it. `handlevV1DeliveriesFailureEvents` rebuilds per-job states from metadata and reads only `error.destinationResponse?.response` — the **4th** argument — at `postTransformation.ts:212`. `iterable_audience/audience-list.ts:141` and `customerio/networkHandler.ts:94` both compute and pass it for nothing. Removing the parameter is a separate cleanup across the ~50 handlers that pass it; this design removes the temptation by never exposing the throw.

--- a/src/constants/batchedDestinationsMap.test.ts
+++ b/src/constants/batchedDestinationsMap.test.ts
@@ -1,0 +1,75 @@
+describe('isBatchingFrameworkDeliveryEnabled', () => {
+  const ORIGINAL_ENV = process.env;
+
+  const load = () => {
+    // The GA map is read at module load, so each case needs a fresh module registry.
+    let mod: typeof import('./batchedDestinationsMap');
+    jest.isolateModules(() => {
+      // eslint-disable-next-line global-require, @typescript-eslint/no-var-requires
+      mod = require('./batchedDestinationsMap');
+    });
+    return mod!;
+  };
+
+  beforeEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    delete process.env.CUSTOMERIO_BATCHING_FRAMEWORK_ENABLED_WORKSPACE_IDS;
+    delete process.env.CUSTOMERIO_BATCHING_FRAMEWORK_DELIVERY_ENABLED_WORKSPACE_IDS;
+    delete process.env.ITERABLE_AUDIENCE_BATCHING_FRAMEWORK_DELIVERY_ENABLED_WORKSPACE_IDS;
+  });
+
+  afterAll(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  it('defaults to off, so delivery keeps using the legacy networkHandler', () => {
+    const { isBatchingFrameworkDeliveryEnabled } = load();
+    expect(isBatchingFrameworkDeliveryEnabled('customerio', 'ws-1')).toBe(false);
+  });
+
+  it('stays off for a GA destination that never opts delivery in', () => {
+    // iterable_audience has batching: true, so the *transform* flag is unconditionally on. The
+    // delivery flag has no GA map, so it must still be off.
+    const { isBatchingFrameworkEnabled, isBatchingFrameworkDeliveryEnabled } = load();
+    expect(isBatchingFrameworkEnabled('iterable_audience', 'ws-1')).toBe(true);
+    expect(isBatchingFrameworkDeliveryEnabled('iterable_audience', 'ws-1')).toBe(false);
+  });
+
+  it('enables delivery for a named workspace once both flags are set', () => {
+    process.env.CUSTOMERIO_BATCHING_FRAMEWORK_ENABLED_WORKSPACE_IDS = 'ws-1,ws-2';
+    process.env.CUSTOMERIO_BATCHING_FRAMEWORK_DELIVERY_ENABLED_WORKSPACE_IDS = 'ws-1';
+    const { isBatchingFrameworkDeliveryEnabled } = load();
+    expect(isBatchingFrameworkDeliveryEnabled('customerio', 'ws-1')).toBe(true);
+    // ws-2 is on the framework transform but has not opted delivery in.
+    expect(isBatchingFrameworkDeliveryEnabled('customerio', 'ws-2')).toBe(false);
+  });
+
+  it('refuses delivery when the workspace is not on the batching-framework transform', () => {
+    // The dangerous case: delivery on, transform off. The payload would have been built by the
+    // legacy processRouterDest, so the framework must not interpret its response.
+    process.env.CUSTOMERIO_BATCHING_FRAMEWORK_DELIVERY_ENABLED_WORKSPACE_IDS = 'ALL';
+    const { isBatchingFrameworkDeliveryEnabled } = load();
+    expect(isBatchingFrameworkDeliveryEnabled('customerio', 'ws-1')).toBe(false);
+  });
+
+  it("honours 'ALL' on both flags", () => {
+    process.env.CUSTOMERIO_BATCHING_FRAMEWORK_ENABLED_WORKSPACE_IDS = 'ALL';
+    process.env.CUSTOMERIO_BATCHING_FRAMEWORK_DELIVERY_ENABLED_WORKSPACE_IDS = 'ALL';
+    const { isBatchingFrameworkDeliveryEnabled } = load();
+    expect(isBatchingFrameworkDeliveryEnabled('customerio', 'any-workspace')).toBe(true);
+  });
+
+  it('is case-insensitive on destType and trims workspace ids', () => {
+    process.env.CUSTOMERIO_BATCHING_FRAMEWORK_ENABLED_WORKSPACE_IDS = 'ws-1';
+    process.env.CUSTOMERIO_BATCHING_FRAMEWORK_DELIVERY_ENABLED_WORKSPACE_IDS = ' ws-1 , ws-9 ';
+    const { isBatchingFrameworkDeliveryEnabled } = load();
+    expect(isBatchingFrameworkDeliveryEnabled('CUSTOMERIO', ' ws-1 ')).toBe(true);
+  });
+
+  it('treats an empty env var as off', () => {
+    process.env.CUSTOMERIO_BATCHING_FRAMEWORK_ENABLED_WORKSPACE_IDS = 'ALL';
+    process.env.CUSTOMERIO_BATCHING_FRAMEWORK_DELIVERY_ENABLED_WORKSPACE_IDS = '  ,  ';
+    const { isBatchingFrameworkDeliveryEnabled } = load();
+    expect(isBatchingFrameworkDeliveryEnabled('customerio', 'ws-1')).toBe(false);
+  });
+});

--- a/src/constants/batchedDestinationsMap.ts
+++ b/src/constants/batchedDestinationsMap.ts
@@ -4,18 +4,28 @@ import { getBatchingFrameworkGaDestinations } from '../features';
 // Once a destination is added here, it always uses the new path regardless of env var.
 export const batchedDestinationsMap: Record<string, true> = getBatchingFrameworkGaDestinations();
 
-// Per-destination env var: {DEST}_BATCHING_FRAMEWORK_ENABLED_WORKSPACE_IDS
+// Per-destination env var: {DEST}_{SUFFIX}
 // Values: comma-separated workspace IDs, or 'ALL' for all workspaces
 // Example: POSTHOG_BATCHING_FRAMEWORK_ENABLED_WORKSPACE_IDS="ws-1,ws-2" or "ALL"
 // If not set or empty → disabled for that destination (legacy path)
-const getEnabledWorkspaceIds = (destType: string): string[] => {
-  const envKey = `${destType.toUpperCase()}_BATCHING_FRAMEWORK_ENABLED_WORKSPACE_IDS`;
+const getEnabledWorkspaceIds = (destType: string, suffix: string): string[] => {
+  const envKey = `${destType.toUpperCase()}_${suffix}`;
   return (
     process.env[envKey]
       ?.split(',')
       ?.map((s) => s.trim())
       ?.filter((s) => s) ?? []
   );
+};
+
+const matchesWorkspace = (enabledWorkspaceIds: string[], workspaceId: string): boolean => {
+  if (enabledWorkspaceIds.length === 0) {
+    return false;
+  }
+  if (enabledWorkspaceIds.includes('ALL')) {
+    return true;
+  }
+  return enabledWorkspaceIds.includes(workspaceId?.trim());
 };
 
 // OR logic:
@@ -30,12 +40,38 @@ export const isBatchingFrameworkEnabled = (destType: string, workspaceId: string
   }
 
   // Pre-GA: check per-destination env var
-  const enabledWorkspaceIds = getEnabledWorkspaceIds(upperDestType);
-  if (enabledWorkspaceIds.length === 0) {
+  return matchesWorkspace(
+    getEnabledWorkspaceIds(upperDestType, 'BATCHING_FRAMEWORK_ENABLED_WORKSPACE_IDS'),
+    workspaceId,
+  );
+};
+
+/**
+ * Whether the batching framework also owns *delivery* (response handling) for this destination and
+ * workspace, rather than the destination's own networkHandler.
+ *
+ * Per-destination env var: {DEST}_BATCHING_FRAMEWORK_DELIVERY_ENABLED_WORKSPACE_IDS
+ * Values: comma-separated workspace IDs, or 'ALL'. Unset or empty → the legacy networkHandler.
+ *
+ * Two deliberate properties:
+ *
+ *  - **No GA map.** Unlike the transform flag there is no destination list that force-enables this,
+ *    so delivery stays on the legacy handler everywhere until a workspace is named explicitly.
+ *  - **Requires the transform flag.** The delivery path has to interpret a payload built by the
+ *    matching transform path — an unenrolled workspace's events are still built by the legacy
+ *    `processRouterDest`, and its response must be read by the legacy handler. Enabling delivery
+ *    for a workspace that is not on the batching-framework transform would pair the two halves
+ *    incorrectly, so this returns false regardless of the delivery env var.
+ */
+export const isBatchingFrameworkDeliveryEnabled = (
+  destType: string,
+  workspaceId: string,
+): boolean => {
+  if (!isBatchingFrameworkEnabled(destType, workspaceId)) {
     return false;
   }
-  if (enabledWorkspaceIds.includes('ALL')) {
-    return true;
-  }
-  return enabledWorkspaceIds.includes(workspaceId.trim());
+  return matchesWorkspace(
+    getEnabledWorkspaceIds(destType, 'BATCHING_FRAMEWORK_DELIVERY_ENABLED_WORKSPACE_IDS'),
+    workspaceId,
+  );
 };

--- a/src/constants/batchedDestinationsMap.ts
+++ b/src/constants/batchedDestinationsMap.ts
@@ -4,12 +4,15 @@ import { getBatchingFrameworkGaDestinations } from '../features';
 // Once a destination is added here, it always uses the new path regardless of env var.
 export const batchedDestinationsMap: Record<string, true> = getBatchingFrameworkGaDestinations();
 
-// Per-destination env var: {DEST}_{SUFFIX}
+// Per-destination env var: {DEST}_{FEATURE}_ENABLED_WORKSPACE_IDS
 // Values: comma-separated workspace IDs, or 'ALL' for all workspaces
 // Example: POSTHOG_BATCHING_FRAMEWORK_ENABLED_WORKSPACE_IDS="ws-1,ws-2" or "ALL"
 // If not set or empty → disabled for that destination (legacy path)
-const getEnabledWorkspaceIds = (destType: string, suffix: string): string[] => {
-  const envKey = `${destType.toUpperCase()}_${suffix}`;
+const getEnabledWorkspaceIds = (
+  destType: string,
+  feature: 'BATCHING_FRAMEWORK' | 'BATCHING_FRAMEWORK_DELIVERY',
+): string[] => {
+  const envKey = `${destType.toUpperCase()}_${feature}_ENABLED_WORKSPACE_IDS`;
   return (
     process.env[envKey]
       ?.split(',')
@@ -40,10 +43,7 @@ export const isBatchingFrameworkEnabled = (destType: string, workspaceId: string
   }
 
   // Pre-GA: check per-destination env var
-  return matchesWorkspace(
-    getEnabledWorkspaceIds(upperDestType, 'BATCHING_FRAMEWORK_ENABLED_WORKSPACE_IDS'),
-    workspaceId,
-  );
+  return matchesWorkspace(getEnabledWorkspaceIds(upperDestType, 'BATCHING_FRAMEWORK'), workspaceId);
 };
 
 /**
@@ -71,7 +71,7 @@ export const isBatchingFrameworkDeliveryEnabled = (
     return false;
   }
   return matchesWorkspace(
-    getEnabledWorkspaceIds(destType, 'BATCHING_FRAMEWORK_DELIVERY_ENABLED_WORKSPACE_IDS'),
+    getEnabledWorkspaceIds(destType, 'BATCHING_FRAMEWORK_DELIVERY'),
     workspaceId,
   );
 };

--- a/src/services/destination/__tests__/deliverBatchingFramework.test.ts
+++ b/src/services/destination/__tests__/deliverBatchingFramework.test.ts
@@ -1,0 +1,165 @@
+import networkHandlerFactory from '../../../adapters/networkHandlerFactory';
+import { NativeIntegrationDestinationService } from '../nativeIntegration';
+import type { DeliveryV1Response, ProxyV1Request } from '../../../types';
+
+const DEST = 'customerio';
+const WORKSPACE = 'ws-1';
+
+const job = (jobId: number) =>
+  ({
+    jobId,
+    attemptNum: 0,
+    userId: `u${jobId}`,
+    sourceId: 's1',
+    destinationId: 'd1',
+    workspaceId: WORKSPACE,
+    secret: {},
+    dontBatch: false,
+  }) as never;
+
+const proxyRequest = (): ProxyV1Request =>
+  ({
+    version: '1',
+    type: 'REST',
+    method: 'POST',
+    endpoint: 'https://track.customer.io/api/v2/batch',
+    userId: '',
+    body: { JSON: { batch: [{ event: 'a' }, { event: 'b' }] } },
+    metadata: [job(1), job(2)],
+    destinationConfig: {},
+  }) as unknown as ProxyV1Request;
+
+/** Stub transport so no HTTP happens; the destination "responds" with `status` and `response`. */
+const stubTransport = (status: number, response: unknown) => {
+  const legacyResponseHandler = jest.fn(() => ({
+    status: 999,
+    message: 'from the legacy handler',
+    response: [],
+  }));
+  jest.spyOn(networkHandlerFactory, 'getNetworkHandler').mockReturnValue({
+    networkHandler: {
+      proxy: jest.fn().mockResolvedValue({ success: true }),
+      processAxiosResponse: jest.fn().mockReturnValue({ status, response }),
+      responseHandler: legacyResponseHandler,
+      prepareProxy: jest.fn(),
+    },
+    handlerVersion: 'v1',
+  } as never);
+  return legacyResponseHandler;
+};
+
+describe('deliver() — batching-framework delivery flag', () => {
+  const ORIGINAL_ENV = process.env;
+  const service = new NativeIntegrationDestinationService();
+
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    process.env = { ...ORIGINAL_ENV };
+    process.env.CUSTOMERIO_BATCHING_FRAMEWORK_ENABLED_WORKSPACE_IDS = WORKSPACE;
+    delete process.env.CUSTOMERIO_BATCHING_FRAMEWORK_DELIVERY_ENABLED_WORKSPACE_IDS;
+  });
+
+  afterAll(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  it('uses the legacy networkHandler when the flag is unset', async () => {
+    const legacy = stubTransport(207, { errors: [{ batch_index: 1, reason: 'invalid' }] });
+
+    const result = await service.deliver(proxyRequest(), DEST, {}, 'v1');
+
+    expect(legacy).toHaveBeenCalledTimes(1);
+    expect((result as DeliveryV1Response).message).toBe('from the legacy handler');
+  });
+
+  it('uses the framework when the flag names the workspace', async () => {
+    process.env.CUSTOMERIO_BATCHING_FRAMEWORK_DELIVERY_ENABLED_WORKSPACE_IDS = WORKSPACE;
+    const legacy = stubTransport(207, {
+      errors: [{ batch_index: 1, reason: 'invalid', field: 'email' }],
+    });
+
+    const result = (await service.deliver(proxyRequest(), DEST, {}, 'v1')) as DeliveryV1Response;
+
+    expect(legacy).not.toHaveBeenCalled();
+    expect(result.status).toBe(207);
+    expect(result.response.map((r) => r.statusCode)).toEqual([200, 400]);
+    expect(result.response[1].error).toBe('reason: invalid, field: email');
+    expect(result.response.map((r) => r.metadata.jobId)).toEqual([1, 2]);
+  });
+
+  it('stays on the legacy handler for a workspace the flag does not name', async () => {
+    process.env.CUSTOMERIO_BATCHING_FRAMEWORK_DELIVERY_ENABLED_WORKSPACE_IDS = 'some-other-ws';
+    const legacy = stubTransport(200, { ok: true });
+
+    await service.deliver(proxyRequest(), DEST, {}, 'v1');
+
+    expect(legacy).toHaveBeenCalledTimes(1);
+  });
+
+  it('stays on the legacy handler for a v0 proxy request even with the flag on', async () => {
+    // The bridge only produces a v1 response, so v0 delivery must not take the new path.
+    process.env.CUSTOMERIO_BATCHING_FRAMEWORK_DELIVERY_ENABLED_WORKSPACE_IDS = WORKSPACE;
+    const legacy = stubTransport(200, { ok: true });
+    const v0Request = { ...proxyRequest(), metadata: job(1) } as never;
+
+    await service.deliver(v0Request, DEST, {}, 'v0');
+
+    expect(legacy).toHaveBeenCalledTimes(1);
+  });
+
+  it('emits the same statTags for a returned failure as for a thrown one', async () => {
+    process.env.CUSTOMERIO_BATCHING_FRAMEWORK_DELIVERY_ENABLED_WORKSPACE_IDS = WORKSPACE;
+    // A 207 where every posted item failed: a uniform whole-response failure that is *returned*
+    // (2xx status, so the throw path is excluded) rather than thrown.
+    stubTransport(207, {
+      errors: [
+        { batch_index: 0, reason: 'invalid' },
+        { batch_index: 1, reason: 'invalid' },
+      ],
+    });
+
+    const returned = (await service.deliver(proxyRequest(), DEST, {}, 'v1')) as DeliveryV1Response;
+    expect(returned.response.map((r) => r.statusCode)).toEqual([400, 400]);
+
+    stubTransport(400, { msg: 'bad request' });
+    const thrown = (await service.deliver(proxyRequest(), DEST, {}, 'v1')) as DeliveryV1Response;
+
+    // Same keys either way: a counter carrying only `errorType` could not be attributed to a
+    // destination or a workspace.
+    expect(Object.keys(returned.statTags ?? {}).sort()).toEqual(
+      Object.keys(thrown.statTags ?? {}).sort(),
+    );
+    expect(returned.statTags).toEqual({
+      destType: 'CUSTOMERIO',
+      errorCategory: 'network',
+      errorType: 'aborted',
+      feature: 'dataDelivery',
+      implementation: 'native',
+      module: 'destination',
+      destinationId: 'd1',
+      workspaceId: WORKSPACE,
+    });
+  });
+
+  it('leaves statTags off a partially-succeeded batch', async () => {
+    process.env.CUSTOMERIO_BATCHING_FRAMEWORK_DELIVERY_ENABLED_WORKSPACE_IDS = WORKSPACE;
+    stubTransport(207, { errors: [{ batch_index: 1, reason: 'invalid' }] });
+
+    const result = (await service.deliver(proxyRequest(), DEST, {}, 'v1')) as DeliveryV1Response;
+
+    expect(result.response.map((r) => r.statusCode)).toEqual([200, 400]);
+    expect(result).not.toHaveProperty('statTags');
+  });
+
+  it('routes a whole-batch failure through the framework error path', async () => {
+    process.env.CUSTOMERIO_BATCHING_FRAMEWORK_DELIVERY_ENABLED_WORKSPACE_IDS = WORKSPACE;
+    stubTransport(400, { msg: 'bad request' });
+
+    const result = (await service.deliver(proxyRequest(), DEST, {}, 'v1')) as DeliveryV1Response;
+
+    // The bridge throws, and deliver()'s existing catch turns it into a v1 failure response.
+    expect(result.status).toBe(400);
+    expect(result.response).toHaveLength(2);
+    expect(result.response.map((r) => r.statusCode)).toEqual([400, 400]);
+  });
+});

--- a/src/services/destination/nativeBatching/batchDestination.ts
+++ b/src/services/destination/nativeBatching/batchDestination.ts
@@ -8,6 +8,7 @@ import type {
   ExtractDestinationConfig,
   ExtractConnectionConfig,
 } from './types';
+import type { DeliverySpec } from './delivery';
 
 export type {
   TransformedEvent,
@@ -22,6 +23,31 @@ export { BodyFormat, parseSizeToBytes } from './types';
 export { makeRouterInputSchema } from './inputSchema';
 export { ChunkBatchStrategy } from './chunkBatchStrategy';
 export { CustomBatchStrategy } from './customBatchStrategy';
+export type {
+  Verdict,
+  ItemVerdict,
+  PerItemVerdicts,
+  HandleResponseResult,
+  DeliveryContext,
+  DeliverySpec,
+  ResolvedDeliverySpec,
+  StatusOverride,
+  StatusKey,
+  StatusOverrideMap,
+} from './delivery';
+export {
+  success,
+  abort,
+  retry,
+  throttled,
+  authExpired,
+  authRevoked,
+  perItem,
+  reasonOf,
+  defaultFailureReason,
+  resolveDeliverySpec,
+  handleDeliveryResponse,
+} from './delivery';
 
 // ---------------------------------------------------------------------------
 // Abstract class: BatchDestination<TBody, TInputSchema>
@@ -29,14 +55,34 @@ export { CustomBatchStrategy } from './customBatchStrategy';
 
 // Constructor type for BatchDestination subclasses — used by the framework to instantiate per request.
 // Only TBody is needed; TInputSchema is an internal concern of the concrete class.
+// The delivery spec is part of the contract, so the constructor type carries it: the delivery path
+// resolves a class through this type and reads `delivery` off it without ever instantiating (the
+// proxy payload has no `destination` or `connection` to construct one with).
 export type BatchDestinationConstructor<
   TBody extends Record<string, unknown> = Record<string, unknown>,
-> = new (destination: Destination, connection?: Connection) => BatchDestination<TBody>;
+> = (new (destination: Destination, connection?: Connection) => BatchDestination<TBody>) & {
+  readonly delivery: DeliverySpec;
+};
 
 export abstract class BatchDestination<
   TBody extends Record<string, unknown> = Record<string, unknown>,
   TInputSchema extends ZodType = ZodType<Record<string, unknown>>,
 > {
+  /**
+   * What this destination does with a delivery *response* — `statusOverrides` and `failureReason`,
+   * grouped so that they read as delivery rather than as more transform surface. Everything else
+   * on this class is about transforming an event; this one property is not.
+   *
+   * A static, and read as one, because the proxy payload carries `destinationConfig` and
+   * `metadata` but no `destination` object and no `connection` (see zodTypes.ts): no instance can
+   * be constructed on the delivery path, and for the audience destinations, whose constructors
+   * require a connection, it must not be. `resolveDeliverySpec` merges this down the prototype
+   * chain, so a subclass declaring its own spec does not drop what an ancestor declared.
+   *
+   * The framework applies it via `handleDeliveryResponse`; there is nothing here to override.
+   */
+  static readonly delivery: DeliverySpec = {};
+
   protected destination: Destination<ExtractDestinationConfig<z.infer<TInputSchema>>>;
 
   // All inputs in a single router-transform call share the same (source, destination)

--- a/src/services/destination/nativeBatching/delivery.test.ts
+++ b/src/services/destination/nativeBatching/delivery.test.ts
@@ -1,0 +1,473 @@
+import {
+  abort,
+  authExpired,
+  authRevoked,
+  classifyByStatus,
+  handleDeliveryResponse,
+  perItem,
+  resolveDeliverySpec,
+  retry,
+  statusClassOf,
+  success,
+  throttled,
+  toDeliveryV1Response,
+  type DeliveryContext,
+  type DeliverySpec,
+  type ItemVerdict,
+} from './delivery';
+import { BatchDestination } from './batchDestination';
+import type { ProxyMetdata, ProxyV1Request } from '../../../types';
+
+const DEST = 'TEST_DEST';
+
+const job = (jobId: number): ProxyMetdata =>
+  ({
+    jobId,
+    attemptNum: 0,
+    userId: `u${jobId}`,
+    sourceId: 's1',
+    destinationId: 'd1',
+    workspaceId: 'w1',
+    secret: {},
+    dontBatch: false,
+  }) as ProxyMetdata;
+
+const ctxFor = (
+  status: number,
+  response: unknown,
+  jobCount = 2,
+  body: Record<string, unknown> = {},
+): DeliveryContext => ({
+  status,
+  response,
+  jobs: Array.from({ length: jobCount }, (_, i) => job(i + 1)),
+  request: { body: { JSON: body }, endpoint: 'https://example.test/batch' } as ProxyV1Request,
+  destinationConfig: {},
+});
+
+/** The fields `TransformerProxyError` carries that the bridge is responsible for populating. */
+type ThrownProxyError = {
+  status: number;
+  statTags: { errorType: string };
+  authErrorCategory: string;
+  destinationResponse: { status: number; response: unknown };
+};
+
+/** Run `fn`, and fail the test unless it threw. Typed so assertions need no non-null assertions. */
+const captureThrow = (fn: () => unknown): ThrownProxyError => {
+  try {
+    fn();
+  } catch (e) {
+    return e as ThrownProxyError;
+  }
+  throw new Error('expected the call to throw a TransformerProxyError, but it returned');
+};
+
+describe('statusClassOf', () => {
+  const cases = [
+    { status: 200, expected: '2xx' },
+    { status: 207, expected: '2xx' },
+    { status: 299, expected: '2xx' },
+    { status: 400, expected: '4xx' },
+    { status: 429, expected: '4xx' },
+    { status: 500, expected: '5xx' },
+    { status: 599, expected: '5xx' },
+    { status: 302, expected: undefined },
+    { status: 100, expected: undefined },
+  ];
+
+  it.each(cases)('maps $status to $expected', ({ status, expected }) => {
+    expect(statusClassOf(status)).toBe(expected);
+  });
+});
+
+describe('classifyByStatus', () => {
+  const cases = [
+    { status: 200, kind: 'success', as: undefined },
+    { status: 207, kind: 'success', as: undefined },
+    { status: 429, kind: 'retry', as: 'throttled' },
+    { status: 500, kind: 'retry', as: undefined },
+    { status: 502, kind: 'retry', as: undefined },
+    // 401/403/422 are plain aborts: the framework never infers an auth verdict from a status.
+    { status: 400, kind: 'abort', as: undefined },
+    { status: 401, kind: 'abort', as: undefined },
+    { status: 403, kind: 'abort', as: undefined },
+    { status: 422, kind: 'abort', as: undefined },
+  ];
+
+  it.each(cases)('classifies $status as $kind ($as)', ({ status, kind, as }) => {
+    const verdict = classifyByStatus(status, 'boom') as { kind: string; as?: string };
+    expect(verdict.kind).toBe(kind);
+    expect(verdict.as).toBe(as);
+  });
+});
+
+describe('resolveDeliverySpec', () => {
+  const baseEntry = jest.fn();
+  const familyEntry = jest.fn();
+  const leafEntry = jest.fn();
+  const baseReason = jest.fn(() => 'from base');
+  const leafReason = jest.fn(() => 'from leaf');
+
+  class Base {
+    static readonly delivery: DeliverySpec = {
+      statusOverrides: { 500: baseEntry },
+      failureReason: baseReason,
+    };
+  }
+  class Family extends Base {
+    static readonly delivery: DeliverySpec = { statusOverrides: { 429: familyEntry } };
+  }
+  class Leaf extends Family {
+    static readonly delivery: DeliverySpec = { statusOverrides: { 207: leafEntry } };
+  }
+  class LeafNoDecl extends Family {}
+  class LeafShadowing extends Family {
+    static readonly delivery: DeliverySpec = {
+      statusOverrides: { 429: leafEntry },
+      failureReason: leafReason,
+    };
+  }
+
+  it('merges statusOverrides down the whole chain instead of shadowing', () => {
+    const merged = resolveDeliverySpec(Leaf).statusOverrides;
+    expect(Object.keys(merged).sort()).toEqual(['207', '429', '500']);
+    expect(merged[207]).toBe(leafEntry);
+    expect(merged[429]).toBe(familyEntry);
+    expect(merged[500]).toBe(baseEntry);
+  });
+
+  it('inherits when the subclass declares no spec of its own', () => {
+    expect(Object.keys(resolveDeliverySpec(LeafNoDecl).statusOverrides).sort()).toEqual([
+      '429',
+      '500',
+    ]);
+  });
+
+  it('lets the child win on a status key its ancestor also declares', () => {
+    expect(resolveDeliverySpec(LeafShadowing).statusOverrides[429]).toBe(leafEntry);
+  });
+
+  it('keeps an ancestor failureReason a nearer spec does not declare', () => {
+    // Family and Leaf declare only statusOverrides, so Base's extractor still applies — the whole
+    // point of resolving rather than reading the nearest `delivery` object.
+    expect(resolveDeliverySpec(Leaf).failureReason(ctxFor(500, {}))).toBe('from base');
+  });
+
+  it('takes the nearest failureReason when more than one is declared', () => {
+    expect(resolveDeliverySpec(LeafShadowing).failureReason(ctxFor(500, {}))).toBe('from leaf');
+  });
+
+  it('returns the framework defaults for a class declaring nothing anywhere', () => {
+    const spec = resolveDeliverySpec(BatchDestination);
+    expect(spec.statusOverrides).toEqual({});
+    expect(spec.failureReason(ctxFor(503, { msg: 'ignored' }))).toBe(
+      '[Generic Response Handler] Request failed with status: 503',
+    );
+  });
+});
+
+describe('handleDeliveryResponse', () => {
+  const exact = jest.fn(() => success());
+  const klass = jest.fn(() => abort('from class key'));
+
+  class Dest extends BatchDestination<Record<string, unknown>> {
+    static readonly delivery: DeliverySpec = { statusOverrides: { 207: exact, '2xx': klass } };
+
+    transformEvent() {
+      return { body: {}, endpoint: '', endpointPath: '', method: 'POST' };
+    }
+
+    getBatchStrategy(): never {
+      throw new Error('not used');
+    }
+
+    getInputSchema(): never {
+      throw new Error('not used');
+    }
+  }
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('prefers the exact status entry over the class entry', () => {
+    handleDeliveryResponse(Dest, ctxFor(207, {}));
+    expect(exact).toHaveBeenCalledTimes(1);
+    expect(klass).not.toHaveBeenCalled();
+  });
+
+  it('falls to the class entry when no exact entry matches', () => {
+    expect(handleDeliveryResponse(Dest, ctxFor(200, {}))).toEqual({
+      kind: 'abort',
+      reason: 'from class key',
+    });
+  });
+
+  it('classifies itself when no entry matches at all', () => {
+    expect(handleDeliveryResponse(Dest, ctxFor(500, { e: 1 }))).toEqual({
+      kind: 'retry',
+      reason: '[Generic Response Handler] Request failed with status: 500',
+    });
+  });
+
+  it('does not read the response body for the default reason', () => {
+    // The framework has no general way to find a message in an arbitrary destination's body.
+    // A destination that wants its API's error text declares `delivery.failureReason`.
+    const withMessage = handleDeliveryResponse(
+      Dest,
+      ctxFor(500, { message: 'destination said this' }),
+    );
+    expect(withMessage).toEqual(
+      handleDeliveryResponse(Dest, ctxFor(500, { totally: 'different' })),
+    );
+  });
+
+  it('passes a fallback that produces the framework classification', () => {
+    class Declining extends Dest {
+      static readonly delivery: DeliverySpec = {
+        statusOverrides: { '4xx': (_ctx, fallback) => fallback() },
+      };
+    }
+    expect(handleDeliveryResponse(Declining, ctxFor(400, { e: 2 }))).toEqual({
+      kind: 'abort',
+      reason: '[Generic Response Handler] Request failed with status: 400',
+    });
+  });
+
+  it('uses a declared failureReason for the reason', () => {
+    class Custom extends Dest {
+      static readonly delivery: DeliverySpec = {
+        failureReason: (ctx: DeliveryContext) => (ctx.response as { msg: string }).msg,
+      };
+    }
+    expect(handleDeliveryResponse(Custom, ctxFor(400, { msg: 'nice message' }))).toEqual({
+      kind: 'abort',
+      reason: 'nice message',
+    });
+  });
+});
+
+describe('toDeliveryV1Response — whole-batch failure on a non-2xx throws', () => {
+  const cases = [
+    { name: 'abort', verdict: abort('bad request'), status: 400, errorType: 'aborted', auth: '' },
+    { name: 'retry', verdict: retry('server down'), status: 500, errorType: 'retryable', auth: '' },
+    {
+      name: 'throttled',
+      verdict: throttled('slow down'),
+      status: 429,
+      errorType: 'throttled',
+      auth: '',
+    },
+    {
+      name: 'authExpired',
+      verdict: authExpired('token stale'),
+      status: 401,
+      errorType: 'retryable',
+      auth: 'REFRESH_TOKEN',
+    },
+    {
+      name: 'authRevoked',
+      verdict: authRevoked('grant gone'),
+      status: 403,
+      errorType: 'aborted',
+      auth: 'AUTH_STATUS_INACTIVE',
+    },
+  ];
+
+  it.each(cases)('$name -> TransformerProxyError', ({ verdict, status, errorType, auth }) => {
+    const ctx = ctxFor(status, { detail: 'x' });
+    const thrown = captureThrow(() => toDeliveryV1Response(verdict, ctx, DEST));
+    expect(thrown.status).toBe(status);
+    expect(thrown.statTags.errorType).toBe(errorType);
+    expect(thrown.authErrorCategory).toBe(auth);
+    // The bridge reassembles the processed proxy response from ctx.status + ctx.response.
+    expect(thrown.destinationResponse).toEqual({ status, response: { detail: 'x' } });
+  });
+});
+
+describe('toDeliveryV1Response — responses returned directly', () => {
+  it('reports uniform success with the destination status passed through', () => {
+    const result = toDeliveryV1Response(success(), ctxFor(201, { ok: true }), DEST);
+    expect(result.status).toBe(201);
+    expect(result.message).toBe(`[${DEST}] Request processed successfully`);
+    expect(result.response.map((r) => r.statusCode)).toEqual([200, 200]);
+    expect(result.response.map((r) => r.error)).toEqual(['success', 'success']);
+  });
+
+  it('omits destinationResponse on success', () => {
+    expect(toDeliveryV1Response(success(), ctxFor(200, { ok: true }), DEST)).not.toHaveProperty(
+      'destinationResponse',
+    );
+  });
+
+  it('passes the destination status through on a mixed batch, with per-item codes', () => {
+    const verdicts: ItemVerdict[] = [success(), abort('item 2 bad')];
+    const result = toDeliveryV1Response(perItem(verdicts), ctxFor(207, {}), DEST);
+    expect(result.status).toBe(207);
+    // One distinct failure reason, so it is the batch message.
+    expect(result.message).toBe(`[${DEST}] item 2 bad`);
+    // Partly delivered, so there is no single errorType to tag the whole response with.
+    expect(result).not.toHaveProperty('statTags');
+    expect(result.response).toEqual([
+      { statusCode: 200, metadata: job(1), error: 'success' },
+      { statusCode: 400, metadata: job(2), error: 'item 2 bad' },
+    ]);
+  });
+
+  it('does NOT echo a 2xx status into per-job codes when the whole batch failed', () => {
+    // A destination reporting failure in the body of a 200. Echoing 200 per job would make
+    // rudder-server's isSuccessStatus treat failed events as delivered.
+    const result = toDeliveryV1Response(
+      abort('error in body'),
+      ctxFor(200, { error: 'nope' }),
+      DEST,
+    );
+    expect(result.status).toBe(200);
+    expect(result.response.map((r) => r.statusCode)).toEqual([400, 400]);
+    expect(result.response.map((r) => r.error)).toEqual(['error in body', 'error in body']);
+  });
+
+  it('counts the failures instead of quoting one when the reasons differ', () => {
+    const result = toDeliveryV1Response(
+      perItem([abort('bad email'), abort('bad phone')]),
+      ctxFor(200, {}),
+      DEST,
+    );
+    expect(result.message).toBe(`[${DEST}] 2 of 2 events failed; see per-event errors`);
+    expect(result.response.map((r) => r.error)).toEqual(['bad email', 'bad phone']);
+  });
+
+  it('tags the response when every job failed the same way, and not otherwise', () => {
+    // A uniform whole-response failure is the one case where `integration.failure_detailed` has a
+    // single honest label. This response is returned rather than thrown because ctx.status is 2xx.
+    // The bridge sets only the error-describing half; nativeIntegration merges the identifying
+    // tags (destType, destinationId, workspaceId, …) from the same getTags metadata the thrown
+    // path uses — asserted end to end in deliverBatchingFramework.test.ts.
+    const uniformFailure = toDeliveryV1Response(abort('all bad'), ctxFor(200, {}), DEST);
+    expect(uniformFailure.statTags).toEqual({ errorCategory: 'network', errorType: 'aborted' });
+
+    const mixedKinds = toDeliveryV1Response(
+      perItem([abort('bad'), retry('transient')]),
+      ctxFor(200, {}),
+      DEST,
+    );
+    expect(mixedKinds).not.toHaveProperty('statTags');
+  });
+
+  it('maps a throttled item to 429 and a retry item to 500', () => {
+    const result = toDeliveryV1Response(
+      perItem([throttled('rate limited'), retry('transient')]),
+      ctxFor(200, {}),
+      DEST,
+    );
+    expect(result.response.map((r) => r.statusCode)).toEqual([429, 500]);
+  });
+
+  it('stamps dontBatch on the job that asked for it, and only that job', () => {
+    const result = toDeliveryV1Response(
+      perItem([retry('needs unbatched retry', { dontBatch: true }), success()]),
+      ctxFor(200, {}),
+      DEST,
+    );
+    expect(result.response[0].metadata.dontBatch).toBe(true);
+    expect(result.response[1].metadata.dontBatch).toBe(false);
+  });
+});
+
+describe('toDeliveryV1Response — perItem bounds guard', () => {
+  it('retries every job when items outnumber jobs', () => {
+    const ctx = ctxFor(200, {}, 2);
+    const result = toDeliveryV1Response(
+      perItem([success(), abort('bad'), retry('worse')]),
+      ctx,
+      DEST,
+    );
+    // Never indexes past the end, so no job state carries an undefined metadata.
+    expect(result.response).toHaveLength(2);
+    expect(result.response.every((r) => r.metadata !== undefined)).toBe(true);
+    expect(result.response.map((r) => r.statusCode)).toEqual([500, 500]);
+  });
+
+  it('retries every job when items are fewer than jobs', () => {
+    // The one abort is discarded rather than fanned out: it cannot be tied to a job, and aborting
+    // jobs on the strength of a verdict that might not be theirs drops data permanently.
+    const result = toDeliveryV1Response(perItem([abort('bad')]), ctxFor(200, {}, 3), DEST);
+    expect(result.response).toHaveLength(3);
+    expect(result.response.map((r) => r.statusCode)).toEqual([500, 500, 500]);
+  });
+
+  it('retries rather than reporting success when the present items all succeeded', () => {
+    // The job with no verdict at all has an unknown outcome. Folding it in as success would
+    // report an event as delivered on no evidence.
+    const result = toDeliveryV1Response(perItem([success()]), ctxFor(200, {}, 2), DEST);
+    expect(result.status).toBe(200);
+    expect(result.response.map((r) => r.statusCode)).toEqual([500, 500]);
+  });
+
+  it('retries rather than reporting success when the item list is empty', () => {
+    // Only a handler that believed there were failures returns perItem([]) — the empty list is
+    // the strongest case for not claiming delivery.
+    const result = toDeliveryV1Response(perItem([]), ctxFor(200, { failed: true }, 2), DEST);
+    expect(result.response.map((r) => r.statusCode)).toEqual([500, 500]);
+  });
+
+  it('names the mismatch in the per-job error so it is diagnosable from live events', () => {
+    const result = toDeliveryV1Response(perItem([success()]), ctxFor(200, {}, 2), DEST);
+    expect(result.response[0].error).toBe(`[${DEST}] per-item verdicts (1) do not match jobs (2)`);
+  });
+});
+
+describe('toDeliveryV1Response — per-item detail survives a non-2xx', () => {
+  it('returns a response rather than throwing when every item failed on a 400', () => {
+    // postTransformation rebuilds job states from metadata, so throwing here would replace the
+    // per-item reasons with one stringified response. mixpanel's /import reports exactly this way.
+    const ctx = ctxFor(400, { failed: true }, 2);
+    const result = toDeliveryV1Response(
+      perItem([abort('item 1: bad id'), abort('item 2: bad email')]),
+      ctx,
+      DEST,
+    );
+    // The destination's own 400 is passed through, and because every job failed the same way the
+    // response still carries the single errorType that a non-2xx response is expected to have.
+    expect(result.status).toBe(400);
+    expect(result.statTags).toEqual({ errorCategory: 'network', errorType: 'aborted' });
+    expect(result.response.map((r) => r.statusCode)).toEqual([400, 400]);
+    expect(result.response.map((r) => r.error)).toEqual(['item 1: bad id', 'item 2: bad email']);
+  });
+
+  it('still throws for a whole-batch verdict on a non-2xx', () => {
+    expect(() => toDeliveryV1Response(abort('all bad'), ctxFor(400, {}, 2), DEST)).toThrow(
+      'all bad',
+    );
+  });
+
+  it('returns a retry rather than throwing when a per-item list could not be attributed', () => {
+    // The throw carries ctx.status, so a 400 would reach rudder-server's isJobTerminated as an
+    // abort — terminating the batch the mismatch guard just decided to retry.
+    const result = toDeliveryV1Response(
+      perItem([abort('a'), abort('b'), abort('c')]),
+      ctxFor(400, {}, 2),
+      DEST,
+    );
+    expect(result.response.map((r) => r.statusCode)).toEqual([500, 500]);
+  });
+});
+
+describe('toDeliveryV1Response — dontBatch on a whole-batch retry', () => {
+  it('returns a response rather than throwing, so the flag survives', () => {
+    // dontBatch exists only as a stamp on a job state's metadata. The throw path rebuilds job
+    // states from the request metadata in postTransformation and has nowhere to put it.
+    const result = toDeliveryV1Response(
+      retry('batch too large', { dontBatch: true }),
+      ctxFor(400, { detail: 'x' }, 2),
+      DEST,
+    );
+    expect(result.response.map((r) => r.statusCode)).toEqual([500, 500]);
+    expect(result.response.every((r) => r.metadata.dontBatch === true)).toBe(true);
+  });
+
+  it('still throws for a whole-batch retry that does not ask for dontBatch', () => {
+    expect(() => toDeliveryV1Response(retry('server down'), ctxFor(500, {}, 2), DEST)).toThrow(
+      'server down',
+    );
+  });
+});

--- a/src/services/destination/nativeBatching/delivery.test.ts
+++ b/src/services/destination/nativeBatching/delivery.test.ts
@@ -496,40 +496,6 @@ describe('toDeliveryV1Response — per-item detail survives a non-2xx', () => {
     );
     expect(result.response.map((r) => r.statusCode)).toEqual([500, 500]);
   });
-
-  it('still carries statTags when only some items failed on a non-2xx', () => {
-    // `validateStatTags` rejects a non-2xx response with empty statTags, so the "one failure only"
-    // rule cannot apply here without the response failing the harness that parses it — and this is
-    // the case the perItemPreserved exclusion above exists to let through.
-    const result = toDeliveryV1Response(
-      perItem([success(), abort('bad id')]),
-      ctxFor(400, { failed: true }, 2),
-      DEST,
-    );
-    expect(result.status).toBe(400);
-    expect(result.statTags).toEqual({ errorCategory: 'network', errorType: 'aborted' });
-    expect(result.response.map((r) => r.statusCode)).toEqual([200, 400]);
-  });
-
-  it('takes the errorType from a failing verdict, not from a leading success', () => {
-    const result = toDeliveryV1Response(
-      perItem([success(), retry('try later')]),
-      ctxFor(503, { failed: true }, 2),
-      DEST,
-    );
-    expect(result.statTags).toEqual({ errorCategory: 'network', errorType: 'retryable' });
-  });
-
-  it('leaves statTags off a partially-failed 2xx', () => {
-    // Unchanged by the floor: a 2xx is not rejected for missing statTags, and tagging a batch that
-    // partly delivered as a whole-batch abort is what gaec's legacy handler got wrong.
-    const result = toDeliveryV1Response(
-      perItem([success(), abort('bad id')]),
-      ctxFor(200, {}, 2),
-      DEST,
-    );
-    expect(result.statTags).toBeUndefined();
-  });
 });
 
 describe('toDeliveryV1Response — dontBatch on a whole-batch retry', () => {

--- a/src/services/destination/nativeBatching/delivery.test.ts
+++ b/src/services/destination/nativeBatching/delivery.test.ts
@@ -3,6 +3,7 @@ import {
   authExpired,
   authRevoked,
   classifyByStatus,
+  firstJobIdentity,
   handleDeliveryResponse,
   perItem,
   resolveDeliverySpec,
@@ -37,13 +38,17 @@ const ctxFor = (
   response: unknown,
   jobCount = 2,
   body: Record<string, unknown> = {},
-): DeliveryContext => ({
-  status,
-  response,
-  jobs: Array.from({ length: jobCount }, (_, i) => job(i + 1)),
-  request: { body: { JSON: body }, endpoint: 'https://example.test/batch' } as ProxyV1Request,
-  destinationConfig: {},
-});
+): DeliveryContext => {
+  const jobs = Array.from({ length: jobCount }, (_, i) => job(i + 1));
+  return {
+    status,
+    response,
+    jobs,
+    request: { body: { JSON: body }, endpoint: 'https://example.test/batch' } as ProxyV1Request,
+    destinationConfig: {},
+    ...firstJobIdentity(jobs),
+  };
+};
 
 /** The fields `TransformerProxyError` carries that the bridge is responsible for populating. */
 type ThrownProxyError = {

--- a/src/services/destination/nativeBatching/delivery.test.ts
+++ b/src/services/destination/nativeBatching/delivery.test.ts
@@ -182,6 +182,18 @@ describe('resolveDeliverySpec', () => {
       '[Generic Response Handler] Request failed with status: 503',
     );
   });
+
+  it.each([
+    ['undefined', undefined],
+    ['null', null],
+    ['a plain object', {}],
+  ])('throws rather than degrading to the empty spec for %s', (_name, notAClass) => {
+    // `MiscService.getBatchDestinationHandler` is `require(...).Integration`, so a renamed or
+    // missing export lands here as undefined. Resolving that to `{}` is indistinguishable from a
+    // destination that genuinely classifies on status alone — every partial failure reported on a
+    // 2xx would come back `statusCode: 200, error: 'success'`, dropped with no throw and no metric.
+    expect(() => resolveDeliverySpec(notAClass)).toThrow(/does not export `Integration`/);
+  });
 });
 
 describe('handleDeliveryResponse', () => {
@@ -483,6 +495,40 @@ describe('toDeliveryV1Response — per-item detail survives a non-2xx', () => {
       DEST,
     );
     expect(result.response.map((r) => r.statusCode)).toEqual([500, 500]);
+  });
+
+  it('still carries statTags when only some items failed on a non-2xx', () => {
+    // `validateStatTags` rejects a non-2xx response with empty statTags, so the "one failure only"
+    // rule cannot apply here without the response failing the harness that parses it — and this is
+    // the case the perItemPreserved exclusion above exists to let through.
+    const result = toDeliveryV1Response(
+      perItem([success(), abort('bad id')]),
+      ctxFor(400, { failed: true }, 2),
+      DEST,
+    );
+    expect(result.status).toBe(400);
+    expect(result.statTags).toEqual({ errorCategory: 'network', errorType: 'aborted' });
+    expect(result.response.map((r) => r.statusCode)).toEqual([200, 400]);
+  });
+
+  it('takes the errorType from a failing verdict, not from a leading success', () => {
+    const result = toDeliveryV1Response(
+      perItem([success(), retry('try later')]),
+      ctxFor(503, { failed: true }, 2),
+      DEST,
+    );
+    expect(result.statTags).toEqual({ errorCategory: 'network', errorType: 'retryable' });
+  });
+
+  it('leaves statTags off a partially-failed 2xx', () => {
+    // Unchanged by the floor: a 2xx is not rejected for missing statTags, and tagging a batch that
+    // partly delivered as a whole-batch abort is what gaec's legacy handler got wrong.
+    const result = toDeliveryV1Response(
+      perItem([success(), abort('bad id')]),
+      ctxFor(200, {}, 2),
+      DEST,
+    );
+    expect(result.statTags).toBeUndefined();
   });
 });
 

--- a/src/services/destination/nativeBatching/delivery.test.ts
+++ b/src/services/destination/nativeBatching/delivery.test.ts
@@ -17,6 +17,7 @@ import {
   type ItemVerdict,
 } from './delivery';
 import { BatchDestination } from './batchDestination';
+import stats from '../../../util/stats';
 import type { ProxyMetdata, ProxyV1Request } from '../../../types';
 
 const DEST = 'TEST_DEST';
@@ -101,9 +102,20 @@ describe('classifyByStatus', () => {
   ];
 
   it.each(cases)('classifies $status as $kind ($as)', ({ status, kind, as }) => {
-    const verdict = classifyByStatus(status, 'boom') as { kind: string; as?: string };
+    const verdict = classifyByStatus(status, () => 'boom') as { kind: string; as?: string };
     expect(verdict.kind).toBe(kind);
     expect(verdict.as).toBe(as);
+  });
+
+  it('does not evaluate the reason on a success', () => {
+    // The success path is every plain 2xx, and a destination's extractor can be expensive — braze's
+    // falls through to JSON.stringify over the whole response body.
+    const reason = jest.fn(() => 'boom');
+    classifyByStatus(200, reason);
+    expect(reason).not.toHaveBeenCalled();
+
+    classifyByStatus(500, reason);
+    expect(reason).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -418,6 +430,23 @@ describe('toDeliveryV1Response — perItem bounds guard', () => {
   it('names the mismatch in the per-job error so it is diagnosable from live events', () => {
     const result = toDeliveryV1Response(perItem([success()]), ctxFor(200, {}, 2), DEST);
     expect(result.response[0].error).toBe(`[${DEST}] per-item verdicts (1) do not match jobs (2)`);
+  });
+
+  it('keeps the two counts out of the metric labels', () => {
+    // MAX_BATCH_SIZE is 1000 for braze_audience and iterable_audience, so tagging both counts would
+    // open a 1000x1000 label space per (destType, destinationId, workspaceId) — and this counter
+    // fires exactly when a destination is stuck in the mismatch/retry loop.
+    const counter = jest.spyOn(stats, 'counter').mockImplementation(() => {});
+    try {
+      toDeliveryV1Response(perItem([success()]), ctxFor(200, {}, 2), DEST);
+      expect(counter).toHaveBeenCalledWith('batch_delivery_per_item_mismatch', 1, {
+        destType: DEST,
+        destinationId: 'd1',
+        workspaceId: 'w1',
+      });
+    } finally {
+      counter.mockRestore();
+    }
   });
 });
 

--- a/src/services/destination/nativeBatching/delivery.ts
+++ b/src/services/destination/nativeBatching/delivery.ts
@@ -10,6 +10,7 @@ import { TransformerProxyError } from '../../../v0/util/errorTypes';
 import { isHttpStatusSuccess, isHttpStatusRetryable } from '../../../v0/util';
 import tags from '../../../v0/util/tags';
 import stats from '../../../util/stats';
+import logger from '../../../logger';
 import {
   REFRESH_TOKEN,
   AUTH_STATUS_INACTIVE,
@@ -41,10 +42,16 @@ export type Verdict = SuccessVerdict | AbortVerdict | RetryVerdict;
  * The subset of verdicts expressible per item. The auth refinements are absent deliberately:
  * rudder-server overwrites the status code of *every* job in a batch whenever an
  * `authErrorCategory` is present, so a per-item auth verdict cannot be represented.
+ *
+ * Both refinements are excluded by construction, not by omission. `as?: 'throttled'` already makes
+ * `authExpired()` a type error, but a plain `{ kind: 'abort'; reason: string }` would *accept*
+ * `authRevoked()` — a returned value gets no excess-property check, so the extra `auth: 'revoked'`
+ * would be silently dropped and the record would abort as an ordinary 400. `auth?: never` closes
+ * that, so both builders fail at the call site rather than one of them degrading quietly.
  */
 export type ItemVerdict =
   | SuccessVerdict
-  | { kind: 'abort'; reason: string }
+  | { kind: 'abort'; reason: string; auth?: never }
   | { kind: 'retry'; reason: string; as?: 'throttled'; dontBatch?: boolean };
 
 export const success = (): SuccessVerdict => ({ kind: 'success' });
@@ -93,6 +100,13 @@ export type PerItemVerdicts = { kind: 'perItem'; verdicts: ItemVerdict[] };
  * One verdict per **request body item**, in the order they were sent. Positional and 1:1 — the
  * framework carries no item→job map, so this is only correct when each job contributed exactly
  * one body item. A length mismatch degrades to a whole-batch verdict rather than misattributing.
+ *
+ * That makes a delivery spec and an **array-returning `transformEvent`** mutually exclusive.
+ * `ctx.jobs` is one entry per job (`processBatchedDestination` builds it from a `Set<number>` of
+ * job ids), so one job contributing two body items puts the two lengths permanently out of step:
+ * the guard retries the batch, the retry reproduces the same mismatch, and it never converges.
+ * `batchDestination.ts`'s `transformEvent` and the VDM V2 dispatch table both permit an array, so
+ * a destination that returns one must not declare `statusOverrides` that call `perItem`.
  */
 export const perItem = (verdicts: ItemVerdict[]): PerItemVerdicts => ({
   kind: 'perItem',
@@ -174,12 +188,20 @@ export const statusClassOf = (status: number): StatusKey | undefined => {
 export const defaultFailureReason = (status: number): string =>
   `[Generic Response Handler] Request failed with status: ${status}`;
 
-/** The framework's own status classification. Mirrors genericNetworkHandler's responseHandler. */
-export const classifyByStatus = (status: number, reason: string): Verdict => {
+/**
+ * The framework's own status classification. Mirrors genericNetworkHandler's responseHandler.
+ *
+ * `reason` is a thunk so the success path costs nothing. `fallback()` is called for every response
+ * with no override — including every plain 2xx — and an eagerly-evaluated reason would run the
+ * destination's extractor over the whole body just to discard the result. `braze_audience`'s falls
+ * through to `JSON.stringify(response)` when there is no `message`, which on a large batch response
+ * is the expensive kind of nothing.
+ */
+export const classifyByStatus = (status: number, reason: () => string): Verdict => {
   if (isHttpStatusSuccess(status)) return success();
-  if (status === 429) return throttled(reason);
-  if (isHttpStatusRetryable(status)) return retry(reason);
-  return abort(reason);
+  if (status === 429) return throttled(reason());
+  if (isHttpStatusRetryable(status)) return retry(reason());
+  return abort(reason());
 };
 
 // ---------------------------------------------------------------------------
@@ -271,7 +293,7 @@ export function handleDeliveryResponse(klass: unknown, ctx: DeliveryContext): Ha
   const statusClass = statusClassOf(ctx.status);
   const override =
     statusOverrides[ctx.status] ?? (statusClass ? statusOverrides[statusClass] : undefined);
-  const fallback = () => classifyByStatus(ctx.status, failureReason(ctx));
+  const fallback = () => classifyByStatus(ctx.status, () => failureReason(ctx));
   return override ? override(ctx, fallback) : fallback();
 }
 
@@ -321,12 +343,23 @@ export function toDeliveryV1Response(
     // Never index past the end — that is how a job state with `metadata: undefined` gets emitted,
     // which rudder-server reports as a non-fatal in/out breach and then redelivers. Degrade to a
     // whole-batch verdict instead, and make the mismatch visible.
+    //
+    // The two counts stay out of the label set and go in the log line instead. They are unbounded
+    // in practice — MAX_BATCH_SIZE is 1000 for both braze_audience and iterable_audience, so tagging
+    // both would open a 1000x1000 label space per (destType, destinationId, workspaceId). This
+    // counter fires precisely when a destination is stuck in the mismatch/retry loop, so the guard
+    // that surfaces the problem would be the thing that takes the metrics backend down with it.
     stats.counter('batch_delivery_per_item_mismatch', 1, {
       destType,
       destinationId: ctx.destinationId,
       workspaceId: ctx.workspaceId,
-      items: String(result.verdicts.length),
-      jobs: String(ctx.jobs.length),
+    });
+    logger.error('Batching framework delivery: per-item verdicts do not match the job list', {
+      destType,
+      destinationId: ctx.destinationId,
+      workspaceId: ctx.workspaceId,
+      items: result.verdicts.length,
+      jobs: ctx.jobs.length,
     });
     // Retry the batch rather than guess at it. Folding the verdicts into a worst-of would report
     // *success* whenever the ones that are present happen to be clean — including the empty-list

--- a/src/services/destination/nativeBatching/delivery.ts
+++ b/src/services/destination/nativeBatching/delivery.ts
@@ -482,37 +482,30 @@ export function toDeliveryV1Response(
   // `TransformerProxyError`. The identifying half — destType, destinationId, workspaceId, module,
   // implementation, feature — is merged in by the caller from the same `getTags` metadata that
   // `postTransformation` merges for a thrown error, so both paths emit one tag set from one source.
-  //
-  // A non-2xx `status` forces the tag set on regardless. `DeliveryV1ResponseSchema` refines on
-  // `validateStatTags` (`zodTypes.ts:169-174,228`), which rejects a non-2xx response carrying no
-  // `statTags` — so without this a part-failed per-item list on a 400, the very case the
-  // `perItemPreserved` exclusion above exists to serve, would fail the component and live harnesses
-  // that parse it. Nothing reaches it today: every current override is 2xx-keyed except gaec's
-  // `4xx`, which returns whole-batch verdicts.
-  //
-  // Tagging it is honest rather than a workaround. The status being passed through already tells
-  // rudder-server the response failed as a whole; a tag set describing that agrees with the status
-  // instead of contradicting it. The rule above still governs which errorType is chosen — where the
-  // failures do not agree, it comes from a failing verdict rather than from `first`, which may be a
-  // success on a mixed batch.
   const allFailed = failures.length === verdicts.length && failures.length > 0;
-  const describesOneFailure = uniform && allFailed;
-  const taggedVerdict = describesOneFailure ? first : (failures[0] ?? first);
   const statTags =
-    describesOneFailure || !isHttpStatusSuccess(ctx.status)
+    uniform && allFailed
       ? {
           statTags: {
             [tags.TAG_NAMES.ERROR_CATEGORY]: tags.ERROR_CATEGORIES.NETWORK,
-            [tags.TAG_NAMES.ERROR_TYPE]: errorTypeOf(taggedVerdict),
+            [tags.TAG_NAMES.ERROR_TYPE]: errorTypeOf(first),
           },
         }
       : undefined;
 
   return {
     // The destination's own status, always. `ProxyResponseV1` has no `status` field
-    // (`router/transformer/transformer_proxy_adapter.go:40-44`), so rudder-server takes disposition
-    // from each job state and never reads this; substituting 207 for a status the destination did
-    // not send would invent a difference from the legacy handler that nothing benefits from.
+    // (`router/transformer/transformer_proxy_adapter.go:41-45` — only `message`, `response` and
+    // `authErrorCategory`), so rudder-server takes disposition from each job state and never reads
+    // this; substituting 207 for a status the destination did not send would invent a difference
+    // from the legacy handler that nothing benefits from.
+    //
+    // It is not dead, though, and it is not the status rudder-server sees on the wire. The v1
+    // controller returns HTTP 200 for this response unless `authErrorCategory` is set, in which
+    // case it derives the wire status from this field (`controllers/delivery.ts`). The framework
+    // never sets `authErrorCategory` on a *returned* response — whole-batch auth verdicts go down
+    // the throw path above — so for everything built here the field is carried but not read. The
+    // shared `DeliveryV1Response` type and its zod schema both require it regardless.
     status: ctx.status,
     message,
     ...statTags,

--- a/src/services/destination/nativeBatching/delivery.ts
+++ b/src/services/destination/nativeBatching/delivery.ts
@@ -6,6 +6,7 @@
  * Integrations never build a `DeliveryV1Response`, never choose an HTTP status code, and never
  * throw. See docs/superpowers/specs/2026-07-30-network-handler-abstraction-design.md.
  */
+import { PlatformError } from '@rudderstack/integrations-lib';
 import { TransformerProxyError } from '../../../v0/util/errorTypes';
 import { isHttpStatusSuccess, isHttpStatusRetryable } from '../../../v0/util';
 import tags from '../../../v0/util/tags';
@@ -254,8 +255,24 @@ const statusOnlyFailureReason = (ctx: DeliveryContext): string => defaultFailure
  * `failureReason` resolves to the nearest declaration — which is what a plain static override
  * would have done. Not cached: the walk is three levels of small objects, nothing next to the HTTP
  * call it accompanies, and a cache would go stale whenever a test swaps a spec.
+ *
+ * Throws when handed anything that is not a class. `MiscService.getBatchDestinationHandler` is
+ * `require(...).Integration`, so a missing or renamed export arrives here as `undefined`, and
+ * walking from `undefined` resolves to the empty spec — which is a *valid* configuration meaning
+ * "classify on status alone". Every destination that reports partial failures on a 2xx
+ * (braze_audience, customerio, iterable_audience) would then answer each rejected record with
+ * `statusCode: 200, error: 'success'`: dropped with no throw, no log and no metric. The transform
+ * path already refuses the same mistake loudly, so this does too.
  */
 export function resolveDeliverySpec(klass: unknown): ResolvedDeliverySpec {
+  if (typeof klass !== 'function') {
+    throw new PlatformError(
+      'Delivery spec resolution: expected a BatchDestination class, got ' +
+        `${klass === null ? 'null' : typeof klass}. The destination's routerTransform module ` +
+        'likely does not export `Integration`.',
+    );
+  }
+
   // Leaf-first.
   const chain: DeliverySpec[] = [];
   let current: unknown = klass;
@@ -465,13 +482,28 @@ export function toDeliveryV1Response(
   // `TransformerProxyError`. The identifying half — destType, destinationId, workspaceId, module,
   // implementation, feature — is merged in by the caller from the same `getTags` metadata that
   // `postTransformation` merges for a thrown error, so both paths emit one tag set from one source.
+  //
+  // A non-2xx `status` forces the tag set on regardless. `DeliveryV1ResponseSchema` refines on
+  // `validateStatTags` (`zodTypes.ts:169-174,228`), which rejects a non-2xx response carrying no
+  // `statTags` — so without this a part-failed per-item list on a 400, the very case the
+  // `perItemPreserved` exclusion above exists to serve, would fail the component and live harnesses
+  // that parse it. Nothing reaches it today: every current override is 2xx-keyed except gaec's
+  // `4xx`, which returns whole-batch verdicts.
+  //
+  // Tagging it is honest rather than a workaround. The status being passed through already tells
+  // rudder-server the response failed as a whole; a tag set describing that agrees with the status
+  // instead of contradicting it. The rule above still governs which errorType is chosen — where the
+  // failures do not agree, it comes from a failing verdict rather than from `first`, which may be a
+  // success on a mixed batch.
   const allFailed = failures.length === verdicts.length && failures.length > 0;
+  const describesOneFailure = uniform && allFailed;
+  const taggedVerdict = describesOneFailure ? first : (failures[0] ?? first);
   const statTags =
-    uniform && allFailed
+    describesOneFailure || !isHttpStatusSuccess(ctx.status)
       ? {
           statTags: {
             [tags.TAG_NAMES.ERROR_CATEGORY]: tags.ERROR_CATEGORIES.NETWORK,
-            [tags.TAG_NAMES.ERROR_TYPE]: errorTypeOf(first),
+            [tags.TAG_NAMES.ERROR_TYPE]: errorTypeOf(taggedVerdict),
           },
         }
       : undefined;

--- a/src/services/destination/nativeBatching/delivery.ts
+++ b/src/services/destination/nativeBatching/delivery.ts
@@ -1,0 +1,442 @@
+/**
+ * Delivery contract for the native batching framework.
+ *
+ * An integration says what should happen to a batch in terms the platform can act on — retry it,
+ * drop it, or accept it — and this module turns that into the shape the delivery API requires.
+ * Integrations never build a `DeliveryV1Response`, never choose an HTTP status code, and never
+ * throw. See docs/superpowers/specs/2026-07-30-network-handler-abstraction-design.md.
+ */
+import { TransformerProxyError } from '../../../v0/util/errorTypes';
+import { isHttpStatusSuccess, isHttpStatusRetryable } from '../../../v0/util';
+import tags from '../../../v0/util/tags';
+import stats from '../../../util/stats';
+import type {
+  DeliveryJobState,
+  DeliveryV1Response,
+  ProxyMetdata,
+  ProxyV1Request,
+} from '../../../types';
+
+const {
+  REFRESH_TOKEN,
+  AUTH_STATUS_INACTIVE,
+} = require('../../../adapters/networkhandler/authConstants');
+
+// ---------------------------------------------------------------------------
+// Verdicts
+// ---------------------------------------------------------------------------
+
+type SuccessVerdict = { kind: 'success' };
+type AbortVerdict = { kind: 'abort'; reason: string; auth?: 'revoked' };
+type RetryVerdict = {
+  kind: 'retry';
+  reason: string;
+  as?: 'throttled' | 'authExpired';
+  dontBatch?: boolean;
+};
+
+/** What should happen to a job (or to the whole batch). */
+export type Verdict = SuccessVerdict | AbortVerdict | RetryVerdict;
+
+/**
+ * The subset of verdicts expressible per item. The auth refinements are absent deliberately:
+ * rudder-server overwrites the status code of *every* job in a batch whenever an
+ * `authErrorCategory` is present, so a per-item auth verdict cannot be represented.
+ */
+export type ItemVerdict =
+  | SuccessVerdict
+  | { kind: 'abort'; reason: string }
+  | { kind: 'retry'; reason: string; as?: 'throttled'; dontBatch?: boolean };
+
+export const success = (): SuccessVerdict => ({ kind: 'success' });
+
+export const abort = (reason: string): { kind: 'abort'; reason: string } => ({
+  kind: 'abort',
+  reason,
+});
+
+export const retry = (
+  reason: string,
+  opts?: { dontBatch?: boolean },
+): { kind: 'retry'; reason: string; dontBatch?: boolean } => ({
+  kind: 'retry',
+  reason,
+  ...(opts?.dontBatch ? { dontBatch: true } : {}),
+});
+
+export const throttled = (reason: string): { kind: 'retry'; reason: string; as: 'throttled' } => ({
+  kind: 'retry',
+  reason,
+  as: 'throttled',
+});
+
+/** Token is stale but recoverable → rudder-server refreshes it and retries the batch. */
+export const authExpired = (
+  reason: string,
+): { kind: 'retry'; reason: string; as: 'authExpired' } => ({
+  kind: 'retry',
+  reason,
+  as: 'authExpired',
+});
+
+/** Grant is gone → rudder-server aborts the batch. */
+export const authRevoked = (
+  reason: string,
+): { kind: 'abort'; reason: string; auth: 'revoked' } => ({
+  kind: 'abort',
+  reason,
+  auth: 'revoked',
+});
+
+export type PerItemVerdicts = { kind: 'perItem'; verdicts: ItemVerdict[] };
+
+/**
+ * One verdict per **request body item**, in the order they were sent. Positional and 1:1 — the
+ * framework carries no item→job map, so this is only correct when each job contributed exactly
+ * one body item. A length mismatch degrades to a whole-batch verdict rather than misattributing.
+ */
+export const perItem = (verdicts: ItemVerdict[]): PerItemVerdicts => ({
+  kind: 'perItem',
+  verdicts,
+});
+
+export type HandleResponseResult = Verdict | PerItemVerdicts;
+
+// ---------------------------------------------------------------------------
+// Context and overrides
+// ---------------------------------------------------------------------------
+
+export type DeliveryContext = {
+  /** HTTP status from the destination, after processAxiosResponse. */
+  status: number;
+  /** Parsed destination response body. */
+  response: unknown;
+  /** One entry per job in this batch, in the order the framework built them. */
+  jobs: ProxyMetdata[];
+  /** The request that was sent — for correlating response items back to what was posted. */
+  request: ProxyV1Request;
+  destinationConfig: Record<string, unknown>;
+};
+
+/**
+ * Behaviour for one status (or status class). Return a verdict, or per-item verdicts, or call
+ * `fallback()` for the framework's own classification — useful when a handler owns only some of
+ * the responses carrying its status (a particular endpoint, a decodable body).
+ */
+export type StatusOverride = (
+  ctx: DeliveryContext,
+  fallback: () => Verdict,
+) => HandleResponseResult;
+
+/** An exact status, or a whole class of them. Exact keys win. */
+export type StatusKey = number | '2xx' | '4xx' | '5xx';
+
+export type StatusOverrideMap = Readonly<Partial<Record<StatusKey, StatusOverride>>>;
+
+export const statusClassOf = (status: number): StatusKey | undefined => {
+  if (isHttpStatusSuccess(status)) return '2xx';
+  if (status >= 400 && status < 500) return '4xx';
+  if (status >= 500 && status < 600) return '5xx';
+  return undefined;
+};
+
+// ---------------------------------------------------------------------------
+// Error messages
+// ---------------------------------------------------------------------------
+
+/**
+ * The framework's default failure reason.
+ *
+ * Deliberately does not look at the response body. `genericNetworkHandler` — the fallback every
+ * destination without its own handler already gets — builds exactly this kind of status-only
+ * string and leaves the body to travel separately in `destinationResponse`
+ * (`adapters/networkhandler/genericNetworkHandler.js`). There is no shared body-parsing
+ * convention on the legacy path to inherit: every destination that wants a message out of its
+ * body writes that itself, against the shape its own API returns.
+ *
+ * So the framework stays out of it, and an integration that wants better reads its own body in its
+ * own `delivery.failureReason`.
+ */
+export const defaultFailureReason = (status: number): string =>
+  `[Generic Response Handler] Request failed with status: ${status}`;
+
+/** The framework's own status classification. Mirrors genericNetworkHandler's responseHandler. */
+export const classifyByStatus = (status: number, reason: string): Verdict => {
+  if (isHttpStatusSuccess(status)) return success();
+  if (status === 429) return throttled(reason);
+  if (isHttpStatusRetryable(status)) return retry(reason);
+  return abort(reason);
+};
+
+// ---------------------------------------------------------------------------
+// The delivery spec
+// ---------------------------------------------------------------------------
+
+/**
+ * Everything an integration declares about **delivery**, in one object.
+ *
+ * It is grouped rather than spread across loose statics because a `BatchDestination` is otherwise
+ * entirely about *transformation* — `transformEvent`, `getBatchStrategy`, `getInputSchema` — and a
+ * bare `statusOverrides` or `failureReason` sitting beside them reads as more of the same. Behind
+ * `static readonly delivery`, the scope is stated at the declaration site: these describe what to
+ * do with the destination's *response*, and they are the only members that do.
+ *
+ * Both entries are optional. A destination that needs neither declares no `delivery` at all and
+ * gets the framework's classification, which reproduces `genericNetworkHandler`.
+ */
+export type DeliverySpec = {
+  /**
+   * Per-status behaviour, consulted before the framework's own classification. Exact status keys
+   * take precedence over class keys ('2xx' / '4xx' / '5xx').
+   */
+  statusOverrides?: StatusOverrideMap;
+
+  /**
+   * The reason carried by a failure verdict.
+   *
+   * The default is status-only and never reads the body: the framework has no general way to find
+   * a message in an arbitrary destination's response, and guessing at common field names
+   * generalises one destination's shape onto every other. An integration whose API returns usable
+   * error text supplies an extractor written against that API.
+   */
+  failureReason?: (ctx: DeliveryContext) => string;
+};
+
+/** A spec with both members filled in — what the framework actually runs against. */
+export type ResolvedDeliverySpec = Required<DeliverySpec>;
+
+/** Hoisted so resolving a spec that declares no `failureReason` allocates nothing per request. */
+const statusOnlyFailureReason = (ctx: DeliveryContext): string => defaultFailureReason(ctx.status);
+
+/**
+ * Collect the `delivery` specs down the prototype chain and fold them into one, child winning.
+ *
+ * Static properties are inherited but *shadowed*, not merged: a subclass declaring its own
+ * `delivery` would otherwise silently drop everything an ancestor declared, with no type or
+ * runtime error. `statusOverrides` is therefore merged key-by-key, so a family-level map on e.g.
+ * VDMV2ObjectDestination keeps working when a concrete destination adds an entry of its own, and
+ * `failureReason` resolves to the nearest declaration — which is what a plain static override
+ * would have done. Not cached: the walk is three levels of small objects, nothing next to the HTTP
+ * call it accompanies, and a cache would go stale whenever a test swaps a spec.
+ */
+export function resolveDeliverySpec(klass: unknown): ResolvedDeliverySpec {
+  // Leaf-first.
+  const chain: DeliverySpec[] = [];
+  let current: unknown = klass;
+  while (typeof current === 'function') {
+    if (Object.hasOwn(current, 'delivery')) {
+      const own = (current as { delivery?: DeliverySpec }).delivery;
+      if (own) {
+        chain.push(own);
+      }
+    }
+    current = Object.getPrototypeOf(current);
+  }
+
+  return {
+    // Assign parent-first so the leaf wins.
+    statusOverrides: Object.assign(
+      {},
+      ...chain.map((spec) => spec.statusOverrides ?? {}).reverse(),
+    ) as StatusOverrideMap,
+    failureReason:
+      chain.find((spec) => spec.failureReason)?.failureReason ?? statusOnlyFailureReason,
+  };
+}
+
+/**
+ * Apply a class's delivery spec to one response.
+ *
+ * Framework-owned, and a free function rather than a static so there is nothing for an integration
+ * to override or to call `super` on. The resolution order — exact status, then status class, then
+ * the framework's own classification — *is* the contract; a destination that wants different
+ * behaviour declares an override for the status it cares about.
+ */
+export function handleDeliveryResponse(klass: unknown, ctx: DeliveryContext): HandleResponseResult {
+  const { statusOverrides, failureReason } = resolveDeliverySpec(klass);
+  const statusClass = statusClassOf(ctx.status);
+  const override =
+    statusOverrides[ctx.status] ?? (statusClass ? statusOverrides[statusClass] : undefined);
+  const fallback = () => classifyByStatus(ctx.status, failureReason(ctx));
+  return override ? override(ctx, fallback) : fallback();
+}
+
+// ---------------------------------------------------------------------------
+// Bridge: verdicts -> DeliveryV1Response
+// ---------------------------------------------------------------------------
+
+/**
+ * The message a verdict carries. Exported so an override that refines `fallback()` — turning a
+ * plain abort into an auth-revoked one, say — can keep the framework's own message rather than
+ * re-deriving it from the body.
+ */
+export const reasonOf = (v: Verdict): string => (v.kind === 'success' ? 'success' : v.reason);
+
+/** The `statTags.errorType` a verdict implies. Shared by the throw path and the returned one. */
+const errorTypeOf = (v: Verdict): string => {
+  if (v.kind !== 'retry') return tags.ERROR_TYPES.ABORTED;
+  return v.as === 'throttled' ? tags.ERROR_TYPES.THROTTLED : tags.ERROR_TYPES.RETRYABLE;
+};
+
+/**
+ * Turn a handler's result into the delivery API response.
+ *
+ * Throws `TransformerProxyError` when the whole batch failed and there is no per-item detail to
+ * lose — that path preserves statTags, the destinationResponse echo, authErrorCategory and error
+ * reporting via the existing postTransformation handling. Everything else returns a response.
+ */
+export function toDeliveryV1Response(
+  result: HandleResponseResult,
+  ctx: DeliveryContext,
+  destType: string,
+): DeliveryV1Response {
+  // `perItemPreserved` tracks whether we actually ended up with per-item detail: false for a
+  // whole-batch verdict, and false when a per-item list had to be discarded.
+  // `attributionLost` is the second of those — a per-item list whose length did not match the job
+  // list, so nothing in it can be tied to a job.
+  let verdicts: Verdict[];
+  let perItemPreserved = false;
+  let attributionLost = false;
+
+  if (result.kind !== 'perItem') {
+    verdicts = ctx.jobs.map(() => result);
+  } else if (result.verdicts.length === ctx.jobs.length) {
+    verdicts = result.verdicts;
+    perItemPreserved = true;
+  } else {
+    // Never index past the end — that is how a job state with `metadata: undefined` gets emitted,
+    // which rudder-server reports as a non-fatal in/out breach and then redelivers. Degrade to a
+    // whole-batch verdict instead, and make the mismatch visible.
+    stats.counter('batch_delivery_per_item_mismatch', 1, {
+      destType,
+      destinationId: ctx.jobs[0]?.destinationId ?? '',
+      workspaceId: ctx.jobs[0]?.workspaceId ?? '',
+      items: String(result.verdicts.length),
+      jobs: String(ctx.jobs.length),
+    });
+    // Retry the batch rather than guess at it. Folding the verdicts into a worst-of would report
+    // *success* whenever the ones that are present happen to be clean — including the empty-list
+    // case, where the handler has decided there were failures but produced nothing to attribute
+    // them to. A job with no verdict has an unknown outcome, and the only honest reading of an
+    // unknown outcome is that it must be redelivered; re-sending items that already succeeded is
+    // the accepted cost under the platform's at-least-once contract.
+    attributionLost = true;
+    verdicts = ctx.jobs.map(() =>
+      retry(
+        `[${destType}] per-item verdicts (${result.verdicts.length}) do not match jobs (${ctx.jobs.length})`,
+      ),
+    );
+  }
+
+  const first = verdicts[0] ?? success();
+
+  // Uniform means same class, not same reason: two aborts with different messages are still one
+  // abort as far as the platform is concerned.
+  const uniform = verdicts.every(
+    (v) =>
+      v.kind === first.kind &&
+      (v as RetryVerdict).as === (first as RetryVerdict).as &&
+      (v as AbortVerdict).auth === (first as AbortVerdict).auth,
+  );
+  const allSucceeded = uniform && first.kind === 'success';
+
+  // The classic whole-batch error. Four deliberate exclusions, all of them cases where the throw
+  // would lose or contradict something the per-job path carries correctly:
+  //
+  //  - a 2xx status, because postTransformation echoes the thrown status into every job's
+  //    statusCode and rudder-server's isSuccessStatus would then read failed events as delivered;
+  //  - a preserved per-item list, because postTransformation rebuilds job states from metadata and
+  //    would discard the per-item reasons. A destination reporting per-item failures on a non-2xx
+  //    (mixpanel's /import does exactly that on a 400) keeps its detail this way;
+  //  - a lost-attribution retry, because the throw carries `ctx.status` rather than a status
+  //    derived from the verdict, so on a 4xx rudder-server's isJobTerminated would abort the very
+  //    batch we just decided to retry. The per-job path derives 500 from the verdict;
+  //  - a `dontBatch` retry, because that flag only exists as a metadata stamp on a job state and
+  //    the throw has no job states to stamp.
+  const carriesDontBatch = first.kind === 'retry' && first.dontBatch === true;
+  if (
+    uniform &&
+    !allSucceeded &&
+    !perItemPreserved &&
+    !attributionLost &&
+    !carriesDontBatch &&
+    !isHttpStatusSuccess(ctx.status)
+  ) {
+    let authErrorCategory = '';
+    if (first.kind === 'retry') {
+      if (first.as === 'authExpired') authErrorCategory = REFRESH_TOKEN;
+    } else if (first.kind === 'abort' && first.auth === 'revoked') {
+      authErrorCategory = AUTH_STATUS_INACTIVE;
+    }
+
+    throw new TransformerProxyError(
+      `[${destType}] ${reasonOf(first)}`,
+      ctx.status,
+      { [tags.TAG_NAMES.ERROR_TYPE]: errorTypeOf(first) },
+      { status: ctx.status, response: ctx.response },
+      authErrorCategory,
+    );
+  }
+
+  const response: DeliveryJobState[] = verdicts.map((verdict, i) => {
+    let statusCode = 400;
+    if (verdict.kind === 'success') {
+      statusCode = 200;
+    } else if (verdict.kind === 'retry') {
+      statusCode = verdict.as === 'throttled' ? 429 : 500;
+    }
+    const metadata = ctx.jobs[i];
+    return {
+      statusCode,
+      metadata:
+        verdict.kind === 'retry' && verdict.dontBatch ? { ...metadata, dontBatch: true } : metadata,
+      error: reasonOf(verdict),
+    };
+  });
+
+  const failures = verdicts.filter((v) => v.kind !== 'success');
+  const distinctReasons = new Set(failures.map(reasonOf));
+
+  // One reason is only worth quoting as *the* batch message when every failure agrees on it —
+  // gaec's `partialFailureError.message`, or a single failed record. With several different
+  // reasons, picking the first would present one job's error as the batch's, so say how many
+  // failed and leave the detail to the per-job entries, which carry every reason keyed to its job.
+  let message = `[${destType}] Request processed successfully`;
+  if (distinctReasons.size === 1) {
+    message = `[${destType}] ${[...distinctReasons][0]}`;
+  } else if (distinctReasons.size > 1) {
+    message = `[${destType}] ${failures.length} of ${verdicts.length} events failed; see per-event errors`;
+  }
+
+  // `statTags` drives rudder-server's `integration.failure_detailed` counter
+  // (`processor/integrations/integrations.go:29-37`), which tags the response as a whole. That is
+  // only honest when the response as a whole is one failure: every job failed, the same way. A
+  // partially-succeeded batch has no single errorType, and labelling one 'aborted' — as gaec's
+  // legacy handler did — counts a batch that partly delivered as a whole-batch abort.
+  //
+  // Only the error-describing half is set here, matching what the throw path hands
+  // `TransformerProxyError`. The identifying half — destType, destinationId, workspaceId, module,
+  // implementation, feature — is merged in by the caller from the same `getTags` metadata that
+  // `postTransformation` merges for a thrown error, so both paths emit one tag set from one source.
+  const allFailed = failures.length === verdicts.length && failures.length > 0;
+  const statTags =
+    uniform && allFailed
+      ? {
+          statTags: {
+            [tags.TAG_NAMES.ERROR_CATEGORY]: tags.ERROR_CATEGORIES.NETWORK,
+            [tags.TAG_NAMES.ERROR_TYPE]: errorTypeOf(first),
+          },
+        }
+      : undefined;
+
+  return {
+    // The destination's own status, always. `ProxyResponseV1` has no `status` field
+    // (`router/transformer/transformer_proxy_adapter.go:40-44`), so rudder-server takes disposition
+    // from each job state and never reads this; substituting 207 for a status the destination did
+    // not send would invent a difference from the legacy handler that nothing benefits from.
+    status: ctx.status,
+    message,
+    ...statTags,
+    response,
+  };
+}

--- a/src/services/destination/nativeBatching/delivery.ts
+++ b/src/services/destination/nativeBatching/delivery.ts
@@ -10,17 +10,16 @@ import { TransformerProxyError } from '../../../v0/util/errorTypes';
 import { isHttpStatusSuccess, isHttpStatusRetryable } from '../../../v0/util';
 import tags from '../../../v0/util/tags';
 import stats from '../../../util/stats';
+import {
+  REFRESH_TOKEN,
+  AUTH_STATUS_INACTIVE,
+} from '../../../adapters/networkhandler/authConstants';
 import type {
   DeliveryJobState,
   DeliveryV1Response,
   ProxyMetdata,
   ProxyV1Request,
 } from '../../../types';
-
-const {
-  REFRESH_TOKEN,
-  AUTH_STATUS_INACTIVE,
-} = require('../../../adapters/networkhandler/authConstants');
 
 // ---------------------------------------------------------------------------
 // Verdicts
@@ -116,7 +115,22 @@ export type DeliveryContext = {
   /** The request that was sent — for correlating response items back to what was posted. */
   request: ProxyV1Request;
   destinationConfig: Record<string, unknown>;
+  /**
+   * `jobs[0]`'s destinationId/workspaceId, empty string if there is no first job. Set once where
+   * the context is built, so a spec that needs them — for a stat tag, say — reads them here
+   * instead of re-deriving from `jobs[0]` itself.
+   */
+  destinationId: string;
+  workspaceId: string;
 };
+
+/** `DeliveryContext`'s `destinationId`/`workspaceId`, derived from its first job. */
+export const firstJobIdentity = (
+  jobs: ProxyMetdata[],
+): Pick<DeliveryContext, 'destinationId' | 'workspaceId'> => ({
+  destinationId: jobs[0]?.destinationId ?? '',
+  workspaceId: jobs[0]?.workspaceId ?? '',
+});
 
 /**
  * Behaviour for one status (or status class). Return a verdict, or per-item verdicts, or call
@@ -309,8 +323,8 @@ export function toDeliveryV1Response(
     // whole-batch verdict instead, and make the mismatch visible.
     stats.counter('batch_delivery_per_item_mismatch', 1, {
       destType,
-      destinationId: ctx.jobs[0]?.destinationId ?? '',
-      workspaceId: ctx.jobs[0]?.workspaceId ?? '',
+      destinationId: ctx.destinationId,
+      workspaceId: ctx.workspaceId,
       items: String(result.verdicts.length),
       jobs: String(ctx.jobs.length),
     });

--- a/src/services/destination/nativeBatching/vdmV2ObjectDestination.ts
+++ b/src/services/destination/nativeBatching/vdmV2ObjectDestination.ts
@@ -6,6 +6,7 @@ import type { RudderRecordV2 } from '../../../types/rudderEvents';
 import { MappedToDestinationKey } from '../../../constants';
 import { addExternalIdToTraits, adduserIdFromExternalId } from '../../../v0/util';
 import { BatchDestination } from './batchDestination';
+import type { DeliverySpec } from './delivery';
 import type { TransformedEvent } from './types';
 
 // Record message shape known to the framework after schema validation
@@ -74,6 +75,16 @@ export abstract class VDMV2ObjectDestination<
   TRecordSchema extends ZodType = ZodType,
   TEventStreamSchema extends ZodType = ZodType,
 > extends BatchDestination<TBody, ObjectRouterInput<TRecordSchema, TEventStreamSchema>> {
+  /**
+   * Deliberately empty — `BatchDestination.delivery` already defaults to `{}`, so this adds no
+   * behaviour on its own. It exists so a concern shared across *VDM V2 object destinations as a
+   * family* (not one destination's particular API shape) has a declaration site between the
+   * framework root and a leaf like `CustomerIOIntegration`, and so `resolveDeliverySpec`'s
+   * prototype walk has a real family-level entry to merge rather than jumping straight from the
+   * leaf to the root default.
+   */
+  static readonly delivery: DeliverySpec = {};
+
   // Subclasses declare the two variant schemas (built via makeRouterInputSchema, each
   // carrying the shared destinationConfig via a common constant). The framework owns the
   // union — subclasses do not implement getInputSchema.

--- a/src/services/destination/nativeIntegration.ts
+++ b/src/services/destination/nativeIntegration.ts
@@ -33,7 +33,11 @@ import {
   isBatchingFrameworkEnabled,
 } from '../../constants/batchedDestinationsMap';
 import { processBatchedDestination } from './nativeBatching/processBatchedDestination';
-import { handleDeliveryResponse, toDeliveryV1Response } from './nativeBatching/delivery';
+import {
+  handleDeliveryResponse,
+  toDeliveryV1Response,
+  firstJobIdentity,
+} from './nativeBatching/delivery';
 import type { DeliveryContext } from './nativeBatching/delivery';
 
 /**
@@ -253,6 +257,7 @@ export class NativeIntegrationDestinationService implements DestinationService {
           jobs: deliveryRequest.metadata,
           request: deliveryRequest,
           destinationConfig: deliveryRequest.destinationConfig,
+          ...firstJobIdentity(deliveryRequest.metadata),
         };
         const IntegrationClass = FetchHandler.getBatchDestinationHandler(destinationType);
         // Uppercased to match `statTags.destType`, which is what every other destination tag in a
@@ -271,8 +276,8 @@ export class NativeIntegrationDestinationService implements DestinationService {
         if (frameworkResponse.statTags) {
           const deliveryMetaTO = this.getTags(
             destinationType,
-            ctx.jobs[0]?.destinationId,
-            ctx.jobs[0]?.workspaceId,
+            ctx.destinationId,
+            ctx.workspaceId,
             tags.FEATURES.DATA_DELIVERY,
           );
           frameworkResponse.statTags = {

--- a/src/services/destination/nativeIntegration.ts
+++ b/src/services/destination/nativeIntegration.ts
@@ -41,14 +41,28 @@ import {
 import type { DeliveryContext } from './nativeBatching/delivery';
 
 /**
- * Discriminates the two proxy request shapes on the only field that differs: v1 carries one
- * metadata entry per job, v0 carries a single object. Preferred over `ProxyV1RequestSchema` here —
- * that schema requires `secret` and `dontBatch` on every entry, so a real payload omitting either
- * would fail validation and silently fall through to the legacy handler, which is a worse failure
- * than the cast it replaces.
+ * Whether the framework's delivery branch may answer this request — the route rudder-server called
+ * *and* the shape it sent, because neither alone is sufficient.
+ *
+ * The route alone does not prove the shape: the branch indexes `metadata`, hands it to
+ * `handleDeliveryResponse` as the job list, and returns a `DeliveryV1Response` shaped to it.
+ * Narrowing on the array both proves that and removes the cast.
+ *
+ * The shape alone does not prove the route: a v0 payload carrying an array is not a v1 request, and
+ * answering it with a `DeliveryV1Response` gives rudder-server a body its v0 reader cannot parse.
+ * `intercom_v2`'s `INTERCOM_V2_v0_oauth_scenario_1` is exactly that request — a `version: 'v0'`
+ * scenario whose body comes from `generateProxyV1Payload`.
+ *
+ * Requiring both also keeps this branch strictly narrower than the `version === 'v1'` test the catch
+ * below uses, so any request this accepts is one the catch also treats as v1. A single call can
+ * therefore never answer with a v1 body when the destination succeeds and a v0 body when it fails.
+ *
+ * Preferred over `ProxyV1RequestSchema` for the shape half — that schema requires `secret` and
+ * `dontBatch` on every entry, so a real payload omitting either would fail validation and silently
+ * fall through to the legacy handler, which is a worse failure than the cast it replaces.
  */
-const isProxyV1Request = (request: ProxyRequest): request is ProxyV1Request =>
-  Array.isArray(request.metadata);
+const isProxyV1Request = (request: ProxyRequest, version: string): request is ProxyV1Request =>
+  version.toLowerCase() === 'v1' && Array.isArray(request.metadata);
 
 export class NativeIntegrationDestinationService implements DestinationService {
   public init() {}
@@ -238,14 +252,10 @@ export class NativeIntegrationDestinationService implements DestinationService {
       // so is the v0->v1 adaptation below — the framework produces a v1 response natively, and
       // that adaptation would collapse the metadata array to its first entry.
       //
-      // The guard is `isProxyV1Request`, not `version === 'v1'`, because the array-ness of
-      // `metadata` is the thing this branch actually depends on: it indexes it, hands it to
-      // `handleDeliveryResponse` as the job list, and returns a `DeliveryV1Response` shaped to it.
-      // `version` is the API route rudder-server called ('v0'/'v1' are literals passed by the two
-      // controller entry points), so it only tells us which shape to *expect*; narrowing on the
-      // shape itself both proves it and removes the cast.
+      // The guard is `isProxyV1Request`, which requires the v1 route *and* an array `metadata`;
+      // see its declaration for why neither half alone is enough.
       if (
-        isProxyV1Request(deliveryRequest) &&
+        isProxyV1Request(deliveryRequest, version) &&
         isBatchingFrameworkDeliveryEnabled(
           destinationType,
           deliveryRequest.metadata[0]?.workspaceId,
@@ -285,6 +295,13 @@ export class NativeIntegrationDestinationService implements DestinationService {
             ...deliveryMetaTO.errorDetails,
           };
         }
+        // `ErrorReportingService.reportError` is deliberately not called for a *returned* failure,
+        // and that matches the legacy path rather than diverging from it: `deliver` returns
+        // `networkHandler.responseHandler(...)` straight through, and no network handler reports
+        // either — reporting fires only from `postTransformation`, i.e. only on the throw path,
+        // for both. A returned per-job failure is a delivery outcome the router acts on, not a
+        // transformer error, and routing every partial batch failure into error reporting would be
+        // a new behaviour for the 20 v1 handlers this replaces, not parity with them.
         return frameworkResponse;
       }
 

--- a/src/services/destination/nativeIntegration.ts
+++ b/src/services/destination/nativeIntegration.ts
@@ -28,8 +28,23 @@ import stats from '../../util/stats';
 import tags from '../../v0/util/tags';
 import { DestinationPostTransformationService } from './postTransformation';
 import { groupRouterTransformEvents } from '../../v0/util';
-import { isBatchingFrameworkEnabled } from '../../constants/batchedDestinationsMap';
+import {
+  isBatchingFrameworkDeliveryEnabled,
+  isBatchingFrameworkEnabled,
+} from '../../constants/batchedDestinationsMap';
 import { processBatchedDestination } from './nativeBatching/processBatchedDestination';
+import { handleDeliveryResponse, toDeliveryV1Response } from './nativeBatching/delivery';
+import type { DeliveryContext } from './nativeBatching/delivery';
+
+/**
+ * Discriminates the two proxy request shapes on the only field that differs: v1 carries one
+ * metadata entry per job, v0 carries a single object. Preferred over `ProxyV1RequestSchema` here —
+ * that schema requires `secret` and `dontBatch` on every entry, so a real payload omitting either
+ * would fail validation and silently fall through to the legacy handler, which is a worse failure
+ * than the cast it replaces.
+ */
+const isProxyV1Request = (request: ProxyRequest): request is ProxyV1Request =>
+  Array.isArray(request.metadata);
 
 export class NativeIntegrationDestinationService implements DestinationService {
   public init() {}
@@ -214,6 +229,60 @@ export class NativeIntegrationDestinationService implements DestinationService {
       );
       const rawProxyResponse = await networkHandler.proxy(deliveryRequest, destinationType);
       const processedProxyResponse = networkHandler.processAxiosResponse(rawProxyResponse);
+
+      // Opt-in per workspace, off by default: `handlerVersion` is deliberately ignored here, and
+      // so is the v0->v1 adaptation below — the framework produces a v1 response natively, and
+      // that adaptation would collapse the metadata array to its first entry.
+      //
+      // The guard is `isProxyV1Request`, not `version === 'v1'`, because the array-ness of
+      // `metadata` is the thing this branch actually depends on: it indexes it, hands it to
+      // `handleDeliveryResponse` as the job list, and returns a `DeliveryV1Response` shaped to it.
+      // `version` is the API route rudder-server called ('v0'/'v1' are literals passed by the two
+      // controller entry points), so it only tells us which shape to *expect*; narrowing on the
+      // shape itself both proves it and removes the cast.
+      if (
+        isProxyV1Request(deliveryRequest) &&
+        isBatchingFrameworkDeliveryEnabled(
+          destinationType,
+          deliveryRequest.metadata[0]?.workspaceId,
+        )
+      ) {
+        const ctx: DeliveryContext = {
+          status: processedProxyResponse.status,
+          response: processedProxyResponse.response,
+          jobs: deliveryRequest.metadata,
+          request: deliveryRequest,
+          destinationConfig: deliveryRequest.destinationConfig,
+        };
+        const IntegrationClass = FetchHandler.getBatchDestinationHandler(destinationType);
+        // Uppercased to match `statTags.destType`, which is what every other destination tag in a
+        // delivery response and in the stats emitted alongside it uses.
+        const frameworkResponse = toDeliveryV1Response(
+          handleDeliveryResponse(IntegrationClass, ctx),
+          ctx,
+          destinationType.toUpperCase(),
+        );
+
+        // The bridge sets `statTags` only for a uniform whole-response failure, and only the
+        // error-describing half of it. Enrich it with the same identifying tags
+        // `handlevV1DeliveriesFailureEvents` merges for a thrown error, so a returned failure and a
+        // thrown one produce the same tag set on `integration.failure_detailed` — a counter carrying
+        // just `errorType` could not be attributed to a destination or workspace.
+        if (frameworkResponse.statTags) {
+          const deliveryMetaTO = this.getTags(
+            destinationType,
+            ctx.jobs[0]?.destinationId,
+            ctx.jobs[0]?.workspaceId,
+            tags.FEATURES.DATA_DELIVERY,
+          );
+          frameworkResponse.statTags = {
+            ...frameworkResponse.statTags,
+            ...deliveryMetaTO.errorDetails,
+          };
+        }
+        return frameworkResponse;
+      }
+
       let rudderJobMetadata =
         version.toLowerCase() === 'v1'
           ? (deliveryRequest as ProxyV1Request).metadata

--- a/src/v0/destinations/braze_audience/__tests__/utils.test.ts
+++ b/src/v0/destinations/braze_audience/__tests__/utils.test.ts
@@ -1,4 +1,4 @@
-import { normalizeExternalId } from '../utils';
+import { isIdentityAborted, normalizeExternalId } from '../utils';
 
 describe('normalizeExternalId', () => {
   it.each([
@@ -18,5 +18,29 @@ describe('normalizeExternalId', () => {
     ['Infinity', Number.POSITIVE_INFINITY],
   ] as const)('rejects %s', (_label, raw) => {
     expect(normalizeExternalId(raw)).toBeNull();
+  });
+});
+
+// Shared by the legacy network handler and the batching-framework delivery path, so it is tested
+// where it lives rather than only through each caller.
+describe('isIdentityAborted', () => {
+  it.each([
+    ['documented enum', 'EXTERNAL_USER_ID_TOO_LARGE'],
+    ['blacklist enum', 'BLACKLISTED_EXTERNAL_USER_ID'],
+    ['lowercased enum form', 'external_user_id_too_large'],
+    ['live length message', "'external_id' must be fewer than 988 bytes"],
+    ['live blacklist message', 'external_id is blacklisted'],
+  ])('aborts on %s', (_label, type) => {
+    expect(isIdentityAborted(type)).toBe(true);
+  });
+
+  it.each([
+    ['undefined', undefined],
+    ['empty string', ''],
+    ['an unrelated attribute error', 'SOME_TRANSIENT_ATTR_ERROR'],
+    // The pre-#5408 regex matched this; a missing user is retryable, not a permanent identity fault.
+    ['a not-found message mentioning external_id', 'user not found for external_id'],
+  ])('does not abort on %s', (_label, type) => {
+    expect(isIdentityAborted(type)).toBe(false);
   });
 });

--- a/src/v0/destinations/braze_audience/delivery.test.ts
+++ b/src/v0/destinations/braze_audience/delivery.test.ts
@@ -7,6 +7,7 @@ jest.mock('../../../util/stats', () => ({
 import stats from '../../../util/stats';
 import { Integration as BrazeAudienceIntegration } from './routerTransform';
 import {
+  firstJobIdentity,
   handleDeliveryResponse,
   resolveDeliverySpec,
   toDeliveryV1Response,
@@ -46,16 +47,20 @@ const ctxFor = (
     external_id: `u${i}`,
     audience_x: true,
   })),
-): DeliveryContext => ({
-  status,
-  response,
-  jobs: Array.from({ length: itemCount }, (_, i) => job(i + 1)),
-  request: {
-    body: { JSON: { attributes } },
-    endpoint: 'https://rest.iad-03.braze.com/users/track/bulk',
-  } as unknown as ProxyV1Request,
-  destinationConfig: {},
-});
+): DeliveryContext => {
+  const jobs = Array.from({ length: itemCount }, (_, i) => job(i + 1));
+  return {
+    status,
+    response,
+    jobs,
+    request: {
+      body: { JSON: { attributes } },
+      endpoint: 'https://rest.iad-03.braze.com/users/track/bulk',
+    } as unknown as ProxyV1Request,
+    destinationConfig: {},
+    ...firstJobIdentity(jobs),
+  };
+};
 
 /** Run the new path end to end, normalising the throw into a comparable shape. */
 const viaFramework = (ctx: DeliveryContext) => {

--- a/src/v0/destinations/braze_audience/delivery.test.ts
+++ b/src/v0/destinations/braze_audience/delivery.test.ts
@@ -1,0 +1,398 @@
+jest.mock('../../../util/stats', () => ({
+  increment: jest.fn(),
+  counter: jest.fn(),
+  gauge: jest.fn(),
+}));
+
+import stats from '../../../util/stats';
+import { Integration as BrazeAudienceIntegration } from './routerTransform';
+import {
+  handleDeliveryResponse,
+  resolveDeliverySpec,
+  toDeliveryV1Response,
+} from '../../../services/destination/nativeBatching/delivery';
+import type { DeliveryContext } from '../../../services/destination/nativeBatching/delivery';
+import {
+  responseHandler as legacyResponseHandler,
+  type BrazeAudienceProxyParams,
+} from '../../../v1/destinations/braze_audience/networkHandler';
+import type { ProxyMetdata, ProxyV1Request } from '../../../types';
+
+const DEST = 'BRAZE_AUDIENCE';
+
+const mockStats = stats as jest.Mocked<typeof stats>;
+
+const job = (jobId: number): ProxyMetdata =>
+  ({
+    jobId,
+    attemptNum: 0,
+    userId: `u${jobId}`,
+    sourceId: 's1',
+    destinationId: 'dest-1',
+    workspaceId: 'workspace-1',
+    secret: {},
+    dontBatch: false,
+  }) as ProxyMetdata;
+
+/**
+ * `attributes` defaults to one posted record per job — the 1:1 case. Pass it explicitly to build a
+ * body whose length differs from the job list, which is what the bounds guard has to cope with.
+ */
+const ctxFor = (
+  status: number,
+  response: unknown,
+  itemCount: number,
+  attributes: Array<Record<string, unknown>> = Array.from({ length: itemCount }, (_, i) => ({
+    external_id: `u${i}`,
+    audience_x: true,
+  })),
+): DeliveryContext => ({
+  status,
+  response,
+  jobs: Array.from({ length: itemCount }, (_, i) => job(i + 1)),
+  request: {
+    body: { JSON: { attributes } },
+    endpoint: 'https://rest.iad-03.braze.com/users/track/bulk',
+  } as unknown as ProxyV1Request,
+  destinationConfig: {},
+});
+
+/** Run the new path end to end, normalising the throw into a comparable shape. */
+const viaFramework = (ctx: DeliveryContext) => {
+  try {
+    const result = handleDeliveryResponse(BrazeAudienceIntegration, ctx);
+    const response = toDeliveryV1Response(result, ctx, DEST);
+    return {
+      threw: false,
+      status: response.status,
+      codes: response.response.map((r) => r.statusCode),
+      errors: response.response.map((r) => r.error),
+    };
+  } catch (e: any) {
+    return {
+      threw: true,
+      status: e.status,
+      errorType: e.statTags?.errorType,
+      authErrorCategory: e.authErrorCategory,
+    };
+  }
+};
+
+type LegacyResponseBody = BrazeAudienceProxyParams['destinationResponse']['response'];
+type LegacyRequestBody = NonNullable<
+  NonNullable<BrazeAudienceProxyParams['destinationRequest']>['body']
+>['JSON'];
+
+/** Run the retained legacy handler the same way, for parity comparison. */
+const viaLegacy = (ctx: DeliveryContext) => {
+  try {
+    const response = legacyResponseHandler({
+      rudderJobMetadata: ctx.jobs,
+      destinationResponse: { status: ctx.status, response: ctx.response as LegacyResponseBody },
+      destinationRequest: { body: { JSON: ctx.request.body?.JSON as LegacyRequestBody } },
+    });
+    return {
+      threw: false,
+      status: response.status,
+      codes: response.response.map((r) => r.statusCode),
+      errors: response.response.map((r) => r.error),
+    };
+  } catch (e: any) {
+    return {
+      threw: true,
+      status: e.status,
+      errorType: e.statTags?.errorType,
+      authErrorCategory: e.authErrorCategory,
+    };
+  }
+};
+
+describe('braze_audience delivery — parity with the retained legacy handler', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const parityCases = [
+    { name: '2xx, no errors field', status: 201, response: { message: 'success' }, items: 2 },
+    {
+      name: '2xx, empty errors array',
+      status: 201,
+      response: { message: 'success', errors: [] },
+      items: 2,
+    },
+    {
+      name: '2xx, indexed identity failure (enum)',
+      status: 201,
+      response: { message: 'success', errors: [{ type: 'EXTERNAL_USER_ID_TOO_LARGE', index: 1 }] },
+      items: 3,
+    },
+    {
+      name: '2xx, indexed identity failure (live message form)',
+      status: 201,
+      response: {
+        message: 'success',
+        errors: [{ type: "'external_id' must be fewer than 988 bytes", index: 1 }],
+      },
+      items: 3,
+    },
+    {
+      name: '2xx, indexed blacklisted id',
+      status: 201,
+      response: {
+        message: 'success',
+        errors: [{ type: 'BLACKLISTED_EXTERNAL_USER_ID', index: 0 }],
+      },
+      items: 1,
+    },
+    {
+      name: '2xx, indexed unknown type stays retryable',
+      status: 201,
+      response: { message: 'success', errors: [{ type: 'SOME_TRANSIENT_ATTR_ERROR', index: 0 }] },
+      items: 2,
+    },
+    {
+      name: '2xx, indexed error with no type',
+      status: 201,
+      response: { message: 'success', errors: [{ index: 0 }] },
+      items: 2,
+    },
+    {
+      name: '2xx, unindexed error marks every unmapped record retryable',
+      status: 201,
+      response: { message: 'success', errors: [{ type: 'UNINDEXED_FAILURE' }] },
+      items: 3,
+    },
+    {
+      name: '2xx, indexed abort mixed with an unindexed error',
+      status: 201,
+      response: {
+        message: 'success',
+        errors: [{ type: 'EXTERNAL_USER_ID_TOO_LARGE', index: 0 }, { type: 'ORPHAN_ERROR' }],
+      },
+      items: 3,
+    },
+    {
+      name: 'unindexed error with no type falls back to a placeholder reason',
+      status: 201,
+      response: { message: 'success', errors: [{}] },
+      items: 2,
+    },
+    { name: 'non-2xx, 400', status: 400, response: { message: 'invalid api key' }, items: 2 },
+    { name: 'non-2xx, 401', status: 401, response: { message: 'unauthorized' }, items: 2 },
+    { name: 'non-2xx, 429', status: 429, response: { message: 'rate limited' }, items: 2 },
+    { name: 'non-2xx, 500', status: 500, response: { message: 'server error' }, items: 2 },
+    { name: 'non-2xx with no message field', status: 503, response: { detail: 'down' }, items: 2 },
+  ];
+
+  it.each(parityCases)('per-job codes and errors match: $name', ({ status, response, items }) => {
+    const ctx = ctxFor(status, response, items);
+    const next = viaFramework(ctx);
+    const prev = viaLegacy(ctx);
+
+    expect(next.threw).toBe(prev.threw);
+    if (prev.threw) {
+      // Whole-batch failure: postTransformation rebuilds the per-job states from this error, so
+      // matching status + errorType + authErrorCategory is matching the delivered response.
+      expect(next.status).toBe(prev.status);
+      expect(next.errorType).toBe(prev.errorType);
+      expect(next.authErrorCategory ?? '').toBe(prev.authErrorCategory ?? '');
+      return;
+    }
+    expect(next.codes).toEqual(prev.codes);
+    expect(next.errors).toEqual(prev.errors);
+  });
+
+  it('keeps authErrorCategory empty on a 401, as the legacy handler did', () => {
+    // Braze is REST-API-key authenticated, so there is no auth category to infer either way.
+    const ctx = ctxFor(401, { message: 'unauthorized' }, 2);
+    expect(viaLegacy(ctx).authErrorCategory).toBe('');
+    expect(viaFramework(ctx).authErrorCategory).toBe('');
+  });
+
+  it.each([
+    {
+      name: 'partial failure and abort counters',
+      response: { errors: [{ type: 'EXTERNAL_USER_ID_TOO_LARGE', index: 0 }] },
+    },
+    {
+      name: 'partial failure and retryable counters',
+      response: { errors: [{ type: 'SOME_TRANSIENT_ATTR_ERROR', index: 0 }] },
+    },
+    {
+      name: 'unindexed retryable counter',
+      response: { errors: [{ type: 'UNINDEXED_FAILURE' }] },
+    },
+  ])('emits the same metrics as the legacy handler: $name', ({ response }) => {
+    const ctx = ctxFor(201, response, 2);
+
+    viaFramework(ctx);
+    // Copied, not aliased — `clearAllMocks` must not be able to empty what is being compared.
+    const nextCalls = [...mockStats.increment.mock.calls];
+    jest.clearAllMocks();
+
+    viaLegacy(ctx);
+    expect(nextCalls).toEqual(mockStats.increment.mock.calls);
+  });
+});
+
+describe('braze_audience delivery — partial failure on a 2xx', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('keeps the destination status on a mixed batch and reports per-record codes', () => {
+    const ctx = ctxFor(
+      201,
+      {
+        message: 'success',
+        errors: [
+          { type: 'EXTERNAL_USER_ID_TOO_LARGE', index: 0 },
+          { type: 'SOME_TRANSIENT_ATTR_ERROR', index: 2 },
+        ],
+      },
+      4,
+    );
+    const result = toDeliveryV1Response(
+      handleDeliveryResponse(BrazeAudienceIntegration, ctx),
+      ctx,
+      DEST,
+    );
+
+    // Braze answers 201; the bridge passes that through rather than relabelling the batch 207.
+    expect(result.status).toBe(201);
+    expect(result.response.map((r) => r.statusCode)).toEqual([400, 200, 500, 200]);
+    // Two records failed for different reasons, so the batch message counts them rather than
+    // presenting one job's error as the batch's. The reasons stay on the per-job entries.
+    expect(result.message).toBe(`[${DEST}] 2 of 4 events failed; see per-event errors`);
+    expect(result.response[0].error).toBe('EXTERNAL_USER_ID_TOO_LARGE');
+    expect(result.response[2].error).toBe('SOME_TRANSIENT_ATTR_ERROR');
+    expect(result.response[1].error).toBe('success');
+  });
+
+  it('keeps the destination status on a clean 2xx', () => {
+    const ctx = ctxFor(201, { message: 'success', errors: [] }, 2);
+    const result = toDeliveryV1Response(
+      handleDeliveryResponse(BrazeAudienceIntegration, ctx),
+      ctx,
+      DEST,
+    );
+
+    expect(result.status).toBe(201);
+    expect(result.response.map((r) => r.statusCode)).toEqual([200, 200]);
+  });
+
+  it('drives the index off the posted attributes array, not the job list', () => {
+    // Braze indexes `errors[].index` into `attributes`; a shorter body must not fail a job the
+    // response never named. The bridge's bounds guard collapses rather than misattributing.
+    const ctx = ctxFor(201, { message: 'success', errors: [{ type: 'BAD', index: 0 }] }, 3, [
+      { external_id: 'u0' },
+    ]);
+
+    const result = toDeliveryV1Response(
+      handleDeliveryResponse(BrazeAudienceIntegration, ctx),
+      ctx,
+      DEST,
+    );
+    expect(result.response).toHaveLength(3);
+    expect(result.response.every((r) => r.metadata !== undefined)).toBe(true);
+    // One item, three jobs → collapsed to the worst verdict rather than indexing past the end.
+    expect(result.response.map((r) => r.statusCode)).toEqual([500, 500, 500]);
+  });
+
+  it('falls back to the job list when the request body cannot be read', () => {
+    // An unreadable body must not turn a batch Braze flagged as failed into a whole-batch success.
+    const ctx = {
+      ...ctxFor(201, { message: 'success', errors: [{ type: 'UNINDEXED_FAILURE' }] }, 2),
+      request: { body: {} } as ProxyV1Request,
+    };
+    const result = toDeliveryV1Response(
+      handleDeliveryResponse(BrazeAudienceIntegration, ctx),
+      ctx,
+      DEST,
+    );
+
+    expect(result.response.map((r) => r.statusCode)).toEqual([500, 500]);
+    expect(result.response.map((r) => r.error)).toEqual(['UNINDEXED_FAILURE', 'UNINDEXED_FAILURE']);
+  });
+
+  it('treats a non-array errors field as no errors', () => {
+    const ctx = ctxFor(201, { message: 'success', errors: 'unexpected' }, 2);
+    const result = toDeliveryV1Response(
+      handleDeliveryResponse(BrazeAudienceIntegration, ctx),
+      ctx,
+      DEST,
+    );
+
+    expect(result.status).toBe(201);
+    expect(result.response.map((r) => r.statusCode)).toEqual([200, 200]);
+  });
+
+  it('ignores a non-numeric index rather than guessing which record it names', () => {
+    const ctx = ctxFor(
+      201,
+      { message: 'success', errors: [{ type: 'STRINGY_INDEX', index: '1' as unknown as number }] },
+      2,
+    );
+    const result = toDeliveryV1Response(
+      handleDeliveryResponse(BrazeAudienceIntegration, ctx),
+      ctx,
+      DEST,
+    );
+
+    // Unattributable, so it is treated as unindexed: every record is retried, none is dropped.
+    expect(result.response.map((r) => r.statusCode)).toEqual([500, 500]);
+    expect(result.response.map((r) => r.error)).toEqual(['STRINGY_INDEX', 'STRINGY_INDEX']);
+  });
+});
+
+describe('braze_audience delivery — error message extraction', () => {
+  const reasonFor = (response: unknown) =>
+    resolveDeliverySpec(BrazeAudienceIntegration).failureReason({
+      ...ctxFor(500, {}, 1),
+      response,
+    });
+
+  it('prefers the response message over the whole body, unquoted', () => {
+    expect(reasonFor({ message: 'nope' })).toBe('nope');
+  });
+
+  it('returns a bare string body as-is', () => {
+    expect(reasonFor('Invalid API key')).toBe('Invalid API key');
+  });
+
+  it('falls back to the whole body when there is no message field', () => {
+    expect(reasonFor({ detail: 'down' })).toBe('{"detail":"down"}');
+  });
+
+  it('never returns an empty string', () => {
+    expect(reasonFor(undefined)).toBe('unknown error');
+  });
+
+  // The legacy handler (`v1/destinations/braze_audience/networkHandler.ts`) is
+  // `JSON.stringify(response?.message ?? response)`, which quotes a string message. Dropping
+  // the quotes is the one deliberate divergence; the selection itself is unchanged.
+  it('matches the legacy selection, minus the quoting', () => {
+    type BrazeErrorBody = Record<string, unknown> | null;
+
+    const legacy = (response: BrazeErrorBody): string =>
+      JSON.stringify(response?.message ?? response) || 'unknown error';
+
+    // Parsing rather than stripping quotes textually keeps escapes intact.
+    const unquote = (json: string): string => {
+      const parsed: unknown = JSON.parse(json);
+      return typeof parsed === 'string' ? parsed : json;
+    };
+
+    const bodies: BrazeErrorBody[] = [
+      { message: 'nope' },
+      { message: 'he said "hi"' },
+      { message: { a: 1 } },
+      { detail: 'down' },
+      null,
+    ];
+
+    for (const body of bodies) {
+      expect(reasonFor(body)).toBe(unquote(legacy(body)));
+    }
+  });
+});

--- a/src/v0/destinations/braze_audience/delivery.ts
+++ b/src/v0/destinations/braze_audience/delivery.ts
@@ -57,12 +57,11 @@ export const extractBrazeAudienceErrorMessage = (response: unknown): string => {
 
 const brazeAudienceStatusOverrides: StatusOverrideMap = {
   '2xx': (ctx, fallback) => {
-    const rawErrors = (ctx.response as { errors?: unknown } | undefined)?.errors;
+    const { response, destinationId, workspaceId, request, jobs } = ctx;
+    const rawErrors = (response as { errors?: unknown } | undefined)?.errors;
     const errors: BrazeAudienceError[] = Array.isArray(rawErrors) ? rawErrors : [];
     if (errors.length === 0) return fallback();
 
-    const destinationId = ctx.jobs[0]?.destinationId ?? '';
-    const workspaceId = ctx.jobs[0]?.workspaceId ?? '';
     // Destination-scoped, deliberately not the shared event-stream `braze_partial_failure`.
     stats.increment('braze_audience_partial_failure', { destinationId, workspaceId });
 
@@ -82,13 +81,12 @@ const brazeAudienceStatusOverrides: StatusOverrideMap = {
     }
 
     // `errors[].index` indexes the posted `attributes` array, so that is what the loop is driven
-    // from. It falls back to `ctx.jobs` — which the framework builds 1:1 with `attributes` — when
+    // from. It falls back to `jobs` — which the framework builds 1:1 with `attributes` — when
     // the body cannot be read, so that per-record verdicts survive. Without it the bridge sees a
     // length mismatch and retries the whole batch, which would keep redelivering an identity
     // failure that can never succeed instead of aborting it.
-    const attributes = (ctx.request.body?.JSON as { attributes?: unknown } | undefined)?.attributes;
-    const items: unknown[] =
-      Array.isArray(attributes) && attributes.length > 0 ? attributes : ctx.jobs;
+    const attributes = (request.body?.JSON as { attributes?: unknown } | undefined)?.attributes;
+    const items: unknown[] = Array.isArray(attributes) && attributes.length > 0 ? attributes : jobs;
 
     const verdicts: ItemVerdict[] = items.map((_item, index) => {
       if (!failedByIndex.has(index)) {

--- a/src/v0/destinations/braze_audience/delivery.ts
+++ b/src/v0/destinations/braze_audience/delivery.ts
@@ -1,0 +1,127 @@
+/**
+ * Delivery handling for the Braze audience bulk attribute sync.
+ *
+ * Braze answers `/users/track/bulk` with a **2xx** even when individual records were rejected,
+ * listing them in `errors[]`. Each entry carries `index` — a position in the posted `attributes`
+ * array — so correlation is positional, and without this entry the framework would read a
+ * partially-failed batch as a plain success. Keyed on '2xx' rather than 201 because the check it
+ * replaces is `isHttpStatusSuccess(status)` (`v1/destinations/braze_audience/networkHandler.ts`).
+ *
+ * Three branches carry over from the legacy handler:
+ *
+ *  - an indexed error naming a permanent identity problem aborts that record — no retry can fix an
+ *    id Braze has blacklisted or that exceeds its length cap;
+ *  - any other indexed error is retryable, since Braze does not distinguish transient attribute
+ *    failures from permanent ones;
+ *  - an error with **no** index cannot be attributed to a record, so every record the indexed
+ *    errors did not name is marked retryable rather than reported as delivered. Braze flagged the
+ *    batch as partially failed and we cannot say which part, so the safe reading is to redeliver.
+ *
+ * The non-2xx path needs no override: the framework's own classification already aborts a 400 and
+ * retries a 500 with no auth inference, which is what the legacy handler's empty
+ * `authErrorCategory` was expressing — Braze is REST-API-key authenticated, not OAuth.
+ *
+ * NOTE: `src/v1/destinations/braze_audience/networkHandler.ts` keeps this logic while delivery is
+ * still resolved through networkHandlerFactory; both are deleted together when the framework owns
+ * delivery for this destination. The identity classifier itself is shared (`./utils`) rather than
+ * copied, so the two cannot drift.
+ */
+import {
+  abort,
+  perItem,
+  retry,
+  success,
+  type DeliverySpec,
+  type ItemVerdict,
+  type StatusOverrideMap,
+} from '../../../services/destination/nativeBatching/batchDestination';
+import { isIdentityAborted } from './utils';
+
+const stats = require('../../../util/stats');
+
+type BrazeAudienceError = { type?: string; index?: number };
+
+/**
+ * Braze puts its failure text on `message`; a body without one is handed back whole.
+ *
+ * Mirrors the legacy handler (`v1/destinations/braze_audience/networkHandler.ts`), with one
+ * deliberate difference: a string is returned bare rather than JSON-quoted. The per-job `error`
+ * is what live events display and what error reporting groups on, so `Invalid API key` beats
+ * `"Invalid API key"`.
+ */
+export const extractBrazeAudienceErrorMessage = (response: unknown): string => {
+  const message = (response as { message?: unknown } | undefined)?.message ?? response;
+  if (typeof message === 'string') return message || 'unknown error';
+  return JSON.stringify(message) ?? 'unknown error';
+};
+
+const brazeAudienceStatusOverrides: StatusOverrideMap = {
+  '2xx': (ctx, fallback) => {
+    const rawErrors = (ctx.response as { errors?: unknown } | undefined)?.errors;
+    const errors: BrazeAudienceError[] = Array.isArray(rawErrors) ? rawErrors : [];
+    if (errors.length === 0) return fallback();
+
+    const destinationId = ctx.jobs[0]?.destinationId ?? '';
+    const workspaceId = ctx.jobs[0]?.workspaceId ?? '';
+    // Destination-scoped, deliberately not the shared event-stream `braze_partial_failure`.
+    stats.increment('braze_audience_partial_failure', { destinationId, workspaceId });
+
+    // Values are the raw `type`, which is both the abortability signal and the reported reason.
+    const failedByIndex = new Map<number, string | undefined>();
+    let hasUnindexedError = false;
+    let unindexedMessage = 'braze_partial_error_unindexed';
+    for (const error of errors) {
+      if (typeof error?.index === 'number') {
+        failedByIndex.set(error.index, error.type);
+      } else {
+        hasUnindexedError = true;
+        if (typeof error?.type === 'string' && error.type.length > 0) {
+          unindexedMessage = error.type;
+        }
+      }
+    }
+
+    // `errors[].index` indexes the posted `attributes` array, so that is what the loop is driven
+    // from. It falls back to `ctx.jobs` — which the framework builds 1:1 with `attributes` — when
+    // the body cannot be read, so that per-record verdicts survive. Without it the bridge sees a
+    // length mismatch and retries the whole batch, which would keep redelivering an identity
+    // failure that can never succeed instead of aborting it.
+    const attributes = (ctx.request.body?.JSON as { attributes?: unknown } | undefined)?.attributes;
+    const items: unknown[] =
+      Array.isArray(attributes) && attributes.length > 0 ? attributes : ctx.jobs;
+
+    const verdicts: ItemVerdict[] = items.map((_item, index) => {
+      if (!failedByIndex.has(index)) {
+        if (!hasUnindexedError) return success();
+        stats.increment('braze_audience_retryable', {
+          destinationId,
+          workspaceId,
+          reason: 'partial_unindexed',
+        });
+        return retry(unindexedMessage);
+      }
+
+      const type = failedByIndex.get(index);
+      const reason = type || 'braze_partial_error';
+
+      if (isIdentityAborted(type)) {
+        stats.increment('braze_audience_aborted', { destinationId, workspaceId });
+        return abort(reason);
+      }
+
+      stats.increment('braze_audience_retryable', {
+        destinationId,
+        workspaceId,
+        reason: 'partial',
+      });
+      return retry(reason);
+    });
+
+    return perItem(verdicts);
+  },
+};
+
+export const brazeAudienceDelivery: DeliverySpec = {
+  statusOverrides: brazeAudienceStatusOverrides,
+  failureReason: (ctx) => extractBrazeAudienceErrorMessage(ctx.response),
+};

--- a/src/v0/destinations/braze_audience/routerTransform.ts
+++ b/src/v0/destinations/braze_audience/routerTransform.ts
@@ -8,6 +8,7 @@ import {
 import type { BatchStrategy } from '../../../services/destination/nativeBatching/types';
 import { ACTION_ATTR_VALUE, MAX_BATCH_SIZE, MAX_PAYLOAD_SIZE } from './config';
 import { buildBulkBody, getBulkTrackEndpoint, normalizeExternalId } from './utils';
+import { brazeAudienceDelivery } from './delivery';
 import {
   BrazeAudienceRouterRequestSchema,
   type BrazeAudienceAttributePayload,
@@ -18,6 +19,9 @@ class BrazeAudienceIntegration extends BatchDestination<
   BrazeAudienceAttributePayload,
   typeof BrazeAudienceRouterRequestSchema
 > {
+  // Partial failure arrives on a 2xx keyed by index into `attributes`; see ./delivery.
+  static readonly delivery = brazeAudienceDelivery;
+
   private readonly headers: Record<string, string>;
 
   constructor(...args: ConstructorParameters<typeof BatchDestination>) {

--- a/src/v0/destinations/braze_audience/utils.ts
+++ b/src/v0/destinations/braze_audience/utils.ts
@@ -14,6 +14,32 @@ export const getBulkTrackEndpoint = (
   };
 };
 
+/**
+ * Permanent Braze `/users/track` identity error `type` values.
+ * Docs list uppercase enums; live `/users/track/bulk` often returns human
+ * messages (e.g. "'external_id' must be fewer than 988 bytes") instead.
+ */
+const ABORTED_IDENTITY_TYPES = new Set([
+  'BLACKLISTED_EXTERNAL_USER_ID',
+  'EXTERNAL_USER_ID_TOO_LARGE',
+]);
+
+/**
+ * Whether a Braze partial-failure `type` names a permanent identity problem, which no retry can
+ * fix. Shared by the legacy network handler and the batching-framework delivery path so the two
+ * cannot classify the same response differently while both are live.
+ */
+export const isIdentityAborted = (type?: string): boolean => {
+  if (!type) return false;
+  if (ABORTED_IDENTITY_TYPES.has(type)) return true;
+  // Live Braze message forms for permanent identity failures (not retryable).
+  return (
+    /external_user_id_too_large|blacklisted_external_user_id/i.test(type) ||
+    /external_id.*(?:fewer|bytes|too\s*large|blacklist)/i.test(type) ||
+    /blacklist(?:ed)?.*external_id/i.test(type)
+  );
+};
+
 export const buildBulkBody = (
   attributes: BrazeAudienceAttributePayload[],
 ): { attributes: BrazeAudienceAttributePayload[] } => ({ attributes });

--- a/src/v0/destinations/customerio/routerTransform.ts
+++ b/src/v0/destinations/customerio/routerTransform.ts
@@ -31,6 +31,7 @@ import {
 } from './v2/util';
 import { process as v1ProcessEventStream } from './transform';
 import { CUSTOMERIO_RECORD_OBJECTS, type CustomerIORecordObject } from './types';
+import { customerIODelivery } from './v2/delivery';
 
 class CustomerIOIntegration extends VDMV2ObjectDestination<
   CustomerIOV2Payload,
@@ -40,6 +41,9 @@ class CustomerIOIntegration extends VDMV2ObjectDestination<
   protected readonly recordSchema = recordInputSchema;
 
   protected readonly eventStreamSchema = eventStreamInputSchema;
+
+  // Only the 207 multi-status needs handling; see ./v2/delivery.
+  static readonly delivery = customerIODelivery;
 
   private assertObjectSize(body: unknown): void {
     const size = Buffer.byteLength(JSON.stringify(body), 'utf8');

--- a/src/v0/destinations/customerio/v2/delivery.test.ts
+++ b/src/v0/destinations/customerio/v2/delivery.test.ts
@@ -1,0 +1,215 @@
+import { Integration as CustomerIOIntegration } from '../routerTransform';
+import {
+  handleDeliveryResponse,
+  toDeliveryV1Response,
+} from '../../../../services/destination/nativeBatching/delivery';
+import type { DeliveryContext } from '../../../../services/destination/nativeBatching/delivery';
+import { networkHandler as legacyNetworkHandler } from '../../../../v1/destinations/customerio/networkHandler';
+import type { DeliveryV1Response, ProxyMetdata, ProxyV1Request } from '../../../../types';
+
+const DEST = 'CUSTOMERIO';
+
+/** The shape `networkHandler.call(...)` installs on its receiver — the part this test drives. */
+type LegacyV1Handler = {
+  responseHandler: (params: {
+    rudderJobMetadata: ProxyMetdata[];
+    destinationResponse: { response: unknown; status: number };
+    destinationRequest: ProxyV1Request;
+  }) => DeliveryV1Response;
+};
+
+const job = (jobId: number): ProxyMetdata =>
+  ({
+    jobId,
+    attemptNum: 0,
+    userId: `u${jobId}`,
+    sourceId: 's1',
+    destinationId: 'd1',
+    workspaceId: 'w1',
+    secret: {},
+    dontBatch: false,
+  }) as ProxyMetdata;
+
+const ctxFor = (status: number, response: unknown, itemCount: number): DeliveryContext => ({
+  status,
+  response,
+  jobs: Array.from({ length: itemCount }, (_, i) => job(i + 1)),
+  request: {
+    body: { JSON: { batch: Array.from({ length: itemCount }, (_, i) => ({ event: `e${i}` })) } },
+    endpoint: 'https://track.customer.io/api/v2/batch',
+  } as unknown as ProxyV1Request,
+  destinationConfig: {},
+});
+
+/** Run the new path end to end, normalising the throw into a comparable shape. */
+const viaFramework = (ctx: DeliveryContext) => {
+  try {
+    const result = handleDeliveryResponse(CustomerIOIntegration, ctx);
+    const response = toDeliveryV1Response(result, ctx, DEST);
+    return {
+      threw: false,
+      status: response.status,
+      codes: response.response.map((r) => r.statusCode),
+      errors: response.response.map((r) => r.error),
+    };
+  } catch (e: any) {
+    return {
+      threw: true,
+      status: e.status,
+      errorType: e.statTags?.errorType,
+      authErrorCategory: e.authErrorCategory,
+    };
+  }
+};
+
+/** Run the retained legacy handler the same way, for parity comparison. */
+const viaLegacy = (ctx: DeliveryContext) => {
+  const handler = {} as LegacyV1Handler;
+  legacyNetworkHandler.call(handler);
+  try {
+    const response = handler.responseHandler({
+      rudderJobMetadata: ctx.jobs,
+      destinationResponse: { status: ctx.status, response: ctx.response },
+      destinationRequest: ctx.request,
+    });
+    return {
+      threw: false,
+      status: response.status,
+      codes: response.response.map((r) => r.statusCode),
+      errors: response.response.map((r) => r.error),
+    };
+  } catch (e: any) {
+    return {
+      threw: true,
+      status: e.status,
+      errorType: e.statTags?.errorType,
+      authErrorCategory: e.authErrorCategory,
+    };
+  }
+};
+
+describe('customerio delivery — parity with the retained legacy handler', () => {
+  const partialFailure = {
+    errors: [{ batch_index: 1, reason: 'invalid', field: 'email', message: 'bad email' }],
+  };
+
+  const parityCases = [
+    { name: 'non-207 success (200)', status: 200, response: { ok: true }, items: 2 },
+    { name: 'non-207 failure (400)', status: 400, response: { msg: 'bad' }, items: 2 },
+    { name: 'non-207 failure (500)', status: 500, response: { msg: 'oops' }, items: 2 },
+    { name: '207 with a failed item', status: 207, response: partialFailure, items: 3 },
+    { name: '207 with an empty errors array', status: 207, response: { errors: [] }, items: 2 },
+  ];
+
+  it.each(parityCases)('per-job codes and errors match: $name', ({ status, response, items }) => {
+    const ctx = ctxFor(status, response, items);
+    const next = viaFramework(ctx);
+    const prev = viaLegacy(ctx);
+
+    expect(next.threw).toBe(prev.threw);
+    if (prev.threw) {
+      // Whole-batch failure: postTransformation rebuilds the per-job states from this error, so
+      // matching status + errorType + authErrorCategory is matching the delivered response.
+      expect(next.status).toBe(prev.status);
+      expect(next.errorType).toBe(prev.errorType);
+      expect(next.authErrorCategory ?? '').toBe(prev.authErrorCategory ?? '');
+      return;
+    }
+    expect(next.codes).toEqual(prev.codes);
+    expect(next.errors).toEqual(prev.errors);
+  });
+
+  it.each([
+    { status: 401, category: 'REFRESH_TOKEN' },
+    { status: 403, category: 'AUTH_STATUS_INACTIVE' },
+  ])(
+    'drops the status-inferred authErrorCategory $category on a $status',
+    ({ status, category }) => {
+      // The legacy handler ran every non-2xx through `getAuthErrCategoryFromStCode`. customerio
+      // authenticates the v2 batch API with Basic auth over siteID:apiKey, and rudder-server's
+      // OAuth transport returns before reading the field for a non-OAuth destination
+      // (`services/oauth/v2/http/transport.go`, `if !isOauthDestination`), so neither the refresh
+      // nor the 401->500 rewrite it implies was ever reachable. The framework does not infer auth
+      // from a status code and customerio does not declare one, so the field goes.
+      const ctx = ctxFor(status, { msg: 'auth' }, 2);
+      expect(viaLegacy(ctx).authErrorCategory).toBe(category);
+      expect(viaFramework(ctx).authErrorCategory).toBe('');
+      // The job outcome is what it always was: a 4xx is terminal either way.
+      expect(viaFramework(ctx).status).toBe(status);
+      expect(viaFramework(ctx).errorType).toBe('aborted');
+    },
+  );
+});
+
+describe('customerio delivery — 207 multi-status', () => {
+  it('marks only the indices named in errors, keyed on batch_index', () => {
+    const ctx = ctxFor(
+      207,
+      {
+        errors: [
+          { batch_index: 0, reason: 'invalid', field: 'id' },
+          { batch_index: 2, message: 'nope' },
+        ],
+      },
+      4,
+    );
+    const result = toDeliveryV1Response(
+      handleDeliveryResponse(CustomerIOIntegration, ctx),
+      ctx,
+      DEST,
+    );
+    expect(result.status).toBe(207);
+    expect(result.response.map((r) => r.statusCode)).toEqual([400, 200, 400, 200]);
+    expect(result.response[0].error).toBe('reason: invalid, field: id');
+    expect(result.response[2].error).toBe('message: nope');
+    expect(result.response[1].error).toBe('success');
+  });
+
+  it('falls back to a generic message when an error entry has no detail fields', () => {
+    const ctx = ctxFor(207, { errors: [{ batch_index: 0 }] }, 1);
+    const result = toDeliveryV1Response(
+      handleDeliveryResponse(CustomerIOIntegration, ctx),
+      ctx,
+      DEST,
+    );
+    expect(result.response[0].error).toBe('Unknown error from CustomerIO');
+  });
+
+  it('ignores malformed error entries that carry no numeric batch_index', () => {
+    const ctx = ctxFor(207, { errors: [{ reason: 'no index' }, 'garbage', null] }, 2);
+    const result = toDeliveryV1Response(
+      handleDeliveryResponse(CustomerIOIntegration, ctx),
+      ctx,
+      DEST,
+    );
+    expect(result.response.map((r) => r.statusCode)).toEqual([200, 200]);
+  });
+
+  it('treats a non-array errors field as no errors', () => {
+    const ctx = ctxFor(207, { errors: 'unexpected' }, 2);
+    const result = toDeliveryV1Response(
+      handleDeliveryResponse(CustomerIOIntegration, ctx),
+      ctx,
+      DEST,
+    );
+    expect(result.status).toBe(207);
+    expect(result.response.map((r) => r.statusCode)).toEqual([200, 200]);
+  });
+
+  it('retries the batch when the body is missing so item count cannot be derived', () => {
+    const ctx = {
+      ...ctxFor(207, { errors: [{ batch_index: 0, message: 'x' }] }, 2),
+      request: { body: {}, endpoint: 'https://track.customer.io/api/v2/batch' } as ProxyV1Request,
+    };
+    const result = toDeliveryV1Response(
+      handleDeliveryResponse(CustomerIOIntegration, ctx),
+      ctx,
+      DEST,
+    );
+    // No items to index, so the bounds guard degrades rather than emitting undefined metadata.
+    expect(result.response).toHaveLength(2);
+    expect(result.response.every((r) => r.metadata !== undefined)).toBe(true);
+    // CustomerIO reported an error, so reporting these jobs delivered would drop an event.
+    expect(result.response.map((r) => r.statusCode)).toEqual([500, 500]);
+  });
+});

--- a/src/v0/destinations/customerio/v2/delivery.test.ts
+++ b/src/v0/destinations/customerio/v2/delivery.test.ts
@@ -1,5 +1,6 @@
 import { Integration as CustomerIOIntegration } from '../routerTransform';
 import {
+  firstJobIdentity,
   handleDeliveryResponse,
   toDeliveryV1Response,
 } from '../../../../services/destination/nativeBatching/delivery';
@@ -30,16 +31,20 @@ const job = (jobId: number): ProxyMetdata =>
     dontBatch: false,
   }) as ProxyMetdata;
 
-const ctxFor = (status: number, response: unknown, itemCount: number): DeliveryContext => ({
-  status,
-  response,
-  jobs: Array.from({ length: itemCount }, (_, i) => job(i + 1)),
-  request: {
-    body: { JSON: { batch: Array.from({ length: itemCount }, (_, i) => ({ event: `e${i}` })) } },
-    endpoint: 'https://track.customer.io/api/v2/batch',
-  } as unknown as ProxyV1Request,
-  destinationConfig: {},
-});
+const ctxFor = (status: number, response: unknown, itemCount: number): DeliveryContext => {
+  const jobs = Array.from({ length: itemCount }, (_, i) => job(i + 1));
+  return {
+    status,
+    response,
+    jobs,
+    request: {
+      body: { JSON: { batch: Array.from({ length: itemCount }, (_, i) => ({ event: `e${i}` })) } },
+      endpoint: 'https://track.customer.io/api/v2/batch',
+    } as unknown as ProxyV1Request,
+    destinationConfig: {},
+    ...firstJobIdentity(jobs),
+  };
+};
 
 /** Run the new path end to end, normalising the throw into a comparable shape. */
 const viaFramework = (ctx: DeliveryContext) => {

--- a/src/v0/destinations/customerio/v2/delivery.ts
+++ b/src/v0/destinations/customerio/v2/delivery.ts
@@ -1,0 +1,69 @@
+/**
+ * Delivery handling for the CustomerIO v2 batch API.
+ *
+ * The `/v2/batch` endpoint answers a partially-failed batch with HTTP 207 and an `errors` array
+ * whose entries carry `batch_index` — an index into the `batch` array that was posted, not into
+ * the job list. 207 is a 2xx, so without this entry the framework would read a partially-failed
+ * batch as a plain success. Keyed on the exact status rather than '2xx' because only 207 carries
+ * `errors`. Everything else — plain success, every failure status — is left to the framework.
+ *
+ * NOTE: `src/v1/destinations/customerio/networkHandler.ts` keeps its own copy of this logic while
+ * customerio is pre-GA, because workspaces not enrolled in the batching framework still transform
+ * through the legacy `processRouterDest` and are delivered by that handler. Both are deleted
+ * together when customerio reaches GA.
+ */
+import {
+  abort,
+  perItem,
+  success,
+  type DeliverySpec,
+  type StatusOverrideMap,
+} from '../../../../services/destination/nativeBatching/batchDestination';
+
+type CustomerIOError = {
+  batch_index: number;
+  reason?: string;
+  field?: string;
+  message?: string;
+};
+
+const customerIOStatusOverrides: StatusOverrideMap = {
+  207: (ctx) => {
+    const items = (ctx.request.body?.JSON as { batch?: unknown[] })?.batch ?? [];
+    const rawErrors = (ctx.response as { errors?: unknown })?.errors;
+
+    const failedByIndex = new Map<number, string>();
+    if (Array.isArray(rawErrors)) {
+      for (const raw of rawErrors) {
+        const error = raw as CustomerIOError;
+        // Anything without a numeric batch_index cannot be attributed, so ignore it rather than
+        // guess — a mis-keyed entry would fail the wrong event.
+        if (typeof error?.batch_index === 'number') {
+          const parts = [
+            error.reason ? `reason: ${error.reason}` : undefined,
+            error.field ? `field: ${error.field}` : undefined,
+            error.message ? `message: ${error.message}` : undefined,
+          ].filter(Boolean);
+          failedByIndex.set(
+            error.batch_index,
+            parts.length > 0 ? parts.join(', ') : 'Unknown error from CustomerIO',
+          );
+        }
+      }
+    }
+
+    return perItem(
+      items.map((_item, index) => {
+        const reason = failedByIndex.get(index);
+        return reason ? abort(reason) : success();
+      }),
+    );
+  },
+};
+
+// No `failureReason`: the per-job `error` on a whole-batch failure comes from the thrown error's
+// `destinationResponse` (postTransformation.ts), not from here, so the framework default is what
+// keeps it byte-identical to the legacy handler's.
+export const customerIODelivery: DeliverySpec = {
+  statusOverrides: customerIOStatusOverrides,
+};

--- a/src/v0/destinations/google_adwords_enhanced_conversions/delivery.test.ts
+++ b/src/v0/destinations/google_adwords_enhanced_conversions/delivery.test.ts
@@ -1,0 +1,254 @@
+import { Integration as GaecIntegration } from './routerTransform';
+import {
+  handleDeliveryResponse,
+  toDeliveryV1Response,
+} from '../../../services/destination/nativeBatching/delivery';
+import type { DeliveryContext } from '../../../services/destination/nativeBatching/delivery';
+import { gaecResponseHandler } from '../../../v1/destinations/google_adwords_enhanced_conversions/networkHandler';
+import type { ProxyMetdata, ProxyV1Request } from '../../../types';
+
+const DEST = 'GOOGLE_ADWORDS_ENHANCED_CONVERSIONS';
+
+const job = (jobId: number): ProxyMetdata =>
+  ({
+    jobId,
+    attemptNum: 0,
+    userId: `u${jobId}`,
+    sourceId: 's1',
+    destinationId: 'd1',
+    workspaceId: 'w1',
+    secret: {},
+    dontBatch: false,
+  }) as ProxyMetdata;
+
+/**
+ * `adjustments` defaults to one posted adjustment per job, which is what routerTransform emits.
+ * Pass it explicitly to build a body the framework cannot line up with the job list.
+ */
+const ctxFor = (
+  status: number,
+  response: unknown,
+  jobCount = 2,
+  adjustments: unknown = Array.from({ length: jobCount }, (_, i) => ({ adjustment: i })),
+): DeliveryContext => ({
+  status,
+  response,
+  jobs: Array.from({ length: jobCount }, (_, i) => job(i + 1)),
+  request: {
+    body: { JSON: { conversionAdjustments: adjustments, partialFailure: true } },
+    endpoint: '',
+  } as unknown as ProxyV1Request,
+  destinationConfig: {},
+});
+
+const viaFramework = (ctx: DeliveryContext) => {
+  try {
+    const response = toDeliveryV1Response(handleDeliveryResponse(GaecIntegration, ctx), ctx, DEST);
+    return {
+      threw: false,
+      status: response.status,
+      codes: response.response.map((r) => r.statusCode),
+      errors: response.response.map((r) => r.error),
+    };
+  } catch (e: any) {
+    return {
+      threw: true,
+      status: e.status,
+      errorType: e.statTags?.errorType,
+      authErrorCategory: e.authErrorCategory,
+    };
+  }
+};
+
+const viaLegacy = (ctx: DeliveryContext) => {
+  try {
+    const response = gaecResponseHandler({
+      destinationResponse: { status: ctx.status, response: ctx.response },
+      rudderJobMetadata: ctx.jobs,
+    });
+    return {
+      threw: false,
+      status: response.status,
+      // `response` is optional on ResponseProxyObject; a missing one would make the parity
+      // assertion fail loudly against the framework's populated list, which is what we want.
+      codes: response.response?.map((r) => r.statusCode) ?? [],
+      errors: response.response?.map((r) => r.error) ?? [],
+    };
+  } catch (e: any) {
+    return {
+      threw: true,
+      status: e.status,
+      errorType: e.statTags?.errorType,
+      authErrorCategory: e.authErrorCategory,
+    };
+  }
+};
+
+const twoStepAuthError = {
+  error: {
+    message: 'auth problem',
+    details: [
+      { errors: [{ errorCode: { authenticationError: 'TWO_STEP_VERIFICATION_NOT_ENROLLED' } }] },
+    ],
+  },
+};
+
+describe('gaec delivery — parity with the existing response handler', () => {
+  const parityCases = [
+    {
+      name: '2xx, no partialFailureError',
+      status: 200,
+      response: { results: [{ a: 1 }, { b: 2 }] },
+    },
+    {
+      name: '2xx, partialFailureError code 0 means no error',
+      status: 200,
+      response: { partialFailureError: { code: 0 }, results: [{ a: 1 }, { b: 2 }] },
+    },
+    {
+      name: '2xx, one empty result means that adjustment failed',
+      status: 200,
+      response: {
+        partialFailureError: { code: 3, message: 'duplicate enhancement' },
+        results: [{ a: 1 }, {}],
+      },
+    },
+    { name: '400 abort', status: 400, response: { error: { message: 'bad request' } } },
+    { name: '500 retry', status: 500, response: { error: { message: 'internal' } } },
+    { name: '403 access denied', status: 403, response: { error: { message: 'denied' } } },
+    { name: '401 stale token', status: 401, response: { error: { message: 'unauthorized' } } },
+    { name: '401 two-step not enrolled', status: 401, response: twoStepAuthError },
+  ];
+
+  it.each(parityCases)('per-job codes match: $name', ({ status, response }) => {
+    const ctx = ctxFor(status, response);
+    const next = viaFramework(ctx);
+    const prev = viaLegacy(ctx);
+
+    expect(next.threw).toBe(prev.threw);
+    if (prev.threw) {
+      expect(next.status).toBe(prev.status);
+      expect(next.authErrorCategory ?? '').toBe(prev.authErrorCategory ?? '');
+      return;
+    }
+    expect(next.codes).toEqual(prev.codes);
+  });
+});
+
+describe('gaec delivery — auth categories come from the response body', () => {
+  const authCases = [
+    {
+      name: '401 with TWO_STEP_VERIFICATION_NOT_ENROLLED -> revoked, aborts',
+      status: 401,
+      response: twoStepAuthError,
+      authErrorCategory: 'AUTH_STATUS_INACTIVE',
+      errorType: 'aborted',
+    },
+    {
+      name: '401 with CUSTOMER_NOT_FOUND -> revoked, aborts',
+      status: 401,
+      response: {
+        error: {
+          message: 'no customer',
+          details: [{ errors: [{ errorCode: { authenticationError: 'CUSTOMER_NOT_FOUND' } }] }],
+        },
+      },
+      authErrorCategory: 'AUTH_STATUS_INACTIVE',
+      errorType: 'aborted',
+    },
+    {
+      name: '401 otherwise -> expired, retries after refresh',
+      status: 401,
+      response: { error: { message: 'token stale' } },
+      authErrorCategory: 'REFRESH_TOKEN',
+      errorType: 'retryable',
+    },
+    {
+      name: '403 -> revoked, aborts',
+      status: 403,
+      response: { error: { message: 'access denied' } },
+      authErrorCategory: 'AUTH_STATUS_INACTIVE',
+      errorType: 'aborted',
+    },
+    {
+      name: '400 -> no auth category at all',
+      status: 400,
+      response: { error: { message: 'bad request' } },
+      authErrorCategory: '',
+      errorType: 'aborted',
+    },
+  ];
+
+  it.each(authCases)('$name', ({ status, response, authErrorCategory, errorType }) => {
+    const result = viaFramework(ctxFor(status, response));
+    expect(result.threw).toBe(true);
+    expect(result.authErrorCategory).toBe(authErrorCategory);
+    expect(result.errorType).toBe(errorType);
+  });
+
+  it('uses the destination error message as the failure reason', () => {
+    const ctx = ctxFor(400, { error: { message: 'INVALID_GCLID' } });
+    expect(() =>
+      toDeliveryV1Response(handleDeliveryResponse(GaecIntegration, ctx), ctx, DEST),
+    ).toThrow('INVALID_GCLID');
+  });
+});
+
+describe('gaec delivery — partial failure on a 2xx', () => {
+  it('maps empty results positionally, keeping the destination status', () => {
+    const ctx = ctxFor(
+      200,
+      {
+        partialFailureError: { code: 3, message: 'duplicate enhancement' },
+        results: [{ ok: 1 }, {}, { ok: 1 }],
+      },
+      3,
+    );
+    const result = toDeliveryV1Response(handleDeliveryResponse(GaecIntegration, ctx), ctx, DEST);
+    // Google answered 200; the bridge passes that through rather than relabelling the batch 207.
+    expect(result.status).toBe(200);
+    expect(result.response.map((r) => r.statusCode)).toEqual([200, 400, 200]);
+    expect(result.response[1].error).toBe('duplicate enhancement');
+    // The batch-level message keeps Google's reason, which used to be lost to a fixed string.
+    expect(result.message).toBe(`[${DEST}] duplicate enhancement`);
+  });
+
+  it('does not echo the 200 into per-job codes when every adjustment failed', () => {
+    const ctx = ctxFor(200, {
+      partialFailureError: { code: 3, message: 'all bad' },
+      results: [{}, {}],
+    });
+    const result = toDeliveryV1Response(handleDeliveryResponse(GaecIntegration, ctx), ctx, DEST);
+    expect(result.response.map((r) => r.statusCode)).toEqual([400, 400]);
+  });
+
+  it('aborts every adjustment when results is absent despite partialFailureError being set', () => {
+    // Indexing off the posted adjustments keeps the list job-aligned, so a missing `results` reads
+    // as "no adjustment confirmed" — the same conclusion `results?.[i] ?? {}` reached in the legacy
+    // handler, rather than a lost-attribution retry that would re-upload accepted adjustments.
+    const ctx = ctxFor(200, { partialFailureError: { code: 3, message: 'no results' } });
+    const result = toDeliveryV1Response(handleDeliveryResponse(GaecIntegration, ctx), ctx, DEST);
+    expect(result.response).toHaveLength(2);
+    expect(result.response.map((r) => r.statusCode)).toEqual([400, 400]);
+    expect(result.response.map((r) => r.error)).toEqual(['no results', 'no results']);
+  });
+
+  it('aborts only the tail when results is shorter than the posted adjustments', () => {
+    const ctx = ctxFor(200, {
+      partialFailureError: { code: 3, message: 'partial' },
+      results: [{ adjustment: 'ok' }],
+    });
+    const result = toDeliveryV1Response(handleDeliveryResponse(GaecIntegration, ctx), ctx, DEST);
+    expect(result.response.map((r) => r.statusCode)).toEqual([200, 400]);
+  });
+
+  it('falls back to the bridge retry when the posted adjustments cannot be read', () => {
+    // Nothing job-aligned to index, so the framework's attribution guard takes over rather than
+    // reporting jobs Google flagged as failed delivered.
+    // `null` rather than `undefined`: an omitted argument would take the default body.
+    const ctx = ctxFor(200, { partialFailureError: { code: 3, message: 'unreadable' } }, 2, null);
+    const result = toDeliveryV1Response(handleDeliveryResponse(GaecIntegration, ctx), ctx, DEST);
+    expect(result.response.every((r) => r.metadata !== undefined)).toBe(true);
+    expect(result.response.map((r) => r.statusCode)).toEqual([500, 500]);
+  });
+});

--- a/src/v0/destinations/google_adwords_enhanced_conversions/delivery.test.ts
+++ b/src/v0/destinations/google_adwords_enhanced_conversions/delivery.test.ts
@@ -1,5 +1,6 @@
 import { Integration as GaecIntegration } from './routerTransform';
 import {
+  firstJobIdentity,
   handleDeliveryResponse,
   toDeliveryV1Response,
 } from '../../../services/destination/nativeBatching/delivery';
@@ -30,16 +31,20 @@ const ctxFor = (
   response: unknown,
   jobCount = 2,
   adjustments: unknown = Array.from({ length: jobCount }, (_, i) => ({ adjustment: i })),
-): DeliveryContext => ({
-  status,
-  response,
-  jobs: Array.from({ length: jobCount }, (_, i) => job(i + 1)),
-  request: {
-    body: { JSON: { conversionAdjustments: adjustments, partialFailure: true } },
-    endpoint: '',
-  } as unknown as ProxyV1Request,
-  destinationConfig: {},
-});
+): DeliveryContext => {
+  const jobs = Array.from({ length: jobCount }, (_, i) => job(i + 1));
+  return {
+    status,
+    response,
+    jobs,
+    request: {
+      body: { JSON: { conversionAdjustments: adjustments, partialFailure: true } },
+      endpoint: '',
+    } as unknown as ProxyV1Request,
+    destinationConfig: {},
+    ...firstJobIdentity(jobs),
+  };
+};
 
 const viaFramework = (ctx: DeliveryContext) => {
   try {
@@ -118,6 +123,10 @@ describe('gaec delivery — parity with the existing response handler', () => {
     { name: '403 access denied', status: 403, response: { error: { message: 'denied' } } },
     { name: '401 stale token', status: 401, response: { error: { message: 'unauthorized' } } },
     { name: '401 two-step not enrolled', status: 401, response: twoStepAuthError },
+    // Non-object 2xx bodies: `body?.partialFailureError` reads as undefined without needing the
+    // v0 handler's explicit `isPartialFailureBody` guard, so these are read as plain success.
+    { name: '2xx, empty string body', status: 200, response: '' },
+    { name: '2xx, null body', status: 200, response: null },
   ];
 
   it.each(parityCases)('per-job codes match: $name', ({ status, response }) => {

--- a/src/v0/destinations/google_adwords_enhanced_conversions/delivery.ts
+++ b/src/v0/destinations/google_adwords_enhanced_conversions/delivery.ts
@@ -1,0 +1,83 @@
+/**
+ * Delivery handling for Google Ads Enhanced Conversions.
+ *
+ * Two things are destination-specific:
+ *
+ * 1. Partial failure arrives on a **2xx** carrying `partialFailureError`, with a positional
+ *    `results` array in which an empty entry means that adjustment failed. Keyed on '2xx' rather
+ *    than 200 because the check it replaces is `isHttpStatusSuccess(status)`.
+ * 2. Google Ads is OAuth-backed, so the auth category is real and is derived from the response
+ *    body (2SV-not-enrolled and CUSTOMER_NOT_FOUND mean the grant is gone, not that the token is
+ *    stale). The framework never infers auth from a status, so this is declared explicitly.
+ *
+ * Transport — the SDK-based proxy, the conversionActionId cache and processAxiosResponse — stays
+ * in ./networkHandler, which the framework continues to use.
+ */
+import { isEmptyObject } from '../../util';
+import {
+  abort,
+  authExpired,
+  authRevoked,
+  perItem,
+  success,
+  type DeliverySpec,
+  type StatusOverrideMap,
+} from '../../../services/destination/nativeBatching/batchDestination';
+
+const { getAuthErrCategory } = require('../../util/googleUtils');
+const {
+  REFRESH_TOKEN,
+  AUTH_STATUS_INACTIVE,
+} = require('../../../adapters/networkhandler/authConstants');
+
+export const extractGaecErrorMessage = (response: unknown): string =>
+  (response as { error?: { message?: string } })?.error?.message || 'unknown error';
+
+const gaecStatusOverrides: StatusOverrideMap = {
+  '2xx': (ctx, fallback) => {
+    const body = ctx.response as
+      | { partialFailureError?: { code?: number; message?: string }; results?: unknown[] }
+      | undefined;
+    const partialFailureError = body?.partialFailureError;
+
+    // code 0 is Google's "no error"; treat it the same as an absent field.
+    if (!partialFailureError || partialFailureError.code === 0) return fallback();
+
+    const reason = partialFailureError.message || 'unknown error format';
+    const results = Array.isArray(body?.results) ? body.results : [];
+
+    // Indexed off the *posted* adjustments rather than off `results`, matching what customerio and
+    // braze_audience do with their own request bodies. This destination is strictly 1:1
+    // (routerTransform.ts:44 emits one adjustment per event), so the posted array is the one array
+    // guaranteed to be the same length as the job list — which keeps the bridge's attribution
+    // guard out of the picture entirely.
+    //
+    // Reading a missing `results` entry as failed is deliberate and reproduces the legacy handler's
+    // `results?.[i] ?? {}`. Google omits or truncates `results` on some partial failures, and the
+    // alternative — losing attribution and retrying the batch — would re-upload adjustments Google
+    // has already accepted, which come back as duplicate-enhancement failures on every attempt.
+    const items = (ctx.request.body?.JSON as { conversionAdjustments?: unknown[] })
+      ?.conversionAdjustments;
+    const positions = Array.isArray(items) ? items : results;
+
+    return perItem(
+      positions.map((_item, index) =>
+        isEmptyObject(results[index] ?? {}) ? abort(reason) : success(),
+      ),
+    );
+  },
+
+  '4xx': (ctx, fallback) => {
+    const category = getAuthErrCategory({ response: ctx.response, status: ctx.status });
+    if (category === REFRESH_TOKEN) return authExpired(extractGaecErrorMessage(ctx.response));
+    if (category === AUTH_STATUS_INACTIVE) {
+      return authRevoked(extractGaecErrorMessage(ctx.response));
+    }
+    return fallback();
+  },
+};
+
+export const gaecDelivery: DeliverySpec = {
+  statusOverrides: gaecStatusOverrides,
+  failureReason: (ctx) => extractGaecErrorMessage(ctx.response),
+};

--- a/src/v0/destinations/google_adwords_enhanced_conversions/routerTransform.ts
+++ b/src/v0/destinations/google_adwords_enhanced_conversions/routerTransform.ts
@@ -10,6 +10,7 @@ import type { BatchStrategy } from '../../../services/destination/nativeBatching
 // reused here so no transform logic is duplicated.
 import { process as transformSingleEvent } from './transform';
 import { MAX_CONVERSION_ADJUSTMENTS_PER_BATCH } from './config';
+import { gaecDelivery } from './delivery';
 
 // Each batched item is a single Google Ads conversion adjustment.
 type ConversionAdjustment = Record<string, unknown>;
@@ -29,6 +30,9 @@ class GoogleAdwordsEnhancedConversionsIntegration extends BatchDestination<
   ConversionAdjustment,
   typeof gaecInputSchema
 > {
+  // Partial failure on a 2xx, plus body-derived auth categories; see ./delivery.
+  static readonly delivery = gaecDelivery;
+
   transformEvent(input: z.infer<typeof gaecInputSchema>): TransformedEvent<ConversionAdjustment> {
     // Reuse the existing per-event transform untouched. It returns a delivery request whose
     // body.JSON is `{ conversionAdjustments: [<single adjustment>], partialFailure: true }`.

--- a/src/v0/destinations/iterable_audience/delivery.test.ts
+++ b/src/v0/destinations/iterable_audience/delivery.test.ts
@@ -1,0 +1,255 @@
+import { Integration as IterableAudienceIntegration } from './routerTransform';
+import {
+  handleDeliveryResponse,
+  resolveDeliverySpec,
+  toDeliveryV1Response,
+} from '../../../services/destination/nativeBatching/delivery';
+import type { DeliveryContext } from '../../../services/destination/nativeBatching/delivery';
+import { AudienceListStrategy } from '../../../v1/destinations/iterable_audience/strategies/audience-list';
+import type { DeliveryV1Response, ProxyMetdata, ProxyV1Request } from '../../../types';
+
+const DEST = 'ITERABLE_AUDIENCE';
+const SUBSCRIBE = 'https://api.iterable.com/api/lists/subscribe';
+const UNSUBSCRIBE = 'https://api.iterable.com/api/lists/unsubscribe';
+
+const job = (jobId: number): ProxyMetdata =>
+  ({
+    jobId,
+    attemptNum: 0,
+    userId: `u${jobId}`,
+    sourceId: 's1',
+    destinationId: 'd1',
+    workspaceId: 'w1',
+    secret: {},
+    dontBatch: false,
+  }) as ProxyMetdata;
+
+type Subscriber = { email?: string; userId?: string };
+
+const ctxFor = (
+  status: number,
+  response: unknown,
+  subscribers: Subscriber[],
+  endpoint = SUBSCRIBE,
+): DeliveryContext => ({
+  status,
+  response,
+  jobs: subscribers.map((_s, i) => job(i + 1)),
+  request: {
+    body: { JSON: { listId: 42, subscribers } },
+    endpoint,
+  } as unknown as ProxyV1Request,
+  destinationConfig: {},
+});
+
+const viaFramework = (ctx: DeliveryContext) => {
+  try {
+    const response = toDeliveryV1Response(
+      handleDeliveryResponse(IterableAudienceIntegration, ctx),
+      ctx,
+      DEST,
+    );
+    return {
+      threw: false,
+      codes: response.response.map((r) => r.statusCode),
+      errors: response.response.map((r) => r.error),
+    };
+  } catch (e: any) {
+    return { threw: true, status: e.status, authErrorCategory: e.authErrorCategory };
+  }
+};
+
+const viaLegacy = (ctx: DeliveryContext) => {
+  const strategy = new AudienceListStrategy();
+  try {
+    // `BaseStrategy.handleResponse` is declared `void` even though every concrete `handleSuccess`
+    // returns a DeliveryV1Response, so the result has to be re-stated rather than inferred.
+    const response = strategy.handleResponse({
+      destinationResponse: { status: ctx.status, response: ctx.response },
+      rudderJobMetadata: ctx.jobs,
+      destType: DEST,
+      destinationRequest: ctx.request,
+    }) as unknown as DeliveryV1Response;
+    return {
+      threw: false,
+      codes: response.response.map((r) => r.statusCode),
+      errors: response.response.map((r) => r.error),
+    };
+  } catch (e: any) {
+    return { threw: true, status: e.status, authErrorCategory: e.authErrorCategory };
+  }
+};
+
+const twoSubscribers: Subscriber[] = [{ email: 'a@x.com' }, { email: 'b@x.com' }];
+
+describe('iterable_audience delivery — parity with the AudienceListStrategy', () => {
+  const parityCases = [
+    {
+      name: '200 clean',
+      status: 200,
+      response: { successCount: 2, failCount: 0 },
+      subscribers: twoSubscribers,
+      endpoint: SUBSCRIBE,
+    },
+    {
+      name: '200 with an invalid email',
+      status: 200,
+      response: { failCount: 1, invalidEmails: ['b@x.com'] },
+      subscribers: twoSubscribers,
+      endpoint: SUBSCRIBE,
+    },
+    {
+      name: '200 with a GDPR-forgotten email — accepted, not aborted',
+      status: 200,
+      response: { failCount: 1, failedUpdates: { forgottenEmails: ['b@x.com'] } },
+      subscribers: twoSubscribers,
+      endpoint: SUBSCRIBE,
+    },
+    {
+      name: '200 notFound on unsubscribe — no-op success',
+      status: 200,
+      response: { failCount: 1, failedUpdates: { notFoundEmails: ['b@x.com'] } },
+      subscribers: twoSubscribers,
+      endpoint: UNSUBSCRIBE,
+    },
+    {
+      name: '200 with an invalid userId',
+      status: 200,
+      response: { failCount: 1, invalidUserIds: ['uid-2'] },
+      subscribers: [{ userId: 'uid-1' }, { userId: 'uid-2' }],
+      endpoint: SUBSCRIBE,
+    },
+    {
+      name: '401 auth failure',
+      status: 401,
+      response: { msg: 'bad key' },
+      subscribers: twoSubscribers,
+      endpoint: SUBSCRIBE,
+    },
+    {
+      name: '500 server error',
+      status: 500,
+      response: { msg: 'boom' },
+      subscribers: twoSubscribers,
+      endpoint: SUBSCRIBE,
+    },
+  ];
+
+  it.each(parityCases)(
+    'per-job codes and errors match: $name',
+    ({ status, response, subscribers, endpoint }) => {
+      const ctx = ctxFor(status, response, subscribers, endpoint);
+      const next = viaFramework(ctx);
+      const prev = viaLegacy(ctx);
+
+      expect(next.threw).toBe(prev.threw);
+      if (prev.threw) {
+        expect(next.status).toBe(prev.status);
+        expect(next.authErrorCategory ?? '').toBe(prev.authErrorCategory ?? '');
+        return;
+      }
+      expect(next.codes).toEqual(prev.codes);
+      expect(next.errors).toEqual(prev.errors);
+    },
+  );
+});
+
+describe('iterable_audience delivery — the two deliberate successes', () => {
+  it('accepts a GDPR-forgotten user as 200 rather than aborting', () => {
+    const ctx = ctxFor(
+      200,
+      { failCount: 1, failedUpdates: { forgottenEmails: ['b@x.com'] } },
+      twoSubscribers,
+    );
+    const result = toDeliveryV1Response(
+      handleDeliveryResponse(IterableAudienceIntegration, ctx),
+      ctx,
+      DEST,
+    );
+    expect(result.response.map((r) => r.statusCode)).toEqual([200, 200]);
+  });
+
+  it('treats notFound as success on unsubscribe but not on subscribe', () => {
+    const response = { failCount: 1, failedUpdates: { notFoundEmails: ['b@x.com'] } };
+
+    const unsub = ctxFor(200, response, twoSubscribers, UNSUBSCRIBE);
+    expect(
+      toDeliveryV1Response(
+        handleDeliveryResponse(IterableAudienceIntegration, unsub),
+        unsub,
+        DEST,
+      ).response.map((r) => r.statusCode),
+    ).toEqual([200, 200]);
+
+    // On subscribe the same payload is a real failure, which the shared checker reports.
+    const sub = ctxFor(200, response, twoSubscribers, SUBSCRIBE);
+    const subResult = toDeliveryV1Response(
+      handleDeliveryResponse(IterableAudienceIntegration, sub),
+      sub,
+      DEST,
+    );
+    expect(subResult.response[1].statusCode).toBe(400);
+  });
+
+  it('case-folds emails on both sides when matching identities', () => {
+    const ctx = ctxFor(200, { failCount: 1, failedUpdates: { forgottenEmails: ['B@X.COM'] } }, [
+      { email: 'a@x.com' },
+      { email: 'b@x.com' },
+    ]);
+    const result = toDeliveryV1Response(
+      handleDeliveryResponse(IterableAudienceIntegration, ctx),
+      ctx,
+      DEST,
+    );
+    expect(result.response.map((r) => r.statusCode)).toEqual([200, 200]);
+  });
+});
+
+describe('iterable_audience delivery — failureReason', () => {
+  const reasonFor = (response: unknown) =>
+    resolveDeliverySpec(IterableAudienceIntegration).failureReason({
+      ...ctxFor(500, {}, []),
+      response,
+    });
+
+  /**
+   * The legacy handler JSON-quoted everything it returned; the framework returns a string bare.
+   * Undoing just the quoting keeps the comparison about which field was *selected*, not how it
+   * was formatted. Parsing rather than stripping quotes textually keeps escapes intact.
+   */
+  const unquote = (json: string): string => {
+    const parsed: unknown = JSON.parse(json);
+    return typeof parsed === 'string' ? parsed : json;
+  };
+
+  const cases = [
+    // Structured `params` has no message of its own, so it is serialised — as the legacy handler
+    // did. A plain string is returned as-is rather than JSON-quoted.
+    { name: 'params', response: { params: { detail: 'p' } }, expected: '{"detail":"p"}' },
+    { name: 'msg', response: { msg: 'a message' }, expected: 'a message' },
+    { name: 'message', response: { message: 'another' }, expected: 'another' },
+    { name: 'a bare string body', response: 'Invalid API key', expected: 'Invalid API key' },
+    // Nothing recognisable: the body beats the old 'unknown error format' placeholder, which told
+    // whoever read the job's error nothing at all.
+    { name: 'nothing recognisable', response: { other: 1 }, expected: '{"other":1}' },
+  ];
+
+  it.each(cases)('reads $name', ({ response, expected }) => {
+    expect(reasonFor(response)).toBe(expected);
+  });
+
+  // Iterable's real envelope is `{ msg, code, params }` — both fields present at once. The legacy
+  // handler's `??` chain (`v1/destinations/iterable_audience/strategies/audience-list.ts`) takes
+  // `params` whenever it is non-null, including when it is empty. Pinned so the precedence
+  // cannot drift silently.
+  type IterableErrorBody = { msg?: string; message?: string; params?: unknown };
+
+  it.each<{ name: string; response: IterableErrorBody }>([
+    { name: 'populated params beats msg', response: { msg: 'generic', params: { bad: 'x' } } },
+    { name: 'even empty params beats msg', response: { msg: 'generic', params: {} } },
+    { name: 'null params yields to msg', response: { msg: 'generic', params: null } },
+  ])('$name', ({ response }) => {
+    const legacy = JSON.stringify(response.params ?? response.msg ?? response.message);
+    expect(reasonFor(response)).toBe(unquote(legacy));
+  });
+});

--- a/src/v0/destinations/iterable_audience/delivery.test.ts
+++ b/src/v0/destinations/iterable_audience/delivery.test.ts
@@ -1,5 +1,6 @@
 import { Integration as IterableAudienceIntegration } from './routerTransform';
 import {
+  firstJobIdentity,
   handleDeliveryResponse,
   resolveDeliverySpec,
   toDeliveryV1Response,
@@ -31,16 +32,20 @@ const ctxFor = (
   response: unknown,
   subscribers: Subscriber[],
   endpoint = SUBSCRIBE,
-): DeliveryContext => ({
-  status,
-  response,
-  jobs: subscribers.map((_s, i) => job(i + 1)),
-  request: {
-    body: { JSON: { listId: 42, subscribers } },
-    endpoint,
-  } as unknown as ProxyV1Request,
-  destinationConfig: {},
-});
+): DeliveryContext => {
+  const jobs = subscribers.map((_s, i) => job(i + 1));
+  return {
+    status,
+    response,
+    jobs,
+    request: {
+      body: { JSON: { listId: 42, subscribers } },
+      endpoint,
+    } as unknown as ProxyV1Request,
+    destinationConfig: {},
+    ...firstJobIdentity(jobs),
+  };
+};
 
 const viaFramework = (ctx: DeliveryContext) => {
   try {

--- a/src/v0/destinations/iterable_audience/delivery.ts
+++ b/src/v0/destinations/iterable_audience/delivery.ts
@@ -101,8 +101,8 @@ const iterableAudienceStatusOverrides: StatusOverrideMap = {
       if (matchesIdentifier(subscriber, forgotten)) {
         stats.counter('iterable_forgotten_user_violations', 1, {
           destType: 'ITERABLE_AUDIENCE',
-          destinationId: ctx.jobs[0]?.destinationId ?? '',
-          workspaceId: ctx.jobs[0]?.workspaceId ?? '',
+          destinationId: ctx.destinationId,
+          workspaceId: ctx.workspaceId,
           identifierType: subscriber.email ? 'email' : 'userId',
           // NEVER tag the identifier VALUE — it is GDPR-protected.
         });

--- a/src/v0/destinations/iterable_audience/delivery.ts
+++ b/src/v0/destinations/iterable_audience/delivery.ts
@@ -1,0 +1,130 @@
+/**
+ * Delivery handling for Iterable audience list subscribe/unsubscribe.
+ *
+ * Iterable's bulk list APIs answer a partially-failed request with HTTP 200 and a `failedUpdates`
+ * object naming the *identities* that failed — no indices anywhere. So correlation is content-keyed:
+ * each subscriber in the request body is tested against those identity sets.
+ *
+ * Two branches deliberately report success where a naive reading would abort:
+ *
+ *  - a GDPR-forgotten user can never be delivered, so retrying or aborting is pointless noise;
+ *    it is counted and accepted.
+ *  - `notFound` on an unsubscribe means the user was already off the list, which is the outcome
+ *    the request asked for.
+ *
+ * Keyed on '2xx' rather than 200 because the check this replaces is `isHttpStatusSuccess(status)`
+ * (BaseStrategy.handleResponse). The non-2xx path needs no entry: the framework's own
+ * classification already aborts a 401 and retries a 500, with no auth inference — which is what
+ * the legacy handler's empty `authErrorCategory` was expressing, Iterable list APIs being
+ * Api-Key authenticated rather than OAuth.
+ *
+ * NOTE: `src/v1/destinations/iterable_audience/` keeps its strategy while the delivery path is
+ * still resolved through networkHandlerFactory. Both are deleted together when the framework owns
+ * delivery for this destination.
+ */
+import {
+  abort,
+  perItem,
+  success,
+  type DeliverySpec,
+  type ItemVerdict,
+  type StatusOverrideMap,
+} from '../../../services/destination/nativeBatching/batchDestination';
+import { createBatchErrorChecker } from '../../../v1/destinations/iterable/utils';
+import type { IterableSubscriber } from '../../../v1/destinations/iterable_audience/types';
+import { UNSUBSCRIBE_CATEGORY } from './config';
+
+const stats = require('../../../util/stats');
+
+type IdentifierLookups = { emails: Set<string>; userIds: Set<string> };
+
+/** Emails are case-folded on both sides, mirroring Iterable's server-side lowercasing. */
+const lookupsFrom = (
+  emails: string[] | undefined,
+  userIds: string[] | undefined,
+): IdentifierLookups => ({
+  emails: new Set((emails ?? []).map((v) => v.toLowerCase())),
+  userIds: new Set(userIds ?? []),
+});
+
+/** A subscriber may carry both identifiers (hybrid projects) — a match on either one counts. */
+const matchesIdentifier = (subscriber: IterableSubscriber, lookups: IdentifierLookups): boolean =>
+  (subscriber.email ? lookups.emails.has(subscriber.email.toLowerCase()) : false) ||
+  (subscriber.userId ? lookups.userIds.has(subscriber.userId) : false);
+
+/**
+ * Iterable's error envelope is `{ msg, code, params }`.
+ *
+ * `params` wins over `msg` even when both are present — the structured detail names the offending
+ * identifiers, where `msg` is a generic summary. That precedence is the legacy handler's `??`
+ * chain (`v1/destinations/iterable_audience/strategies/audience-list.ts`), kept deliberately.
+ *
+ * One difference from that handler: a string is returned bare rather than JSON-quoted.
+ */
+export const extractIterableAudienceErrorMessage = (response: unknown): string => {
+  const body = response as { params?: unknown; msg?: unknown; message?: unknown } | undefined;
+  // The trailing `?? response` is the framework default the legacy handler lacked: a body with
+  // none of these fields is shown whole rather than replaced by a placeholder that says nothing.
+  const message = body?.params ?? body?.msg ?? body?.message ?? response;
+  if (typeof message === 'string') return message || 'unknown error format';
+  return JSON.stringify(message) ?? 'unknown error format';
+};
+
+const iterableAudienceStatusOverrides: StatusOverrideMap = {
+  '2xx': (ctx) => {
+    const requestBody = ctx.request.body?.JSON as
+      | { subscribers?: IterableSubscriber[] }
+      | undefined;
+    const subscribers = requestBody?.subscribers ?? [];
+
+    const failedUpdates = (
+      ctx.response as {
+        failedUpdates?: {
+          forgottenEmails?: string[];
+          forgottenUserIds?: string[];
+          notFoundEmails?: string[];
+          notFoundUserIds?: string[];
+        };
+      }
+    )?.failedUpdates;
+
+    const forgotten = lookupsFrom(failedUpdates?.forgottenEmails, failedUpdates?.forgottenUserIds);
+    const notFound = lookupsFrom(failedUpdates?.notFoundEmails, failedUpdates?.notFoundUserIds);
+    const isUnsubscribe = (ctx.request.endpoint ?? '').includes(UNSUBSCRIBE_CATEGORY.endpoint);
+    const checkEventError = createBatchErrorChecker({
+      status: ctx.status,
+      response: ctx.response,
+    } as never);
+
+    const verdicts: ItemVerdict[] = subscribers.map((subscriber) => {
+      // 1. GDPR-forgotten user → success + metric. Can never be retried successfully.
+      if (matchesIdentifier(subscriber, forgotten)) {
+        stats.counter('iterable_forgotten_user_violations', 1, {
+          destType: 'ITERABLE_AUDIENCE',
+          destinationId: ctx.jobs[0]?.destinationId ?? '',
+          workspaceId: ctx.jobs[0]?.workspaceId ?? '',
+          identifierType: subscriber.email ? 'email' : 'userId',
+          // NEVER tag the identifier VALUE — it is GDPR-protected.
+        });
+        return success();
+      }
+
+      // 2. notFound on unsubscribe → no-op success; the user was already off the list.
+      if (isUnsubscribe && matchesIdentifier(subscriber, notFound)) return success();
+
+      // 3. Everything else goes to the shared abortability check.
+      const { isAbortable, errorMsg } = checkEventError({
+        email: subscriber.email ? subscriber.email.toLowerCase() : undefined,
+        userId: subscriber.userId,
+      });
+      return isAbortable ? abort(errorMsg) : success();
+    });
+
+    return perItem(verdicts);
+  },
+};
+
+export const iterableAudienceDelivery: DeliverySpec = {
+  statusOverrides: iterableAudienceStatusOverrides,
+  failureReason: (ctx) => extractIterableAudienceErrorMessage(ctx.response),
+};

--- a/src/v0/destinations/iterable_audience/routerTransform.ts
+++ b/src/v0/destinations/iterable_audience/routerTransform.ts
@@ -20,6 +20,7 @@ import {
   buildUnsubscribeBody,
   selectIdentifierForRow,
 } from './utils';
+import { iterableAudienceDelivery } from './delivery';
 import {
   IterableAudienceRouterRequestSchema,
   type IterableAudiencePayload,
@@ -30,6 +31,9 @@ class IterableAudienceIntegration extends BatchDestination<
   IterableAudiencePayload,
   typeof IterableAudienceRouterRequestSchema
 > {
+  // Partial failure arrives on a 2xx keyed by identity; see ./delivery.
+  static readonly delivery = iterableAudienceDelivery;
+
   // Headers are constant per (destination + connection) — build once.
   private readonly headers: Record<string, string>;
 

--- a/src/v0/destinations/test_destination/delivery.test.ts
+++ b/src/v0/destinations/test_destination/delivery.test.ts
@@ -1,0 +1,111 @@
+// ⚠️ DEV-ONLY TEST FIXTURE — NOT A REAL DESTINATION (INT-6492). See config.ts.
+//
+// test_destination declares no `delivery` spec: its network handler composes
+// genericNetworkHandler and replaces only `proxy`, so the framework's own classification already
+// is its response behaviour. These tests hold that equivalence, so the day it stops being true is
+// the day one of them fails rather than the day delivery quietly changes.
+import { Integration as TestDestinationIntegration } from './routerTransform';
+import {
+  handleDeliveryResponse,
+  resolveDeliverySpec,
+  toDeliveryV1Response,
+} from '../../../services/destination/nativeBatching/delivery';
+import type { DeliveryContext } from '../../../services/destination/nativeBatching/delivery';
+import { networkHandler as genericNetworkHandler } from '../../../adapters/networkhandler/genericNetworkHandler';
+import type { ProxyMetdata, ProxyV1Request } from '../../../types';
+
+const DEST = 'test_destination';
+
+const job = (jobId: number): ProxyMetdata =>
+  ({
+    jobId,
+    attemptNum: 0,
+    userId: `u${jobId}`,
+    sourceId: 's1',
+    destinationId: 'd1',
+    workspaceId: 'w1',
+    secret: {},
+    dontBatch: false,
+  }) as ProxyMetdata;
+
+const ctxFor = (status: number, response: unknown): DeliveryContext => ({
+  status,
+  response,
+  jobs: [job(1), job(2)],
+  request: { body: { JSON: {} }, endpoint: 'https://example.test/v1' } as ProxyV1Request,
+  destinationConfig: {},
+});
+
+/** The part of the receiver `genericNetworkHandler.call(...)` populates that this test drives. */
+type GenericHandler = {
+  responseHandler: (params: {
+    destinationResponse: { status: number; response: unknown };
+    destType: string;
+    rudderJobMetadata: ProxyMetdata[];
+  }) => { status: number; message: string; destinationResponse: unknown };
+};
+
+const viaGeneric = (ctx: DeliveryContext) => {
+  const handler = {} as GenericHandler;
+  (genericNetworkHandler as (this: GenericHandler) => void).call(handler);
+  try {
+    const response = handler.responseHandler({
+      destinationResponse: { status: ctx.status, response: ctx.response },
+      destType: DEST,
+      rudderJobMetadata: ctx.jobs,
+    });
+    return { threw: false, status: response.status };
+  } catch (e: any) {
+    return { threw: true, status: e.status, errorType: e.statTags?.errorType };
+  }
+};
+
+const viaFramework = (ctx: DeliveryContext) => {
+  try {
+    const response = toDeliveryV1Response(
+      handleDeliveryResponse(TestDestinationIntegration, ctx),
+      ctx,
+      DEST,
+    );
+    return {
+      threw: false,
+      status: response.status,
+      codes: response.response.map((r) => r.statusCode),
+    };
+  } catch (e: any) {
+    return { threw: true, status: e.status, errorType: e.statTags?.errorType };
+  }
+};
+
+describe('test_destination delivery', () => {
+  it('declares no statusOverrides anywhere in its chain', () => {
+    expect(resolveDeliverySpec(TestDestinationIntegration).statusOverrides).toEqual({});
+  });
+
+  const cases = [
+    { name: '200 success', status: 200, response: { ok: true } },
+    { name: '201 success', status: 201, response: { ok: true } },
+    { name: '400 abort', status: 400, response: { msg: 'bad' } },
+    { name: '429 throttled', status: 429, response: { msg: 'slow' } },
+    { name: '500 retry', status: 500, response: { msg: 'boom' } },
+    { name: '502 retry', status: 502, response: { msg: 'gateway' } },
+  ];
+
+  it.each(cases)('matches genericNetworkHandler on $name', ({ status, response }) => {
+    const ctx = ctxFor(status, response);
+    const generic = viaGeneric(ctx);
+    const framework = viaFramework(ctx);
+
+    expect(framework.threw).toBe(generic.threw);
+    expect(framework.status).toBe(generic.status);
+    if (generic.threw) {
+      // Same classification: the generic handler throws NetworkError, the framework throws
+      // TransformerProxyError, and both reach the same generateErrorObject path.
+      expect(framework.errorType).toBe(generic.errorType);
+    }
+  });
+
+  it('reports every job as delivered on a success', () => {
+    expect(viaFramework(ctxFor(200, { ok: true })).codes).toEqual([200, 200]);
+  });
+});

--- a/src/v0/destinations/test_destination/delivery.test.ts
+++ b/src/v0/destinations/test_destination/delivery.test.ts
@@ -6,6 +6,7 @@
 // the day one of them fails rather than the day delivery quietly changes.
 import { Integration as TestDestinationIntegration } from './routerTransform';
 import {
+  firstJobIdentity,
   handleDeliveryResponse,
   resolveDeliverySpec,
   toDeliveryV1Response,
@@ -28,13 +29,17 @@ const job = (jobId: number): ProxyMetdata =>
     dontBatch: false,
   }) as ProxyMetdata;
 
-const ctxFor = (status: number, response: unknown): DeliveryContext => ({
-  status,
-  response,
-  jobs: [job(1), job(2)],
-  request: { body: { JSON: {} }, endpoint: 'https://example.test/v1' } as ProxyV1Request,
-  destinationConfig: {},
-});
+const ctxFor = (status: number, response: unknown): DeliveryContext => {
+  const jobs = [job(1), job(2)];
+  return {
+    status,
+    response,
+    jobs,
+    request: { body: { JSON: {} }, endpoint: 'https://example.test/v1' } as ProxyV1Request,
+    destinationConfig: {},
+    ...firstJobIdentity(jobs),
+  };
+};
 
 /** The part of the receiver `genericNetworkHandler.call(...)` populates that this test drives. */
 type GenericHandler = {

--- a/src/v1/destinations/braze_audience/networkHandler.ts
+++ b/src/v1/destinations/braze_audience/networkHandler.ts
@@ -5,31 +5,11 @@ import { TransformerProxyError } from '../../../v0/util/errorTypes';
 import tags from '../../../v0/util/tags';
 import stats from '../../../util/stats';
 import type { DeliveryJobState, DeliveryV1Response, ProxyMetdata } from '../../../types';
+import { isIdentityAborted } from '../../../v0/destinations/braze_audience/utils';
 
 const DEST = 'BRAZE_AUDIENCE';
 
-/**
- * Permanent Braze `/users/track` identity error `type` values.
- * Docs list uppercase enums; live `/users/track/bulk` often returns human
- * messages (e.g. "'external_id' must be fewer than 988 bytes") instead.
- */
-const ABORTED_IDENTITY_TYPES = new Set([
-  'BLACKLISTED_EXTERNAL_USER_ID',
-  'EXTERNAL_USER_ID_TOO_LARGE',
-]);
-
-const isIdentityAborted = (type?: string): boolean => {
-  if (!type) return false;
-  if (ABORTED_IDENTITY_TYPES.has(type)) return true;
-  // Live Braze message forms for permanent identity failures (not retryable).
-  return (
-    /external_user_id_too_large|blacklisted_external_user_id/i.test(type) ||
-    /external_id.*(?:fewer|bytes|too\s*large|blacklist)/i.test(type) ||
-    /blacklist(?:ed)?.*external_id/i.test(type)
-  );
-};
-
-type BrazeAudienceProxyParams = {
+export type BrazeAudienceProxyParams = {
   destinationResponse: {
     response?: {
       message?: string;

--- a/test/integrations/component.live.test.ts
+++ b/test/integrations/component.live.test.ts
@@ -83,6 +83,22 @@ describe('Live Integration Test Suite', () => {
   // One describe per enrolled destination: resolve its credentials and base config, then run its
   // enabled scenarios. A missing/invalid secret throws here (fail-closed), failing the destination.
   describe.each(enrolledDestinations)('$destination', ({ destination, spec }) => {
+    // Applied around the whole destination rather than per scenario: the flags a live spec names
+    // gate the transform and delivery paths themselves, so every scenario has to run under them.
+    const envManager = new EnvManager();
+    beforeAll(() => {
+      if (spec.envOverrides) {
+        envManager.takeSnapshot(destination, Object.keys(spec.envOverrides));
+        envManager.applyOverrides(spec.envOverrides);
+      }
+    });
+    afterAll(() => {
+      if (spec.envOverrides) {
+        envManager.restoreSnapshot(destination);
+      }
+      envManager.cleanup();
+    });
+
     const liveSecret: LiveSecret = resolver.resolve(destination);
 
     beforeAll(async () => {

--- a/test/integrations/destinations/braze_audience/dataDelivery/data.ts
+++ b/test/integrations/destinations/braze_audience/dataDelivery/data.ts
@@ -19,7 +19,11 @@ import {
   serverErrorResponse,
 } from './network';
 
-const SUCCESS_MESSAGE = '[BRAZE_AUDIENCE Response Handler] - Request Processed Successfully';
+// Messages produced by the batching framework's delivery bridge, which owns response handling for
+// this destination once BRAZE_AUDIENCE_BATCHING_FRAMEWORK_DELIVERY_ENABLED_WORKSPACE_IDS is set.
+const FRAMEWORK_SUCCESS_MESSAGE = '[BRAZE_AUDIENCE] Request processed successfully';
+// A mixed batch keeps Braze's own status (201) and reports the first real failure reason.
+const frameworkFailure = (reason: string) => `[BRAZE_AUDIENCE] ${reason}`;
 
 const proxyPayload = (
   JSON: Record<string, unknown>,
@@ -35,7 +39,7 @@ const proxyPayload = (
     metadata,
   );
 
-export const data: ProxyV1TestData[] = [
+const scenarios: ProxyV1TestData[] = [
   {
     id: 'braze_audience_v1_bulk_full_success',
     name: destType,
@@ -57,8 +61,7 @@ export const data: ProxyV1TestData[] = [
         body: {
           output: {
             status: 201,
-            message: SUCCESS_MESSAGE,
-            destinationResponse: { status: 201, response: successResponse },
+            message: FRAMEWORK_SUCCESS_MESSAGE,
             response: [
               { statusCode: 200, metadata: generateMetadata(1), error: 'success' },
               { statusCode: 200, metadata: generateMetadata(2), error: 'success' },
@@ -93,8 +96,7 @@ export const data: ProxyV1TestData[] = [
         body: {
           output: {
             status: 201,
-            message: SUCCESS_MESSAGE,
-            destinationResponse: { status: 201, response: partialIdentityResponse },
+            message: frameworkFailure('EXTERNAL_USER_ID_TOO_LARGE'),
             response: [
               { statusCode: 200, metadata: generateMetadata(1), error: 'success' },
               {
@@ -130,8 +132,7 @@ export const data: ProxyV1TestData[] = [
         body: {
           output: {
             status: 201,
-            message: SUCCESS_MESSAGE,
-            destinationResponse: { status: 201, response: partialRetryableResponse },
+            message: frameworkFailure('SOME_TRANSIENT_ATTR_ERROR'),
             response: [
               {
                 statusCode: 500,
@@ -166,7 +167,7 @@ export const data: ProxyV1TestData[] = [
         body: {
           output: {
             status: 401,
-            message: 'BRAZE_AUDIENCE: Error during response transformation. "Invalid API key"',
+            message: frameworkFailure('Invalid API key'),
             statTags: {
               destType: 'BRAZE_AUDIENCE',
               errorCategory: 'network',
@@ -210,7 +211,7 @@ export const data: ProxyV1TestData[] = [
         body: {
           output: {
             status: 429,
-            message: 'BRAZE_AUDIENCE: Error during response transformation. "Rate limited"',
+            message: frameworkFailure('Rate limited'),
             statTags: {
               destType: 'BRAZE_AUDIENCE',
               errorCategory: 'network',
@@ -254,8 +255,7 @@ export const data: ProxyV1TestData[] = [
         body: {
           output: {
             status: 500,
-            message:
-              'BRAZE_AUDIENCE: Error during response transformation. "Internal server error"',
+            message: frameworkFailure('Internal server error'),
             statTags: {
               destType: 'BRAZE_AUDIENCE',
               errorCategory: 'network',
@@ -284,3 +284,15 @@ export const data: ProxyV1TestData[] = [
     },
   },
 ];
+
+/**
+ * BRAZE_AUDIENCE is already GA for the batching-framework transform, so only the delivery flag is
+ * needed to move these scenarios onto the framework response path.
+ */
+export const data = scenarios.map((scenario) => ({
+  ...scenario,
+  envOverrides: {
+    ...scenario.envOverrides,
+    BRAZE_AUDIENCE_BATCHING_FRAMEWORK_DELIVERY_ENABLED_WORKSPACE_IDS: 'ALL',
+  },
+}));

--- a/test/integrations/destinations/braze_audience/live/spec.ts
+++ b/test/integrations/destinations/braze_audience/live/spec.ts
@@ -54,6 +54,12 @@ const verifyMembership =
 export const live = {
   enabled: true,
   authType: 'apiKey',
+  // braze_audience is GA for the batching-framework transform, so only delivery needs naming.
+  // Without this the live run would deliver through v1/destinations/braze_audience/networkHandler
+  // and prove nothing about the path this destination is moving to.
+  envOverrides: {
+    BRAZE_AUDIENCE_BATCHING_FRAMEWORK_DELIVERY_ENABLED_WORKSPACE_IDS: 'ALL',
+  },
   resolveConfig: (s) => ({
     // Account: REST key + data center (US-01…08 / EU-01…03 / AU-01).
     ...s.config,

--- a/test/integrations/destinations/customerio/dataDelivery/data.ts
+++ b/test/integrations/destinations/customerio/dataDelivery/data.ts
@@ -49,7 +49,7 @@ export const v1BusinessTestScenarios: ProxyV1TestData[] = [
         body: {
           output: {
             status: 200,
-            message: '[CustomerIO Response Handler] - Request Processed Successfully',
+            message: '[CUSTOMERIO] Request processed successfully',
             response: [{ statusCode: 200, metadata: generateMetadata(1), error: 'success' }],
           },
         },
@@ -101,7 +101,8 @@ export const v1BusinessTestScenarios: ProxyV1TestData[] = [
         body: {
           output: {
             status: 207,
-            message: '[CustomerIO Response Handler] - Batch completed with partial failures',
+            message:
+              '[CUSTOMERIO] reason: invalid, field: attributes.plan, message: property value cannot be longer than 1000 bytes',
             response: [
               { statusCode: 200, metadata: generateMetadata(1), error: 'success' },
               {
@@ -158,8 +159,7 @@ export const v1BusinessTestScenarios: ProxyV1TestData[] = [
               destinationId: 'default-destinationId',
               workspaceId: 'default-workspaceId',
             },
-            message:
-              '[CustomerIO Response Handler] - Error in transformer proxy during CustomerIO response transformation',
+            message: '[CUSTOMERIO] [Generic Response Handler] Request failed with status: 400',
             response: [
               {
                 error: JSON.stringify({ message: 'Bad Request' }),
@@ -175,10 +175,10 @@ export const v1BusinessTestScenarios: ProxyV1TestData[] = [
   {
     id: 'customerio_dataDelivery_401',
     name: 'customerio',
-    description: '[401] Auth failure — TransformerProxyError with REFRESH_TOKEN',
+    description: '[401] Auth failure — TransformerProxyError, no auth error category',
     feature: 'dataDelivery',
     scenario: 'business',
-    successCriteria: 'Should surface 401 with REFRESH_TOKEN auth error category',
+    successCriteria: 'Should surface the 401 per job, with no authErrorCategory',
     module: 'destination',
     version: 'v1',
     input: {
@@ -200,11 +200,12 @@ export const v1BusinessTestScenarios: ProxyV1TestData[] = [
     },
     output: {
       response: {
-        status: 401,
+        // 200, not 401: the controller only propagates the delivery status to the HTTP response
+        // when authErrorCategory is set, and the framework no longer infers one from a 401.
+        status: 200,
         body: {
           output: {
             status: 401,
-            authErrorCategory: 'REFRESH_TOKEN',
             statTags: {
               destType: 'CUSTOMERIO',
               errorCategory: 'network',
@@ -215,8 +216,7 @@ export const v1BusinessTestScenarios: ProxyV1TestData[] = [
               destinationId: 'default-destinationId',
               workspaceId: 'default-workspaceId',
             },
-            message:
-              '[CustomerIO Response Handler] - Error in transformer proxy during CustomerIO response transformation',
+            message: '[CUSTOMERIO] [Generic Response Handler] Request failed with status: 401',
             response: [
               {
                 error: JSON.stringify({ message: 'Unauthorized' }),
@@ -231,4 +231,18 @@ export const v1BusinessTestScenarios: ProxyV1TestData[] = [
   },
 ];
 
-export const data = [...v1BusinessTestScenarios];
+/**
+ * These scenarios run through the batching framework's delivery path rather than
+ * `v1/destinations/customerio/networkHandler`. The transform flag is required because
+ * `isBatchingFrameworkDeliveryEnabled` refuses to enable delivery without it, and customerio is
+ * not yet GA for batching so it does not get that flag implicitly.
+ */
+const batchingFrameworkDelivery = {
+  CUSTOMERIO_BATCHING_FRAMEWORK_ENABLED_WORKSPACE_IDS: 'ALL',
+  CUSTOMERIO_BATCHING_FRAMEWORK_DELIVERY_ENABLED_WORKSPACE_IDS: 'ALL',
+};
+
+export const data = v1BusinessTestScenarios.map((scenario) => ({
+  ...scenario,
+  envOverrides: { ...scenario.envOverrides, ...batchingFrameworkDelivery },
+}));

--- a/test/integrations/destinations/google_adwords_enhanced_conversions/dataDelivery/business.ts
+++ b/test/integrations/destinations/google_adwords_enhanced_conversions/dataDelivery/business.ts
@@ -237,7 +237,7 @@ export const testScenariosForV1API: ProxyV1TestData[] = [
         status: 200,
         body: {
           output: {
-            message: 'Request Processed Successfully',
+            message: '[GOOGLE_ADWORDS_ENHANCED_CONVERSIONS] Request processed successfully',
             response: [
               {
                 error: 'success',
@@ -286,36 +286,13 @@ export const testScenariosForV1API: ProxyV1TestData[] = [
         status: 200,
         body: {
           output: {
+            status: 200,
             message:
-              '[Google Ads Enhanced Conversions]:: Conversion already has enhancements with the same Order ID and conversion action. Make sure your data is correctly configured and try again., at conversion_adjustments[0]',
-            destinationResponse: {
-              response: {
-                partialFailureError: {
-                  code: 3,
-                  message:
-                    'Conversion already has enhancements with the same Order ID and conversion action. Make sure your data is correctly configured and try again., at conversion_adjustments[0]',
-                  details: [
-                    {
-                      '@type':
-                        'type.googleapis.com/google.ads.googleads.v15.errors.GoogleAdsFailure',
-                      errors: [
-                        {
-                          errorCode: {
-                            conversionAdjustmentUploadError: 'CONVERSION_ALREADY_ENHANCED',
-                          },
-                          message:
-                            'Conversion already has enhancements with the same Order ID and conversion action. Make sure your data is correctly configured and try again.',
-                          location: {
-                            fieldPathElements: [{ fieldName: 'conversion_adjustments', index: 0 }],
-                          },
-                        },
-                      ],
-                    },
-                  ],
-                },
-              },
-              status: 200,
-            },
+              '[GOOGLE_ADWORDS_ENHANCED_CONVERSIONS] Conversion already has enhancements with the same Order ID and conversion action. Make sure your data is correctly configured and try again., at conversion_adjustments[0]',
+            // Every adjustment in this batch failed, the same way, so the response still carries
+            // the whole-response tag set for `integration.failure_detailed` — byte-identical to
+            // what the legacy handler emitted.
+            statTags: expectedStatTags,
             response: [
               {
                 error:
@@ -324,8 +301,6 @@ export const testScenariosForV1API: ProxyV1TestData[] = [
                 statusCode: 400,
               },
             ],
-            statTags: expectedStatTags,
-            status: 400,
           },
         },
       },
@@ -431,12 +406,20 @@ export const testScenariosForV1API: ProxyV1TestData[] = [
         body: {
           output: {
             authErrorCategory: 'REFRESH_TOKEN',
+            // The framework surfaces the destination's own error message rather than appending
+            // ' during <destType> response transformation' to it.
             message:
-              'Request had invalid authentication credentials. Expected OAuth 2 access token, login cookie or other valid authentication credential. See https://developers.google.com/identity/sign-in/web/devconsole-project. during Google_adwords_enhanced_conversions response transformation',
+              '[GOOGLE_ADWORDS_ENHANCED_CONVERSIONS] Request had invalid authentication credentials. Expected OAuth 2 access token, login cookie or other valid authentication credential. See https://developers.google.com/identity/sign-in/web/devconsole-project.',
             response: [
               {
-                error:
-                  'Request had invalid authentication credentials. Expected OAuth 2 access token, login cookie or other valid authentication credential. See https://developers.google.com/identity/sign-in/web/devconsole-project. during Google_adwords_enhanced_conversions response transformation',
+                error: JSON.stringify({
+                  error: {
+                    code: 401,
+                    message:
+                      'Request had invalid authentication credentials. Expected OAuth 2 access token, login cookie or other valid authentication credential. See https://developers.google.com/identity/sign-in/web/devconsole-project.',
+                    status: 'UNAUTHENTICATED',
+                  },
+                }),
                 metadata: {
                   attemptNum: 1,
                   destinationId: 'default-destinationId',
@@ -452,7 +435,9 @@ export const testScenariosForV1API: ProxyV1TestData[] = [
                 statusCode: 401,
               },
             ],
-            statTags: expectedStatTags,
+            // REFRESH_TOKEN asks rudder-server to refresh and redeliver, so the framework derives
+            // 'retryable' from the verdict. The legacy handler tagged the same response 'aborted'.
+            statTags: { ...expectedStatTags, errorType: 'retryable' },
             status: 401,
           },
         },
@@ -551,45 +536,9 @@ export const testScenariosForV1API: ProxyV1TestData[] = [
         status: 200,
         body: {
           output: {
+            status: 200,
             message:
-              '[Google Ads Enhanced Conversions]:: Conversion already has enhancements with the same Order ID and conversion action. Make sure your data is correctly configured and try again., at conversion_adjustments[1]',
-            destinationResponse: {
-              response: {
-                partialFailureError: {
-                  code: 3,
-                  message:
-                    'Conversion already has enhancements with the same Order ID and conversion action. Make sure your data is correctly configured and try again., at conversion_adjustments[1]',
-                  details: [
-                    {
-                      '@type':
-                        'type.googleapis.com/google.ads.googleads.v15.errors.GoogleAdsFailure',
-                      errors: [
-                        {
-                          errorCode: {
-                            conversionAdjustmentUploadError: 'CONVERSION_ALREADY_ENHANCED',
-                          },
-                          message:
-                            'Conversion already has enhancements with the same Order ID and conversion action. Make sure your data is correctly configured and try again.',
-                          location: {
-                            fieldPathElements: [{ fieldName: 'conversion_adjustments', index: 1 }],
-                          },
-                        },
-                      ],
-                    },
-                  ],
-                },
-                results: [
-                  {
-                    adjustmentType: 'ENHANCEMENT',
-                    conversionAction: 'customers/1234567777/conversionActions/123434350',
-                    adjustmentDateTime: '2022-01-01 12:32:45-08:00',
-                    orderId: '10000',
-                  },
-                  {},
-                ],
-              },
-              status: 200,
-            },
+              '[GOOGLE_ADWORDS_ENHANCED_CONVERSIONS] Conversion already has enhancements with the same Order ID and conversion action. Make sure your data is correctly configured and try again., at conversion_adjustments[1]',
             response: [
               {
                 error: 'success',
@@ -603,8 +552,6 @@ export const testScenariosForV1API: ProxyV1TestData[] = [
                 statusCode: 400,
               },
             ],
-            statTags: expectedStatTags,
-            status: 400,
           },
         },
       },

--- a/test/integrations/destinations/google_adwords_enhanced_conversions/dataDelivery/data.ts
+++ b/test/integrations/destinations/google_adwords_enhanced_conversions/dataDelivery/data.ts
@@ -1,9 +1,29 @@
 import { v0oauthScenarios, v1oauthScenarios } from './oauth';
 import { testScenariosForV0API, testScenariosForV1API } from './business';
+import { EnvOverride } from '../../../envUtils';
+
+/**
+ * gaec is not GA for the batching framework, so the transform flag has to be set alongside the
+ * delivery one — `isBatchingFrameworkDeliveryEnabled` returns false without it.
+ *
+ * Applied to the v0 scenarios too, harmlessly: the framework branch is guarded on the request
+ * carrying a metadata *array*, which only the v1 proxy route produces, so those stay on the legacy
+ * handler and continue to assert its behaviour.
+ */
+const batchingFrameworkDelivery = {
+  GOOGLE_ADWORDS_ENHANCED_CONVERSIONS_BATCHING_FRAMEWORK_ENABLED_WORKSPACE_IDS: 'ALL',
+  GOOGLE_ADWORDS_ENHANCED_CONVERSIONS_BATCHING_FRAMEWORK_DELIVERY_ENABLED_WORKSPACE_IDS: 'ALL',
+};
 
 export const data = [
   ...v0oauthScenarios,
   ...v1oauthScenarios,
   ...testScenariosForV0API,
   ...testScenariosForV1API,
-];
+].map((scenario) => ({
+  ...scenario,
+  envOverrides: {
+    ...(scenario as { envOverrides?: EnvOverride }).envOverrides,
+    ...batchingFrameworkDelivery,
+  },
+}));

--- a/test/integrations/destinations/google_adwords_enhanced_conversions/dataDelivery/data.ts
+++ b/test/integrations/destinations/google_adwords_enhanced_conversions/dataDelivery/data.ts
@@ -3,27 +3,46 @@ import { testScenariosForV0API, testScenariosForV1API } from './business';
 import { EnvOverride } from '../../../envUtils';
 
 /**
- * gaec is not GA for the batching framework, so the transform flag has to be set alongside the
- * delivery one — `isBatchingFrameworkDeliveryEnabled` returns false without it.
+ * Only the delivery flag is load-bearing here.
  *
- * Applied to the v0 scenarios too, harmlessly: the framework branch is guarded on the request
- * carrying a metadata *array*, which only the v1 proxy route produces, so those stay on the legacy
- * handler and continue to assert its behaviour.
+ * gaec is already **GA** for the batching framework's transform path — `features.ts` declares
+ * `{ routerTransform: true, batching: true }` and `getBatchingFrameworkGaDestinations()` reads
+ * `batching`, so `isBatchingFrameworkEnabled` returns true before any env var is consulted.
+ * Setting `GOOGLE_ADWORDS_ENHANCED_CONVERSIONS_BATCHING_FRAMEWORK_ENABLED_WORKSPACE_IDS` would do
+ * nothing; a pre-GA destination is the one that needs it, because
+ * `isBatchingFrameworkDeliveryEnabled` short-circuits on the transform flag.
+ *
+ * Applied to the v0 scenarios harmlessly: the framework branch is guarded on the request carrying
+ * a metadata *array*, which only the v1 proxy route produces, so those stay on the legacy handler
+ * and continue to assert its behaviour — which is itself the assertion that the shape guard works.
  */
 const batchingFrameworkDelivery = {
-  GOOGLE_ADWORDS_ENHANCED_CONVERSIONS_BATCHING_FRAMEWORK_ENABLED_WORKSPACE_IDS: 'ALL',
   GOOGLE_ADWORDS_ENHANCED_CONVERSIONS_BATCHING_FRAMEWORK_DELIVERY_ENABLED_WORKSPACE_IDS: 'ALL',
 };
 
-export const data = [
-  ...v0oauthScenarios,
-  ...v1oauthScenarios,
-  ...testScenariosForV0API,
-  ...testScenariosForV1API,
-].map((scenario) => ({
+/**
+ * The oauth scenarios are deliberately **not** enrolled.
+ *
+ * Every one of them makes `gaecProxyRequest` throw inside `getConversionActionId`
+ * (`networkHandler.ts`) — the mocked 401/403 sit on `googleAds:searchStream`, which runs before the
+ * upload — so the delivery branch is never reached and they assert the legacy handler's
+ * `'... during Google_adwords_enhanced_conversions response transformation'` message either way.
+ * Enrolling them would advertise coverage of the framework's auth path that does not exist.
+ *
+ * That path is covered where it can actually be reached: `gaec_v1_scenario_4` mocks a 401 on
+ * `uploadConversionAdjustments` and asserts the framework's REFRESH_TOKEN response, and
+ * `delivery.test.ts` covers the 403 -> AUTH_STATUS_INACTIVE branch against the legacy handler.
+ */
+const withDeliveryFlag = <T>(scenario: T) => ({
   ...scenario,
   envOverrides: {
     ...(scenario as { envOverrides?: EnvOverride }).envOverrides,
     ...batchingFrameworkDelivery,
   },
-}));
+});
+
+export const data = [
+  ...v0oauthScenarios,
+  ...v1oauthScenarios,
+  ...[...testScenariosForV0API, ...testScenariosForV1API].map(withDeliveryFlag),
+];

--- a/test/integrations/destinations/iterable_audience/dataDelivery/data.ts
+++ b/test/integrations/destinations/iterable_audience/dataDelivery/data.ts
@@ -34,9 +34,29 @@ import {
 
 const subscribeEndpoint = 'https://api.iterable.com/api/lists/subscribe';
 const unsubscribeEndpoint = 'https://api.iterable.com/api/lists/unsubscribe';
-const SUCCESS_MESSAGE = '[ITERABLE_AUDIENCE Response Handler] - Request Processed Successfully';
+// Messages produced by the batching framework's delivery bridge, which owns response handling
+// for this destination once ITERABLE_AUDIENCE_BATCHING_FRAMEWORK_DELIVERY_ENABLED_WORKSPACE_IDS
+// is set. A batch where every job succeeded keeps the destination's own status; a mixed batch is
+// reported as 207 with per-job detail.
+const FRAMEWORK_SUCCESS_MESSAGE = '[ITERABLE_AUDIENCE] Request processed successfully';
+// A mixed batch keeps Iterable's own status (200) and reports the first real failure reason.
+const frameworkFailure = (reason: string) => `[ITERABLE_AUDIENCE] ${reason}`;
 
-export const data: ProxyV1TestData[] = [
+// A batch in which every subscriber failed the same way is a whole-response failure, so it carries
+// the same tag set a thrown error would — `integration.failure_detailed` needs the identifying
+// fields, not just errorType.
+const abortedStatTags = {
+  destType: 'ITERABLE_AUDIENCE',
+  destinationId: 'default-destinationId',
+  errorCategory: 'network',
+  errorType: 'aborted',
+  feature: 'dataDelivery',
+  implementation: 'native',
+  module: 'destination',
+  workspaceId: 'default-workspaceId',
+};
+
+const scenarios: ProxyV1TestData[] = [
   {
     id: 'iterable_audience_v1_subscribe_full_success',
     name: 'iterable_audience',
@@ -66,8 +86,7 @@ export const data: ProxyV1TestData[] = [
         body: {
           output: {
             status: 200,
-            message: SUCCESS_MESSAGE,
-            destinationResponse: { status: 200, response: subscribeSuccessResponse },
+            message: FRAMEWORK_SUCCESS_MESSAGE,
             response: [
               { statusCode: 200, metadata: generateMetadata(1), error: 'success' },
               { statusCode: 200, metadata: generateMetadata(2), error: 'success' },
@@ -106,8 +125,9 @@ export const data: ProxyV1TestData[] = [
         body: {
           output: {
             status: 200,
-            message: SUCCESS_MESSAGE,
-            destinationResponse: { status: 200, response: subscribeInvalidEmailResponse },
+            message: frameworkFailure(
+              'email error:"bad@example.com" in "failedUpdates.invalidEmails".',
+            ),
             response: [
               { statusCode: 200, metadata: generateMetadata(1), error: 'success' },
               {
@@ -150,8 +170,10 @@ export const data: ProxyV1TestData[] = [
         body: {
           output: {
             status: 200,
-            message: SUCCESS_MESSAGE,
-            destinationResponse: { status: 200, response: subscribeConflictUserIdResponse },
+            message: frameworkFailure(
+              'userId error:"conflict_user" in "failedUpdates.conflictUserIds".',
+            ),
+            statTags: abortedStatTags,
             response: [
               {
                 statusCode: 400,
@@ -193,8 +215,10 @@ export const data: ProxyV1TestData[] = [
         body: {
           output: {
             status: 200,
-            message: SUCCESS_MESSAGE,
-            destinationResponse: { status: 200, response: subscribeNotFoundResponse },
+            message: frameworkFailure(
+              'email error:"missing@example.com" in "failedUpdates.notFoundEmails".',
+            ),
+            statTags: abortedStatTags,
             response: [
               {
                 statusCode: 400,
@@ -236,8 +260,7 @@ export const data: ProxyV1TestData[] = [
         body: {
           output: {
             status: 200,
-            message: SUCCESS_MESSAGE,
-            destinationResponse: { status: 200, response: subscribeForgottenResponse },
+            message: FRAMEWORK_SUCCESS_MESSAGE,
             response: [{ statusCode: 200, metadata: generateMetadata(1), error: 'success' }],
           },
         },
@@ -273,8 +296,10 @@ export const data: ProxyV1TestData[] = [
         body: {
           output: {
             status: 200,
-            message: SUCCESS_MESSAGE,
-            destinationResponse: { status: 200, response: subscribeEmailCaseResponse },
+            message: frameworkFailure(
+              'email error:"mixedcase@example.com" in "failedUpdates.invalidEmails".',
+            ),
+            statTags: abortedStatTags,
             response: [
               {
                 statusCode: 400,
@@ -316,8 +341,7 @@ export const data: ProxyV1TestData[] = [
         body: {
           output: {
             status: 200,
-            message: SUCCESS_MESSAGE,
-            destinationResponse: { status: 200, response: subscribeUserIdCaseResponse },
+            message: FRAMEWORK_SUCCESS_MESSAGE,
             response: [{ statusCode: 200, metadata: generateMetadata(1), error: 'success' }],
           },
         },
@@ -359,8 +383,7 @@ export const data: ProxyV1TestData[] = [
         body: {
           output: {
             status: 200,
-            message: SUCCESS_MESSAGE,
-            destinationResponse: { status: 200, response: subscribeMixedResponse },
+            message: frameworkFailure('2 of 5 events failed; see per-event errors'),
             response: [
               { statusCode: 200, metadata: generateMetadata(1), error: 'success' },
               {
@@ -410,8 +433,7 @@ export const data: ProxyV1TestData[] = [
         body: {
           output: {
             status: 200,
-            message: SUCCESS_MESSAGE,
-            destinationResponse: { status: 200, response: unsubscribeNotFoundEmailResponse },
+            message: FRAMEWORK_SUCCESS_MESSAGE,
             response: [{ statusCode: 200, metadata: generateMetadata(1), error: 'success' }],
           },
         },
@@ -447,8 +469,7 @@ export const data: ProxyV1TestData[] = [
         body: {
           output: {
             status: 200,
-            message: SUCCESS_MESSAGE,
-            destinationResponse: { status: 200, response: unsubscribeNotFoundUserIdResponse },
+            message: FRAMEWORK_SUCCESS_MESSAGE,
             response: [{ statusCode: 200, metadata: generateMetadata(1), error: 'success' }],
           },
         },
@@ -484,8 +505,10 @@ export const data: ProxyV1TestData[] = [
         body: {
           output: {
             status: 200,
-            message: SUCCESS_MESSAGE,
-            destinationResponse: { status: 200, response: subscribeInvalidDataResponse },
+            message: frameworkFailure(
+              'email error:"baddata@example.com" in "failedUpdates.invalidDataEmails".',
+            ),
+            statTags: abortedStatTags,
             response: [
               {
                 statusCode: 400,
@@ -529,8 +552,7 @@ export const data: ProxyV1TestData[] = [
         body: {
           output: {
             status: 200,
-            message: SUCCESS_MESSAGE,
-            destinationResponse: { status: 200, response: subscribeBothForgottenResponse },
+            message: FRAMEWORK_SUCCESS_MESSAGE,
             response: [{ statusCode: 200, metadata: generateMetadata(1), error: 'success' }],
           },
         },
@@ -567,8 +589,7 @@ export const data: ProxyV1TestData[] = [
         body: {
           output: {
             status: 401,
-            message:
-              'ITERABLE_AUDIENCE: Error transformer proxy during ITERABLE_AUDIENCE response transformation. "Invalid API key"',
+            message: frameworkFailure('Invalid API key'),
             statTags: {
               destType: 'ITERABLE_AUDIENCE',
               errorCategory: 'network',
@@ -620,8 +641,7 @@ export const data: ProxyV1TestData[] = [
         body: {
           output: {
             status: 500,
-            message:
-              'ITERABLE_AUDIENCE: Error transformer proxy during ITERABLE_AUDIENCE response transformation. "Internal server error"',
+            message: frameworkFailure('Internal server error'),
             statTags: {
               destType: 'ITERABLE_AUDIENCE',
               errorCategory: 'network',
@@ -650,3 +670,15 @@ export const data: ProxyV1TestData[] = [
     },
   },
 ];
+
+/**
+ * ITERABLE_AUDIENCE is already GA for the batching-framework transform, so only the delivery flag is
+ * needed to move these scenarios onto the framework response path.
+ */
+export const data = scenarios.map((scenario) => ({
+  ...scenario,
+  envOverrides: {
+    ...scenario.envOverrides,
+    ITERABLE_AUDIENCE_BATCHING_FRAMEWORK_DELIVERY_ENABLED_WORKSPACE_IDS: 'ALL',
+  },
+}));

--- a/test/integrations/destinations/test_destination/dataDelivery/data.ts
+++ b/test/integrations/destinations/test_destination/dataDelivery/data.ts
@@ -16,7 +16,7 @@ const v1ProxyPayload = (destinationVersion?: number) => ({
   destinationVersion,
 });
 
-export const data: ProxyV1TestData[] = [
+const scenarios: ProxyV1TestData[] = [
   {
     id: 'test_destination-delivery-v1',
     name: 'test_destination',
@@ -33,11 +33,12 @@ export const data: ProxyV1TestData[] = [
         body: {
           output: {
             status: 200,
-            message:
-              '[Generic Response Handler] Request for destination: test_destination Processed Successfully',
+            message: '[TEST_DESTINATION] Request processed successfully',
             response: [
               {
-                error: JSON.stringify({ success: true }),
+                // The framework reports a succeeded job as 'success' rather than echoing the
+                // destination body, which the v0->v1 adaptation used to stuff into every job.
+                error: 'success',
                 statusCode: 200,
                 metadata: generateMetadata(1),
               },
@@ -79,3 +80,15 @@ export const data: ProxyV1TestData[] = [
     },
   },
 ];
+
+/**
+ * TEST_DESTINATION is already GA for the batching-framework transform, so only the delivery flag is
+ * needed to move these scenarios onto the framework response path.
+ */
+export const data = scenarios.map((scenario) => ({
+  ...scenario,
+  envOverrides: {
+    ...scenario.envOverrides,
+    TEST_DESTINATION_BATCHING_FRAMEWORK_DELIVERY_ENABLED_WORKSPACE_IDS: 'ALL',
+  },
+}));

--- a/test/integrations/live/types.ts
+++ b/test/integrations/live/types.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { EnvOverride } from '../envUtils';
 
 // Account definition rudder-auth uses to describe an OAuth account.
 const AccountDefinitionSchema = z.object({
@@ -159,6 +160,10 @@ interface LiveSpec {
   enabled: boolean; // false parks the whole destination — the registry skips it
   authType: AuthType;
   oauthVersion?: OAuthVersion;
+  // Environment variables set for the duration of this destination's scenarios and restored after.
+  // Live runs exercise the real transform and delivery paths, so a destination behind a rollout
+  // flag has to name it here or the suite silently tests the legacy path instead.
+  envOverrides?: EnvOverride;
   // Map the resolved secret into the destination.Config the transform expects (merge non-secret
   // defaults with the credentials in `s.config`).
   resolveConfig: (s: LiveSecret) => Record<string, unknown>;


### PR DESCRIPTION
Moves delivery response handling from a separate `networkHandler.ts` file onto the destination's own `BatchDestination`-family class, and stops expressing it in terms of the delivery API.

Design, evidence and per-destination parity tables: `docs/superpowers/specs/2026-07-30-network-handler-abstraction-design.md`.

## The contract

An integration declares a **single `delivery` object** — a status-keyed map plus an optional error-message extractor. Applying it is framework-owned: `handleDeliveryResponse(Class, ctx)` is a free function in `delivery.ts`, so there is no member to override and no `super` to call.

```ts
type StatusOverride = (ctx: DeliveryContext, fallback: () => Verdict) => HandleResponseResult;

type DeliverySpec = {
  statusOverrides?: Partial<Record<StatusKey, StatusOverride>>;
  failureReason?: (ctx: DeliveryContext) => string;
};

static readonly delivery: DeliverySpec;
```

Both are grouped under `delivery` because everything else on a `BatchDestination` — `transformEvent`, `getBatchStrategy`, `getInputSchema` — is about turning an event into a request, while these two are about reading the response that comes back: a different phase, behind a different flag. As bare statics they read as more transform surface. Each destination's `delivery.ts` exports one spec object, so the class carries one line for delivery however much that contract grows.

Keys are an exact status or a class (`'2xx'` / `'4xx'` / `'5xx'`), exact winning. A handler that owns only *some* of the responses carrying its status — mixpanel's `400` applies to `/import` but not `/engage` — calls `fallback()`, so the return type stays total with no sentinel value. The spec is **resolved down the prototype chain** by `resolveDeliverySpec`: static properties are shadowed rather than merged, so a subclass declaring one would otherwise silently drop an ancestor's entries with no type or runtime error. `statusOverrides` merges key-by-key child-over-parent; `failureReason` takes the nearest declaration, which is what static-method shadowing did.

Verdicts are `success` / `abort` / `retry`, with throttling and the two auth categories as refinements, because that is what rudder-server can act on — `REFRESH_TOKEN` ends as a 500 and retries, `AUTH_STATUS_INACTIVE` ends as a 400 and aborts (§2.1 traces this).

**It never infers an auth verdict from a status code.** `getAuthErrCategoryFromStCode`'s unconditional 401→`REFRESH_TOKEN` is wrong more often than right — a 401 from an API-key destination is a bad key, not a refreshable token — and guessing costs a real control-plane token refresh. A destination that genuinely wants the mapping declares it; `gaec` derives its category from the response body, as it always did.

## What the response looks like

Shaped to what rudder-server actually reads, verified against its source rather than assumed:

| field | behaviour | why |
|---|---|---|
| `status` | `ctx.status`, passed through | `ProxyResponseV1` has no `status` field (`transformer_proxy_adapter.go:40-44`) — disposition comes from each job state. Relabelling a mixed batch `207` would invent a difference from the legacy handler for no reader. `am/networkHandler.ts:75` records the same fact in a comment. |
| `message` | the shared failure reason when every failure agrees on one; `<n> of <m> events failed; see per-event errors` when they differ | quoting the first of several would present one job's error as the batch's. Also the only place the batch-level reason survives, which a fixed "partial failures" string discarded. |
| `statTags` | the whole tag set when every job failed the same way; absent otherwise | drives `integration.failure_detailed` (`processor/integrations/integrations.go:29-37`), which tags the response as a whole — only honest when the response as a whole is one failure. The bridge supplies `errorCategory`/`errorType`, `deliver()` merges the identifying tags from the same `getTags` metadata `postTransformation` uses for a thrown error, so returned and thrown failures are tagged identically. |
| `destinationResponse` | not echoed | confirmed unread: not a field on `ProxyResponseV1`; live events and the debugger ship the per-job `error` (`routerJobResponseBodys`); the reporting extractor's `destinationResponse` lookup runs against that stored per-job string. |

Error messages are **strings, not JSON blobs**, and **each integration owns its own extraction**. The per-job `error` is what the v1 adapter stores as the job's response body (`transformer_proxy_adapter.go:169`) — what live events show and what error reporting groups on — so a string is returned bare rather than JSON-quoted.

The framework itself does not parse the body. `delivery.failureReason(ctx)` defaults to the status-only string `genericNetworkHandler` already produces (`[Generic Response Handler] Request failed with status: <n>`), and a destination that wants its API's error text declares one against that API's shape.

An earlier revision had a shared `messageFromResponse` helper that searched the body for `message`, then `msg`, then `error`, then `description`. It was withdrawn: there is no shared convention on the legacy path to generalise — customerio joins `reason`/`field`/`message` from its own `errors[]`, gaec reads `error.message`, braze_audience does `JSON.stringify(response?.message ?? response)`, iterable_audience uses `params ?? msg ?? message`, and `genericNetworkHandler` reads nothing. A key-ordered search looks like it unifies those but only imposes one destination's field order on every other, and a quirk added for one leaks into all: Iterable's `params`-before-`msg` precedence meant an object-valued early key silently masked a good message on a later key for *every* destination on the default list, so `{ error: {}, description: 'real message' }` returned `{}`.

## Destinations migrated

Every batching-framework destination that has its own network handler, because gating delivery on the flag switches the path for all of them at once (§4.0):

| destination | overrides | parity |
|---|---|---|
| `customerio` | `207` | 5/5 branches vs the legacy handler |
| `gaec` | `'2xx'`, `'4xx'` | 8/8 vs `gaecResponseHandler` |
| `iterable_audience` | `'2xx'` | 7/7 vs `AudienceListStrategy` |
| `braze_audience` | `'2xx'` | 15/15 vs the legacy handler, plus counter-for-counter |
| `test_destination` | none needed | 6/6 statuses vs `genericNetworkHandler` |

Each per-item list is indexed off the **posted request body**, not off the response, because that is the array guaranteed to line up with the job list. `gaec` drove its list off `results` at first, which diverged whenever Google omitted or truncated it — the existing `gaec_v1_scenario_2` fixture does exactly that — and turned an abort into a batch retry that could never converge, since re-uploading accepted adjustments returns duplicate-enhancement failures on every attempt.

`iterable_audience` is the only Pattern D case — Iterable reports failures by *identity*, not index. Both of its deliberate-success branches carry over: a GDPR-forgotten user is counted and accepted rather than aborted, and `notFound` on an unsubscribe is a no-op success.

`test_destination` needs nothing — it composes `genericNetworkHandler` and replaces only `proxy`, which the framework default already reproduces. A test holds that equivalence so it fails if the two ever drift.

## Behaviour changes

Two, both `customerio`, both in §4.1:

1. **The top-level `message` text.** Framework-generated; no per-job field derives from it.
2. **The status-inferred `authErrorCategory` is dropped.** It is unreachable for a Basic-auth destination — `OAuthTransport.RoundTrip` returns at `if !isOauthDestination` before `postRoundTrip`, so neither the token refresh nor the 401→500 rewrite could ever fire. This takes the *transformer's own* HTTP status for those responses from 401/403 to 200, which is read in exactly one place: the `statusCode` label on the `transformer_outgoing_request` metric (`router/worker.go:528`). **No job outcome changes** — the per-job `statusCode` stays 401/403.

`gaec`'s 401 moves `errorType` from `aborted` to `retryable`, and that one is a correction: `gaec` *is* OAuth-backed (`auth: { type: 'OAuth', rudderScopes: ['delivery'] }`), so a successful refresh makes rudder-server return 500 and retry the batch (`services/oauth/v2/http/transport.go:195`) — the legacy tag described the opposite of what happens.

## Gated behind its own flag, default off

`isBatchingFrameworkDeliveryEnabled(destType, workspaceId)`, env `{DEST}_BATCHING_FRAMEWORK_DELIVERY_ENABLED_WORKSPACE_IDS`. Two deliberate properties: **no GA map**, so already-GA destinations keep the legacy handler until a workspace is named; and it **requires the transform flag**, because the delivery path has to interpret a payload built by the matching transform path. Nothing changes in production until a workspace opts in.

The branch is guarded by an `isProxyV1Request` type predicate rather than a version string — the array-ness of `metadata` is what the code actually depends on, and narrowing on it removes the `ProxyV1Request` casts. `ProxyV1RequestSchema` was rejected: it is unused anywhere and marks `secret`/`dontBatch` required, so a real payload omitting either would fail validation and fall through to the legacy handler silently.

## Parity is tested, not asserted

Each destination's `delivery.test.ts` drives **both** the new path and the existing handler over the same responses and compares per-job codes and errors. For `braze_audience` it additionally compares `stats.increment` call lists, so all three of its counters are held to parity too.

All five destinations set the delivery flag via `envOverrides` on their `dataDelivery` component tests, so **CI exercises the framework path** rather than dead code behind an off flag. `gaec`'s v0 scenarios get the flag too and are unaffected, which is itself the assertion that the shape guard works. `braze_audience`'s live tests run on it as well, via a new `envOverrides` hook on `LiveSpec`.

## Skills updated

`batching-framework`, `vdm-next-audience-integration` and `vdm-v2-object-destination` all described delivery as a separate `networkHandler.ts`, which would have sent the next integration down the path this PR replaces.

The contract lives in **one new skill**, `batching-framework-delivery` — verdict builders, `statusOverrides` resolution, indexing `perItem` off the posted request body rather than the response, the no-auth-inference rule, the delivery flag, and that transport stays in `networkHandler.ts` with the legacy handler retained until GA. The other three point at it and keep only what is specific to them: the single-item transport audit (`batching-framework`), identity-keyed failures (`vdm-next-audience-integration`), CustomerIO's 207 (`vdm-v2-object-destination`).

`live-integration-test` also documents `LiveSpec`, which gained `envOverrides` here, so it now covers naming a rollout flag — without one a live run exercises the legacy path.

## Bugs found while surveying (not fixed here)

- `iterable` / `iterable_audience` can emit `metadata: undefined` job states. rudder-server detects this as a non-fatal in/out breach and backfills the job to 500, so no data is lost — but the reported outcome is discarded and the event is redelivered. Migrating `iterable_audience` fixes it as a side effect, since the framework bounds-checks `perItem`.
- `TransformerProxyError`'s 6th argument is written and never read; ~50 handlers compute and pass it for nothing.
- Of the 20 v1 handlers that can produce a per-job response array, only `gaec` and `gaoc` set `statTags` on a returned response — the same hand-rolled block copied between them, both hardcoding `errorType: 'aborted'` and `status: 400` on a *partial* failure.


