### PR TITLE
feat(braze): add live integration test suite

### DIFF
--- a/.github/workflows/live-integration-tests.yml
+++ b/.github/workflows/live-integration-tests.yml
@@ -40,7 +40,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        destination: [hs, braze_audience]
+        destination: [hs, braze_audience, braze]
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4

--- a/test/integrations/destinations/braze/live.ts
+++ b/test/integrations/destinations/braze/live.ts
@@ -1,0 +1,2 @@
+// Registry entrypoint: discovers destinations/<dest>/live.ts. Spec + helpers live under ./live/.
+export { live, default } from './live/spec';

--- a/test/integrations/destinations/braze/live/api.ts
+++ b/test/integrations/destinations/braze/live/api.ts
@@ -1,0 +1,201 @@
+import axios from 'axios';
+import { Agent } from 'https';
+import { RunContext } from '../../../live/types';
+import { RUDDER_ALIAS_LABEL } from './profiles';
+
+// keepAlive:false so read-back/cleanup sockets don't linger as open handles when the suite finishes.
+const brazeAgent = new Agent({ keepAlive: false });
+
+// Fields the read-back requests from Braze's export endpoint.
+const FIELDS_TO_EXPORT = [
+  'external_id',
+  'email',
+  'first_name',
+  'last_name',
+  'custom_attributes',
+  'user_aliases',
+];
+
+// Credentials for the direct Braze API helpers (read-back + cleanup). Same restApiKey/dataCenter the
+// transform authenticates with — the key just needs users.export.ids + users.delete (+ subscription
+// scopes) in addition to the delivery scopes.
+const apiCreds = (ctx: RunContext): { restApiKey: string; dataCenter: string } => {
+  const config = (ctx.liveSecret.config ?? {}) as Record<string, unknown>;
+  const restApiKey = config.restApiKey as string | undefined;
+  const dataCenter = config.dataCenter as string | undefined;
+  if (!restApiKey) {
+    throw new Error('Braze restApiKey missing from LIVE_SECRET_BRAZE.config');
+  }
+  if (!dataCenter) {
+    throw new Error('Braze dataCenter missing from LIVE_SECRET_BRAZE.config');
+  }
+  return { restApiKey, dataCenter };
+};
+
+// Mirrors src/v0/destinations/braze/util.ts getEndpointFromConfig so read-back/cleanup hit the same
+// cluster the transform delivered to.
+export const restEndpoint = (dataCenter: string): string => {
+  const [region, number] = dataCenter.trim().toLowerCase().split('-');
+  switch (region) {
+    case 'eu':
+      return `https://rest.fra-${number}.braze.eu`;
+    case 'us':
+      return `https://rest.iad-${number}.braze.com`;
+    case 'au':
+      return `https://rest.au-${number}.braze.com`;
+    default:
+      throw new Error(`Invalid Braze Data Center: ${dataCenter} (valid regions: EU, US, AU)`);
+  }
+};
+
+const authHeaders = (restApiKey: string) => ({
+  'Content-Type': 'application/json',
+  Accept: 'application/json',
+  Authorization: `Bearer ${restApiKey}`,
+  Connection: 'close' as const,
+});
+
+export type BrazeUserProfile = {
+  external_id?: string;
+  email?: string;
+  first_name?: string;
+  last_name?: string;
+  custom_attributes?: Record<string, unknown>;
+  user_aliases?: Array<{ alias_name: string; alias_label: string }>;
+};
+
+type ExportSelector = {
+  externalIds?: string[];
+  userAliases?: Array<{ alias_name: string; alias_label?: string }>;
+};
+
+// POST /users/export/ids — the read-back. Returns the matched user profiles (empty array if none).
+export const exportUsers = async (
+  ctx: RunContext,
+  selector: ExportSelector,
+): Promise<BrazeUserProfile[]> => {
+  const { restApiKey, dataCenter } = apiCreds(ctx);
+  const body: Record<string, unknown> = { fields_to_export: FIELDS_TO_EXPORT };
+  if (selector.externalIds?.length) {
+    body.external_ids = selector.externalIds;
+  }
+  if (selector.userAliases?.length) {
+    body.user_aliases = selector.userAliases.map((a) => ({
+      alias_name: a.alias_name,
+      alias_label: a.alias_label ?? RUDDER_ALIAS_LABEL,
+    }));
+  }
+  const res = await axios.post(`${restEndpoint(dataCenter)}/users/export/ids`, body, {
+    headers: authHeaders(restApiKey),
+    httpsAgent: brazeAgent,
+    timeout: 15000,
+  });
+  return (res.data?.users ?? []) as BrazeUserProfile[];
+};
+
+export const exportUserByExternalId = async (
+  ctx: RunContext,
+  externalId: string,
+): Promise<BrazeUserProfile | null> => {
+  const users = await exportUsers(ctx, { externalIds: [externalId] });
+  return users[0] ?? null;
+};
+
+export const exportUserByAlias = async (
+  ctx: RunContext,
+  aliasName: string,
+  aliasLabel?: string,
+): Promise<BrazeUserProfile | null> => {
+  const users = await exportUsers(ctx, {
+    userAliases: [{ alias_name: aliasName, alias_label: aliasLabel }],
+  });
+  return users[0] ?? null;
+};
+
+// POST /users/delete — teardown. Best-effort: logs and swallows so one failure can't strand siblings.
+export const deleteUsers = async (ctx: RunContext, selector: ExportSelector): Promise<void> => {
+  const { restApiKey, dataCenter } = apiCreds(ctx);
+  const body: Record<string, unknown> = {};
+  if (selector.externalIds?.length) {
+    body.external_ids = selector.externalIds;
+  }
+  if (selector.userAliases?.length) {
+    body.user_aliases = selector.userAliases.map((a) => ({
+      alias_name: a.alias_name,
+      alias_label: a.alias_label ?? RUDDER_ALIAS_LABEL,
+    }));
+  }
+  if (Object.keys(body).length === 0) {
+    return;
+  }
+  try {
+    await axios.post(`${restEndpoint(dataCenter)}/users/delete`, body, {
+      headers: authHeaders(restApiKey),
+      httpsAgent: brazeAgent,
+      timeout: 15000,
+    });
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error('[live:braze] teardown (users/delete) failed', err);
+  }
+};
+
+export const deleteUserByExternalId = (ctx: RunContext): Promise<void> =>
+  deleteUsers(ctx, { externalIds: [ctx.identity('user')] });
+
+export const deleteAnonymousUser = (ctx: RunContext): Promise<void> =>
+  deleteUsers(ctx, { userAliases: [{ alias_name: ctx.identity('anon') }] });
+
+// Create/update a user profile directly via /users/track attributes — used by setup steps that need
+// prerequisite state (e.g. the two users an alias-merge collapses). _update_existing_only:false so
+// Braze creates the profile if it doesn't exist.
+export const createUserWithAttributes = async (
+  ctx: RunContext,
+  externalId: string,
+  attributes: Record<string, unknown>,
+): Promise<void> => {
+  const { restApiKey, dataCenter } = apiCreds(ctx);
+  await axios.post(
+    `${restEndpoint(dataCenter)}/users/track`,
+    {
+      partner: 'RudderStack',
+      attributes: [{ external_id: externalId, _update_existing_only: false, ...attributes }],
+    },
+    { headers: authHeaders(restApiKey), httpsAgent: brazeAgent, timeout: 15000 },
+  );
+};
+
+export type BrazeSubscriptionGroup = {
+  id?: string;
+  name?: string;
+  channel?: string;
+  status?: string;
+};
+
+// GET /subscription/user/status — read a user's subscription-group statuses back for the
+// /v2/subscription/status/set verify.
+export const getSubscriptionGroups = async (
+  ctx: RunContext,
+  externalId: string,
+): Promise<BrazeSubscriptionGroup[]> => {
+  const { restApiKey, dataCenter } = apiCreds(ctx);
+  const res = await axios.get(`${restEndpoint(dataCenter)}/subscription/user/status`, {
+    params: { external_id: externalId },
+    headers: authHeaders(restApiKey),
+    httpsAgent: brazeAgent,
+    timeout: 15000,
+  });
+  return (res.data?.users?.[0]?.subscription_groups ?? []) as BrazeSubscriptionGroup[];
+};
+
+// The subscription_group_id must come from the real Braze account (account-scoped), supplied via
+// LIVE_SECRET_BRAZE.resourceIds.subscriptionGroupId.
+export const subscriptionGroupId = (ctx: RunContext): string => {
+  const id = ctx.liveSecret.resourceIds?.subscriptionGroupId;
+  if (!id) {
+    throw new Error(
+      'subscriptionGroupId missing — set resourceIds.subscriptionGroupId in LIVE_SECRET_BRAZE',
+    );
+  }
+  return id;
+};

--- a/test/integrations/destinations/braze/live/api.ts
+++ b/test/integrations/destinations/braze/live/api.ts
@@ -135,8 +135,12 @@ export const deleteUsers = async (ctx: RunContext, selector: ExportSelector): Pr
       timeout: 15000,
     });
   } catch (err) {
+    const status = (err as { response?: { status?: number } })?.response?.status;
     // eslint-disable-next-line no-console
-    console.error('[live:braze] teardown (users/delete) failed', err);
+    console.error(
+      `[live:braze] teardown (users/delete) failed${status ? ` (status ${status})` : ''}:`,
+      err instanceof Error ? err.message : String(err),
+    );
   }
 };
 

--- a/test/integrations/destinations/braze/live/profiles.ts
+++ b/test/integrations/destinations/braze/live/profiles.ts
@@ -83,13 +83,6 @@ export const ecomCartUpdatedTraits = (ctx: RunContext): Record<string, string> =
   tier: `ci-${ctx.runId}-ecom-cart-updated`,
 });
 
