### PR TITLE
feat(ivm): add ivm_execution_duration histogram

### DIFF
--- a/src/util/ivm/scriptRunner.gate.test.ts
+++ b/src/util/ivm/scriptRunner.gate.test.ts
@@ -24,6 +24,9 @@ interface MockPendingExecution {
 let mockPendingExecutions: MockPendingExecution[] = [];
 let mockRunningNow = 0;
 let mockPeakRunning = 0;
+// When set, isolate construction fails, so execute() never reaches evalClosure. Lets a test
+// separate "evaluation ran and threw" from "evaluation never started". Reset in beforeEach.
+let mockIsolateBuildError: Error | undefined;
 
 // --- Mocks ---
 
@@ -76,6 +79,9 @@ jest.mock('isolated-vm', () => {
 
   class MockIsolate {
     async createContext() {
+      if (mockIsolateBuildError) {
+        throw mockIsolateBuildError;
+      }
       return new MockContext();
     }
 
@@ -140,14 +146,20 @@ const gatesOf = (runner: IvmScriptRunner): Map<string, unknown> =>
 const queuedCount = () =>
   mockStats.increment.mock.calls.filter(([name]) => name === 'ivm_execution_queued').length;
 
+/** Every `ivm_execution_duration` observation recorded so far, as [name, startedAt, tags]. */
+const durationTimings = () =>
+  mockStats.timing.mock.calls.filter(([name]) => name === 'ivm_execution_duration');
+
 describe('IvmScriptRunner execution gate', () => {
   beforeEach(() => {
     mockPendingExecutions = [];
     mockRunningNow = 0;
     mockPeakRunning = 0;
+    mockIsolateBuildError = undefined;
     mockStats.increment.mockClear();
     mockStats.gauge.mockClear();
     mockStats.timing.mockClear();
+    mockStats.timing.mockImplementation(() => undefined);
   });
 
   describe('concurrency cap', () => {
@@ -340,6 +352,93 @@ describe('IvmScriptRunner execution gate', () => {
       });
       finishOldest();
       await expect(Promise.all([running, queued])).resolves.toEqual(['ok', 'ok']);
+    });
+  });
+
+  describe('execution duration metric', () => {
+    it('should record how long an evaluation held its slot, tagged per pool', async () => {
+      const runner = buildRunner({ maxConcurrentExecutions: 2 });
+
+      const call = runner.execute('ws-1', 'mapping-call', []);
+      await waitForRunning(1);
+      // Nothing recorded while the evaluation is still in flight — the observation is the
+      // slot-hold time, so it can only be taken once the call settles.
+      expect(durationTimings()).toHaveLength(0);
+
+      finishOldest();
+      await expect(call).resolves.toBe('ok');
+
+      // Deliberately no workspaceId: this fires on every execution, unlike the gate metrics.
+      expect(durationTimings()).toEqual([
+        [
+          'ivm_execution_duration',
+          expect.any(Date),
+          { functionName: 'mapping-call', cache: 'test_ivm' },
+        ],
+      ]);
+    });
+
+    it('should record a duration for an evaluation that threw', async () => {
+      const runner = buildRunner({ maxConcurrentExecutions: 2 });
+
+      const call = runner.execute('ws-1', 'doomed-call', []);
+      await waitForRunning(1);
+      failOldest(new Error('Script execution timed out'));
+
+      await expect(call).rejects.toThrow('Script execution timed out');
+      // A call that runs to execTimeoutMs and throws holds its slot for the full duration, so
+      // excluding it would understate the drain rate the queue is bounded by.
+      expect(durationTimings()).toEqual([
+        [
+          'ivm_execution_duration',
+          expect.any(Date),
+          { functionName: 'doomed-call', cache: 'test_ivm' },
+        ],
+      ]);
+      expect(mockStats.increment).toHaveBeenCalledWith('ivm_platform_error', {
+        functionName: 'doomed-call',
+        workspaceId: 'ws-1',
+        cache: 'test_ivm',
+      });
+    });
+
+    it('should not record a duration when the isolate never built', async () => {
+      const runner = buildRunner({ maxConcurrentExecutions: 2 });
+      mockIsolateBuildError = new Error('isolate build failed');
+
+      await expect(runner.execute('ws-1', 'never-ran', [])).rejects.toThrow('isolate build failed');
+
+      // The failure is real, but there was no evaluation to attribute time to — folding it in
+      // would put isolate-construction cost into the service-time distribution.
+      expect(durationTimings()).toHaveLength(0);
+      expect(mockStats.increment).toHaveBeenCalledWith('ivm_platform_error', {
+        functionName: 'never-ran',
+        workspaceId: 'ws-1',
+        cache: 'test_ivm',
+      });
+    });
+
+    it('should hand the slot on even if recording the duration throws', async () => {
+      const runner = buildRunner({ maxConcurrentExecutions: 1 });
+      mockStats.timing.mockImplementation((name: string) => {
+        if (name === 'ivm_execution_duration') {
+          throw new Error('metrics registry unavailable');
+        }
+      });
+
+      const running = runner.execute('ws-1', 'first', []);
+      const queued = runner.execute('ws-1', 'second', []);
+      await waitForRunning(1);
+
+      // The slot is released before the metric is emitted, so a throwing registry cannot wedge
+      // the gate: the queued caller must still be admitted once the first one settles.
+      finishOldest();
+      await expect(running).rejects.toThrow('metrics registry unavailable');
+      await waitForRunning(1);
+
+      finishOldest();
+      await expect(queued).rejects.toThrow('metrics registry unavailable');
+      expect(gatesOf(runner).size).toBe(0);
     });
   });
 });

--- a/src/util/ivm/scriptRunner.test.ts
+++ b/src/util/ivm/scriptRunner.test.ts
@@ -13,6 +13,8 @@ jest.mock('../stats', () => ({
   counter: jest.fn(),
   increment: jest.fn(),
   gauge: jest.fn(),
+  // execute() records ivm_execution_duration on every settled evaluation, success or failure.
+  timing: jest.fn(),
 }));
 
 // Avoid reading a real bundle from disk — the runner only feeds this into compileScript, which is mocked.

--- a/src/util/ivm/scriptRunner.ts
+++ b/src/util/ivm/scriptRunner.ts
@@ -139,16 +139,24 @@ export class IvmScriptRunner {
    * unbounded concurrent evaluations onto one fixed-size heap.
    */
   async execute<T>(cacheKey: string, expression: string, args: unknown[]): Promise<T> {
+    // Pool-level labels, carried by the always-on execution-duration histogram. Deliberately
+    // *without* workspaceId: the gate metrics below can afford that label because they only fire
+    // when a pool saturates, which the cap makes rare, whereas this one fires on every
+    // execution — a per-workspace histogram would mint 16 series (14 buckets + _sum + _count)
+    // per workspace per pod for as long as the process lives. Pool-level is also what the metric
+    // is *for*: service rate is a property of the isolate, not the tenant, and it is what the
+    // concurrency cap has to be sized against.
+    const durationTags = { functionName: expression, cache: this.cache.cacheName };
     // One label set for every metric this call can emit — the platform-error counter and both
     // gate metrics — so they can be joined on (workspaceId, functionName, cache) in a query.
-    const metricTags = {
-      functionName: expression,
-      workspaceId: cacheKey,
-      cache: this.cache.cacheName,
-    };
+    // Built from `durationTags` so the shared labels cannot drift between the two.
+    const metricTags = { ...durationTags, workspaceId: cacheKey };
     // Outside the try so `releaseSlot` is in scope for the finally. Waiting for a slot is
     // not a failure mode — acquireSlot never rejects, it only ever admits or queues.
     const releaseSlot = await this.acquireSlot(cacheKey, metricTags);
+    // Set once the isolate exists and evaluation is about to begin, so the `finally` can tell
+    // "never evaluated" (isolate build failed — nothing to time) from "evaluated and threw".
+    let evalStartedAt: Date | undefined;
     try {
       // Seed the platform-error counter at 0 when a fresh isolate is built for this label set
       // (once per isolate, not per call — warm-isolate calls never touch the registry).
@@ -162,6 +170,7 @@ export class IvmScriptRunner {
       const entry = await this.getOrCreate(cacheKey, () =>
         stats.counter('ivm_platform_error', 0, metricTags),
       );
+      evalStartedAt = new Date();
       const result = await entry.context.evalClosure(expression, args, {
         arguments: { copy: true },
         result: { copy: true, promise: true },
@@ -176,7 +185,18 @@ export class IvmScriptRunner {
       stats.increment('ivm_platform_error', metricTags);
       throw err;
     } finally {
+      // Released before the metric, not after: `releaseSlot` hands the slot to the next waiter,
+      // and a throwing metric must not be able to strand it — the same ordering rule the two
+      // gate metrics in `acquireSlot` follow.
       releaseSlot();
+      if (evalStartedAt) {
+        // Timed on the failure path too. This measures how long the call held its concurrency
+        // slot, and a call that runs to `execTimeoutMs` and throws holds it just as long as one
+        // that succeeds — so excluding failures would understate exactly the drain rate the
+        // queue depends on. Skipped only when evaluation never started (isolate build failed),
+        // where there is no evaluation to attribute the time to.
+        stats.timing('ivm_execution_duration', evalStartedAt, durationTags);
+      }
     }
   }
 

--- a/src/util/prometheus.js
+++ b/src/util/prometheus.js
@@ -8,6 +8,22 @@ const instanceID = process.env.INSTANCE_ID || 'localhost';
 const prefix = 'transformer';
 const defaultLabels = { instanceName: instanceID };
 
+// Shared by the two IVM execution histograms (queue wait and evaluation duration). Declared
+// explicitly because prom-client's default bucket set starts at 5ms, and both of these are
+// routinely sub-millisecond: measured locally, 99.45% of 312k queue waits landed in that single
+// first default bucket, which makes histogram_quantile() interpolate inside it and report
+// nothing useful. These start at 0.5ms so a healthy sub-millisecond sample is distinguishable
+// from a degraded one, and extend to 10s so a real backlog (queue depth growing behind
+// timed-out executions) stays on-scale instead of pinning p99 at the top finite bucket.
+//
+// One constant rather than two copies because the two metrics are meant to be read against each
+// other — "is a caller's latency dominated by waiting for a slot or by the evaluation itself"
+// is only answerable on a shared scale, and separate literals would let them drift apart
+// silently the first time one is tuned.
+const IVM_EXECUTION_BUCKETS = [
+  0.0005, 0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10,
+];
+
 function appendPrefix(name) {
   return `${prefix}_${name}`;
 }
@@ -1003,14 +1019,22 @@ class Prometheus {
         help: 'Time an evaluation waited for a free isolate concurrency slot (seconds)',
         type: 'histogram',
         labelNames: ['functionName', 'workspaceId', 'cache'],
-        // Declared explicitly because the default bucket set starts at 5ms, and a gated
-        // isolate drains far faster than that: measured locally, 99.45% of 312k waits landed
-        // in that single first bucket, which makes histogram_quantile() interpolate inside it
-        // and report nothing useful. These start at 0.5ms so a healthy sub-millisecond wait is
-        // distinguishable from a degraded one, and extend to 10s so a real backlog (queue depth
-        // growing behind timed-out executions) stays on-scale instead of pinning p99 at the top
-        // finite bucket.
-        buckets: [0.0005, 0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10],
+        buckets: IVM_EXECUTION_BUCKETS,
+      },
+      {
+        name: 'ivm_execution_duration',
+        help: 'Time spent evaluating a closure inside a cached isolate (seconds)',
+        type: 'histogram',
+        // No workspaceId, unlike ivm_execution_queue_wait: that one only fires when a pool
+        // saturates, this one fires on every execution. See the note in IvmScriptRunner.execute.
+        labelNames: ['functionName', 'cache'],
+        // A V8 isolate evaluates one script at a time, so for a gated pool this is the service
+        // time that sets the queue's drain rate, and it is what the concurrency cap
+        // (e.g. CUSTOM_MAPPINGS_IVM_MAX_CONCURRENT_EXECUTIONS) has to be sized against. Emitted
+        // for ungated pools too, where it is simply evaluation cost with no slot to hold.
+        // Includes calls that run to execTimeoutMs and throw, which occupy the isolate for
+        // their full duration and so belong in the same distribution.
+        buckets: IVM_EXECUTION_BUCKETS,
       },
       {
         name: 'fetchV2_call_duration',

--- a/src/util/prometheus.test.js
+++ b/src/util/prometheus.test.js
@@ -37,4 +37,54 @@ describe('Prometheus platform-error zero-seed semantics', () => {
     // inc(0) is add-only, so the second seed must leave the series at 1, not reset it to 0.
     expect(await valueFor(tags)).toBe(1);
   });
+
+  // The two IVM execution histograms are meant to be read against each other: queue wait and
+  // evaluation duration answer "is this caller's latency waiting for a slot, or the work itself",
+  // which only holds on a shared bucket scale. They share one IVM_EXECUTION_BUCKETS constant for
+  // that reason, and this pins the property rather than the constant — the assertion still fails
+  // if someone reintroduces a second literal that drifts.
+  describe('IVM execution histograms', () => {
+    const bucketsFor = async (name) => {
+      const metrics = await client.prometheusRegistry.getMetricsAsJSON();
+      const metric = metrics.find((m) => m.name === name);
+      expect(metric).toBeDefined();
+      // Bucket boundaries are exposed as the `le` label on the generated _bucket series.
+      return [...new Set(metric.values.map((v) => v.labels.le).filter((le) => le !== undefined))];
+    };
+
+    it('records execution duration on the same scale as queue wait', async () => {
+      // Observe once on each so prom-client materialises their bucket series.
+      client.timing('ivm_execution_queue_wait', new Date(), {
+        functionName: 'fn',
+        workspaceId: 'ws-hist',
+        cache: 'custom_mappings_ivm',
+      });
+      client.timing('ivm_execution_duration', new Date(), {
+        functionName: 'fn',
+        cache: 'custom_mappings_ivm',
+      });
+
+      const wait = await bucketsFor('transformer_ivm_execution_queue_wait');
+      const duration = await bucketsFor('transformer_ivm_execution_duration');
+
+      expect(duration).toEqual(wait);
+      // Sub-millisecond floor: prom-client's default set starts at 5ms, which is coarser than
+      // either metric and collapses healthy samples into one bucket.
+      expect(duration).toContain(0.0005);
+    });
+
+    it('keeps execution duration free of workspaceId', async () => {
+      client.timing('ivm_execution_duration', new Date(), {
+        functionName: 'fn',
+        cache: 'custom_mappings_ivm',
+      });
+
+      const metrics = await client.prometheusRegistry.getMetricsAsJSON();
+      const metric = metrics.find((m) => m.name === 'transformer_ivm_execution_duration');
+
+      // Unlike the gate metrics, this one fires on every execution — a per-workspace histogram
+      // would mint a full bucket set per workspace per pod for the life of the process.
+      expect(metric.values.every((v) => v.labels.workspaceId === undefined)).toBe(true);
+    });
+  });
 });

--- a/src/v0/destinations/custom_audience/template/ivmScriptRunner.test.ts
+++ b/src/v0/destinations/custom_audience/template/ivmScriptRunner.test.ts
@@ -33,6 +33,8 @@ const mockStats = {
   counter: jest.fn(),
   increment: jest.fn(),
   gauge: jest.fn(),
+  // execute() records ivm_execution_duration on every settled evaluation, success or failure.
+  timing: jest.fn(),
 };
 jest.mock('../../../../util/stats', () => mockStats);
 


### PR DESCRIPTION
## Why

The isolate concurrency gate ([#5385](https://github.com/rudderlabs/rudder-transformer/pull/5385)) records how long a call **waits** for a slot, but nothing records how long the **evaluation** takes. That makes the pool's service rate unmeasurable — and the service rate is exactly what the cap has to be sized against.

A V8 isolate evaluates one script at a time, so a pool's drain rate is `1 / eval_time`; the cap governs only how many callers keep argument copies alive on the fixed-size heap while they wait their turn. Today `CUSTOM_MAPPINGS_IVM_MAX_CONCURRENT_EXECUTIONS=100` can only be tuned by guesswork, and a change in evaluation cost is invisible in production.

This came out of triaging a workspace that showed 1.65M queued executions over 34h on the IVM Sandbox Health dashboard. The gate turned out to be working exactly as designed — 0.23% of 727M executions queued, p99 wait 359ms, nothing above 1s, zero platform errors — but confirming that, and answering "should the cap change", both ran into the same wall: no eval-duration metric.

## What

- `ivm_execution_duration` histogram around the `evalClosure` call in `IvmScriptRunner.execute`, on the **same bucket scale** as `ivm_execution_queue_wait` so the two can be read against each other: *is this caller's latency the queue, or the work itself?*
- That shared scale is now a single `IVM_EXECUTION_BUCKETS` constant instead of two identical literals that could silently drift the first time one is tuned. A test pins the property (the two metrics' bucket sets must match), not the constant, so reintroducing a divergent literal fails.
- Applies to both pools, since it sits in the shared runner — `custom_mappings_ivm` (gated) and `custom_audience_ivm` (ungated, where it is simply evaluation cost).

## Design notes for review

**No `workspaceId` label.** The gate metrics can afford it because they only fire when a pool saturates, which the cap makes rare. This one fires on *every* execution — a per-workspace histogram would mint 16 series (14 buckets + `_sum` + `_count`) per workspace per pod for the life of the process. Pool-level is also what the metric is *for*: service rate is a property of the isolate, not the tenant. Verified all three `execute()` call sites pass hardcoded expression literals (`return evaluateCustomMappingsInSandbox($0, $1)`, `return parseTemplateInSandbox($0)`, `return evaluateTemplateInSandbox($0, $1, $2)`), so `functionName` is bounded at 3 repo-wide — roughly 48 series per pod — and no user data can reach a label.

**Failures are timed too.** A call that runs to `execTimeoutMs` and throws occupies the isolate for its full duration, so excluding it would understate exactly the drain rate the queue depends on. Skipped only when the isolate build failed and no evaluation ever ran — folding that in would put isolate-construction cost into the service-time distribution.

**Slot released before the metric is emitted,** following the same ordering rule the two gate metrics in `acquireSlot` already use, so a throwing registry cannot strand a waiter. Pinned by a test.

## Testing

- 4 new tests in `scriptRunner.gate.test.ts`: pool-level tags on success, timed on the throwing path, *not* timed when the isolate never built, and the slot still hands over when the metric throws.
- 2 new tests in `prometheus.test.js`: bucket scale matches queue wait, and no `workspaceId` label is ever emitted.
- Full affected suite green: 37 TS tests (`--no-node-snapshot`, as CI runs them) + 4 prometheus tests, `tsc --noEmit` clean, eslint clean.
- Existing stats mocks in two suites needed `timing` added — they stubbed only `counter`/`increment`/`gauge`.

## Follow-ups (not in this PR)

- With this landed, the cap can be sized on evidence. A local benchmark on isolated-vm 5.0.3 suggests useful concurrency saturates around K≈4 (~1.25x over K=1) and that large payloads *degrade* past K≈25 — pointing at a cap nearer 10 than 100 — but that should be confirmed against production eval times rather than a laptop.
- `mappingsSandbox.ts` calls `JsonTemplateEngine.createAsSync(...)` on every invocation, recompiling the template per event. For GA4 v2, which fans out one call per event via `Promise.all`, that is the same static mapping recompiled for every event in the batch. This metric is what would let us measure the win from caching it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)