### PR TITLE
chore: hs live test failures

### DIFF
--- a/test/integrations/component.live.test.ts
+++ b/test/integrations/component.live.test.ts
@@ -86,35 +86,55 @@ describe('Live Integration Test Suite', () => {
         await ctx.runCleanups();
       });
 
+      // Short-circuit: once a step in this scenario fails, skip the remaining steps and the
+      // read-back. Later steps build on earlier ones, so continuing only cascades noise and
+      // burns live API calls on an already-doomed scenario.
+      let scenarioFailed = false;
+      const skipIfFailed = (what: string): boolean => {
+        if (scenarioFailed) {
+          // eslint-disable-next-line no-console
+          console.warn(`[live] skipping ${what} — an earlier step in this scenario failed`);
+        }
+        return scenarioFailed;
+      };
+
       test.each(scenario.steps)(
         'step: $name',
         async (step) => {
-          // Steps run in declared order; dispatch by discriminant — action = direct API side
-          // effect, verify = read-back assertion, pipeline = seed -> transform -> deliver -> assert.
-          switch (step.stepType) {
-            case 'action':
-              await step.run(ctx);
-              return;
-            case 'verify':
-              await step.check(ctx);
-              return;
-            case 'pipeline':
-              await runPipelineStep({
-                destination,
-                scenarioId: scenario.id,
-                step,
-                ctx,
-                config: scenarioConfig,
-                http: {
-                  post: async (url, body) =>
-                    agent()
-                      .post(url)
-                      .send(body as object),
-                },
-              });
+          if (skipIfFailed(`step "${step.name}"`)) {
+            return;
+          }
+          try {
+            // Steps run in declared order; dispatch by discriminant — action = direct API side
+            // effect, verify = read-back assertion, pipeline = seed -> transform -> deliver -> assert.
+            switch (step.stepType) {
+              case 'action':
+                await step.run(ctx);
+                return;
+              case 'verify':
+                await step.check(ctx);
+                return;
+              case 'pipeline':
+                await runPipelineStep({
+                  destination,
+                  scenarioId: scenario.id,
+                  step,
+                  ctx,
+                  config: scenarioConfig,
+                  http: {
+                    post: async (url, body) =>
+                      agent()
+                        .post(url)
+                        .send(body as object),
+                  },
+                });
+            }
+          } catch (err) {
+            scenarioFailed = true;
+            throw err;
           }
         },
-        60000,
+        120000,
       );
 
       // The scenario's common trailing read-back: framework owns the polling, retrying the
@@ -122,8 +142,11 @@ describe('Live Integration Test Suite', () => {
       if (scenario.verify) {
         const { check, attempts, delayMs } = scenario.verify;
         test('verify: scenario read-back', async () => {
+          if (skipIfFailed('read-back')) {
+            return;
+          }
           await retryUntilPasses(() => check(ctx), { attempts, delayMs });
-        }, 60000);
+        }, 120000);
       }
     });
   });

