### PR TITLE
docs(skills): batch-rejection fallback, payload conventions, skills pointer

### DIFF
--- a/.claude/skills/batching-framework/SKILL.md
+++ b/.claude/skills/batching-framework/SKILL.md
@@ -229,6 +229,61 @@ when the handler owns delivery:
 Cover this with a focused unit test that mocks the delivery SDK/client and asserts the per-item
 field is set on **every** item (cheaper and more direct than a full dataDelivery mock).
 
+## Partners that reject the whole batch
+
+Some APIs are **all-or-nothing**: one invalid event fails the entire request (OpenAI Ads,
+Reddit, Amplitude). For these, transform-time validation is **not sufficient on its own** —
+it only covers the rules you knew about when you wrote it. A partner that adds a validation
+rule, or one whose docs are incomplete, will reject a batch of N on one event you believed
+was fine, and the retry re-sends the same batch and fails again.
+
+The fallback belongs in the **networkHandler**, where the partner's actual rejection is
+visible. On a 4xx **when more than one event was sent**, mark every job `dontBatch: true` and
+return **500** so the router re-delivers them individually; the offending event then fails
+alone and the rest succeed.
+
+```ts
+const populateResponseWithDontBatch = (rudderJobMetadata, errorMessage) =>
+  rudderJobMetadata.map((metadata) => ({
+    // already retried as a singleton and still failing → abort instead of looping
+    statusCode: metadata.dontBatch ? 400 : 500,
+    metadata: { ...metadata, dontBatch: true },
+    error: errorMessage,
+  }));
+
+// in responseHandler, on a non-2xx:
+if (!isHttpStatusSuccess(status) && rudderJobMetadata.length > 1) {
+  throw new TransformerProxyError(
+    '<DEST>: error during response transformation',
+    500,
+    { [TAG_NAMES.ERROR_TYPE]: getDynamicErrorType(500) },
+    destinationResponse,
+    '',
+    populateResponseWithDontBatch(rudderJobMetadata, JSON.stringify(response)),
+  );
+}
+```
+
+Two rules that are easy to get wrong:
+
+- **Guard on `rudderJobMetadata.length > 1`.** Without it a genuine single-event failure is
+  converted into a retry, and the event never aborts.
+- **Terminate with `metadata.dontBatch ? 400 : 500`.** An event that already came back as a
+  `dontBatch` singleton and failed again must return the real 4xx. Returning 500
+  unconditionally retries a permanently-bad event forever.
+
+References: `src/v1/destinations/am/networkHandler.ts` (has the termination rule),
+`src/v1/destinations/reddit/networkHandler.js` (has the `length > 1` guard but returns 500
+unconditionally — copy Amplitude's version), `src/v1/destinations/algolia/networkHandler.js`.
+
+Network handlers live at `src/v1/destinations/<dest>/networkHandler.{ts,js}` and are
+auto-discovered by `src/adapters/networkHandlerFactory.js` from the directory name — export
+them as `networkHandler` or `NetworkHandler`; no registration step.
+
+Whether you need this: if the partner documents a per-item result array (partial success),
+you don't — parse it and mark only the failed items. If one bad item fails the request, you
+do.
+
 ## Testing
 
 Test via the framework's `processBatchedDestination` function — pass the `Integration` class (not an instance):
@@ -284,9 +339,20 @@ The framework handles error wrapping automatically:
 
 Use `InstrumentationError` for bad input data (no retry), `ConfigurationError` for bad config (no retry).
 
+Validating in `transformEvent()` is what keeps a known-bad event out of a batch in the first
+place — it fails one job while the rest of the batch still ships. For partners that reject the
+whole request on one bad item, pair it with the networkHandler fallback above; transform-time
+checks cannot cover rules the partner has and you don't.
+
 ## Metrics
 
 The framework emits these metrics automatically:
 
 - `dont_batch_events` — count of events with `dontBatch` flag
 - `output_batch_size` — histogram of events per output batch
+
+Don't add a destination-specific batch-composition counter; these already carry the
+destination tags. A climbing `dont_batch_events` rate on an all-or-nothing partner is the
+signature of a validation rule they enforce and `transformEvent()` doesn't — the preserved
+`destinationResponse` on the failed singleton names the field, and that rule then belongs in
+`transformEvent()` so it stops costing a delivery round-trip.

--- a/.claude/skills/batching-framework/SKILL.md
+++ b/.claude/skills/batching-framework/SKILL.md
@@ -251,8 +251,16 @@ const populateResponseWithDontBatch = (rudderJobMetadata, errorMessage) =>
     error: errorMessage,
   }));
 