-// ─── alias / merge ───
-// A custom attribute set ONLY on the merge-source profile; after /users/merge it must appear on the
-// kept profile. `merged_from` carries the source external_id so the read-back is uniquely asserted.
-export const mergeSourceMarker = (ctx: RunContext): Record<string, string> => ({
-  merged_from: ctx.identity('merge-user'),
-});
-
 // ─── subscription group ───
 export const subscriptionTraits = (ctx: RunContext): Record<string, string> => ({
   email: ctx.email(),

--- a/test/integrations/destinations/braze/live/profiles.ts
+++ b/test/integrations/destinations/braze/live/profiles.ts
@@ -1,0 +1,212 @@
+import { RunContext } from '../../../live/types';
+
+// Braze's user-alias label used by the transform for the anonymousId alias.
+export const RUDDER_ALIAS_LABEL = 'rudder_id';
+
+// The JS-SDK-style context every seeded Braze event carries (mirrors the component fixtures).
+export const brazeLibraryContext = {
+  library: { name: 'RudderLabs JavaScript SDK', version: '1.0.5' },
+  locale: 'en-GB',
+};
+
+// Common envelope fields shared by every seed, built from ctx so each run is isolated.
+export const baseEvent = (ctx: RunContext, suffix: string) => ({
+  channel: 'web',
+  messageId: `${ctx.runId}-${suffix}`,
+  timestamp: ctx.now(),
+  originalTimestamp: ctx.now(),
+  sentAt: ctx.now(),
+  integrations: { All: true },
+});
+
+// ─── Trait profiles ───
+// Each is a (ctx) => ({ ... }) factory shared by a scenario's seed and its read-back verify, so the
+// seeded values and the assertion can't drift. `tier` is a non-reserved trait, so Braze stores it
+// under custom_attributes[tier] — a stable, uniquely-valued field the verify can match exactly.
+
+export const identifyCreateTraits = (ctx: RunContext): Record<string, string> => ({
+  email: ctx.email(),
+  firstName: 'CI-Create',
+  lastName: ctx.runId,
+  tier: `ci-${ctx.runId}-create`,
+});
+
+export const identifyAnonymousTraits = (ctx: RunContext): Record<string, string> => ({
+  email: ctx.email('anon'),
+  firstName: 'CI-Anon',
+  tier: `ci-${ctx.runId}-anon`,
+});
+
+export const identityResolutionTraits = (ctx: RunContext): Record<string, string> => ({
+  email: ctx.email(),
+  firstName: 'CI-IDRes',
+  tier: `ci-${ctx.runId}-idres`,
+});
+
+export const dontBatchTraits = (ctx: RunContext): Record<string, string> => ({
+  email: ctx.email(),
+  firstName: 'CI-DontBatch',
+  tier: `ci-${ctx.runId}-dontbatch`,
+});
+
+// Track / order-completed carry a marker trait so the read-back can prove the /users/track write
+// landed (the delivery verdict alone can be a 2xx/207 without the profile being written).
+export const trackEventTraits = (ctx: RunContext): Record<string, string> => ({
+  email: ctx.email(),
+  tier: `ci-${ctx.runId}-track`,
+});
+
+export const orderCompletedTraits = (ctx: RunContext): Record<string, string> => ({
+  email: ctx.email(),
+  tier: `ci-${ctx.runId}-order`,
+});
+
+// The custom attribute key Braze writes for a group call (ab_rudder_group_<groupId>).
+export const groupId = (ctx: RunContext): string => ctx.identity('group');
+export const groupAttributeKey = (ctx: RunContext): string => `ab_rudder_group_${groupId(ctx)}`;
+
+// ─── Recommended-ecommerce marker traits ───
+// The recommended-events path (useEcommerceRecommendedEvents) delivers an ecommerce.* event; the
+// event body itself isn't returned by /users/export/ids. Seeding a marker trait means the same
+// /users/track call also writes an attributes[] block the read-back can assert, proving the request
+// landed (a batch endpoint can 2xx/207 without the write actually succeeding).
+export const ecomProductViewedTraits = (ctx: RunContext): Record<string, string> => ({
+  email: ctx.email(),
+  tier: `ci-${ctx.runId}-ecom-product-viewed`,
+});
+export const ecomOrderPlacedTraits = (ctx: RunContext): Record<string, string> => ({
+  email: ctx.email(),
+  tier: `ci-${ctx.runId}-ecom-order-placed`,
+});
+export const ecomCartUpdatedTraits = (ctx: RunContext): Record<string, string> => ({
+  email: ctx.email(),
+  tier: `ci-${ctx.runId}-ecom-cart-updated`,
+});
+
+// ─── alias / merge ───
+// A custom attribute set ONLY on the merge-source profile; after /users/merge it must appear on the
+// kept profile. `merged_from` carries the source external_id so the read-back is uniquely asserted.
+export const mergeSourceMarker = (ctx: RunContext): Record<string, string> => ({
+  merged_from: ctx.identity('merge-user'),
+});
+
+// ─── subscription group ───
+export const subscriptionTraits = (ctx: RunContext): Record<string, string> => ({
+  email: ctx.email(),
+  subscriptionState: 'subscribed',
+});
+
+// ─── per-job delivery mapping / supportDedup / page / screen ───
+// All deliver via /users/track attributes; each seeds a unique marker trait the read-back asserts.
+export const perJobTraits = (ctx: RunContext): Record<string, string> => ({
+  email: ctx.email(),
+  firstName: 'CI-PerJob',
+  tier: `ci-${ctx.runId}-perjob`,
+});
+export const dedupTraits = (ctx: RunContext): Record<string, string> => ({
+  email: ctx.email(),
+  firstName: 'CI-Dedup',
+  tier: `ci-${ctx.runId}-dedup`,
+});
+export const pageTraits = (ctx: RunContext): Record<string, string> => ({
+  email: ctx.email(),
+  firstName: 'CI-Page',
+  tier: `ci-${ctx.runId}-page`,
+});
+export const screenTraits = (ctx: RunContext): Record<string, string> => ({
+  email: ctx.email(),
+  firstName: 'CI-Screen',
+  tier: `ci-${ctx.runId}-screen`,
+});
+export const purchaseExtraTraits = (ctx: RunContext): Record<string, string> => ({
+  email: ctx.email(),
+  firstName: 'CI-PurchaseExtra',
+  tier: `ci-${ctx.runId}-purchase-extra`,
+});
+
+// ─── RETL / warehouse (mappedToDestination) ───
+// In the RETL path the transform returns traits VERBATIM (no reserved-key mapping) and derives
+// external_id from context.externalId. `retlTraits` is the verify shape (camelCase, mapped like the
+// other profiles); `retlSeedTraits` is the SAME values under raw Braze attribute names for the seed,
+// so the two can't drift.
+export const retlTraits = (ctx: RunContext): Record<string, string> => ({
+  email: ctx.email(),
+  firstName: 'CI-RETL',
+  tier: `ci-${ctx.runId}-retl`,
+});
+export const retlSeedTraits = (ctx: RunContext): Record<string, string> => {
+  const t = retlTraits(ctx);
+  return { email: t.email, first_name: t.firstName, tier: t.tier };
+};
+
+// ─── remaining recommended-ecommerce event types (marker traits) ───
+export const ecomCheckoutStartedTraits = (ctx: RunContext): Record<string, string> => ({
+  email: ctx.email(),
+  tier: `ci-${ctx.runId}-ecom-checkout`,
+});
+export const ecomOrderRefundedTraits = (ctx: RunContext): Record<string, string> => ({
+  email: ctx.email(),
+  tier: `ci-${ctx.runId}-ecom-refund`,
+});
+export const ecomOrderCancelledTraits = (ctx: RunContext): Record<string, string> => ({
+  email: ctx.email(),
+  tier: `ci-${ctx.runId}-ecom-cancel`,
+});
+export const ecomCartRemoveTraits = (ctx: RunContext): Record<string, string> => ({
+  email: ctx.email(),
+  tier: `ci-${ctx.runId}-ecom-cart-remove`,
+});
+
+// ─── legacy purchase: multi-product + product-level currency + sku fallback ───
+export const multiProductTraits = (ctx: RunContext): Record<string, string> => ({
+  email: ctx.email(),
+  tier: `ci-${ctx.runId}-multiproduct`,
+});
+
+// ─── external_id resolved from context.externalId brazeExternalId ───
+export const brazeExternalIdTraits = (ctx: RunContext): Record<string, string> => ({
+  email: ctx.email(),
+  firstName: 'CI-BrazeExtId',
+  tier: `ci-${ctx.runId}-brazeextid`,
+});
+
+// ─── supportDedup for an EXISTING user (the real dedup-reduce branch) ───
+// Initial state written by setup (raw Braze attribute names for createUserWithAttributes); the
+// update changes `tier` while leaving name/email unchanged, so dedup strips the unchanged keys and
+// delivers only the change. The read-back asserts the changed tier landed.
+export const dedupExistingInitialAttrs = (ctx: RunContext): Record<string, string> => ({
+  email: ctx.email(),
+  first_name: 'CI-DedupX',
+  tier: `ci-${ctx.runId}-dedupx-initial`,
+});
+export const dedupExistingUpdateTraits = (ctx: RunContext): Record<string, string> => ({
+  email: ctx.email(),
+  firstName: 'CI-DedupX',
+  tier: `ci-${ctx.runId}-dedupx-updated`,
+});
+
+// ─── integrations.Braze.alias custom alias-label override ───
+export const CUSTOM_ALIAS_LABEL = 'ci_custom_alias';
+export const customAliasTraits = (ctx: RunContext): Record<string, string> => ({
+  email: ctx.email('custom-alias'),
+  firstName: 'CI-CustomAlias',
+  tier: `ci-${ctx.runId}-custom-alias`,
+});
+
+// ─── nested-array custom-attribute operations (enableNestedArrayOperations) ───
+// The custom attribute the ops target, and a run-unique marker on the $add object so the read-back
+// can find exactly the item this run appended.
+export const NESTED_ARRAY_ATTR = 'ci_objects';
+export const nestedArrayMarker = (ctx: RunContext): string => `ci-${ctx.runId}`;
+
+// Trait shape the transform expects: per-key { update, remove, add } arrays keyed by an `identifier`
+// field (see processor/data.ts Tests 12–14). On a fresh profile the update/remove target nothing and
+// the add appends one object carrying the run marker.
+export const nestedArrayTraits = (ctx: RunContext): Record<string, unknown> => ({
+  email: ctx.email(),
+  [NESTED_ARRAY_ATTR]: {
+    update: [{ identifier: 'id', id: 2, name: `${nestedArrayMarker(ctx)}-upd` }],
+    remove: [{ identifier: 'id', id: 3 }],
+    add: [{ id: 1, name: nestedArrayMarker(ctx), age: 27 }],
+  },
+});

--- a/test/integrations/destinations/braze/live/setup.ts
+++ b/test/integrations/destinations/braze/live/setup.ts
@@ -1,0 +1,43 @@
+import { RunContext } from '../../../live/types';
+import { pollUntil } from '../../../live/poll';
+import { createUserWithAttributes, exportUserByExternalId } from './api';
+import { dedupExistingInitialAttrs, mergeSourceMarker } from './profiles';
+
+// Alias-merge collapses two existing external_id profiles into one. Seed both up front: the "keep"
+// profile (userId) and the "merge" profile (previousId) carrying a marker attribute that, after the
+// merge, must surface on the kept profile — proving data actually moved rather than the call just 2xx-ing.
+export const createMergeUsers = async (ctx: RunContext): Promise<void> => {
+  const keepId = ctx.identity('user');
+  const mergeId = ctx.identity('merge-user');
+  await createUserWithAttributes(ctx, keepId, { first_name: 'CI-Merge-Keep' });
+  await createUserWithAttributes(ctx, mergeId, {
+    first_name: 'CI-Merge-Source',
+    ...mergeSourceMarker(ctx),
+  });
+  ctx.register({ type: 'braze-user', id: keepId });
+  ctx.register({ type: 'braze-user', id: mergeId });
+};
+
+// Subscription-status set attaches to an existing external_id profile; create it first so the group
+// status write lands on a settled user.
+export const createSubscriptionUser = async (ctx: RunContext): Promise<void> => {
+  await createUserWithAttributes(ctx, ctx.identity('user'), {
+    first_name: 'CI-Subscription',
+    email: ctx.email(),
+  });
+};
+
+// supportDedup existing-user scenario: create the user AND wait until it's returned by the export
+// endpoint, so the transform's BrazeDedupUtility.doLookup (same /users/export/ids) reliably finds it
+// in the store and takes the real dedup-reduce branch (rather than treating it as a fresh user).
+export const createDedupUserAndWait = async (ctx: RunContext): Promise<void> => {
+  const externalId = ctx.identity('user');
+  await createUserWithAttributes(ctx, externalId, dedupExistingInitialAttrs(ctx));
+  await pollUntil(
+    async () => {
+      const p = await exportUserByExternalId(ctx, externalId);
+      return { done: Boolean(p?.email), value: p };
+    },
+    { label: 'dedup user searchable', attempts: 6, delayMs: (n) => 1000 * 2 ** n },
+  );
+};

--- a/test/integrations/destinations/braze/live/setup.ts
+++ b/test/integrations/destinations/braze/live/setup.ts
@@ -1,21 +1,16 @@
 import { RunContext } from '../../../live/types';
 import { pollUntil } from '../../../live/poll';
 import { createUserWithAttributes, exportUserByExternalId } from './api';
-import { dedupExistingInitialAttrs, mergeSourceMarker } from './profiles';
+import { dedupExistingInitialAttrs } from './profiles';
 
-// Alias-merge collapses two existing external_id profiles into one. Seed both up front: the "keep"
-// profile (userId) and the "merge" profile (previousId) carrying a marker attribute that, after the
-// merge, must surface on the kept profile — proving data actually moved rather than the call just 2xx-ing.
+// Alias-merge collapses two existing external_id profiles into one. Seed both up front — the "keep"
+// profile (userId) and the "merge" profile (previousId) — so the merge request has real targets. The
+// scenario is delivery-only (Braze merges asynchronously), so no marker attribute / read-back is used.
 export const createMergeUsers = async (ctx: RunContext): Promise<void> => {
   const keepId = ctx.identity('user');
   const mergeId = ctx.identity('merge-user');
   await createUserWithAttributes(ctx, keepId, { first_name: 'CI-Merge-Keep' });
-  await createUserWithAttributes(ctx, mergeId, {
-    first_name: 'CI-Merge-Source',
-    ...mergeSourceMarker(ctx),
-  });
-  ctx.register({ type: 'braze-user', id: keepId });
-  ctx.register({ type: 'braze-user', id: mergeId });
+  await createUserWithAttributes(ctx, mergeId, { first_name: 'CI-Merge-Source' });
 };
 
 // Subscription-status set attaches to an existing external_id profile; create it first so the group

--- a/test/integrations/destinations/braze/live/spec.ts
+++ b/test/integrations/destinations/braze/live/spec.ts
@@ -355,8 +355,8 @@ export const live: LiveSpec = {
 
     // ─── alias → /users/merge ───
     // Distinct endpoint. Setup creates the kept (userId) and source (previousId) profiles; the alias
-    // merges the source into the kept, and the read-back asserts the source-only marker attribute
-    // surfaced on the kept profile (Braze merges asynchronously — the verify polls a wide window).
+    // merges the source into the kept. Delivery-only — Braze processes merges asynchronously with no
+    // read-back SLA (see the note on the scenario below).
     {
       id: 'braze-alias-merge',
       description: 'An alias call merges the previousId profile into the userId profile',
@@ -379,8 +379,7 @@ export const live: LiveSpec = {
       // No read-back verify: Braze processes /users/merge ASYNCHRONOUSLY with no tight SLA, so the
       // merge effect (source attributes copied to the kept profile) isn't observable within the
       // runner's 60s window. The pipeline step already asserts the real API accepted the merge
-      // request (2xx) — that's the contract this scenario verifies. verifyMerge (in verify.ts) can be
-      // wired back as a scenario `verify` if your account merges quickly enough to read back.
+      // request (2xx) — that's the contract this scenario verifies.
     },
 
     // ─── group subscription → /v2/subscription/status/set ───

--- a/test/integrations/destinations/braze/live/spec.ts
+++ b/test/integrations/destinations/braze/live/spec.ts
@@ -1,0 +1,900 @@
+import { LiveSpec, RunContext } from '../../../live/types';
+import {
+  deleteAnonymousUser,
+  deleteUserByExternalId,
+  deleteUsers,
+  subscriptionGroupId,
+} from './api';
+import { createDedupUserAndWait, createMergeUsers, createSubscriptionUser } from './setup';
+import {
+  baseEvent,
+  brazeExternalIdTraits,
+  brazeLibraryContext,
+  CUSTOM_ALIAS_LABEL,
+  customAliasTraits,
+  dedupExistingUpdateTraits,
+  dedupTraits,
+  dontBatchTraits,
+  ecomCartRemoveTraits,
+  ecomCartUpdatedTraits,
+  ecomCheckoutStartedTraits,
+  ecomOrderCancelledTraits,
+  ecomOrderPlacedTraits,
+  ecomOrderRefundedTraits,
+  ecomProductViewedTraits,
+  groupId,
+  identifyAnonymousTraits,
+  identifyCreateTraits,
+  identityResolutionTraits,
+  multiProductTraits,
+  nestedArrayTraits,
+  orderCompletedTraits,
+  pageTraits,
+  perJobTraits,
+  purchaseExtraTraits,
+  retlSeedTraits,
+  retlTraits,
+  screenTraits,
+  subscriptionTraits,
+  trackEventTraits,
+} from './profiles';
+import {
+  verifyGroupAttribute,
+  verifyNestedArrayAttribute,
+  verifyProfileByAlias,
+  verifyProfileByExternalId,
+  verifySubscriptionStatus,
+} from './verify';
+
+// Teardown that removes both profiles an alias-merge scenario touches (kept + source).
+const deleteMergeUsers = (ctx: RunContext): Promise<void> =>
+  deleteUsers(ctx, { externalIds: [ctx.identity('user'), ctx.identity('merge-user')] });
+
+// Retry budget for the scenario-level read-backs. The runner wraps `verify.check` in
+// retryUntilPasses(check, { attempts, delayMs }); the checks are single-shot, so this is the ONLY
+// backoff layer. 6 attempts (waits 1,2,4,8,16s → reads at ~0,1,3,7,15,31s) covers Braze export lag
+// while staying under the runner's 60s per-scenario timeout.
+const READBACK = { attempts: 6, delayMs: (n: number) => 1000 * 2 ** n };
+
+// Must match BRAZE_PER_JOB_DELIVERY_MAPPING_WORKSPACE_IDS set in test/setup.ts. A scenario setting
+// this as its step's destinationOverride.WorkspaceID routes through processBatchWithDeliveryMapping
+// (the ON path); every other scenario stays on the default processBatch path.
+const BRAZE_PER_JOB_DELIVERY_TEST_WORKSPACE_ID = 'braze-pjdm-ws';
+
+export const live: LiveSpec = {
+  enabled: true,
+  authType: 'apiKey',
+  // restApiKey + dataCenter are account-scoped and come from LIVE_SECRET_BRAZE.config; the rest are
+  // fixed non-secret defaults taken from the component destination.Config.
+  resolveConfig: (s) => ({
+    prefixProperties: true,
+    useNativeSDK: false,
+    ...s.config,
+  }),
+  scenarios: [
+    {
+      // identify with only a userId → /users/track attributes keyed by external_id (create/update).
+      id: 'braze-identify-create',
+      description: 'Event-stream identify creates/updates a user profile by external_id',
+      cleanup: deleteUserByExternalId,
+      steps: [
+        {
+          stepType: 'pipeline',
+          name: 'identify by external_id',
+          expectedOutputs: 1,
+          expectedProxyRequests: 1,
+          seed: (ctx) => ({
+            ...baseEvent(ctx, 'identify-create'),
+            type: 'identify',
+            userId: ctx.identity('user'),
+            context: { ...brazeLibraryContext, traits: identifyCreateTraits(ctx) },
+          }),
+        },
+      ],
+      verify: { check: verifyProfileByExternalId(identifyCreateTraits), ...READBACK },
+    },
+    {
+      // identify with only an anonymousId → /users/track attributes keyed by a rudder_id user_alias.
+      id: 'braze-identify-anonymous-alias',
+      description: 'Anonymous-only identify creates a profile addressed by a rudder_id user_alias',
+      cleanup: deleteAnonymousUser,
+      steps: [
+        {
+          stepType: 'pipeline',
+          name: 'identify by user_alias',
+          expectedOutputs: 1,
+          expectedProxyRequests: 1,
+          seed: (ctx) => ({
+            ...baseEvent(ctx, 'identify-anon'),
+            type: 'identify',
+            anonymousId: ctx.identity('anon'),
+            context: { ...brazeLibraryContext, traits: identifyAnonymousTraits(ctx) },
+          }),
+        },
+      ],
+      verify: { check: verifyProfileByAlias('anon', identifyAnonymousTraits), ...READBACK },
+    },
+    {
+      // identify carrying BOTH userId and anonymousId → the transform fires /users/identify to merge
+      // the rudder_id alias into the external_id user (identity resolution) alongside /users/track.
+      id: 'braze-identity-resolution',
+      description:
+        'identify with userId + anonymousId merges the rudder_id alias into the external_id profile',
+      cleanup: deleteUserByExternalId,
+      steps: [
+        {
+          stepType: 'pipeline',
+          name: 'identify + alias merge',
+          expectedOutputs: 1,
+          expectedProxyRequests: 1,
+          seed: (ctx) => ({
+            ...baseEvent(ctx, 'identity-resolution'),
+            type: 'identify',
+            userId: ctx.identity('user'),
+            anonymousId: ctx.identity('user-anon'),
+            context: { ...brazeLibraryContext, traits: identityResolutionTraits(ctx) },
+          }),
+        },
+      ],
+      // Read back the external_id profile's traits (reliably returned by /users/export/ids) rather
+      // than asserting the rudder_id alias in user_aliases — Braze's export doesn't reliably surface
+      // that alias. The /users/identify branch still fires during this run (that's the path under
+      // test); this confirms the combined identify + track landed on the external_id profile.
+      verify: { check: verifyProfileByExternalId(identityResolutionTraits), ...READBACK },
+    },
+    {
+      // track with a custom event → /users/track events[]; the seeded traits also produce an
+      // attributes[] write, which the read-back uses to prove the request actually landed.
+      id: 'braze-track-custom-event',
+      description: 'A custom track event is delivered and updates the user profile',
+      cleanup: deleteUserByExternalId,
+      steps: [
+        {
+          stepType: 'pipeline',
+          name: 'track custom event',
+          expectedOutputs: 1,
+          expectedProxyRequests: 1,
+          seed: (ctx) => ({
+            ...baseEvent(ctx, 'track-custom'),
+            type: 'track',
+            event: 'CI Live Event',
+            userId: ctx.identity('user'),
+            context: { ...brazeLibraryContext, traits: trackEventTraits(ctx) },
+            properties: { plan: 'enterprise', source: 'live-integration-test' },
+          }),
+        },
+      ],
+      verify: { check: verifyProfileByExternalId(trackEventTraits), ...READBACK },
+    },
+    {
+      // "order completed" → /users/track purchases[]; seeded traits again give an attributes[] write
+      // for the read-back (purchase records themselves aren't returned by the export endpoint).
+      id: 'braze-order-completed',
+      description: 'An "order completed" track event is delivered as a Braze purchase',
+      cleanup: deleteUserByExternalId,
+      steps: [
+        {
+          stepType: 'pipeline',
+          name: 'order completed purchase',
+          expectedOutputs: 1,
+          expectedProxyRequests: 1,
+          seed: (ctx) => ({
+            ...baseEvent(ctx, 'order-completed'),
+            type: 'track',
+            event: 'order completed',
+            userId: ctx.identity('user'),
+            context: { ...brazeLibraryContext, traits: orderCompletedTraits(ctx) },
+            properties: {
+              order_id: `ord-${ctx.runId}`,
+              currency: 'USD',
+              revenue: 19.99,
+              products: [
+                { product_id: `sku-${ctx.runId}`, sku: 'CI-SKU', price: 19.99, quantity: 1 },
+              ],
+            },
+          }),
+        },
+      ],
+      verify: { check: verifyProfileByExternalId(orderCompletedTraits), ...READBACK },
+    },
+    {
+      // group → /users/track attributes with ab_rudder_group_<groupId> = true on the external_id user.
+      id: 'braze-group',
+      description:
+        'A group call sets the ab_rudder_group_<groupId> custom attribute on the profile',
+      cleanup: deleteUserByExternalId,
+      steps: [
+        {
+          stepType: 'pipeline',
+          name: 'group membership attribute',
+          expectedOutputs: 1,
+          expectedProxyRequests: 1,
+          seed: (ctx) => ({
+            ...baseEvent(ctx, 'group'),
+            type: 'group',
+            userId: ctx.identity('user'),
+            groupId: groupId(ctx),
+            traits: { email: ctx.email() },
+          }),
+        },
+      ],
+      verify: { check: verifyGroupAttribute, ...READBACK },
+    },
+    {
+      // Same create path as the first scenario, but with dontBatch=true — the proxy-request count is
+      // pinned so a batching regression that collapses/fans out delivery is caught even though it 2xxs.
+      id: 'braze-identify-create-dontbatch',
+      description: 'identify with dontBatch=true delivers un-batched (single proxy request)',
+      cleanup: deleteUserByExternalId,
+      steps: [
+        {
+          stepType: 'pipeline',
+          name: 'identify (dontBatch)',
+          metadataOverride: { dontBatch: true },
+          expectedOutputs: 1,
+          expectedProxyRequests: 1,
+          seed: (ctx) => ({
+            ...baseEvent(ctx, 'identify-dontbatch'),
+            type: 'identify',
+            userId: ctx.identity('user'),
+            context: { ...brazeLibraryContext, traits: dontBatchTraits(ctx) },
+          }),
+        },
+      ],
+      verify: { check: verifyProfileByExternalId(dontBatchTraits), ...READBACK },
+    },
+
+    // ─── Recommended-ecommerce events (useEcommerceRecommendedEvents) ───
+    // A config-gated branch that maps RS ecommerce events to Braze `ecommerce.*` events and runs
+    // ahead of the legacy custom-event / purchase paths. configOverride flips the flag on; the seeded
+    // marker traits give an attributes[] write the read-back asserts (the ecommerce.* event body
+    // itself isn't returned by /users/export/ids).
+    {
+      // Flat event, no products[] (product_viewed is the only mapping with a null product mapping).
+      id: 'braze-ecom-product-viewed',
+      description:
+        'Recommended-events: "product viewed" is delivered as an ecommerce.product_viewed event',
+      configOverride: (base) => ({ ...base, useEcommerceRecommendedEvents: true }),
+      cleanup: deleteUserByExternalId,
+      steps: [
+        {
+          stepType: 'pipeline',
+          name: 'product viewed (ecommerce.product_viewed)',
+          expectedOutputs: 1,
+          expectedProxyRequests: 1,
+          seed: (ctx) => ({
+            ...baseEvent(ctx, 'ecom-product-viewed'),
+            type: 'track',
+            event: 'product viewed',
+            userId: ctx.identity('user'),
+            context: { ...brazeLibraryContext, traits: ecomProductViewedTraits(ctx) },
+            properties: {
+              product_id: `sku-${ctx.runId}`,
+              name: 'CI Live Product',
+              price: 24.99,
+              currency: 'USD',
+              image_url: 'https://example.com/p.png',
+              url: 'https://example.com/p',
+            },
+          }),
+        },
+      ],
+      verify: { check: verifyProfileByExternalId(ecomProductViewedTraits), ...READBACK },
+    },
+    {
+      // products[] array + order semantics. With the flag ON, "order completed" routes HERE
+      // (ecommerce.order_placed), not to the legacy purchases path.
+      id: 'braze-ecom-order-placed',
+      description:
+        'Recommended-events: "order completed" is delivered as an ecommerce.order_placed event',
+      configOverride: (base) => ({ ...base, useEcommerceRecommendedEvents: true }),
+      cleanup: deleteUserByExternalId,
+      steps: [
+        {
+          stepType: 'pipeline',
+          name: 'order completed (ecommerce.order_placed)',
+          expectedOutputs: 1,
+          expectedProxyRequests: 1,
+          seed: (ctx) => ({
+            ...baseEvent(ctx, 'ecom-order-placed'),
+            type: 'track',
+            event: 'order completed',
+            userId: ctx.identity('user'),
+            context: { ...brazeLibraryContext, traits: ecomOrderPlacedTraits(ctx) },
+            properties: {
+              order_id: `ord-${ctx.runId}`,
+              total: 44.98,
+              currency: 'USD',
+              products: [
+                {
+                  product_id: `sku-${ctx.runId}`,
+                  name: 'CI Live Product',
+                  quantity: 2,
+                  price: 22.49,
+                },
+              ],
+            },
+          }),
+        },
+      ],
+      verify: { check: verifyProfileByExternalId(ecomOrderPlacedTraits), ...READBACK },
+    },
+    {
+      // cart_updated single-product wrap (top-level product fields, no explicit products[]) + the
+      // add/remove action variant.
+      id: 'braze-ecom-cart-updated',
+      description:
+        'Recommended-events: "product added" is delivered as an ecommerce.cart_updated (add) event',
+      configOverride: (base) => ({ ...base, useEcommerceRecommendedEvents: true }),
+      cleanup: deleteUserByExternalId,
+      steps: [
+        {
+          stepType: 'pipeline',
+          name: 'product added (ecommerce.cart_updated, add)',
+          expectedOutputs: 1,
+          expectedProxyRequests: 1,
+          seed: (ctx) => ({
+            ...baseEvent(ctx, 'ecom-cart-updated'),
+            type: 'track',
+            event: 'product added',
+            userId: ctx.identity('user'),
+            context: { ...brazeLibraryContext, traits: ecomCartUpdatedTraits(ctx) },
+            properties: {
+              cart_id: `cart-${ctx.runId}`,
+              currency: 'USD',
+              product_id: `sku-${ctx.runId}`,
+              name: 'CI Live Product',
+              price: 22.49,
+              quantity: 1,
+            },
+          }),
+        },
+      ],
+      verify: { check: verifyProfileByExternalId(ecomCartUpdatedTraits), ...READBACK },
+    },
+
+    // ─── alias → /users/merge ───
+    // Distinct endpoint. Setup creates the kept (userId) and source (previousId) profiles; the alias
+    // merges the source into the kept, and the read-back asserts the source-only marker attribute
+    // surfaced on the kept profile (Braze merges asynchronously — the verify polls a wide window).
+    {
+      id: 'braze-alias-merge',
+      description: 'An alias call merges the previousId profile into the userId profile',
+      cleanup: deleteMergeUsers,
+      steps: [
+        { stepType: 'action', name: 'setup: create keep + source users', run: createMergeUsers },
+        {
+          stepType: 'pipeline',
+          name: 'alias merge',
+          expectedOutputs: 1,
+          expectedProxyRequests: 1,
+          seed: (ctx) => ({
+            ...baseEvent(ctx, 'alias-merge'),
+            type: 'alias',
+            userId: ctx.identity('user'),
+            previousId: ctx.identity('merge-user'),
+          }),
+        },
+      ],
+      // No read-back verify: Braze processes /users/merge ASYNCHRONOUSLY with no tight SLA, so the
+      // merge effect (source attributes copied to the kept profile) isn't observable within the
+      // runner's 60s window. The pipeline step already asserts the real API accepted the merge
+      // request (2xx) — that's the contract this scenario verifies. verifyMerge (in verify.ts) can be
+      // wired back as a scenario `verify` if your account merges quickly enough to read back.
+    },
+
+    // ─── group subscription → /v2/subscription/status/set ───
+    // The other endpoint the base scenarios don't touch. Gated by enableSubscriptionGroupInGroupCall
+    // and needs a real subscription_group_id (resourceIds.subscriptionGroupId). If your sandbox has
+    // no subscription group, set enabled:false on this scenario.
+    {
+      id: 'braze-group-subscription',
+      // Parked by default: needs a real subscription_group_id from the account. Set
+      // resourceIds.subscriptionGroupId in LIVE_SECRET_BRAZE and flip this to true (or delete the
+      // line) to run it.
+      enabled: false,
+      description:
+        'A group call with enableSubscriptionGroupInGroupCall sets a subscription-group status',
+      configOverride: (base) => ({ ...base, enableSubscriptionGroupInGroupCall: true }),
+      cleanup: deleteUserByExternalId,
+      steps: [
+        { stepType: 'action', name: 'setup: create user', run: createSubscriptionUser },
+        {
+          stepType: 'pipeline',
+          name: 'set subscription status',
+          expectedOutputs: 1,
+          expectedProxyRequests: 1,
+          seed: (ctx) => ({
+            ...baseEvent(ctx, 'group-subscription'),
+            type: 'group',
+            userId: ctx.identity('user'),
+            groupId: subscriptionGroupId(ctx),
+            traits: subscriptionTraits(ctx),
+          }),
+        },
+      ],
+      verify: { check: verifySubscriptionStatus, ...READBACK },
+    },
+
+    // ─── nested-array custom-attribute operations (enableNestedArrayOperations) ───
+    // A distinct transform branch: traits carry per-key { update, remove, add } arrays that become
+    // Braze $update/$remove/$add object-array ops. The read-back asserts the $add object landed.
+    // NOTE: requires object-array custom attributes to be enabled in the Braze workspace.
+    {
+      id: 'braze-nested-array-attribute-ops',
+      description:
+        'identify with enableNestedArrayOperations applies $add/$update/$remove to an array attribute',
+      configOverride: (base) => ({ ...base, enableNestedArrayOperations: true }),
+      cleanup: deleteUserByExternalId,
+      steps: [
+        {
+          stepType: 'pipeline',
+          name: 'nested-array attribute ops',
+          expectedOutputs: 1,
+          expectedProxyRequests: 1,
+          seed: (ctx) => ({
+            ...baseEvent(ctx, 'nested-array-ops'),
+            type: 'identify',
+            userId: ctx.identity('user'),
+            context: { ...brazeLibraryContext, traits: nestedArrayTraits(ctx) },
+          }),
+        },
+      ],
+      verify: { check: verifyNestedArrayAttribute, ...READBACK },
+    },
+
+    // ─── per-job delivery mapping (BRAZE_PER_JOB_DELIVERY_MAPPING_WORKSPACE_IDS) ───
+    // Same create path as braze-identify-create, but tagged with the allow-listed workspaceId so
+    // processRouterDest routes it through processBatchWithDeliveryMapping (one BatchRequestOutput per
+    // HTTP request + per-metadata destInfo). For a single event the delivery must be IDENTICAL to the
+    // default path — same 1 output / 1 proxy request, same profile written.
+    {
+      id: 'braze-per-job-delivery-mapping',
+      description:
+        'identify delivered under the per-job delivery-mapping flag (ON path) lands identically',
+      cleanup: deleteUserByExternalId,
+      steps: [
+        {
+          stepType: 'pipeline',
+          name: 'identify (per-job delivery mapping)',
+          destinationOverride: { WorkspaceID: BRAZE_PER_JOB_DELIVERY_TEST_WORKSPACE_ID },
+          expectedOutputs: 1,
+          expectedProxyRequests: 1,
+          seed: (ctx) => ({
+            ...baseEvent(ctx, 'per-job-delivery'),
+            type: 'identify',
+            userId: ctx.identity('user'),
+            context: { ...brazeLibraryContext, traits: perJobTraits(ctx) },
+          }),
+        },
+      ],
+      verify: { check: verifyProfileByExternalId(perJobTraits), ...READBACK },
+    },
+
+    // ─── supportDedup ───
+    // With supportDedup, processRouterDest first calls BrazeDedupUtility.doLookup (a real
+    // /users/export/ids) to seed the dedup store. A fresh run user isn't in the store, so it's not a
+    // duplicate and delivers normally — exercising the lookup path end-to-end against the real API.
+    {
+      id: 'braze-identify-dedup',
+      description:
+        'identify with supportDedup does a real export lookup then delivers a fresh user',
+      configOverride: (base) => ({ ...base, supportDedup: true }),
+      cleanup: deleteUserByExternalId,
+      steps: [
+        {
+          stepType: 'pipeline',
+          name: 'identify (supportDedup)',
+          expectedOutputs: 1,
+          expectedProxyRequests: 1,
+          seed: (ctx) => ({
+            ...baseEvent(ctx, 'dedup'),
+            type: 'identify',
+            userId: ctx.identity('user'),
+            context: { ...brazeLibraryContext, traits: dedupTraits(ctx) },
+          }),
+        },
+      ],
+      verify: { check: verifyProfileByExternalId(dedupTraits), ...READBACK },
+    },
+
+    // ─── page → /users/track event ───
+    // A page call routes through processTrackEvent with the event name defaulted (name/properties.name
+    // → 'Page Viewed'); seeded traits also write attributes[], which the read-back asserts.
+    {
+      id: 'braze-page',
+      description: 'A page call is delivered as a Braze track event',
+      cleanup: deleteUserByExternalId,
+      steps: [
+        {
+          stepType: 'pipeline',
+          name: 'page',
+          expectedOutputs: 1,
+          expectedProxyRequests: 1,
+          seed: (ctx) => ({
+            ...baseEvent(ctx, 'page'),
+            type: 'page',
+            name: 'Home Page',
+            userId: ctx.identity('user'),
+            context: { ...brazeLibraryContext, traits: pageTraits(ctx) },
+            properties: { path: '/home', title: 'Home' },
+          }),
+        },
+      ],
+      verify: { check: verifyProfileByExternalId(pageTraits), ...READBACK },
+    },
+
+    // ─── screen → /users/track event ───
+    {
+      id: 'braze-screen',
+      description: 'A screen call is delivered as a Braze track event',
+      cleanup: deleteUserByExternalId,
+      steps: [
+        {
+          stepType: 'pipeline',
+          name: 'screen',
+          expectedOutputs: 1,
+          expectedProxyRequests: 1,
+          seed: (ctx) => ({
+            ...baseEvent(ctx, 'screen'),
+            type: 'screen',
+            name: 'Home Screen',
+            userId: ctx.identity('user'),
+            context: { ...brazeLibraryContext, traits: screenTraits(ctx) },
+            properties: { screen: 'Home' },
+          }),
+        },
+      ],
+      verify: { check: verifyProfileByExternalId(screenTraits), ...READBACK },
+    },
+
+    // ─── sendPurchaseEventWithExtraProperties ───
+    // Legacy purchase path with the flag on: non-standard product fields (beyond
+    // product_id/sku/price/quantity/currency) are attached as `properties` on each purchase object.
+    // Braze doesn't return purchase details via /users/export/ids, so the read-back asserts the
+    // seeded marker trait (proving the /users/track call landed); delivery confirms the real API
+    // accepts the extra-properties purchase shape.
+    {
+      id: 'braze-order-purchase-extra-properties',
+      description:
+        'order completed with sendPurchaseEventWithExtraProperties attaches extra product properties to the purchase',
+      configOverride: (base) => ({ ...base, sendPurchaseEventWithExtraProperties: true }),
+      cleanup: deleteUserByExternalId,
+      steps: [
+        {
+          stepType: 'pipeline',
+          name: 'order completed (extra purchase properties)',
+          expectedOutputs: 1,
+          expectedProxyRequests: 1,
+          seed: (ctx) => ({
+            ...baseEvent(ctx, 'purchase-extra'),
+            type: 'track',
+            event: 'order completed',
+            userId: ctx.identity('user'),
+            context: { ...brazeLibraryContext, traits: purchaseExtraTraits(ctx) },
+            properties: {
+              order_id: `ord-${ctx.runId}`,
+              currency: 'USD',
+              products: [
+                {
+                  product_id: `sku-${ctx.runId}`,
+                  price: 19.99,
+                  quantity: 1,
+                  // Non-standard fields → attached under purchase.properties by the flag.
+                  brand: 'CI-Brand',
+                  category: 'CI-Category',
+                },
+              ],
+            },
+          }),
+        },
+      ],
+      verify: { check: verifyProfileByExternalId(purchaseExtraTraits), ...READBACK },
+    },
+
+    // ─── RETL / warehouse (mappedToDestination) ───
+    // A warehouse-sourced identify: context.mappedToDestination flips the transform to pass traits
+    // VERBATIM (raw Braze attribute names, no reserved-key mapping) and derive external_id from
+    // context.externalId (adduserIdFromExternalId) rather than a top-level userId. Delivers /users/track
+    // attributes; the read-back confirms the verbatim traits landed on the external_id profile.
+    {
+      id: 'braze-retl-identify',
+      description:
+        'RETL (mappedToDestination) identify passes traits verbatim and keys the profile by context.externalId',
+      cleanup: deleteUserByExternalId,
+      steps: [
+        {
+          stepType: 'pipeline',
+          name: 'retl identify (mappedToDestination)',
+          expectedOutputs: 1,
+          expectedProxyRequests: 1,
+          seed: (ctx) => ({
+            ...baseEvent(ctx, 'retl-identify'),
+            type: 'identify',
+            context: {
+              ...brazeLibraryContext,
+              mappedToDestination: true,
+              externalId: [{ identifierType: 'external_id', id: ctx.identity('user') }],
+              traits: retlSeedTraits(ctx),
+            },
+          }),
+        },
+      ],
+      verify: { check: verifyProfileByExternalId(retlTraits), ...READBACK },
+    },
+
+    // ─── remaining recommended-ecommerce event types ───
+    // Same ON-flag path as the other ecom scenarios; these cover the event types/mappings not yet
+    // exercised (recommended events are send-anyway, so delivery confirms Braze accepts the shape;
+    // the marker trait's attributes[] write is the read-back).
+    {
+      id: 'braze-ecom-checkout-started',
+      description: 'Recommended-events: "checkout started" → ecommerce.checkout_started',
+      configOverride: (base) => ({ ...base, useEcommerceRecommendedEvents: true }),
+      cleanup: deleteUserByExternalId,
+      steps: [
+        {
+          stepType: 'pipeline',
+          name: 'checkout started (ecommerce.checkout_started)',
+          expectedOutputs: 1,
+          expectedProxyRequests: 1,
+          seed: (ctx) => ({
+            ...baseEvent(ctx, 'ecom-checkout'),
+            type: 'track',
+            event: 'checkout started',
+            userId: ctx.identity('user'),
+            context: { ...brazeLibraryContext, traits: ecomCheckoutStartedTraits(ctx) },
+            properties: {
+              checkout_id: `chk-${ctx.runId}`,
+              order_id: `ord-${ctx.runId}`,
+              total: 42.5,
+              currency: 'USD',
+            },
+          }),
+        },
+      ],
+      verify: { check: verifyProfileByExternalId(ecomCheckoutStartedTraits), ...READBACK },
+    },
+    {
+      id: 'braze-ecom-order-refunded',
+      description: 'Recommended-events: "order refunded" → ecommerce.order_refunded',
+      configOverride: (base) => ({ ...base, useEcommerceRecommendedEvents: true }),
+      cleanup: deleteUserByExternalId,
+      steps: [
+        {
+          stepType: 'pipeline',
+          name: 'order refunded (ecommerce.order_refunded)',
+          expectedOutputs: 1,
+          expectedProxyRequests: 1,
+          seed: (ctx) => ({
+            ...baseEvent(ctx, 'ecom-refund'),
+            type: 'track',
+            event: 'order refunded',
+            userId: ctx.identity('user'),
+            context: { ...brazeLibraryContext, traits: ecomOrderRefundedTraits(ctx) },
+            properties: { order_id: `ord-${ctx.runId}`, total: 42.5, currency: 'USD' },
+          }),
+        },
+      ],
+      verify: { check: verifyProfileByExternalId(ecomOrderRefundedTraits), ...READBACK },
+    },
+    {
+      id: 'braze-ecom-order-cancelled',
+      description: 'Recommended-events: "order cancelled" → ecommerce.order_cancelled',
+      configOverride: (base) => ({ ...base, useEcommerceRecommendedEvents: true }),
+      cleanup: deleteUserByExternalId,
+      steps: [
+        {
+          stepType: 'pipeline',
+          name: 'order cancelled (ecommerce.order_cancelled)',
+          expectedOutputs: 1,
+          expectedProxyRequests: 1,
+          seed: (ctx) => ({
+            ...baseEvent(ctx, 'ecom-cancel'),
+            type: 'track',
+            event: 'order cancelled',
+            userId: ctx.identity('user'),
+            context: { ...brazeLibraryContext, traits: ecomOrderCancelledTraits(ctx) },
+            properties: {
+              order_id: `ord-${ctx.runId}`,
+              total: 42.5,
+              currency: 'USD',
+              cancel_reason: 'ci-test',
+            },
+          }),
+        },
+      ],
+      verify: { check: verifyProfileByExternalId(ecomOrderCancelledTraits), ...READBACK },
+    },
+    {
+      // cart_updated with the REMOVE action (only 'add' was covered).
+      id: 'braze-ecom-cart-updated-remove',
+      description: 'Recommended-events: "product removed" → ecommerce.cart_updated (remove)',
+      configOverride: (base) => ({ ...base, useEcommerceRecommendedEvents: true }),
+      cleanup: deleteUserByExternalId,
+      steps: [
+        {
+          stepType: 'pipeline',
+          name: 'product removed (ecommerce.cart_updated, remove)',
+          expectedOutputs: 1,
+          expectedProxyRequests: 1,
+          seed: (ctx) => ({
+            ...baseEvent(ctx, 'ecom-cart-remove'),
+            type: 'track',
+            event: 'product removed',
+            userId: ctx.identity('user'),
+            context: { ...brazeLibraryContext, traits: ecomCartRemoveTraits(ctx) },
+            properties: {
+              cart_id: `cart-${ctx.runId}`,
+              currency: 'USD',
+              product_id: `sku-${ctx.runId}`,
+              name: 'CI Live Product',
+              price: 22.49,
+              quantity: 1,
+            },
+          }),
+        },
+      ],
+      verify: { check: verifyProfileByExternalId(ecomCartRemoveTraits), ...READBACK },
+    },
+
+    // ─── legacy purchase: multiple products + product-level currency + sku fallback ───
+    // No top-level currency, 2 products (one keyed by sku, each with its own currency) → exercises
+    // getPurchaseObjs' multi-product loop, product-level currency fallback, and product_id||sku.
+    {
+      id: 'braze-order-completed-multi-product',
+      description:
+        'order completed with multiple products, product-level currency, and sku fallback',
+      cleanup: deleteUserByExternalId,
+      steps: [
+        {
+          stepType: 'pipeline',
+          name: 'order completed (multi-product)',
+          expectedOutputs: 1,
+          expectedProxyRequests: 1,
+          seed: (ctx) => ({
+            ...baseEvent(ctx, 'multi-product'),
+            type: 'track',
+            event: 'order completed',
+            userId: ctx.identity('user'),
+            context: { ...brazeLibraryContext, traits: multiProductTraits(ctx) },
+            properties: {
+              order_id: `ord-${ctx.runId}`,
+              products: [
+                { product_id: `p1-${ctx.runId}`, price: 10, quantity: 1, currency: 'USD' },
+                { sku: `sku2-${ctx.runId}`, price: 5.5, quantity: 2, currency: 'EUR' },
+              ],
+            },
+          }),
+        },
+      ],
+      verify: { check: verifyProfileByExternalId(multiProductTraits), ...READBACK },
+    },
+
+    // ─── external_id from context.externalId brazeExternalId (no top-level userId) ───
+    {
+      id: 'braze-identify-braze-external-id',
+      description: 'identify resolves external_id from context.externalId brazeExternalId',
+      cleanup: (ctx) => deleteUsers(ctx, { externalIds: [ctx.identity('braze-ext')] }),
+      steps: [
+        {
+          stepType: 'pipeline',
+          name: 'identify by brazeExternalId',
+          expectedOutputs: 1,
+          expectedProxyRequests: 1,
+          seed: (ctx) => ({
+            ...baseEvent(ctx, 'braze-ext-id'),
+            type: 'identify',
+            context: {
+              ...brazeLibraryContext,
+              externalId: [{ type: 'brazeExternalId', id: ctx.identity('braze-ext') }],
+              traits: brazeExternalIdTraits(ctx),
+            },
+          }),
+        },
+      ],
+      verify: { check: verifyProfileByExternalId(brazeExternalIdTraits, 'braze-ext'), ...READBACK },
+    },
+
+    // ─── supportDedup: EXISTING user (real dedup-reduce branch) ───
+    // Setup creates + settles the user; the identify then changes only `tier`, so dedup strips the
+    // unchanged name/email and delivers just the change. retries covers the export-lag race in setup.
+    {
+      id: 'braze-identify-dedup-existing',
+      description:
+        'identify with supportDedup for an existing user delivers only the changed attribute',
+      configOverride: (base) => ({ ...base, supportDedup: true }),
+      cleanup: deleteUserByExternalId,
+      steps: [
+        {
+          stepType: 'action',
+          name: 'setup: create + settle dedup user',
+          run: createDedupUserAndWait,
+        },
+        {
+          stepType: 'pipeline',
+          name: 'identify existing (supportDedup reduce)',
+          retries: 2,
+          expectedOutputs: 1,
+          expectedProxyRequests: 1,
+          seed: (ctx) => ({
+            ...baseEvent(ctx, 'dedup-existing'),
+            type: 'identify',
+            userId: ctx.identity('user'),
+            context: { ...brazeLibraryContext, traits: dedupExistingUpdateTraits(ctx) },
+          }),
+        },
+      ],
+      verify: { check: verifyProfileByExternalId(dedupExistingUpdateTraits), ...READBACK },
+    },
+
+    // ─── per-job delivery mapping: MERGE branch ───
+    // The per-job-delivery scenario covers the track branch; this routes an alias merge through the ON
+    // path (buildMergeRequest / scopedMetadataForChunk). Delivery-only (merge is async, like
+    // braze-alias-merge).
+    {
+      id: 'braze-per-job-delivery-merge',
+      description: 'alias merge under the per-job delivery-mapping flag (ON-path merge branch)',
+      cleanup: deleteMergeUsers,
+      steps: [
+        { stepType: 'action', name: 'setup: create keep + source users', run: createMergeUsers },
+        {
+          stepType: 'pipeline',
+          name: 'alias merge (per-job delivery mapping)',
+          destinationOverride: { WorkspaceID: BRAZE_PER_JOB_DELIVERY_TEST_WORKSPACE_ID },
+          expectedOutputs: 1,
+          expectedProxyRequests: 1,
+          seed: (ctx) => ({
+            ...baseEvent(ctx, 'pjdm-merge'),
+            type: 'alias',
+            userId: ctx.identity('user'),
+            previousId: ctx.identity('merge-user'),
+          }),
+        },
+      ],
+    },
+
+    // ─── integrations.Braze.alias custom alias-label override ───
+    // No userId/anonymousId, but a custom alias in integrations → setAliasObject keys the profile by a
+    // custom-labelled user_alias. Read back via that custom label.
+    {
+      id: 'braze-custom-alias-label',
+      description:
+        'identify with integrations.Braze.alias delivers via a custom-labelled user_alias',
+      cleanup: (ctx) =>
+        deleteUsers(ctx, {
+          userAliases: [
+            { alias_name: ctx.identity('custom-alias'), alias_label: CUSTOM_ALIAS_LABEL },
+          ],
+        }),
+      steps: [
+        {
+          stepType: 'pipeline',
+          name: 'identify (custom alias label)',
+          expectedOutputs: 1,
+          expectedProxyRequests: 1,
+          seed: (ctx) => ({
+            ...baseEvent(ctx, 'custom-alias'),
+            type: 'identify',
+            integrations: {
+              All: true,
+              Braze: {
+                alias: {
+                  alias_name: ctx.identity('custom-alias'),
+                  alias_label: CUSTOM_ALIAS_LABEL,
+                },
+              },
+            },
+            context: { ...brazeLibraryContext, traits: customAliasTraits(ctx) },
+          }),
+        },
+      ],
+      verify: {
+        check: verifyProfileByAlias('custom-alias', customAliasTraits, CUSTOM_ALIAS_LABEL),
+        ...READBACK,
+      },
+    },
+  ],
+};
+
+export default live;

--- a/test/integrations/destinations/braze/live/verify.ts
+++ b/test/integrations/destinations/braze/live/verify.ts
@@ -9,7 +9,7 @@ import {
 } from './api';
 
 // Each check here is a SINGLE-SHOT assertion. The scenario-level `verify` block owns the
-// retry/backoff for Braze's eventually-consistent export (see READBACK/MERGE_READBACK in spec.ts),
+// retry/backoff for Braze's eventually-consistent export (see READBACK in spec.ts),
 // so a check must NOT also poll internally — nesting the two compounds the waits and blows past the
 // runner's 60s per-scenario timeout (that's what wedged braze-identity-resolution).
 
@@ -61,16 +61,6 @@ export const verifyGroupAttribute = async (ctx: RunContext): Promise<void> => {
   const profile = await exportUserByExternalId(ctx, ctx.identity('user'));
   expect(profile).not.toBeNull();
   expect(profile?.custom_attributes ?? {}).toMatchObject({ [key]: true });
-};
-
-// Alias merge: after /users/merge collapses the source (previousId) into the kept (userId) profile,
-// the source-only marker attribute must surface on the kept profile. Braze processes merges
-// asynchronously, so the scenario gives this a wider retry window (MERGE_READBACK in spec.ts).
-export const verifyMerge = async (ctx: RunContext): Promise<void> => {
-  const want = ctx.identity('merge-user');
-  const profile = await exportUserByExternalId(ctx, ctx.identity('user'));
-  expect(profile).not.toBeNull();
-  expect(profile?.custom_attributes ?? {}).toMatchObject({ merged_from: want });
 };
 
 // Subscription group: the user's status for the target group must read back as subscribed.

--- a/test/integrations/destinations/braze/live/verify.ts
+++ b/test/integrations/destinations/braze/live/verify.ts
@@ -1,0 +1,95 @@
+import { RunContext } from '../../../live/types';
+import { NESTED_ARRAY_ATTR, groupAttributeKey, nestedArrayMarker } from './profiles';
+import {
+  BrazeUserProfile,
+  exportUserByAlias,
+  exportUserByExternalId,
+  getSubscriptionGroups,
+  subscriptionGroupId,
+} from './api';
+
+// Each check here is a SINGLE-SHOT assertion. The scenario-level `verify` block owns the
+// retry/backoff for Braze's eventually-consistent export (see READBACK/MERGE_READBACK in spec.ts),
+// so a check must NOT also poll internally — nesting the two compounds the waits and blows past the
+// runner's 60s per-scenario timeout (that's what wedged braze-identity-resolution).
+
+// Map the traits we seed to the profile fields Braze returns. `firstName`/`lastName`/`email` are
+// reserved (stored as first_name/last_name/email); every other trait lands in custom_attributes.
+const expectedProfileFields = (traits: Record<string, string>) => {
+  const { email, firstName, lastName, tier } = traits;
+  const fields: Record<string, unknown> = {};
+  if (email) fields.email = email.toLowerCase();
+  if (firstName) fields.first_name = firstName;
+  if (lastName) fields.last_name = lastName;
+  return { fields, tier };
+};
+
+const assertProfileMatches = (
+  profile: BrazeUserProfile | null,
+  traits: Record<string, string>,
+): void => {
+  expect(profile).not.toBeNull();
+  const { fields, tier } = expectedProfileFields(traits);
+  expect(profile).toMatchObject(fields);
+  if (tier) {
+    expect(profile?.custom_attributes ?? {}).toMatchObject({ tier });
+  }
+};
+
+// Read the profile back by external_id and assert it carries the seeded traits. `entity` selects
+// which ctx identity holds the external_id (default 'user'; e.g. 'braze-ext' for the brazeExternalId
+// path).
+export const verifyProfileByExternalId =
+  (traits: (ctx: RunContext) => Record<string, string>, entity = 'user') =>
+  async (ctx: RunContext): Promise<void> => {
+    const profile = await exportUserByExternalId(ctx, ctx.identity(entity));
+    assertProfileMatches(profile, traits(ctx));
+  };
+
+// Read the profile back by a user-alias and assert its traits. `aliasLabel` defaults to rudder_id;
+// pass a custom label for the integrations.Braze.alias override path.
+export const verifyProfileByAlias =
+  (aliasEntity: string, traits: (ctx: RunContext) => Record<string, string>, aliasLabel?: string) =>
+  async (ctx: RunContext): Promise<void> => {
+    const profile = await exportUserByAlias(ctx, ctx.identity(aliasEntity), aliasLabel);
+    assertProfileMatches(profile, traits(ctx));
+  };
+
+// Group call: the profile must carry the ab_rudder_group_<groupId> custom attribute set to true.
+export const verifyGroupAttribute = async (ctx: RunContext): Promise<void> => {
+  const key = groupAttributeKey(ctx);
+  const profile = await exportUserByExternalId(ctx, ctx.identity('user'));
+  expect(profile).not.toBeNull();
+  expect(profile?.custom_attributes ?? {}).toMatchObject({ [key]: true });
+};
+
+// Alias merge: after /users/merge collapses the source (previousId) into the kept (userId) profile,
+// the source-only marker attribute must surface on the kept profile. Braze processes merges
+// asynchronously, so the scenario gives this a wider retry window (MERGE_READBACK in spec.ts).
+export const verifyMerge = async (ctx: RunContext): Promise<void> => {
+  const want = ctx.identity('merge-user');
+  const profile = await exportUserByExternalId(ctx, ctx.identity('user'));
+  expect(profile).not.toBeNull();
+  expect(profile?.custom_attributes ?? {}).toMatchObject({ merged_from: want });
+};
+
+// Subscription group: the user's status for the target group must read back as subscribed.
+export const verifySubscriptionStatus = async (ctx: RunContext): Promise<void> => {
+  const targetId = subscriptionGroupId(ctx);
+  const groups = await getSubscriptionGroups(ctx, ctx.identity('user'));
+  const group = groups.find((g) => g.id === targetId);
+  expect(group).toBeDefined();
+  expect((group?.status ?? '').toLowerCase()).toBe('subscribed');
+};
+
+// Nested-array custom-attribute op: the $add must land an object carrying the run marker in the
+// target array attribute. (Requires object-array custom attributes to be enabled in the workspace.)
+export const verifyNestedArrayAttribute = async (ctx: RunContext): Promise<void> => {
+  const marker = nestedArrayMarker(ctx);
+  const profile = await exportUserByExternalId(ctx, ctx.identity('user'));
+  const arr = profile?.custom_attributes?.[NESTED_ARRAY_ATTR];
+  expect(Array.isArray(arr)).toBe(true);
+  expect(arr as unknown[]).toEqual(
+    expect.arrayContaining([expect.objectContaining({ name: marker })]),
+  );
+};

--- a/test/integrations/live/routerTransformRequest.ts
+++ b/test/integrations/live/routerTransformRequest.ts
@@ -11,7 +11,12 @@ export const buildRouterTransformBody = (
   input: [
     {
       message,
-      destination: { ID: `live-${destination}`, Config: config, Enabled: true },
+      destination: {
+        ID: `live-${destination}`,
+        Config: config,
+        Enabled: true,
+        ...(options?.destinationOverride ?? {}),
+      },
       ...(options?.connection ? { connection: options.connection } : {}),
       metadata: {
         jobId,

--- a/test/integrations/live/runPipelineStep.ts
+++ b/test/integrations/live/runPipelineStep.ts
@@ -37,6 +37,7 @@ const attemptDelivery = async ({
     secret: ctx.liveSecret.secret,
     metadataOverride: step.metadataOverride,
     connection,
+    destinationOverride: step.destinationOverride,
   });
 
   const routerResponse = await http.post('/routerTransform', routerBody);

--- a/test/integrations/live/types.ts
+++ b/test/integrations/live/types.ts
@@ -44,12 +44,36 @@ interface Step {
   name: string;
 }
 
+// Fields of the /routerTransform input `metadata` a scenario may override (the harness always sets
+// jobId/attemptNum/userId/sourceId/destinationId/workspaceId/secret). Kept explicit — not a loose
+// Record — so a step can only set fields transforms actually read: dontBatch (un-batched delivery)
+// and workspaceId (per-workspace feature-flag gating on metadata.workspaceId, e.g. HubSpot's rETL
+// split). Add fields here as new needs arise. NOTE: destination.Config is NOT here — per-scenario
+// config is owned by resolveConfig + the scenario's configOverride.
+type MetadataOverride = {
+  workspaceId?: string;
+  dontBatch?: boolean;
+};
+
+// Top-level fields of the /routerTransform input `destination` a scenario may override (the harness
+// always sets ID/Config/Enabled). Kept explicit — not a loose Record — so a step can only override
+// fields transforms actually read. Currently just WorkspaceID, for per-workspace feature-flag gating
+// on destination.WorkspaceID (e.g. Braze's per-job delivery mapping). Config is deliberately absent —
+// it's owned by resolveConfig + configOverride, so there's one clear source for per-scenario config.
+// Add fields here as new gating needs arise.
+type DestinationOverride = {
+  WorkspaceID?: string;
+};
+
 // A pipeline step: seed -> /routerTransform -> /proxy, asserting the event is delivered.
 interface PipelineStep extends Step {
   stepType: 'pipeline';
   seed: (ctx: RunContext) => Record<string, unknown>;
   // Merged into the /routerTransform input metadata, overriding defaults — e.g. { dontBatch: true }.
-  metadataOverride?: Record<string, unknown>;
+  metadataOverride?: MetadataOverride;
+  // Merged into the /routerTransform input `destination` object, overriding defaults — e.g.
+  // { WorkspaceID: '...' } to exercise a transform gated on destination.WorkspaceID.
+  destinationOverride?: DestinationOverride;
   // Exact number of /routerTransform outputs this step expects. The step knows what it seeded, so
   // pin the count when set — a batching regression that collapses/fans out events is otherwise
   // waved through by the default `> 0` check. Omit to keep the loose `> 0` assertion.
@@ -165,7 +189,8 @@ type BatchedRequest = z.infer<typeof LiveProcessorOutputSchema>;
 // Options for buildRouterTransformBody (routerTransformRequest.ts).
 type BuildRouterTransformBodyOptions = {
   secret?: Record<string, string>;
-  metadataOverride?: Record<string, unknown>;
+  metadataOverride?: MetadataOverride;
+  destinationOverride?: DestinationOverride;
   // Full connection object for RETL / audience destinations that read connection.config
   // (e.g. customAttributeName). Absent for event-stream destinations that don't need it.
   connection?: Record<string, unknown>;
@@ -231,6 +256,8 @@ export {
   LiveScenario,
   LiveSpec,
   EnrolledDestination,
+  MetadataOverride,
+  DestinationOverride,
   PipelineStep,
   ActionStep,
   VerifyStep,

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -3,3 +3,4 @@ process.env.GOOGLE_ADS_DEVELOPER_TOKEN = 'test-developer-token-12345';
 process.env.DEST_BRAZE_MAU_WORKSPACE_IDS_SKIP_LIST = 'workspace-non-mau';
 process.env.DEST_GAEC_ADJUSTMENT_TYPE_SUPPORTED_WORKSPACE_IDS = 'workspaceId1,workspaceId2';
 process.env.DEST_HS_RETL_SPLIT_WORKSPACE_IDS = 'retl-split-ws';
+process.env.BRAZE_PER_JOB_DELIVERY_MAPPING_WORKSPACE_IDS = 'braze-pjdm-ws';


### PR DESCRIPTION
## Description
- Enrolls Braze into the live (real-destination) integration suite covering every deliverable transform code path — and extends the shared live harness to support them.
- Resolves INT-6898

### Braze scenarios (`test/integrations/destinations/braze/live/`)

**Event-stream**
- identify by `external_id`, anonymous identify (`rudder_id` user_alias), identity resolution (`/users/identify`), custom track event, order completed (legacy purchases), group attribute, `dontBatch`

**Recommended ecommerce** (`useEcommerceRecommendedEvents`)
- `product_viewed`, `order_placed`, `cart_updated` (add + remove), `checkout_started`, `order_refunded`, `order_cancelled`

**Config / message variants**
- `supportDedup` (fresh + existing-user reduce), `enableNestedArrayOperations`, `sendPurchaseEventWithExtraProperties`, multi-product / product-level currency / sku fallback, `brazeExternalId` external id, `integrations.Braze.alias` custom label, RETL (`mappedToDestination`) identify, and per-job delivery mapping (`BRAZE_PER_JOB_DELIVERY_MAPPING`) for the track and merge branches

**Other endpoints**
- alias → `/users/merge` (delivery-only; Braze processes merges asynchronously, no read-back SLA)
- group → `/v2/subscription/status/set` — parked (`enabled: false`) until a `subscription_group_id` is supplied via `resourceIds`

Read-backs use `/users/export/ids` and `/subscription/user/status`; cleanup via `/users/delete`. Auth is a single `restApiKey` in `LIVE_SECRET_BRAZE.config`.

### Shared harness (`test/integrations/live/`)

- Explicit `MetadataOverride` (`{ workspaceId?, dontBatch? }`) and `DestinationOverride` (`{ WorkspaceID? }`) step-option types, replacing loose `Record` types.
- `destinationOverride` threaded through `buildRouterTransformBody` so transforms gated on `destination.WorkspaceID` (Braze per-job mapping) are exercisable without conflating it with `metadata.workspaceId`. `destination.Config` stays owned by `resolveConfig` + `configOverride`.
- Scenario `verify` checks are single-shot; the framework owns retry/backoff (fixes a compounding poll that could exceed the 60s per-scenario timeout).

🤖 Generated with