--- a/test/integrations/destinations/hs/live/setup.ts
+++ b/test/integrations/destinations/hs/live/setup.ts
@@ -12,10 +12,10 @@ import {
 // The CRM Search index is eventually consistent — a fresh contact can drop out of the next
 // search, so a first-hit poll leaves the transform's own search racing to create and 409-ing on
 // the duplicate. Requiring several CONSECUTIVE hits plus a settle delay closes that window.
-const REQUIRED_CONSECUTIVE_HITS = 3;
+const REQUIRED_CONSECUTIVE_HITS = 5;
 const SEARCH_POLL_INTERVAL_MS = 2000;
 const SEARCH_MAX_POLLS = 25; // ~50s ceiling, within the scenario setup's 60s timeout
-const SEARCH_SETTLE_MS = 3000;
+const SEARCH_SETTLE_MS = 8000;
 
 const waitUntilSearchable = async (
   label: string,

--- a/test/integrations/destinations/hs/live/spec.ts
+++ b/test/integrations/destinations/hs/live/spec.ts
@@ -271,7 +271,10 @@ export const live: LiveSpec = {
           stepType: 'pipeline',
           // RETL splits create-vs-update via HubSpot's eventually-consistent search; retry so a
           // just-created contact that the first search misses (409) is found and updated.
-          retries: 3,
+          retries: 10,
+          // Settle before the pipeline runs so HubSpot's Search index reflects the contact the
+          // setup step just created; without it the create-vs-update split can miss it and 409.
+          delayBeforeMs: 5000,
           seed: (ctx) => ({
             ...baseTimestamps(ctx, 'retl-update'),
             type: 'identify',
@@ -385,7 +388,10 @@ export const live: LiveSpec = {
           stepType: 'pipeline',
           // RETL splits create-vs-update via HubSpot's eventually-consistent search; retry so a
           // just-created contact that the first search misses (409) is found and updated.
-          retries: 3,
+          retries: 10,
+          // Settle before the pipeline runs so HubSpot's Search index reflects the contact the
+          // setup step just created; without it the create-vs-update split can miss it and 409.
+          delayBeforeMs: 5000,
           seed: (ctx) => ({
             ...baseTimestamps(ctx, 'retl-update-v1'),
             type: 'identify',
@@ -472,7 +478,10 @@ export const live: LiveSpec = {
           metadataOverride: { workspaceId: HS_RETL_SPLIT_TEST_WORKSPACE_ID },
           // RETL splits create-vs-update via HubSpot's eventually-consistent search; retry so a
           // just-created contact that the first search misses (409) is found and updated.
-          retries: 3,
+          retries: 10,
+          // Settle before the pipeline runs so HubSpot's Search index reflects the contact the
+          // setup step just created; without it the create-vs-update split can miss it and 409.
+          delayBeforeMs: 5000,
           seed: (ctx) => ({
             ...baseTimestamps(ctx, 'retl-update-split'),
             type: 'identify',
@@ -520,7 +529,10 @@ export const live: LiveSpec = {
           metadataOverride: { workspaceId: HS_RETL_SPLIT_TEST_WORKSPACE_ID },
           // RETL splits create-vs-update via HubSpot's eventually-consistent search; retry so a
           // just-created contact that the first search misses (409) is found and updated.
-          retries: 3,
+          retries: 10,
+          // Settle before the pipeline runs so HubSpot's Search index reflects the contact the
+          // setup step just created; without it the create-vs-update split can miss it and 409.
+          delayBeforeMs: 5000,
           seed: (ctx) => ({
             ...baseTimestamps(ctx, 'retl-update-v1-split'),
             type: 'identify',

--- a/test/integrations/live/runPipelineStep.ts
+++ b/test/integrations/live/runPipelineStep.ts
@@ -94,6 +94,11 @@ const attemptDelivery = async ({
 export const runPipelineStep = async (params: RunPipelineStepParams): Promise<void> => {
   const { destination, scenarioId, step } = params;
   const maxAttempts = (step.retries ?? 0) + 1;
+  // Optional settle before the first attempt — lets an eventually-consistent index catch up with a
+  // record the preceding setup step just created (see PipelineStep.delayBeforeMs).
+  if (step.delayBeforeMs) {
+    await sleep(step.delayBeforeMs);
+  }
   let failure: DeliveryFailure | undefined;
   for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
     // eslint-disable-next-line no-await-in-loop -- attempts are inherently sequential with backoff
@@ -103,7 +108,8 @@ export const runPipelineStep = async (params: RunPipelineStepParams): Promise<vo
     }
     if (attempt < maxAttempts - 1) {
       // eslint-disable-next-line no-await-in-loop -- back off before retrying
-      await sleep(1000 * 2 ** attempt);
+      // Cap the exponential backoff so a higher retry count still fits the per-step timeout.
+      await sleep(Math.min(1000 * 2 ** attempt, 5000));
     }
   }
   if (!failure) {

--- a/test/integrations/live/types.ts
+++ b/test/integrations/live/types.ts
@@ -62,6 +62,11 @@ interface PipelineStep extends Step {
   // freshly set-up record can be missed on the first try and 409, then found on a retry. Only use
   // where a failed attempt persists nothing (e.g. a 409-on-create), so a retry is safe to repeat.
   retries?: number;
+  // Sleep this long before the first delivery attempt. For an update scenario whose setup just
+  // created the record, this gives HubSpot's eventually-consistent Search index extra time to
+  // reflect it before the transform's create-vs-update search runs — so the event resolves to an
+  // update instead of being misrouted to a create (which 409s on the duplicate).
+  delayBeforeMs?: number;
 }
 
 // An action step: a direct destination-API side effect (seed/mutate/delete state), run in order.


### PR DESCRIPTION
🔒 Scanned for secrets using gitleaks 8.29.1

## What are the changes introduced in this PR?

- Two HubSpot live tests were flaking because the rETL create-vs-update split reads HubSpot's eventually-consistent Search index. When a setup-created contact isn't indexed yet, the event misroutes to `create`, 409s on the duplicate, and the update never lands. Test-harness only — no transformer changes.
- Resolves INT-6907

## Changes
- `setup.ts`: wait for 5 consecutive Search hits (was 3) + 8s settle before the pipeline runs.
- `spec.ts`: on the four rETL update scenarios, `retries` 3 → 10 and add `delayBeforeMs: 5000`.
- `types.ts` / `runPipelineStep.ts`: add `PipelineStep.delayBeforeMs` (settle before first attempt) and cap the retry backoff at 5s so 10 retries fit the timeout.
- `component.live.test.ts`: short-circuit a scenario once a step fails (skip remaining steps + read-back) so it reports one clean failure instead of a cascade; per-step timeout 60s → 120s.