-// in responseHandler, on a non-2xx:
-if (!isHttpStatusSuccess(status) && rudderJobMetadata.length > 1) {
+// in responseHandler — order matters; the retryable and throttled cases must be
+// handled BEFORE the split, or a transient failure gets split up permanently:
+if (isHttpStatusRetryable(status)) {
+  throw new RetryableError(/* … */); // 5xx — retry the batch as a batch
+}
+if (isHttpStatusThrottled(status)) {
+  throw new ThrottledError(/* … */); // 429 — back off, don't split
+}
+// only now: a genuine 4xx rejection of the whole batch
+if (rudderJobMetadata.length > 1) {
   throw new TransformerProxyError(
     '<DEST>: error during response transformation',
     500,
@@ -264,17 +272,26 @@ if (!isHttpStatusSuccess(status) && rudderJobMetadata.length > 1) {
 }
 ```
 
-Two rules that are easy to get wrong:
+Three rules that are easy to get wrong:
 
+- **Split only on a 4xx.** A `!isHttpStatusSuccess(status)` guard also catches 429 and 5xx,
+  which turns a rate-limit or a partner outage — transient, and a whole-batch problem — into
+  a permanent `dontBatch` on every job plus N individual redeliveries. Handle retryable and
+  throttled first, as above, or test for 4xx explicitly.
 - **Guard on `rudderJobMetadata.length > 1`.** Without it a genuine single-event failure is
   converted into a retry, and the event never aborts.
 - **Terminate with `metadata.dontBatch ? 400 : 500`.** An event that already came back as a
   `dontBatch` singleton and failed again must return the real 4xx. Returning 500
   unconditionally retries a permanently-bad event forever.
 
-References: `src/v1/destinations/am/networkHandler.ts` (has the termination rule),
-`src/v1/destinations/reddit/networkHandler.js` (has the `length > 1` guard but returns 500
-unconditionally — copy Amplitude's version), `src/v1/destinations/algolia/networkHandler.js`.
+References: `src/v1/destinations/am/networkHandler.ts` — the closest thing to a complete
+reference: it orders the checks as above (`isHttpStatusRetryable` → `isHttpStatusThrottled` →
+split) and has the `dontBatch ? 400 : 500` termination rule. It *returns* a
+`DeliveryV1Response` for the split rather than throwing `TransformerProxyError`; both shapes
+work, pick one. `src/v1/destinations/reddit/networkHandler.js` has the `length > 1` guard and
+correctly narrows to `status === 400`, but its `populateResponseWithDontBatch` returns 500
+unconditionally — take Amplitude's version of that line. Also
+`src/v1/destinations/algolia/networkHandler.js`.
 
 Network handlers live at `src/v1/destinations/<dest>/networkHandler.{ts,js}` and are
 auto-discovered by `src/adapters/networkHandlerFactory.js` from the directory name — export

--- a/.claude/skills/destination-payload-conventions/SKILL.md
+++ b/.claude/skills/destination-payload-conventions/SKILL.md
@@ -1,29 +1,30 @@
 ---
 name: destination-payload-conventions
-description: Conventions for building destination payloads — monetary values and ISO-4217 minor units, where a setting belongs (destination config vs the per-event integrations object), and PII hashing/normalisation. Applied automatically — not user-invocable.
+description: Conventions for building destination payloads — monetary values and ISO-4217 minor units. Applied automatically — not user-invocable.
 ---
 
 # Destination Payload Conventions
-
-Three decisions that recur in every destination and are currently made inconsistently across
-the repo. Each section states what the repo actually does today, so you can tell convention
-from recommendation.
 
 ## Monetary values — never assume two decimal places
 
 **The current state of the repo is a latent bug.** Every monetary conversion multiplies by a
 hardcoded 100:
 
-- `src/v0/destinations/dub/utils.ts:60` — `Math.round(rawPayload.amount * 100)`
 - `src/cdk/v2/destinations/reddit/utils.js:74`, `:81`, `:88`
 - `src/cdk/v2/destinations/rakuten/utils.js:29`
 - `src/cdk/v2/destinations/optimizely_fullstack/procWorkflow.yaml:196`
 
-That is correct only for currencies with an ISO-4217 exponent of 2. **39 of 179 currencies
-are not** — JPY, KRW, VND, CLP, ISK and others are zero-decimal, so `× 100` reports revenue
-**100× too high**; BHD, KWD, TND and others are three-decimal, so it reports 10× too low.
-For an advertising or analytics destination this silently corrupts the customer's reported
-conversion value in those markets, with nothing failing and no error to trace.
+Those three are unconditional. `src/v0/destinations/dub/utils.ts:60` also multiplies by 100,
+but only behind the customer-set `convertAmountToCents` flag, and dub's own field doc already
+carries the caveat (`src/v0/destinations/dub/types.ts:90-92`) — so it is opt-in and documented
+rather than silently wrong. Don't treat it as the pattern to copy either.
+
+Multiplying by 100 is correct only for currencies with an ISO-4217 exponent of 2, and **39 of
+the 179 currencies in the ISO-4217 table are not** (count taken from the `currency-codes`
+package's table, not from this repo). JPY, KRW, VND, CLP and ISK are zero-decimal, so `× 100`
+reports revenue **100× too high**; BHD, KWD and TND are three-decimal, so it reports 10× too
+low. For an advertising or analytics destination this silently corrupts the customer's
+reported conversion value in those markets, with nothing failing and no error to trace.
 
 There is no shared helper in the repo (the only trace is a comment at
 `src/v0/destinations/dub/types.ts:92`). For new work, resolve the exponent from a real
@@ -37,6 +38,13 @@ const toMinorUnits = (value: number, currency?: string) =>
   Math.round(value * 10 ** exponent(currency));
 ```
 
+**`currency-codes` is not currently a dependency of this repo** — the first destination that
+needs this has to add it to `package.json`. If you'd rather not take the dependency, a local
+constant listing only the non-2 exponents (≈39 codes, defaulting everything else to 2) is a
+reasonable substitute; either way the exponent must come from a table, not a literal. Both
+carry the same caveat: the ISO-4217 list is static and needs refreshing when a currency
+redenominates.
+
 Notes:
 
 - `cc.code()` returns `undefined` for an unrecognised code, so you still choose the fallback.
@@ -47,54 +55,5 @@ Notes:
 - If the partner uses "micros" (currency unit × 10⁶ regardless of decimals, e.g. Google Ads),
   that is a fixed multiplier and **not** an exponent — don't route it through this.
 
-Deliberately not fixing the four call sites above in one pass: each needs its own regression
+Deliberately not fixing the call sites above in one pass: each needs its own regression
 testing against the partner. Do it when you touch the destination.
-
-## Where a setting belongs — config vs the per-event `integrations` object
-
-Both channels exist. Destination config (`destination.Config`) is set once in the dashboard;
-the per-event `integrations` object (`getIntegrationsObj(message, '<dest>')`, used by ~45
-destinations) is set by the customer per call. Neither is wrong — the mistake is **exposing
-the same setting through both**.
-
-- **A stable, destination-wide choice → config only.** Channel/`action_source` defaults,
-  API version, default currency. A per-event override on top of a config default gives two
-  places to set one value and two places to look when it's wrong, and the precedence between
-  them becomes undocumented behaviour the customer discovers by experiment.
-- **A genuinely per-event fact → `integrations` object only.** Consent/suppression flags for
-  a specific event, an event-specific test id, a value only the caller knows. There is no
-  sensible dashboard default for these.
-- **Neither, if a message field already carries it.** Don't invent an override for something
-  `properties` / `context` already expresses.
-
-When you find yourself writing `integrationsObj.x ?? Config.x ?? derive()`, that three-step
-chain is the smell — decide which of the two the setting actually is.
-
-## PII hashing
-
-The partner almost always wants SHA-256 of a **normalised** value: trimmed and lowercased
-before hashing, emitted as a lowercase 64-char hex string. Normalising after hashing, or not
-at all, produces a different digest for `Foo@Bar.com ` and `foo@bar.com` and quietly halves
-the match rate. `src/cdk/v2/destinations/reddit/utils.js:191` hashes the raw string — don't
-copy it. `src/v0/destinations/snapchat_conversion/transformV3.js:55` normalises first.
-
-**Handling already-hashed input — the repo is split.** ~17 destinations expose a config
-toggle (`hashData` / `isHashRequired` / `hashUserProperties`) telling the destination the
-customer is sending pre-hashed values. Two detect it instead, testing `/^[\da-f]{64}$/i` and
-passing a match through unchanged (`snapchat_conversion/util.js:28`).
-
-The toggle is the majority pattern, so it is not wrong to follow it. Prefer **detection**
-when the partner's contract forbids raw identifiers outright — a mis-set toggle then leaks
-plaintext PII to the partner, whereas detection is correct in both directions and needs no
-config. Detection's cost is that a 64-hex value that *isn't* a digest passes through unhashed;
-in practice nothing else looks like that.
-
-For audience-style records there is already a shared implementation — `HASHING_CONFIG` /
-`processAudienceRecord` in `src/v0/util/audienceUtils.ts`, which does normalise → validate →
-hash-if-not-already-hashed for SHA-256/SHA-512/MD5. Seven destinations use it
-(`custom_audience`, `fb_custom_audience`, `google_adwords_enhanced_conversions`,
-`google_adwords_remarketing_lists`, `iterable_audience`, `linkedin_audience`). Reuse it if it
-fits; mirror it rather than reinventing the regex if it doesn't.
-
-Finally: log counts and identifiers, never the values. A SHA-256 email is still a stable
-cross-site identifier — logging the digest defeats the hashing.

--- a/.claude/skills/destination-payload-conventions/SKILL.md
+++ b/.claude/skills/destination-payload-conventions/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: destination-payload-conventions
+description: Conventions for building destination payloads — monetary values and ISO-4217 minor units, where a setting belongs (destination config vs the per-event integrations object), and PII hashing/normalisation. Applied automatically — not user-invocable.
+---
+
+# Destination Payload Conventions
+
+Three decisions that recur in every destination and are currently made inconsistently across
+the repo. Each section states what the repo actually does today, so you can tell convention
+from recommendation.
+
+## Monetary values — never assume two decimal places
+
+**The current state of the repo is a latent bug.** Every monetary conversion multiplies by a
+hardcoded 100:
+
+- `src/v0/destinations/dub/utils.ts:60` — `Math.round(rawPayload.amount * 100)`
+- `src/cdk/v2/destinations/reddit/utils.js:74`, `:81`, `:88`
+- `src/cdk/v2/destinations/rakuten/utils.js:29`
+- `src/cdk/v2/destinations/optimizely_fullstack/procWorkflow.yaml:196`
+
+That is correct only for currencies with an ISO-4217 exponent of 2. **39 of 179 currencies
+are not** — JPY, KRW, VND, CLP, ISK and others are zero-decimal, so `× 100` reports revenue
+**100× too high**; BHD, KWD, TND and others are three-decimal, so it reports 10× too low.
+For an advertising or analytics destination this silently corrupts the customer's reported
+conversion value in those markets, with nothing failing and no error to trace.
+
+There is no shared helper in the repo (the only trace is a comment at
+`src/v0/destinations/dub/types.ts:92`). For new work, resolve the exponent from a real
+ISO-4217 source rather than a literal:
+
+```ts
+import cc from 'currency-codes'; // MIT, 179 currencies, exposes `digits`
+const DEFAULT_EXPONENT = 2;
+const exponent = (code?: string) => cc.code(code ?? '')?.digits ?? DEFAULT_EXPONENT;
+const toMinorUnits = (value: number, currency?: string) =>
+  Math.round(value * 10 ** exponent(currency));
+```
+
+Notes:
+
+- `cc.code()` returns `undefined` for an unrecognised code, so you still choose the fallback.
+  Default to 2 **and log once per unrecognised currency** — a code the library doesn't know is
+  either a customer typo or a currency it predates, and both are worth seeing.
+- Decide explicitly what happens when a value resolves but a currency doesn't. Silently
+  assuming one misattributes revenue; failing the single event surfaces it in Live Events.
+- If the partner uses "micros" (currency unit × 10⁶ regardless of decimals, e.g. Google Ads),
+  that is a fixed multiplier and **not** an exponent — don't route it through this.
+
+Deliberately not fixing the four call sites above in one pass: each needs its own regression
+testing against the partner. Do it when you touch the destination.
+
+## Where a setting belongs — config vs the per-event `integrations` object
+
+Both channels exist. Destination config (`destination.Config`) is set once in the dashboard;
+the per-event `integrations` object (`getIntegrationsObj(message, '<dest>')`, used by ~45
+destinations) is set by the customer per call. Neither is wrong — the mistake is **exposing
+the same setting through both**.
+
+- **A stable, destination-wide choice → config only.** Channel/`action_source` defaults,
+  API version, default currency. A per-event override on top of a config default gives two
+  places to set one value and two places to look when it's wrong, and the precedence between
+  them becomes undocumented behaviour the customer discovers by experiment.
+- **A genuinely per-event fact → `integrations` object only.** Consent/suppression flags for
+  a specific event, an event-specific test id, a value only the caller knows. There is no
+  sensible dashboard default for these.
+- **Neither, if a message field already carries it.** Don't invent an override for something
+  `properties` / `context` already expresses.
+
+When you find yourself writing `integrationsObj.x ?? Config.x ?? derive()`, that three-step
+chain is the smell — decide which of the two the setting actually is.
+
+## PII hashing
+
+The partner almost always wants SHA-256 of a **normalised** value: trimmed and lowercased
+before hashing, emitted as a lowercase 64-char hex string. Normalising after hashing, or not
+at all, produces a different digest for `Foo@Bar.com ` and `foo@bar.com` and quietly halves
+the match rate. `src/cdk/v2/destinations/reddit/utils.js:191` hashes the raw string — don't
+copy it. `src/v0/destinations/snapchat_conversion/transformV3.js:55` normalises first.
+
+**Handling already-hashed input — the repo is split.** ~17 destinations expose a config
+toggle (`hashData` / `isHashRequired` / `hashUserProperties`) telling the destination the
+customer is sending pre-hashed values. Two detect it instead, testing `/^[\da-f]{64}$/i` and
+passing a match through unchanged (`snapchat_conversion/util.js:28`).
+
+The toggle is the majority pattern, so it is not wrong to follow it. Prefer **detection**
+when the partner's contract forbids raw identifiers outright — a mis-set toggle then leaks
+plaintext PII to the partner, whereas detection is correct in both directions and needs no
+config. Detection's cost is that a 64-hex value that *isn't* a digest passes through unhashed;
+in practice nothing else looks like that.
+
+For audience-style records there is already a shared implementation — `HASHING_CONFIG` /
+`processAudienceRecord` in `src/v0/util/audienceUtils.ts`, which does normalise → validate →
+hash-if-not-already-hashed for SHA-256/SHA-512/MD5. Seven destinations use it
+(`custom_audience`, `fb_custom_audience`, `google_adwords_enhanced_conversions`,
+`google_adwords_remarketing_lists`, `iterable_audience`, `linkedin_audience`). Reuse it if it
+fits; mirror it rather than reinventing the regex if it doesn't.
+
+Finally: log counts and identifiers, never the values. A SHA-256 email is still a stable
+cross-site identifier — logging the digest defeats the hashing.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,19 +106,16 @@ relevant ones before writing code.** Copying the nearest existing destination is
 failure: most files here predate the current convention, so pattern-matching reproduces the
 old way with no signal that anything is wrong.
 
+Each skill's `description` says when it applies, so listing them here would only go stale —
+read them from the tree instead:
+
 ```bash
-ls .claude/skills/          # one line per skill; read the frontmatter `description` of each
+head -n 4 .claude/skills/*/SKILL.md   # name + description of every skill
 ```
 
-The ones that most often matter when adding or changing a destination:
-
-| Skill | Read it when |
-|---|---|
-| `batching-framework` | Any destination that sends more than one event per request — this is how router transforms are written now, including all-or-nothing partners and `networkHandler` fallbacks |
-| `deprecate-processor-transform` | Anything touching `transform.ts` / `process` — new destinations are router-only |
-| `live-integration-test` | Enrolling a destination in the real-account test suite (`test/integrations/live/`) |
-| `destination-payload-conventions` | Monetary values, config-vs-`integrations` overrides, PII hashing |
-| `code-structure`, `typescript-guidelines`, `writing-tests` | Applied to all code in this repo |
+Skim that, then read in full the ones that cover what you're touching. Anything that sends
+more than one event per request, and anything writing a `networkHandler`, is worth checking
+before you start rather than after.
 
 Where a skill and this file disagree, **the skill is current** — please fix this file.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,6 +98,30 @@ Before starting to work on your first RudderStack integration, it is highly reco
 * When developing a **destination integration**, you'll be parsing the event data according to this event spec and transforming it to your destination's data spec.
 
 
+### Read the repo's skills first
+
+Most conventions in this repo live in `.claude/skills/`, not in this file — they are kept
+short, scoped, and current, and they say which approach is the *current* one. **Read the
+relevant ones before writing code.** Copying the nearest existing destination is the common
+failure: most files here predate the current convention, so pattern-matching reproduces the
+old way with no signal that anything is wrong.
+
+```bash
+ls .claude/skills/          # one line per skill; read the frontmatter `description` of each
+```
+
+The ones that most often matter when adding or changing a destination:
+
+| Skill | Read it when |
+|---|---|
+| `batching-framework` | Any destination that sends more than one event per request — this is how router transforms are written now, including all-or-nothing partners and `networkHandler` fallbacks |
+| `deprecate-processor-transform` | Anything touching `transform.ts` / `process` — new destinations are router-only |
+| `live-integration-test` | Enrolling a destination in the real-account test suite (`test/integrations/live/`) |
+| `destination-payload-conventions` | Monetary values, config-vs-`integrations` overrides, PII hashing |
+| `code-structure`, `typescript-guidelines`, `writing-tests` | Applied to all code in this repo |
+
+Where a skill and this file disagree, **the skill is current** — please fix this file.
+
 ### Overview of integration development journey
 
 
@@ -129,7 +153,10 @@ Understand the code structure
 
 * `src/v0/destinations` - Destination integrations
 * `src/v1/destinations` - Destination integrations (used for network handlers)
-* `src/cdk/v2/destinations` - Destination Integrations that are written in CDK (no longer being developed now)
+* `src/cdk/v2/destinations` - Destination Integrations written in CDK v2 (YAML workflows).
+  **Deprecated — do not add new destinations here, and do not use an existing one as a
+  template.** New destinations go in `src/v0/destinations` as TypeScript; see the
+  `batching-framework` skill for the current router-transform shape.
 * `src/sources` - Source integrations
 * `test/integrations/sources` - Integration tests for source integrations
 * `test/integrations/destinations` - Integration tests for destination integrations
@@ -454,7 +481,10 @@ Understand the code structure
 
 * `src/v0/destinations` - Destination integrations
 * `src/v1/destinations` - Destination integrations (used for network handlers)
-* `src/cdk/v2/destinations` - Destination Integrations that are written in CDK (no longer being developed now)
+* `src/cdk/v2/destinations` - Destination Integrations written in CDK v2 (YAML workflows).
+  **Deprecated — do not add new destinations here, and do not use an existing one as a
+  template.** New destinations go in `src/v0/destinations` as TypeScript; see the
+  `batching-framework` skill for the current router-transform shape.
 * `src/sources` - Source integrations
 * `test/integrations/sources` - Integration tests for source integrations
 * `test/integrations/destinations` - Integration tests for destination integrations


### PR DESCRIPTION
Two gaps found while speccing a new all-or-nothing destination (OpenAI Ads). Docs only — no code changes.

## 1. `batching-framework` — "Partners that reject the whole batch"

The skill covers `BatchDestination`, chunking and `dontBatch` metrics, and its existing networkHandler section covers single-item assumptions. It does **not** cover what to do when a partner rejects the *entire request* on one bad item (OpenAI Ads, Reddit, Amplitude).

Transform-time validation is not sufficient on its own — it only covers the rules you knew about when you wrote it. A partner that adds a validation rule, or whose docs are incomplete, rejects a batch of N on one event you believed was fine, and the retry re-sends the same batch and fails again.

The new section documents the fallback: in the networkHandler, on a 4xx **when `rudderJobMetadata.length > 1`**, mark every job `dontBatch: true` and return 500 so the router re-delivers individually. Three rules that are easy to get wrong are called out explicitly:

- **split only on a 4xx** — a `!isHttpStatusSuccess(status)` guard also catches 429 and 5xx, turning a rate-limit or a partner outage (transient, and a whole-batch problem) into a permanent `dontBatch` on every job plus N individual redeliveries. `src/v1/destinations/am/networkHandler.ts` handles `isHttpStatusRetryable` and `isHttpStatusThrottled` before the split; the snippet now shows that ordering;
- **the `length > 1` guard** — without it a genuine single-event failure is converted into a retry and never aborts;
- **`statusCode: metadata.dontBatch ? 400 : 500`** — an event that already came back as a singleton and failed again must return the real 4xx, or a permanently-bad event retries forever.

Amplitude is cited as the closest thing to a complete reference (it has both the ordering and the termination rule, though it returns a `DeliveryV1Response` rather than throwing). `reddit/networkHandler.js` has the `length > 1` guard and correctly narrows to `status === 400`, but returns 500 unconditionally.

Also adds a line to **Error Handling** on how transform-time validation and the delivery fallback complement each other, and a note under **Metrics** not to add a destination-specific batch counter — `dont_batch_events` already carries destination tags, and a climbing rate on an all-or-nothing partner is the signal that a rule belongs in `transformEvent()`.

## 2. `destination-payload-conventions` (new skill)

**Monetary values — a latent bug.** Three destinations multiply by a hardcoded 100 unconditionally (`reddit/utils.js:74/81/88`, `rakuten/utils.js:29`, `optimizely_fullstack/procWorkflow.yaml:196`). That is right only for currencies with an ISO-4217 exponent of 2 — **39 of the 179 in the ISO-4217 table are not** (count from the `currency-codes` package's table, not from this repo). JPY and KRW are zero-decimal, so `× 100` reports revenue **100× too high**, silently, with nothing failing. `dub/utils.ts:60` also multiplies by 100 but only behind the customer-set `convertAmountToCents` flag, and dub's own field doc carries the caveat — opt-in and documented rather than silently wrong.

No shared helper exists. The skill documents resolving the exponent from a real ISO-4217 source, and notes that **`currency-codes` is not currently a dependency** — the first destination that needs it has to add it, or use a local table of the ~39 non-2 exponents. **Existing call sites are deliberately not changed** — each needs its own regression testing against the partner.

## 3. CONTRIBUTING — a skills pointer, and a stronger cdkV2 warning

Conventions live in `.claude/skills/`, but nothing in CONTRIBUTING says to read them, so the natural move is to copy the nearest existing destination — which usually predates the current convention.

Adds a short **"Read the repo's skills first"** section. It deliberately does *not* list the skills — that list would need constant updating — and instead gives `head -n 4 .claude/skills/*/SKILL.md` to read the names and descriptions straight from the tree, plus "where a skill and this file disagree, the skill is current".

And strengthens the cdkV2 line. It read *"Destination Integrations that are written in CDK (no longer being developed now)"* — accurate, but a parenthetical inside a directory listing is easy to read past, and I did exactly that: I specced a whole destination on cdkV2 despite having read this file. It now says do not add new destinations there and do not use an existing one as a template, pointing at the `batching-framework` skill instead.

## Verification

Every `file:line` citation was read back and confirmed against `develop` at `6f3d780bf`. No genuinely new destination directory has been added under `src/cdk/v2/destinations` in the last 12 months, which is the basis for the deprecation wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
