### PR TITLE
feat: live integrations tests for criteo audience

### DIFF
--- a/.claude/skills/live-integration-test/SKILL.md
+++ b/.claude/skills/live-integration-test/SKILL.md
@@ -159,11 +159,12 @@ defaults per integration. `criteo_audience` is the reference OAuth spec.
    the field-level verify so the two stay in lockstep.
 6. **Enroll**: `enabled: true` (registry auto-discovers `destinations/*/live.ts`; no registration).
    Use `enabled: false` to park a spec in the tree without running it.
-7. **Add the CI matrix entry.** Enrollment isn't complete until the destination runs in CI: add an
-   entry to `matrix.include` in `.github/workflows/live-integration-tests.yml`. The
-   `LIVE_SECRET_<DEST>` name is derived from the destination code. For an **OAuth** destination, also
-   set its `oauth:` field to the Vault path holding its app creds — the workflow gates the rudder-auth
-   ECR pull + app-cred fetch on that field; apiKey destinations omit it.
+7. **CI is automatic.** The `discover` job builds the workflow matrix from `destinations/*/live.ts`,
+   so a new spec runs in CI with no workflow edit. `LIVE_SECRET_<DEST>` is derived from the
+   destination code; an **OAuth** spec (`authType: 'oauth'`) additionally wildcard-imports the whole
+   `control-plane/data/external-services` cred set and starts rudder-auth (the container forwards only
+   the credential-shaped vars), while apiKey destinations do neither. See
+   `.github/scripts/live-test-matrix.js`.
 8. **Verify**:
    `npx tsc --noEmit -p tsconfig.test.json`
    then, with real credentials:
@@ -179,7 +180,9 @@ systems outside the repo — print this checklist at the end so the developer kn
 - **Vault**: add the `LIVE_SECRET_<DEST>` field (the full `LiveSecret` JSON, stored as **single-line**
   JSON — a multi-line value breaks the CI secret import) under
   `engineering_shared/data/integrations_team/e2e_test/rudder-transformer`. For OAuth destinations, also
-  ensure the app creds (client id/secret) exist at the Vault path referenced by the matrix `oauth:` field.
+  ensure the app creds exist under `control-plane/data/external-services` with the names rudder-auth
+  expects (e.g. `<DEST>_CLIENT_ID_DESTINATION`) — the OAuth job imports that whole set and rudder-auth
+  picks the ones it needs, so nothing in the workflow needs to know the exact field names.
 - **GitHub**: any Actions vars/secrets the run needs — the workflow reads `VAULT_ADDR`,
   `VAULT_JWT_AUTH_PATH`, `VAULT_JWT_ROLE` (and, for OAuth, `AWS_ECR_IAM_ROLE_ARN` for the rudder-auth
   image pull); add destination-specific ones if required.

--- a/.claude/skills/live-integration-test/SKILL.md
+++ b/.claude/skills/live-integration-test/SKILL.md
@@ -126,20 +126,23 @@ runs against the previous attempt's state.
 `resolveConfig(s)` maps `s.config` (plus fixed non-secret defaults taken from the component
 `destination.Config`) into the real `destination.Config`.
 
-**OAuth destinations** (`authType: 'oauth'`): supply `oauthRefresh` (the long-lived refresh token +
-`accountDefinition` + any `providerFields` like Salesforce `instance_url`). Note the harness README
-lists the `rudder-auth` container that services OAuth refresh as **deferred (not in the pilot)** — so
-until that layer lands, an OAuth destination's spec typically goes in with `enabled: false` (parked)
-and is validated for shape only. Prefer piloting `apiKey`/`basic` destinations first.
+**OAuth destinations** (`authType: 'oauth'`): supply `oauthRefresh` — the long-lived `refreshToken`,
+the `accountDefinition` (for rudder-auth's V1 route), and any `providerFields` (e.g. Salesforce
+`instance_url`). At run time the suite starts the **rudder-auth** container (testcontainers, ECR
+image) and `OAuthTokenResolver` refreshes the secret — trying V1 (`/auth/v1/refresh`) then the
+legacy route (`/tokens/destination/<dest>/refresh`) — then merges the whole returned secret into
+`metadata.secret`, so the transform reads its token under whatever key rudder-auth returns
+(`accessToken` | `access_token`). The OAuth **app** creds (client id/secret) come from the CI matrix
+`oauth:` Vault path (or `*_CLIENT_ID`/`*_CLIENT_SECRET` in `.env` locally); the image ships working
+defaults per integration. `criteo_audience` is the reference OAuth spec.
 
 ## Steps
 
 1. **Read** the sources above for `<dest>`; enumerate the distinct behaviors its component cases
    cover (dedupe error-only ones).
-2. **Choose** `authType`. **If the destination is OAuth, stop here:** the `rudder-auth` container
-   that services OAuth refresh is deferred (not in the pilot), so park the spec with
-   `enabled: false` and say so in the output — don't generate a spec that can't run yet. Pilot
-   `apiKey`/`basic` destinations first.
+2. **Choose** `authType`. For **OAuth**, set `authType: 'oauth'` and require `oauthRefresh` in the
+   secret; the rudder-auth container handles refresh at run time (see Credentials).
+   `criteo_audience` is the reference OAuth spec. `apiKey`/`basic` destinations need no refresh layer.
 3. **Write `resolveConfig`** from the component `destination.Config` — keep the non-secret fields as
    fixed defaults, spread `s.config` last for the real credentials.
 4. **Emit a credential template.** `resolveConfig` names the destination's config fields, so print a
@@ -155,11 +158,12 @@ and is validated for shape only. Prefer piloting `apiKey`/`basic` destinations f
    behaviors, factor the asserted fields into a `(ctx) => ({ ... })` profile shared by the seed and
    the field-level verify so the two stay in lockstep.
 6. **Enroll**: `enabled: true` (registry auto-discovers `destinations/*/live.ts`; no registration).
-   Use `enabled: false` to park it (e.g. OAuth destinations, until rudder-auth lands).
-7. **Add the CI matrix entry.** Enrollment isn't complete until the destination runs in CI: add its
-   code to the `destination` matrix in `.github/workflows/live-integration-tests.yml`
-   (`destination: [hs, <dest>]`). The secret name is derived from the code (`LIVE_SECRET_<DEST>`),
-   so that's the only workflow edit.
+   Use `enabled: false` to park a spec in the tree without running it.
+7. **Add the CI matrix entry.** Enrollment isn't complete until the destination runs in CI: add an
+   entry to `matrix.include` in `.github/workflows/live-integration-tests.yml`. The
+   `LIVE_SECRET_<DEST>` name is derived from the destination code. For an **OAuth** destination, also
+   set its `oauth:` field to the Vault path holding its app creds — the workflow gates the rudder-auth
+   ECR pull + app-cred fetch on that field; apiKey destinations omit it.
 8. **Verify**:
    `npx tsc --noEmit -p tsconfig.test.json`
    then, with real credentials:
@@ -172,10 +176,13 @@ and is validated for shape only. Prefer piloting `apiKey`/`basic` destinations f
 Generating `live.ts` is only the in-repo half. Enrolling a destination end-to-end also touches
 systems outside the repo — print this checklist at the end so the developer knows what's left:
 
-- **Vault**: add the `LIVE_SECRET_<DEST>` field (the full `LiveSecret` JSON) under
-  `engineering_shared/data/integrations_team/e2e_test/rudder-transformer`.
+- **Vault**: add the `LIVE_SECRET_<DEST>` field (the full `LiveSecret` JSON, stored as **single-line**
+  JSON — a multi-line value breaks the CI secret import) under
+  `engineering_shared/data/integrations_team/e2e_test/rudder-transformer`. For OAuth destinations, also
+  ensure the app creds (client id/secret) exist at the Vault path referenced by the matrix `oauth:` field.
 - **GitHub**: any Actions vars/secrets the run needs — the workflow reads `VAULT_ADDR`,
-  `VAULT_JWT_AUTH_PATH`, and `VAULT_JWT_ROLE`; add destination-specific ones if required.
+  `VAULT_JWT_AUTH_PATH`, `VAULT_JWT_ROLE` (and, for OAuth, `AWS_ECR_IAM_ROLE_ARN` for the rudder-auth
+  image pull); add destination-specific ones if required.
 - **Sandbox account**: who owns it, what a run creates, and what cleanup is expected to remove — a
   live run writes to a real account.
 
@@ -193,7 +200,7 @@ event with `properties` for a conversion, or an audience membership event), swap
 ```ts
 import axios from 'axios';
 import { Agent } from 'https';
-import { LiveSpec, RunContext } from '../../live/types';
+import type { LiveSpec, RunContext } from '../../live/types';
 import { pollUntil } from '../../live/poll';
 
 // keepAlive:false so read-back/cleanup sockets don't linger as open handles.
@@ -226,8 +233,8 @@ const agent = new Agent({ keepAlive: false });
 //   },
 // });
 
-export const live: LiveSpec = {
-  enabled: true, // OAuth destinations: false until rudder-auth lands (see Credentials)
+export const live = {
+  enabled: true,
   authType: 'apiKey', // apiKey | oauth | basic | serviceAccount | custom
   // Non-secret Config defaults from the component test's destination.Config; real creds via s.config.
   resolveConfig: (s) => ({ ...s.config }),
@@ -267,7 +274,7 @@ export const live: LiveSpec = {
     // },
     // { id: '<dest>-variant', description: 'config-driven variant', configOverride: (base) => ({ ...base }), steps: [ ... ] },
   ],
-};
+} satisfies LiveSpec;
 
 export default live;
 ```

--- a/.claude/skills/live-integration-test/SKILL.md
+++ b/.claude/skills/live-integration-test/SKILL.md
@@ -127,14 +127,17 @@ runs against the previous attempt's state.
 `destination.Config`) into the real `destination.Config`.
 
 **OAuth destinations** (`authType: 'oauth'`): supply `oauthRefresh` — the long-lived `refreshToken`,
-the `accountDefinition` (for rudder-auth's V1 route), and any `providerFields` (e.g. Salesforce
-`instance_url`). At run time the suite starts the **rudder-auth** container (testcontainers, ECR
-image) and `OAuthTokenResolver` refreshes the secret — trying V1 (`/auth/v1/refresh`) then the
-legacy route (`/tokens/destination/<dest>/refresh`) — then merges the whole returned secret into
-`metadata.secret`, so the transform reads its token under whatever key rudder-auth returns
-(`accessToken` | `access_token`). The OAuth **app** creds (client id/secret) come from the CI matrix
-`oauth:` Vault path (or `*_CLIENT_ID`/`*_CLIENT_SECRET` in `.env` locally); the image ships working
-defaults per integration. `criteo_audience` is the reference OAuth spec.
+the `accountDefinition` (for rudder-auth's v1 route), and any `providerFields` (e.g. Salesforce
+`instance_url`) — and set `oauthVersion` to the route rudder-auth uses: `'v0'` (legacy
+`/tokens/destination/<dest>/refresh`, the default) or `'v1'` (`/auth/v1/refresh`). At run time the
+suite starts the **rudder-auth** container (testcontainers, ECR image) and `OAuthTokenResolver` calls
+exactly that one route — no fallback — then merges the whole returned secret into `metadata.secret`,
+so the transform reads its token under whatever key rudder-auth returns (`accessToken` |
+`access_token`). The OAuth **app** creds come from Vault: the CI job wildcard-imports
+`control-plane/data/external-services` and the container forwards only the enrolled destinations'
+`<DEST>_…` base/`_DESTINATION` creds (never `_SOURCE`); locally set `*_CLIENT_ID`/`*_CLIENT_SECRET` in
+`.env`. The image ships working defaults per integration. `criteo_audience` is the reference OAuth
+spec.
 
 ## Steps
 
@@ -163,8 +166,8 @@ defaults per integration. `criteo_audience` is the reference OAuth spec.
    so a new spec runs in CI with no workflow edit. `LIVE_SECRET_<DEST>` is derived from the
    destination code; an **OAuth** spec (`authType: 'oauth'`) additionally wildcard-imports the whole
    `control-plane/data/external-services` cred set and starts rudder-auth (the container forwards only
-   the credential-shaped vars), while apiKey destinations do neither. See
-   `.github/scripts/live-test-matrix.js`.
+   the enrolled destinations' `<DEST>_…` base/`_DESTINATION` creds), while apiKey destinations do
+   neither. See `.github/scripts/live-test-matrix.js`.
 8. **Verify**:
    `npx tsc --noEmit -p tsconfig.test.json`
    then, with real credentials:
@@ -181,8 +184,9 @@ systems outside the repo — print this checklist at the end so the developer kn
   JSON — a multi-line value breaks the CI secret import) under
   `engineering_shared/data/integrations_team/e2e_test/rudder-transformer`. For OAuth destinations, also
   ensure the app creds exist under `control-plane/data/external-services` with the names rudder-auth
-  expects (e.g. `<DEST>_CLIENT_ID_DESTINATION`) — the OAuth job imports that whole set and rudder-auth
-  picks the ones it needs, so nothing in the workflow needs to know the exact field names.
+  expects (e.g. `<DEST>_CLIENT_ID_DESTINATION`) — the OAuth job wildcard-imports that whole set and the
+  container forwards this destination's `<DEST>_…` base/`_DESTINATION` creds, so nothing in the
+  workflow needs to know the exact field names.
 - **GitHub**: any Actions vars/secrets the run needs — the workflow reads `VAULT_ADDR`,
   `VAULT_JWT_AUTH_PATH`, `VAULT_JWT_ROLE` (and, for OAuth, `AWS_ECR_IAM_ROLE_ARN` for the rudder-auth
   image pull); add destination-specific ones if required.

--- a/.github/scripts/live-test-matrix.js
+++ b/.github/scripts/live-test-matrix.js
@@ -1,0 +1,32 @@
+// Builds the live-integration-tests CI matrix from the live specs on disk, so destinations are never
+// enumerated by hand in the workflow. A destination is any directory under
+// test/integrations/destinations/ that contains a live.ts. Each entry carries an `oauth` flag
+// (authType: 'oauth'); the workflow uses it to wildcard-import the rudder-auth app credentials and
+// to start rudder-auth, so no per-destination secret names live here.
+//
+// Emits `matrix=<json>` on stdout for "$GITHUB_OUTPUT"; the value is { include: [{ destination,
+// oauth }] }.
+const { readdirSync, readFileSync, existsSync } = require('fs');
+const { join } = require('path');
+
+const DEST_DIR = 'test/integrations/destinations';
+
+const isOAuth = (specPath) => /authType:\s*['"]oauth['"]/.test(readFileSync(specPath, 'utf8'));
+
+const include = readdirSync(DEST_DIR, { withFileTypes: true })
+  .filter((entry) => entry.isDirectory())
+  .map((entry) => entry.name)
+  .sort()
+  .flatMap((destination) => {
+    const specPath = join(DEST_DIR, destination, 'live.ts');
+    if (!existsSync(specPath)) {
+      return [];
+    }
+    return [{ destination, oauth: isOAuth(specPath) }];
+  });
+
+if (include.length === 0) {
+  throw new Error(`No live specs found under ${DEST_DIR}/*/live.ts`);
+}
+
+process.stdout.write(`matrix=${JSON.stringify({ include })}\n`);

--- a/.github/workflows/live-integration-tests.yml
+++ b/.github/workflows/live-integration-tests.yml
@@ -46,8 +46,8 @@ jobs:
           - destination: vero
           - destination: criteo_audience
             appSecrets: |
-              control-plane/data/external-services CRITEO_AUDIENCE_CLIENT_ID_DESTINATION
-              control-plane/data/external-services CRITEO_AUDIENCE_CLIENT_SECRET_DESTINATION
+              control-plane/data/external-services CRITEO_AUDIENCE_CLIENT_ID_DESTINATION ;
+              control-plane/data/external-services CRITEO_AUDIENCE_CLIENT_SECRET_DESTINATION ;
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
@@ -82,7 +82,7 @@ jobs:
           jwtGithubAudience: ${{ vars.VAULT_ADDR }} # MUST match bound_audiences, else auth fails
           exportToken: false # keep the raw Vault token out of env
           secrets: |
-            engineering_shared/data/integrations_team/e2e_test/rudder-transformer ${{ steps.secret.outputs.name }} | ${{ steps.secret.outputs.name }}
+            engineering_shared/data/integrations_team/e2e_test/rudder-transformer ${{ steps.secret.outputs.name }} | ${{ steps.secret.outputs.name }} ;
             ${{ matrix.appSecrets }}
 
       - name: Configure AWS credentials for ECR (OIDC)

--- a/.github/workflows/live-integration-tests.yml
+++ b/.github/workflows/live-integration-tests.yml
@@ -40,7 +40,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        destination: [hs, braze_audience, braze, vero]
+        include:
+          - destination: hs
+          - destination: braze_audience
+          - destination: vero
+          - destination: criteo_audience
+            appSecrets: |
+              control-plane/data/external-services CRITEO_AUDIENCE_CLIENT_ID_DESTINATION
+              control-plane/data/external-services CRITEO_AUDIENCE_CLIENT_SECRET_DESTINATION
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
@@ -64,7 +71,7 @@ jobs:
         id: secret
         run: echo "name=LIVE_SECRET_$(echo '${{ matrix.destination }}' | tr 'a-z' 'A-Z')" >> "$GITHUB_OUTPUT"
 
-      - name: Import destination secret from dev Vault (OIDC/JWT)
+      - name: Import secrets from dev Vault (OIDC/JWT)
         id: vault
         uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
         with:
@@ -76,6 +83,22 @@ jobs:
           exportToken: false # keep the raw Vault token out of env
           secrets: |
             engineering_shared/data/integrations_team/e2e_test/rudder-transformer ${{ steps.secret.outputs.name }} | ${{ steps.secret.outputs.name }}
+            ${{ matrix.appSecrets }}
+
+      - name: Configure AWS credentials for ECR (OIDC)
+        if: matrix.appSecrets != ''
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
+        with:
+          role-to-assume: ${{ vars.AWS_ECR_IAM_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Log in to Amazon ECR
+        if: matrix.appSecrets != ''
+        uses: aws-actions/amazon-ecr-login@d539f0932e70871a027e9d5a9d8fc38589180a64 # 2.1.6
+
+      - name: Pre-pull rudder-auth image (surface ECR/pull errors before the test run)
+        if: matrix.appSecrets != ''
+        run: docker pull 422074288268.dkr.ecr.us-east-1.amazonaws.com/rudderstack/rudder-auth:develop
 
       - name: Run live tests
         # LOG_LEVEL=100 suppresses body logging so tokens can't leak.

--- a/.github/workflows/live-integration-tests.yml
+++ b/.github/workflows/live-integration-tests.yml
@@ -29,7 +29,26 @@ permissions:
   contents: read # for actions/checkout
 
 jobs:
+  discover:
+    name: discover live destinations
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.gen.outputs.matrix }}
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Build matrix from live specs
+        id: gen
+        run: node .github/scripts/live-test-matrix.js >> "$GITHUB_OUTPUT"
+
   live:
+    needs: discover
     name: live (${{ matrix.destination }})
     # required: puts the job in infra1-us → PrivateLink path to dev Vault
     runs-on: [self-hosted, Linux, X64]
@@ -39,15 +58,7 @@ jobs:
       contents: read # for actions/checkout
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - destination: hs
-          - destination: braze_audience
-          - destination: vero
-          - destination: criteo_audience
-            appSecrets: |
-              control-plane/data/external-services CRITEO_AUDIENCE_CLIENT_ID_DESTINATION ;
-              control-plane/data/external-services CRITEO_AUDIENCE_CLIENT_SECRET_DESTINATION ;
+      matrix: ${{ fromJson(needs.discover.outputs.matrix) }}
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
@@ -83,21 +94,21 @@ jobs:
           exportToken: false # keep the raw Vault token out of env
           secrets: |
             engineering_shared/data/integrations_team/e2e_test/rudder-transformer ${{ steps.secret.outputs.name }} | ${{ steps.secret.outputs.name }} ;
-            ${{ matrix.appSecrets }}
+            ${{ matrix.oauth && 'control-plane/data/external-services *' || '' }}
 
       - name: Configure AWS credentials for ECR (OIDC)
-        if: matrix.appSecrets != ''
+        if: matrix.oauth
         uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           role-to-assume: ${{ vars.AWS_ECR_IAM_ROLE_ARN }}
           aws-region: us-east-1
 
       - name: Log in to Amazon ECR
-        if: matrix.appSecrets != ''
+        if: matrix.oauth
         uses: aws-actions/amazon-ecr-login@d539f0932e70871a027e9d5a9d8fc38589180a64 # 2.1.6
 
       - name: Pre-pull rudder-auth image (surface ECR/pull errors before the test run)
-        if: matrix.appSecrets != ''
+        if: matrix.oauth
         run: docker pull 422074288268.dkr.ecr.us-east-1.amazonaws.com/rudderstack/rudder-auth:develop
 
       - name: Run live tests

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -48,6 +48,18 @@
         "NODE_OPTIONS": "--no-node-snapshot",
         "LOG_LEVEL": "silent"
       }
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Debug Jest Live",
+      "program": "${workspaceFolder}/node_modules/jest/bin/jest.js",
+      "args": ["-c", "jest.config.live.js", "--runInBand", "--destination=criteo_audience"],
+      "cwd": "${workspaceFolder}",
+      "runtimeArgs": ["--no-node-snapshot"],
+      "env": { "NODE_ENV": "test" },
+      "console": "integratedTerminal",
+      "skipFiles": ["<node_internals>/**"]
     }
   ]
 }

--- a/jest.config.live.js
+++ b/jest.config.live.js
@@ -12,7 +12,7 @@ module.exports = {
   collectCoverageFrom: ['src/**/*.{ts,js}', '!src/**/*.d.ts'],
   moduleDirectories: ['node_modules'],
   moduleFileExtensions: ['js', 'json', 'ts', 'node'],
-  modulePathIgnorePatterns: ['<rootDir>/dist/', '<rootDir>/dist-test/'],
+  modulePathIgnorePatterns: ['<rootDir>/dist/', '<rootDir>/dist-test/', '<rootDir>/.worktrees/'],
   setupFiles: ['<rootDir>/test/setup.ts'],
   testMatch: ['<rootDir>/test/integrations/component.live.test.ts'],
   testPathIgnorePatterns: ['/node_modules/'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -69,6 +69,7 @@
         "sha256": "^0.2.0",
         "sqlstring": "^2.3.3",
         "stacktrace-parser": "^0.1.10",
+        "testcontainers": "^12.0.4",
         "truncate-utf8-bytes": "^1.0.2",
         "ua-parser-js": "^1.0.37",
         "unset-value": "^2.0.1",
@@ -127,7 +128,6 @@
         "standard-version": "^9.5.0",
         "supertest": "^7.1.4",
         "swagger-cli": "^4.0.4",
-        "testcontainers": "^12.0.4",
         "ts-jest": "^29.2.5",
         "typescript": "^5.0.4"
       }
@@ -1655,7 +1655,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@balena/dockerignore/-/dockerignore-1.0.2.tgz",
       "integrity": "sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q==",
-      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@bcoe/v8-coverage": {
@@ -2695,7 +2694,6 @@
       "version": "1.14.4",
       "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.4.tgz",
       "integrity": "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/proto-loader": "^0.8.0",
@@ -2709,7 +2707,6 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.1.tgz",
       "integrity": "sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "lodash.camelcase": "^4.3.0",
@@ -2728,7 +2725,6 @@
       "version": "0.7.15",
       "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.15.tgz",
       "integrity": "sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "lodash.camelcase": "^4.3.0",
@@ -2831,7 +2827,6 @@
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^5.1.2",
@@ -2847,7 +2842,6 @@
     },
     "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
       "version": "6.1.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -2858,7 +2852,6 @@
     },
     "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
       "version": "6.2.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -2869,12 +2862,10 @@
     },
     "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
       "version": "9.2.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@isaacs/cliui/node_modules/string-width": {
       "version": "5.1.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "eastasianwidth": "^0.2.0",
@@ -2890,7 +2881,6 @@
     },
     "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
       "version": "7.1.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.0.1"
@@ -2904,7 +2894,6 @@
     },
     "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
       "version": "8.1.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^6.1.0",
@@ -3669,7 +3658,6 @@
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
       "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -3699,7 +3687,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
       "integrity": "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.1.1"
@@ -3783,7 +3770,6 @@
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -3805,35 +3791,30 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
       "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
-      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/base64": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
       "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
-      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/codegen": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
       "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
-      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
       "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
-      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/fetch": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
       "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.1"
@@ -3843,28 +3824,24 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
       "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/path": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
       "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
-      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/pool": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
       "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
-      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/utf8": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
       "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
-      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@pyroscope/nodejs": {
@@ -5027,7 +5004,6 @@
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/@types/docker-modem/-/docker-modem-3.0.6.tgz",
       "integrity": "sha512-yKpAGEuKRSS8wwx0joknWxsmLha78wNMe9R2S3UNsVOkZded8UqOrV8KoeDXoXsjndxwyF3eIhyClGbO1SEhEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -5038,7 +5014,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@types/dockerode/-/dockerode-4.0.1.tgz",
       "integrity": "sha512-cmUpB+dPN955PxBEuXE3f6lKO1hHiIGYJA46IVF3BJpNsZGvtBDcRnlrHYHtOH/B6vtDOyl2kZ2ShAu3mgc27Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/docker-modem": "*",
@@ -5230,7 +5205,6 @@
       "version": "1.15.5",
       "resolved": "https://registry.npmjs.org/@types/ssh2/-/ssh2-1.15.5.tgz",
       "integrity": "sha512-N1ASjp/nXH3ovBHddRJpli4ozpk6UdDYIX4RJWFa9L1YKnzdhTlVmiGHm4DZnj/jLbqZpes4aeR30EFGQtvhQQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "^18.11.18"
@@ -5240,7 +5214,6 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/@types/ssh2-streams/-/ssh2-streams-0.1.13.tgz",
       "integrity": "sha512-faHyY3brO9oLEA0QlcO8N2wT7R0+1sHWZvQ+y3rMLwdY1ZyS1z0W3t65j9PqT4HmQ6ALzNe7RZlNuCNE0wBSWA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -5250,7 +5223,6 @@
       "version": "18.19.130",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
       "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -5260,7 +5232,6 @@
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/stack-utils": {
@@ -5998,7 +5969,6 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/archiver/-/archiver-7.0.1.tgz",
       "integrity": "sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "archiver-utils": "^5.0.2",
@@ -6017,7 +5987,6 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-5.0.2.tgz",
       "integrity": "sha512-wuLJMmIBQYCsGZgYLTy5FIB2pF6Lfb6cXMSF8Qywwk3t20zWnAi7zLcQFdKQmIB8wyZpY5ER38x08GbwtR2cLA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "glob": "^10.0.0",
@@ -6036,7 +6005,6 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
       "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6061,7 +6029,6 @@
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
       "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "abort-controller": "^3.0.0",
@@ -6078,7 +6045,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
@@ -6088,7 +6054,6 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
       "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6113,7 +6078,6 @@
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
       "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "abort-controller": "^3.0.0",
@@ -6130,7 +6094,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
@@ -6140,7 +6103,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
       "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "b4a": "^1.6.4",
@@ -6282,7 +6244,6 @@
       "version": "0.2.6",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
       "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": "~2.1.0"
@@ -6311,7 +6272,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/async-lock/-/async-lock-1.4.1.tgz",
       "integrity": "sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/async-rwlock": {
@@ -6389,7 +6349,6 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
       "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
-      "dev": true,
       "license": "Apache-2.0",
       "peerDependencies": {
         "react-native-b4a": "*"
@@ -6584,7 +6543,6 @@
       "version": "2.9.1",
       "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.9.1.tgz",
       "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
-      "dev": true,
       "license": "Apache-2.0",
       "peerDependencies": {
         "bare-abort-controller": "*"
@@ -6599,7 +6557,6 @@
       "version": "4.8.0",
       "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.8.0.tgz",
       "integrity": "sha512-fM+MhCvdQhZ7NV6S95a07gPSqjIYKn6mFaXfx266wN3ajZGl/+1AzH+ubkXQ0fFZvOe2nk9VHkzdYkQE5zMV3Q==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "bare-events": "^2.5.4",
@@ -6624,14 +6581,12 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.1.1.tgz",
       "integrity": "sha512-JprUlveX3QjApC1cTpsUOiscADftCGVWkzitbHsRqv84hzYwYHw2mbluddsq5TvI8mH/8Ov1f4BiMAdcB0oYnQ==",
-      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/bare-stream": {
       "version": "2.13.3",
       "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.3.tgz",
       "integrity": "sha512-Kc+brLqvEqGkjyfiwJmImAOqLZL7OsoLKuavx+hJjgVV3nLTOjloJyPMFxjUPerGGHrNH0fLU06jjykMLWrERQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "b4a": "^1.8.1",
@@ -6656,10 +6611,9 @@
       }
     },
     "node_modules/bare-url": {
-      "version": "2.4.7",
-      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.7.tgz",
-      "integrity": "sha512-o8CRCiJtib+ycO3mE4A5UChtGX4dDP2XxsWVu9P+Zc3H8tcmKwNVEDoDTXmwN+uuMhfKeT7/i7Y26xS8W7ohoA==",
-      "dev": true,
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.5.1.tgz",
+      "integrity": "sha512-cD5ciQuKlx+eumTCfqbfiL+fhQm+dHbVNB/cX4+d+I/nx4JsVop9VoFEPAs5RJ6I84QR6bZIBjpd2kjDOYeWcg==",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-path": "^3.0.0"
@@ -6696,7 +6650,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "tweetnacl": "^0.14.3"
@@ -6937,7 +6890,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
       "integrity": "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
@@ -6952,7 +6904,6 @@
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/buildcheck/-/buildcheck-0.0.7.tgz",
       "integrity": "sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA==",
-      "dev": true,
       "optional": true,
       "engines": {
         "node": ">=10.0.0"
@@ -7322,7 +7273,6 @@
     },
     "node_modules/cliui": {
       "version": "8.0.1",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
@@ -7592,7 +7542,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-6.0.2.tgz",
       "integrity": "sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "crc-32": "^1.2.0",
@@ -7609,7 +7558,6 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
       "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -7634,7 +7582,6 @@
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
       "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "abort-controller": "^3.0.0",
@@ -7651,7 +7598,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
@@ -8027,7 +7973,6 @@
     },
     "node_modules/core-util-is": {
       "version": "1.0.3",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/cosmiconfig": {
@@ -8075,7 +8020,6 @@
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/cpu-features/-/cpu-features-0.0.10.tgz",
       "integrity": "sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==",
-      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "dependencies": {
@@ -8090,7 +8034,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
       "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "crc32": "bin/crc32.njs"
@@ -8103,7 +8046,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-6.0.0.tgz",
       "integrity": "sha512-piICUB6ei4IlTv1+653yq5+KoqfBYmj9bw6LqXoOneTMDXk5nM1qt12mFW1caG3LlJXEKW1Bp0WggEmIfQB34g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "crc-32": "^1.2.0",
@@ -8117,7 +8059,6 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
       "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -8142,7 +8083,6 @@
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
       "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "abort-controller": "^3.0.0",
@@ -8159,7 +8099,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
@@ -8832,7 +8771,6 @@
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/docker-compose/-/docker-compose-1.4.2.tgz",
       "integrity": "sha512-rPHigTKGaEHpkUmfd69QgaOp+Os5vGJwG/Ry8lcr8W/382AmI+z/D7qoa9BybKIkqNppaIbs8RYeHSevdQjWww==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "yaml": "^2.2.2"
@@ -8845,7 +8783,6 @@
       "version": "5.0.7",
       "resolved": "https://registry.npmjs.org/docker-modem/-/docker-modem-5.0.7.tgz",
       "integrity": "sha512-XJgGhoR/CLpqshm4d3L7rzH6t8NgDFUIIpztYlLHIApeJjMZKYJMz2zxPsYxnejq5h3ELYSw/RBsi3t5h7gNTA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "debug": "^4.1.1",
@@ -8861,7 +8798,6 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
@@ -8876,7 +8812,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/dockerode/-/dockerode-5.0.1.tgz",
       "integrity": "sha512-avsq/xk4YPIrn0CgleX5bjT9Y8IT1p9PxrNQ++RBQ2WEyFfHCTDsT9kmyxz+H/axnjAwg8wJWEIuPGOUuNupiA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@balena/dockerignore": "^1.0.2",
@@ -9012,7 +8947,6 @@
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/ee-first": {
@@ -9313,7 +9247,6 @@
     },
     "node_modules/escalade": {
       "version": "3.2.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -9957,7 +9890,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
       "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "bare-events": "^2.7.0"
@@ -10059,7 +9991,6 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
       "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -10457,7 +10388,6 @@
     },
     "node_modules/foreground-child": {
       "version": "3.3.1",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "cross-spawn": "^7.0.6",
@@ -10472,7 +10402,6 @@
     },
     "node_modules/foreground-child/node_modules/signal-exit": {
       "version": "4.1.0",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=14"
@@ -10608,7 +10537,6 @@
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
@@ -10666,7 +10594,6 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/get-port/-/get-port-5.1.1.tgz",
       "integrity": "sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -10789,7 +10716,6 @@
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
       "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
@@ -10818,7 +10744,6 @@
     },
     "node_modules/glob/node_modules/brace-expansion": {
       "version": "2.0.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -10826,7 +10751,6 @@
     },
     "node_modules/glob/node_modules/minimatch": {
       "version": "9.0.5",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -12095,7 +12019,6 @@
     },
     "node_modules/isarray": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/iserror": {
@@ -12214,7 +12137,6 @@
     },
     "node_modules/jackspeak": {
       "version": "3.4.3",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
@@ -14384,7 +14306,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
       "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "readable-stream": "^2.0.5"
@@ -14632,7 +14553,6 @@
     },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.defaults": {
@@ -14989,7 +14909,6 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
       "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
-      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/longest": {
@@ -15520,7 +15439,6 @@
     },
     "node_modules/minipass": {
       "version": "7.1.2",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -15530,7 +15448,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
       "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "mkdirp": "dist/cjs/src/bin.js"
@@ -15866,7 +15783,6 @@
       "version": "2.28.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.28.0.tgz",
       "integrity": "sha512-fTsDz99OTq2sVePhGdp4qQhggZFtKr64ZNVyVajRKtMOkJxYekplBh577PiJB12v/D3s2E5cGtOI45LWp6rnLQ==",
-      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -16081,7 +15997,6 @@
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -16489,7 +16404,6 @@
     },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
-      "dev": true,
       "license": "BlueOak-1.0.0"
     },
     "node_modules/parent-module": {
@@ -16587,7 +16501,6 @@
     },
     "node_modules/path-scurry": {
       "version": "1.11.1",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "lru-cache": "^10.2.0",
@@ -16602,7 +16515,6 @@
     },
     "node_modules/path-scurry/node_modules/lru-cache": {
       "version": "10.4.3",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/path-to-regexp": {
@@ -17235,7 +17147,6 @@
     },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/process-warning": {
@@ -17278,7 +17189,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
       "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
@@ -17290,7 +17200,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/properties-reader/-/properties-reader-3.0.1.tgz",
       "integrity": "sha512-WPn+h9RGEExOKdu4bsF4HksG/uzd3cFq3MFtq8PsFeExPse5Ha/VOjQNyHhjboBFwGXGev6muJYTSPAOkROq2g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@kwsites/file-exists": "^1.1.1",
@@ -17308,7 +17217,6 @@
       "version": "7.6.5",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
       "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -17592,7 +17500,6 @@
     },
     "node_modules/readable-stream": {
       "version": "2.3.8",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
@@ -17606,14 +17513,12 @@
     },
     "node_modules/readable-stream/node_modules/safe-buffer": {
       "version": "5.1.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/readdir-glob": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.3.tgz",
       "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "minimatch": "^5.1.0"
@@ -17623,7 +17528,6 @@
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
       "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -17633,7 +17537,6 @@
       "version": "5.1.9",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
       "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -17763,7 +17666,6 @@
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -17894,7 +17796,6 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
       "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -18522,7 +18423,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/split-ca/-/split-ca-1.0.1.tgz",
       "integrity": "sha512-Q5thBSxp5t8WPTTJQS59LrGqOZqOsrhDGDVm8azCqIBjSBd7nd9o2PM+mDulQQkh8h//4U6hFZnc/mul8t5pWQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/split2": {
@@ -18562,7 +18462,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/ssh-remote-port-forward/-/ssh-remote-port-forward-1.0.4.tgz",
       "integrity": "sha512-x0LV1eVDwjf1gmG7TTnfqIzf+3VPRz7vrNIjX6oYLbeCrf/PeVY6hkT68Mg+q02qXxQhrLjB0jfgvhevoCRmLQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/ssh2": "^0.5.48",
@@ -18573,7 +18472,6 @@
       "version": "0.5.52",
       "resolved": "https://registry.npmjs.org/@types/ssh2/-/ssh2-0.5.52.tgz",
       "integrity": "sha512-lbLLlXxdCZOSJMCInKH2+9V/77ET2J6NPQHpFI0kda61Dd1KglJs+fPQBchizmzYSOJBgdTajhPqBO1xxLywvg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -18584,7 +18482,6 @@
       "version": "1.17.0",
       "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.17.0.tgz",
       "integrity": "sha512-wPldCk3asibAjQ/kziWQQt1Wh3PgDFpC0XpwclzKcdT1vql6KeYxf5LIt4nlFkUeR8WuphYMKqUA56X4rjbfgQ==",
-      "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "asn1": "^0.2.6",
@@ -19064,7 +18961,6 @@
       "version": "2.28.0",
       "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.28.0.tgz",
       "integrity": "sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "events-universal": "^1.0.0",
@@ -19118,7 +19014,6 @@
     "node_modules/string-width-cjs": {
       "name": "string-width",
       "version": "4.2.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -19131,7 +19026,6 @@
     },
     "node_modules/string-width-cjs/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -19225,7 +19119,6 @@
     "node_modules/strip-ansi-cjs": {
       "name": "strip-ansi",
       "version": "6.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -19456,7 +19349,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
       "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "streamx": "^2.12.5"
@@ -19495,10 +19387,9 @@
       }
     },
     "node_modules/testcontainers": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/testcontainers/-/testcontainers-12.1.0.tgz",
-      "integrity": "sha512-YjDLqIITuhGLMnM10yhg3oV6lIG5IMpz1R1DPBZoOOks83q7i7IVpeSWRTiyl7roozjiyLmwIoLK/KY8OnZmIA==",
-      "dev": true,
+      "version": "12.0.4",
+      "resolved": "https://registry.npmjs.org/testcontainers/-/testcontainers-12.0.4.tgz",
+      "integrity": "sha512-QIR/8xF1+F/26cIM+9B4yyxNTbKJxAv3hygZyhPRgZ8Q2AhlPZjDdpXRuk16V37X4bgJRI3hXFhoEICMBA7Adg==",
       "license": "MIT",
       "dependencies": {
         "@balena/dockerignore": "^1.0.2",
@@ -19508,24 +19399,20 @@
         "byline": "^5.0.0",
         "debug": "^4.4.3",
         "docker-compose": "^1.4.2",
-        "dockerode": "^5.0.1",
+        "dockerode": "^5.0.0",
         "get-port": "^5.1.1",
         "proper-lockfile": "^4.1.2",
         "properties-reader": "^3.0.1",
         "ssh-remote-port-forward": "^1.0.4",
-        "tar-fs": "^3.1.3",
+        "tar-fs": "^3.1.2",
         "tmp": "^0.2.7",
-        "undici": "^8.9.0"
-      },
-      "engines": {
-        "node": ">= 22.22"
+        "undici": "^8.5.0"
       }
     },
     "node_modules/testcontainers/node_modules/tar-fs": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.3.tgz",
       "integrity": "sha512-/hU4AXnIdZu+Gvl1pk0oI5f5HxWsCJRtY2aFaJdk9VvyL48DWU6iU5WAIPG+wIi1YvWA6eTJvIviP/tMAZZNwQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pump": "^3.0.0",
@@ -19540,7 +19427,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
       "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "b4a": "^1.6.4",
@@ -19553,7 +19439,6 @@
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
       "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14.14"
@@ -19563,7 +19448,6 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
       "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "b4a": "^1.6.4"
@@ -19869,7 +19753,6 @@
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
-      "dev": true,
       "license": "Unlicense"
     },
     "node_modules/type-check": {
@@ -20059,7 +19942,6 @@
       "version": "8.10.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
       "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=22.19.0"
@@ -20496,7 +20378,6 @@
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -20513,7 +20394,6 @@
     "node_modules/wrap-ansi-cjs": {
       "name": "wrap-ansi",
       "version": "7.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -20529,7 +20409,6 @@
     },
     "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -20543,7 +20422,6 @@
     },
     "node_modules/wrap-ansi-cjs/node_modules/color-convert": {
       "version": "2.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -20554,12 +20432,10 @@
     },
     "node_modules/wrap-ansi-cjs/node_modules/color-name": {
       "version": "1.1.4",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/wrap-ansi/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -20573,7 +20449,6 @@
     },
     "node_modules/wrap-ansi/node_modules/color-convert": {
       "version": "2.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -20584,7 +20459,6 @@
     },
     "node_modules/wrap-ansi/node_modules/color-name": {
       "version": "1.1.4",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/wrappy": {
@@ -20635,7 +20509,6 @@
     },
     "node_modules/y18n": {
       "version": "5.0.8",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=10"
@@ -20663,7 +20536,6 @@
     },
     "node_modules/yargs": {
       "version": "17.7.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cliui": "^8.0.1",
@@ -20688,7 +20560,6 @@
     },
     "node_modules/yargs/node_modules/yargs-parser": {
       "version": "21.1.1",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -20717,7 +20588,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-6.0.1.tgz",
       "integrity": "sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "archiver-utils": "^5.0.0",
@@ -20732,7 +20602,6 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
       "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -20757,7 +20626,6 @@
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
       "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "abort-controller": "^3.0.0",
@@ -20774,7 +20642,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -127,6 +127,7 @@
         "standard-version": "^9.5.0",
         "supertest": "^7.1.4",
         "swagger-cli": "^4.0.4",
+        "testcontainers": "^12.0.4",
         "ts-jest": "^29.2.5",
         "typescript": "^5.0.4"
       }
@@ -1650,6 +1651,13 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@balena/dockerignore": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@balena/dockerignore/-/dockerignore-1.0.2.tgz",
+      "integrity": "sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/@bcoe/v8-coverage": {
       "version": "0.2.3",
       "dev": true,
@@ -2683,6 +2691,58 @@
         "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
+    "node_modules/@grpc/grpc-js": {
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.4.tgz",
+      "integrity": "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.8.0",
+        "@js-sdsl/ordered-map": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=12.10.0"
+      }
+    },
+    "node_modules/@grpc/grpc-js/node_modules/@grpc/proto-loader": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.1.tgz",
+      "integrity": "sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.5.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.7.15",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.15.tgz",
+      "integrity": "sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.2.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/@hapi/bourne": {
       "version": "3.0.0",
       "license": "BSD-3-Clause"
@@ -3605,6 +3665,17 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@js-sdsl/ordered-map": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
+      "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/js-sdsl"
+      }
+    },
     "node_modules/@jsdevtools/ono": {
       "version": "7.1.3",
       "dev": true,
@@ -3622,6 +3693,16 @@
       },
       "engines": {
         "node": ">= 12"
+      }
+    },
+    "node_modules/@kwsites/file-exists": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
+      "integrity": "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1"
       }
     },
     "node_modules/@linear/sdk": {
@@ -3719,6 +3800,72 @@
       "funding": {
         "url": "https://opencollective.com/unts"
       }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
+      "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/@pyroscope/nodejs": {
       "version": "0.4.5",
@@ -4876,6 +5023,29 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/docker-modem": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/docker-modem/-/docker-modem-3.0.6.tgz",
+      "integrity": "sha512-yKpAGEuKRSS8wwx0joknWxsmLha78wNMe9R2S3UNsVOkZded8UqOrV8KoeDXoXsjndxwyF3eIhyClGbO1SEhEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/ssh2": "*"
+      }
+    },
+    "node_modules/@types/dockerode": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/dockerode/-/dockerode-4.0.1.tgz",
+      "integrity": "sha512-cmUpB+dPN955PxBEuXE3f6lKO1hHiIGYJA46IVF3BJpNsZGvtBDcRnlrHYHtOH/B6vtDOyl2kZ2ShAu3mgc27Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/docker-modem": "*",
+        "@types/node": "*",
+        "@types/ssh2": "*"
+      }
+    },
     "node_modules/@types/express": {
       "version": "5.0.0",
       "license": "MIT",
@@ -5055,6 +5225,43 @@
         "@types/node": "*",
         "@types/send": "*"
       }
+    },
+    "node_modules/@types/ssh2": {
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/@types/ssh2/-/ssh2-1.15.5.tgz",
+      "integrity": "sha512-N1ASjp/nXH3ovBHddRJpli4ozpk6UdDYIX4RJWFa9L1YKnzdhTlVmiGHm4DZnj/jLbqZpes4aeR30EFGQtvhQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^18.11.18"
+      }
+    },
+    "node_modules/@types/ssh2-streams": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/@types/ssh2-streams/-/ssh2-streams-0.1.13.tgz",
+      "integrity": "sha512-faHyY3brO9oLEA0QlcO8N2wT7R0+1sHWZvQ+y3rMLwdY1ZyS1z0W3t65j9PqT4HmQ6ALzNe7RZlNuCNE0wBSWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/ssh2/node_modules/@types/node": {
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@types/ssh2/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
@@ -5787,6 +5994,161 @@
       "dev": true,
       "license": "BSD-2-Clause"
     },
+    "node_modules/archiver": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-7.0.1.tgz",
+      "integrity": "sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^5.0.2",
+        "async": "^3.2.4",
+        "buffer-crc32": "^1.0.0",
+        "readable-stream": "^4.0.0",
+        "readdir-glob": "^1.1.2",
+        "tar-stream": "^3.0.0",
+        "zip-stream": "^6.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/archiver-utils": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-5.0.2.tgz",
+      "integrity": "sha512-wuLJMmIBQYCsGZgYLTy5FIB2pF6Lfb6cXMSF8Qywwk3t20zWnAi7zLcQFdKQmIB8wyZpY5ER38x08GbwtR2cLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^10.0.0",
+        "graceful-fs": "^4.2.0",
+        "is-stream": "^2.0.1",
+        "lazystream": "^1.0.0",
+        "lodash": "^4.17.15",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/archiver/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/archiver/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/archiver/node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/archiver/node_modules/tar-stream": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
+      "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "bare-fs": "^4.5.5",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "license": "Python-2.0"
@@ -5916,6 +6278,16 @@
       "version": "2.0.6",
       "license": "MIT"
     },
+    "node_modules/asn1": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
     "node_modules/ast-module-types": {
       "version": "4.0.0",
       "dev": true,
@@ -5934,6 +6306,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/async-lock": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/async-lock/-/async-lock-1.4.1.tgz",
+      "integrity": "sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/async-rwlock": {
       "version": "1.1.1",
@@ -6004,6 +6383,21 @@
       },
       "peerDependencies": {
         "axios": ">= 0.17.0"
+      }
+    },
+    "node_modules/b4a": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
       }
     },
     "node_modules/babel-jest": {
@@ -6186,6 +6580,91 @@
       "version": "1.0.2",
       "license": "MIT"
     },
+    "node_modules/bare-events": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.9.1.tgz",
+      "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.8.0.tgz",
+      "integrity": "sha512-fM+MhCvdQhZ7NV6S95a07gPSqjIYKn6mFaXfx266wN3ajZGl/+1AzH+ubkXQ0fFZvOe2nk9VHkzdYkQE5zMV3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.28.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.1.1.tgz",
+      "integrity": "sha512-JprUlveX3QjApC1cTpsUOiscADftCGVWkzitbHsRqv84hzYwYHw2mbluddsq5TvI8mH/8Ov1f4BiMAdcB0oYnQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/bare-stream": {
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.3.tgz",
+      "integrity": "sha512-Kc+brLqvEqGkjyfiwJmImAOqLZL7OsoLKuavx+hJjgVV3nLTOjloJyPMFxjUPerGGHrNH0fLU06jjykMLWrERQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.8.1",
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
+      },
+      "peerDependencies": {
+        "bare-abort-controller": "*",
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.4.7",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.7.tgz",
+      "integrity": "sha512-o8CRCiJtib+ycO3mE4A5UChtGX4dDP2XxsWVu9P+Zc3H8tcmKwNVEDoDTXmwN+uuMhfKeT7/i7Y26xS8W7ohoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "funding": [
@@ -6211,6 +6690,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tweetnacl": "^0.14.3"
       }
     },
     "node_modules/benchmark-suite": {
@@ -6444,10 +6933,30 @@
         "ieee754": "^1.1.4"
       }
     },
+    "node_modules/buffer-crc32": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
+      "integrity": "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/buildcheck": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/buildcheck/-/buildcheck-0.0.7.tgz",
+      "integrity": "sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/builtin-modules": {
       "version": "3.3.0",
@@ -7079,6 +7588,75 @@
     "node_modules/component-type": {
       "version": "1.0.0"
     },
+    "node_modules/compress-commons": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-6.0.2.tgz",
+      "integrity": "sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "crc32-stream": "^6.0.0",
+        "is-stream": "^2.0.1",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/compress-commons/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/compress-commons/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/compress-commons/node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "license": "MIT"
@@ -7493,6 +8071,100 @@
         "typescript": ">=5"
       }
     },
+    "node_modules/cpu-features": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/cpu-features/-/cpu-features-0.0.10.tgz",
+      "integrity": "sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "buildcheck": "~0.0.6",
+        "nan": "^2.19.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/crc32-stream": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-6.0.0.tgz",
+      "integrity": "sha512-piICUB6ei4IlTv1+653yq5+KoqfBYmj9bw6LqXoOneTMDXk5nM1qt12mFW1caG3LlJXEKW1Bp0WggEmIfQB34g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/crc32-stream/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/crc32-stream/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/crc32-stream/node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/create-jest": {
       "version": "29.7.0",
       "dev": true,
@@ -7705,7 +8377,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.4.0",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -8152,6 +8826,68 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/docker-compose": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/docker-compose/-/docker-compose-1.4.2.tgz",
+      "integrity": "sha512-rPHigTKGaEHpkUmfd69QgaOp+Os5vGJwG/Ry8lcr8W/382AmI+z/D7qoa9BybKIkqNppaIbs8RYeHSevdQjWww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yaml": "^2.2.2"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/docker-modem": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/docker-modem/-/docker-modem-5.0.7.tgz",
+      "integrity": "sha512-XJgGhoR/CLpqshm4d3L7rzH6t8NgDFUIIpztYlLHIApeJjMZKYJMz2zxPsYxnejq5h3ELYSw/RBsi3t5h7gNTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "readable-stream": "^3.5.0",
+        "split-ca": "^1.0.1",
+        "ssh2": "^1.15.0"
+      },
+      "engines": {
+        "node": ">= 8.0"
+      }
+    },
+    "node_modules/docker-modem/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/dockerode": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/dockerode/-/dockerode-5.0.1.tgz",
+      "integrity": "sha512-avsq/xk4YPIrn0CgleX5bjT9Y8IT1p9PxrNQ++RBQ2WEyFfHCTDsT9kmyxz+H/axnjAwg8wJWEIuPGOUuNupiA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@balena/dockerignore": "^1.0.2",
+        "@grpc/grpc-js": "^1.11.1",
+        "@grpc/proto-loader": "^0.7.13",
+        "docker-modem": "^5.0.7",
+        "protobufjs": "^7.3.2",
+        "tar-fs": "^2.1.4"
+      },
+      "engines": {
+        "node": ">= 14.17"
       }
     },
     "node_modules/doctrine": {
@@ -9217,6 +9953,16 @@
         "node": ">=0.8.x"
       }
     },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
+      }
+    },
     "node_modules/execa": {
       "version": "5.1.1",
       "dev": true,
@@ -9308,6 +10054,13 @@
       "version": "1.3.0",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
@@ -9907,6 +10660,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/get-port": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/get-port/-/get-port-5.1.1.tgz",
+      "integrity": "sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-proto": {
@@ -13614,6 +14380,19 @@
         "node": "> 0.8"
       }
     },
+    "node_modules/lazystream": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
+      "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.6.3"
+      }
+    },
     "node_modules/leven": {
       "version": "3.1.0",
       "dev": true,
@@ -14206,6 +14985,13 @@
         "node": ">= 12.0.0"
       }
     },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/longest": {
       "version": "2.0.1",
       "dev": true,
@@ -14740,6 +15526,22 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/mkdirp": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
+      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "dist/cjs/src/bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/mkdirp-classic": {
       "version": "0.5.3",
       "license": "MIT"
@@ -15059,6 +15861,14 @@
     "node_modules/mute-stream": {
       "version": "0.0.8",
       "license": "ISC"
+    },
+    "node_modules/nan": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.28.0.tgz",
+      "integrity": "sha512-fTsDz99OTq2sVePhGdp4qQhggZFtKr64ZNVyVajRKtMOkJxYekplBh577PiJB12v/D3s2E5cGtOI45LWp6rnLQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/nanoid": {
       "version": "3.3.8",
@@ -16464,6 +17274,60 @@
         "node": ">= 6"
       }
     },
+    "node_modules/proper-lockfile": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "retry": "^0.12.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "node_modules/properties-reader": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/properties-reader/-/properties-reader-3.0.1.tgz",
+      "integrity": "sha512-WPn+h9RGEExOKdu4bsF4HksG/uzd3cFq3MFtq8PsFeExPse5Ha/VOjQNyHhjboBFwGXGev6muJYTSPAOkROq2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@kwsites/file-exists": "^1.1.1",
+        "mkdirp": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/steveukx/properties?sponsor=1"
+      }
+    },
+    "node_modules/protobufjs": {
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/proxy-from-env": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
@@ -16745,6 +17609,39 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/readdir-glob": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.3.tgz",
+      "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "minimatch": "^5.1.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/brace-expansion": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -16991,6 +17888,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/reusify": {
@@ -17611,6 +18518,13 @@
         "node": "*"
       }
     },
+    "node_modules/split-ca": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/split-ca/-/split-ca-1.0.1.tgz",
+      "integrity": "sha512-Q5thBSxp5t8WPTTJQS59LrGqOZqOsrhDGDVm8azCqIBjSBd7nd9o2PM+mDulQQkh8h//4U6hFZnc/mul8t5pWQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/split2": {
       "version": "3.2.2",
       "dev": true,
@@ -17642,6 +18556,46 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/ssh-remote-port-forward": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/ssh-remote-port-forward/-/ssh-remote-port-forward-1.0.4.tgz",
+      "integrity": "sha512-x0LV1eVDwjf1gmG7TTnfqIzf+3VPRz7vrNIjX6oYLbeCrf/PeVY6hkT68Mg+q02qXxQhrLjB0jfgvhevoCRmLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/ssh2": "^0.5.48",
+        "ssh2": "^1.4.0"
+      }
+    },
+    "node_modules/ssh-remote-port-forward/node_modules/@types/ssh2": {
+      "version": "0.5.52",
+      "resolved": "https://registry.npmjs.org/@types/ssh2/-/ssh2-0.5.52.tgz",
+      "integrity": "sha512-lbLLlXxdCZOSJMCInKH2+9V/77ET2J6NPQHpFI0kda61Dd1KglJs+fPQBchizmzYSOJBgdTajhPqBO1xxLywvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/ssh2-streams": "*"
+      }
+    },
+    "node_modules/ssh2": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.17.0.tgz",
+      "integrity": "sha512-wPldCk3asibAjQ/kziWQQt1Wh3PgDFpC0XpwclzKcdT1vql6KeYxf5LIt4nlFkUeR8WuphYMKqUA56X4rjbfgQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "asn1": "^0.2.6",
+        "bcrypt-pbkdf": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      },
+      "optionalDependencies": {
+        "cpu-features": "~0.0.10",
+        "nan": "^2.23.0"
       }
     },
     "node_modules/stack-generator": {
@@ -18106,6 +19060,18 @@
         "any-promise": "^1.1.0"
       }
     },
+    "node_modules/streamx": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.28.0.tgz",
+      "integrity": "sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.1.1",
       "license": "MIT",
@@ -18486,6 +19452,16 @@
         "bintrees": "1.0.2"
       }
     },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "streamx": "^2.12.5"
+      }
+    },
     "node_modules/test-exclude": {
       "version": "6.0.0",
       "dev": true,
@@ -18516,6 +19492,81 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/testcontainers": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/testcontainers/-/testcontainers-12.1.0.tgz",
+      "integrity": "sha512-YjDLqIITuhGLMnM10yhg3oV6lIG5IMpz1R1DPBZoOOks83q7i7IVpeSWRTiyl7roozjiyLmwIoLK/KY8OnZmIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@balena/dockerignore": "^1.0.2",
+        "@types/dockerode": "^4.0.1",
+        "archiver": "^7.0.1",
+        "async-lock": "^1.4.1",
+        "byline": "^5.0.0",
+        "debug": "^4.4.3",
+        "docker-compose": "^1.4.2",
+        "dockerode": "^5.0.1",
+        "get-port": "^5.1.1",
+        "proper-lockfile": "^4.1.2",
+        "properties-reader": "^3.0.1",
+        "ssh-remote-port-forward": "^1.0.4",
+        "tar-fs": "^3.1.3",
+        "tmp": "^0.2.7",
+        "undici": "^8.9.0"
+      },
+      "engines": {
+        "node": ">= 22.22"
+      }
+    },
+    "node_modules/testcontainers/node_modules/tar-fs": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.3.tgz",
+      "integrity": "sha512-/hU4AXnIdZu+Gvl1pk0oI5f5HxWsCJRtY2aFaJdk9VvyL48DWU6iU5WAIPG+wIi1YvWA6eTJvIviP/tMAZZNwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0",
+        "tar-stream": "^3.1.5"
+      },
+      "optionalDependencies": {
+        "bare-fs": "^4.0.1",
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/testcontainers/node_modules/tar-stream": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
+      "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "bare-fs": "^4.5.5",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/testcontainers/node_modules/tmp": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
       }
     },
     "node_modules/text-extensions": {
@@ -18814,6 +19865,13 @@
         "node": "*"
       }
     },
+    "node_modules/tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
+      "dev": true,
+      "license": "Unlicense"
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "license": "MIT",
@@ -18996,6 +20054,16 @@
     "node_modules/underscore": {
       "version": "1.12.1",
       "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
+      "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
+      }
     },
     "node_modules/undici-types": {
       "version": "6.21.0",
@@ -19643,6 +20711,73 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zip-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-6.0.1.tgz",
+      "integrity": "sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^5.0.0",
+        "compress-commons": "^6.0.2",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/zip-stream/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/zip-stream/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/zip-stream/node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/zod": {

--- a/package.json
+++ b/package.json
@@ -180,6 +180,7 @@
     "standard-version": "^9.5.0",
     "supertest": "^7.1.4",
     "swagger-cli": "^4.0.4",
+    "testcontainers": "^12.0.4",
     "ts-jest": "^29.2.5",
     "typescript": "^5.0.4"
   },

--- a/package.json
+++ b/package.json
@@ -122,6 +122,7 @@
     "sha256": "^0.2.0",
     "sqlstring": "^2.3.3",
     "stacktrace-parser": "^0.1.10",
+    "testcontainers": "^12.0.4",
     "truncate-utf8-bytes": "^1.0.2",
     "ua-parser-js": "^1.0.37",
     "unset-value": "^2.0.1",
@@ -180,7 +181,6 @@
     "standard-version": "^9.5.0",
     "supertest": "^7.1.4",
     "swagger-cli": "^4.0.4",
-    "testcontainers": "^12.0.4",
     "ts-jest": "^29.2.5",
     "typescript": "^5.0.4"
   },

--- a/test/integrations/component.live.test.ts
+++ b/test/integrations/component.live.test.ts
@@ -46,7 +46,6 @@ describe('Live Integration Test Suite', () => {
   });
 
   const resolver = new SecretResolver();
-  const authContainer = new RudderAuthContainer();
   const agent = () => request(server);
   let tokenResolver: OAuthTokenResolver | undefined;
 
@@ -61,8 +60,13 @@ describe('Live Integration Test Suite', () => {
     return;
   }
 
-  // Manage the rudder-auth container when an OAuth destination is enrolled.
-  const hasOAuthDestination = enrolledDestinations.some((d) => d.spec.authType === 'oauth');
+  // Manage the rudder-auth container when an OAuth destination is enrolled; it forwards only the
+  // enrolled OAuth destinations' credentials (see RudderAuthContainer).
+  const oauthDestinations = enrolledDestinations
+    .filter((d) => d.spec.authType === 'oauth')
+    .map((d) => d.destination);
+  const hasOAuthDestination = oauthDestinations.length > 0;
+  const authContainer = new RudderAuthContainer(oauthDestinations);
   beforeAll(async () => {
     if (hasOAuthDestination) {
       const rudderAuthUrl = await authContainer.start();
@@ -89,7 +93,11 @@ describe('Live Integration Test Suite', () => {
         }
         // Merge rudder-auth's refreshed secret wholesale (mirroring rudder-server) so each
         // transform finds its token under whatever key it reads (accessToken | access_token).
-        const secret = await tokenResolver.resolveSecret(destination, liveSecret);
+        const secret = await tokenResolver.resolveSecret(
+          destination,
+          liveSecret,
+          spec.oauthVersion ?? 'v0',
+        );
         liveSecret.secret = { ...(liveSecret.secret ?? {}), ...secret };
       }
     });

--- a/test/integrations/component.live.test.ts
+++ b/test/integrations/component.live.test.ts
@@ -3,7 +3,7 @@ import bodyParser from 'koa-bodyparser';
 import request from 'supertest';
 import { Command } from 'commander';
 import { createHttpTerminator } from 'http-terminator';
-import { Server } from 'http';
+import type { Server } from 'http';
 import { configureBatchProcessingDefaults } from '@rudderstack/integrations-lib';
 import { applicationRoutes } from '../../src/routes/index';
 import { getEnrolledDestinations } from './live/registry';
@@ -13,7 +13,7 @@ import { runPipelineStep } from './live/runPipelineStep';
 import { retryUntilPasses } from './live/poll';
 import { OAuthTokenResolver } from './live/oauthTokenResolver';
 import { RudderAuthContainer } from './live/rudderAuthContainer';
-import { LiveSecret, EnrolledDestination } from './live/types';
+import type { LiveSecret, EnrolledDestination } from './live/types';
 
 describe('Live Integration Test Suite', () => {
   // npm run test:live
@@ -47,7 +47,7 @@ describe('Live Integration Test Suite', () => {
 
   const resolver = new SecretResolver();
   const authContainer = new RudderAuthContainer();
-  const agent = () => request(server as unknown as Parameters<typeof request>[0]);
+  const agent = () => request(server);
   let tokenResolver: OAuthTokenResolver | undefined;
 
   const enrolledDestinations: EnrolledDestination[] = getEnrolledDestinations(opts.destination);
@@ -80,11 +80,17 @@ describe('Live Integration Test Suite', () => {
   describe.each(enrolledDestinations)('$destination', ({ destination, spec }) => {
     const liveSecret: LiveSecret = resolver.resolve(destination);
 
-    // OAuth: mint an access token via rudder-auth and inject it into metadata.secret.accessToken.
     beforeAll(async () => {
       if (spec.authType === 'oauth') {
-        const accessToken = await tokenResolver!.resolveAccessToken(destination, liveSecret);
-        liveSecret.secret = { ...(liveSecret.secret ?? {}), accessToken };
+        if (!tokenResolver) {
+          throw new Error(
+            '[live] OAuth destination enrolled but rudder-auth token resolver is not ready',
+          );
+        }
+        // Merge rudder-auth's refreshed secret wholesale (mirroring rudder-server) so each
+        // transform finds its token under whatever key it reads (accessToken | access_token).
+        const secret = await tokenResolver.resolveSecret(destination, liveSecret);
+        liveSecret.secret = { ...(liveSecret.secret ?? {}), ...secret };
       }
     });
 
@@ -106,8 +112,6 @@ describe('Live Integration Test Suite', () => {
       return;
     }
 
-    // One describe per scenario, each with its own RunContext (isolated identities) and optional
-    // per-scenario Config override.
     describe.each(activeScenarios)('scenario: $id', (scenario) => {
       const ctx = new RunContextImpl({ liveSecret });
       const scenarioConfig =
@@ -161,12 +165,16 @@ describe('Live Integration Test Suite', () => {
                   config: scenarioConfig,
                   connection,
                   http: {
-                    post: async (url, body) =>
-                      agent()
-                        .post(url)
-                        .send(body as object),
+                    post: async (url, body) => agent().post(url).send(body),
                   },
                 });
+                return;
+              default: {
+                // Exhaustive discriminated-union check: adding a new step type without a case here
+                // becomes a compile error rather than a silent no-op.
+                const exhaustive: never = step;
+                throw new Error(`[live] unknown step type: ${JSON.stringify(exhaustive)}`);
+              }
             }
           } catch (err) {
             scenarioFailed = true;

--- a/test/integrations/component.live.test.ts
+++ b/test/integrations/component.live.test.ts
@@ -11,6 +11,8 @@ import { SecretResolver } from './live/secretResolver';
 import { RunContextImpl } from './live/runContext';
 import { runPipelineStep } from './live/runPipelineStep';
 import { retryUntilPasses } from './live/poll';
+import { OAuthTokenResolver } from './live/oauthTokenResolver';
+import { RudderAuthContainer } from './live/rudderAuthContainer';
 import { LiveSecret, EnrolledDestination } from './live/types';
 
 describe('Live Integration Test Suite', () => {
@@ -44,7 +46,9 @@ describe('Live Integration Test Suite', () => {
   });
 
   const resolver = new SecretResolver();
+  const authContainer = new RudderAuthContainer();
   const agent = () => request(server as unknown as Parameters<typeof request>[0]);
+  let tokenResolver: OAuthTokenResolver | undefined;
 
   const enrolledDestinations: EnrolledDestination[] = getEnrolledDestinations(opts.destination);
   // eslint-disable-next-line no-console
@@ -57,10 +61,33 @@ describe('Live Integration Test Suite', () => {
     return;
   }
 
+  // Manage the rudder-auth container when an OAuth destination is enrolled.
+  const hasOAuthDestination = enrolledDestinations.some((d) => d.spec.authType === 'oauth');
+  beforeAll(async () => {
+    if (hasOAuthDestination) {
+      const rudderAuthUrl = await authContainer.start();
+      tokenResolver = new OAuthTokenResolver(rudderAuthUrl);
+    }
+  }, 900000);
+  afterAll(async () => {
+    if (hasOAuthDestination) {
+      await authContainer.stop();
+    }
+  });
+
   // One describe per enrolled destination: resolve its credentials and base config, then run its
   // enabled scenarios. A missing/invalid secret throws here (fail-closed), failing the destination.
   describe.each(enrolledDestinations)('$destination', ({ destination, spec }) => {
     const liveSecret: LiveSecret = resolver.resolve(destination);
+
+    // OAuth: mint an access token via rudder-auth and inject it into metadata.secret.accessToken.
+    beforeAll(async () => {
+      if (spec.authType === 'oauth') {
+        const accessToken = await tokenResolver!.resolveAccessToken(destination, liveSecret);
+        liveSecret.secret = { ...(liveSecret.secret ?? {}), accessToken };
+      }
+    });
+
     const destinationConfig = spec.resolveConfig(liveSecret);
     // Audience / VDM destinations require connection.config on /routerTransform input.
     const connectionConfig = spec.resolveConnection?.(liveSecret);
@@ -83,7 +110,8 @@ describe('Live Integration Test Suite', () => {
     // per-scenario Config override.
     describe.each(activeScenarios)('scenario: $id', (scenario) => {
       const ctx = new RunContextImpl({ liveSecret });
-      const scenarioConfig = scenario.configOverride?.(destinationConfig) ?? destinationConfig;
+      const scenarioConfig =
+        scenario.configOverride?.(destinationConfig, liveSecret) ?? destinationConfig;
 
       beforeAll(() => {
         // Arm scenario cleanup if present; drained after steps (LIFO, best-effort).

--- a/test/integrations/destinations/braze/live/api.ts
+++ b/test/integrations/destinations/braze/live/api.ts
@@ -1,12 +1,11 @@
 import axios from 'axios';
 import { Agent } from 'https';
-import { RunContext } from '../../../live/types';
+import type { RunContext } from '../../../live/types';
 import { RUDDER_ALIAS_LABEL } from './profiles';
 
 // keepAlive:false so read-back/cleanup sockets don't linger as open handles when the suite finishes.
 const brazeAgent = new Agent({ keepAlive: false });
 
-// Fields the read-back requests from Braze's export endpoint.
 const FIELDS_TO_EXPORT = [
   'external_id',
   'email',
@@ -20,9 +19,9 @@ const FIELDS_TO_EXPORT = [
 // transform authenticates with — the key just needs users.export.ids + users.delete (+ subscription
 // scopes) in addition to the delivery scopes.
 const apiCreds = (ctx: RunContext): { restApiKey: string; dataCenter: string } => {
-  const config = (ctx.liveSecret.config ?? {}) as Record<string, unknown>;
-  const restApiKey = config.restApiKey as string | undefined;
-  const dataCenter = config.dataCenter as string | undefined;
+  const config = ctx.liveSecret.config;
+  const restApiKey = typeof config.restApiKey === 'string' ? config.restApiKey : undefined;
+  const dataCenter = typeof config.dataCenter === 'string' ? config.dataCenter : undefined;
   if (!restApiKey) {
     throw new Error('Braze restApiKey missing from LIVE_SECRET_BRAZE.config');
   }
@@ -55,19 +54,23 @@ const authHeaders = (restApiKey: string) => ({
   Connection: 'close' as const,
 });
 
-export type BrazeUserProfile = {
+export interface BrazeUserProfile {
   external_id?: string;
   email?: string;
   first_name?: string;
   last_name?: string;
   custom_attributes?: Record<string, unknown>;
   user_aliases?: Array<{ alias_name: string; alias_label: string }>;
-};
+}
 
-type ExportSelector = {
+interface BrazeExportResponse {
+  users?: BrazeUserProfile[];
+}
+
+interface ExportSelector {
   externalIds?: string[];
   userAliases?: Array<{ alias_name: string; alias_label?: string }>;
-};
+}
 
 // POST /users/export/ids — the read-back. Returns the matched user profiles (empty array if none).
 export const exportUsers = async (
@@ -85,12 +88,16 @@ export const exportUsers = async (
       alias_label: a.alias_label ?? RUDDER_ALIAS_LABEL,
     }));
   }
-  const res = await axios.post(`${restEndpoint(dataCenter)}/users/export/ids`, body, {
-    headers: authHeaders(restApiKey),
-    httpsAgent: brazeAgent,
-    timeout: 15000,
-  });
-  return (res.data?.users ?? []) as BrazeUserProfile[];
+  const res = await axios.post<BrazeExportResponse>(
+    `${restEndpoint(dataCenter)}/users/export/ids`,
+    body,
+    {
+      headers: authHeaders(restApiKey),
+      httpsAgent: brazeAgent,
+      timeout: 15000,
+    },
+  );
+  return res.data.users ?? [];
 };
 
 export const exportUserByExternalId = async (
@@ -135,11 +142,11 @@ export const deleteUsers = async (ctx: RunContext, selector: ExportSelector): Pr
       timeout: 15000,
     });
   } catch (err) {
-    const status = (err as { response?: { status?: number } })?.response?.status;
+    const status = axios.isAxiosError(err) ? err.response?.status : undefined;
     // eslint-disable-next-line no-console
     console.error(
       `[live:braze] teardown (users/delete) failed${status ? ` (status ${status})` : ''}:`,
-      err instanceof Error ? err.message : String(err),
+      err instanceof Error ? err.message : 'unknown error',
     );
   }
 };
@@ -169,12 +176,16 @@ export const createUserWithAttributes = async (
   );
 };
 
-export type BrazeSubscriptionGroup = {
+export interface BrazeSubscriptionGroup {
   id?: string;
   name?: string;
   channel?: string;
   status?: string;
-};
+}
+
+interface BrazeSubscriptionStatusResponse {
+  users?: Array<{ subscription_groups?: BrazeSubscriptionGroup[] }>;
+}
 
 // GET /subscription/user/status — read a user's subscription-group statuses back for the
 // /v2/subscription/status/set verify.
@@ -183,13 +194,16 @@ export const getSubscriptionGroups = async (
   externalId: string,
 ): Promise<BrazeSubscriptionGroup[]> => {
   const { restApiKey, dataCenter } = apiCreds(ctx);
-  const res = await axios.get(`${restEndpoint(dataCenter)}/subscription/user/status`, {
-    params: { external_id: externalId },
-    headers: authHeaders(restApiKey),
-    httpsAgent: brazeAgent,
-    timeout: 15000,
-  });
-  return (res.data?.users?.[0]?.subscription_groups ?? []) as BrazeSubscriptionGroup[];
+  const res = await axios.get<BrazeSubscriptionStatusResponse>(
+    `${restEndpoint(dataCenter)}/subscription/user/status`,
+    {
+      params: { external_id: externalId },
+      headers: authHeaders(restApiKey),
+      httpsAgent: brazeAgent,
+      timeout: 15000,
+    },
+  );
+  return res.data.users?.[0]?.subscription_groups ?? [];
 };
 
 // The subscription_group_id must come from the real Braze account (account-scoped), supplied via

--- a/test/integrations/destinations/braze/live/profiles.ts
+++ b/test/integrations/destinations/braze/live/profiles.ts
@@ -1,4 +1,4 @@
-import { RunContext } from '../../../live/types';
+import type { RunContext } from '../../../live/types';
 
 // Braze's user-alias label used by the transform for the anonymousId alias.
 export const RUDDER_ALIAS_LABEL = 'rudder_id';

--- a/test/integrations/destinations/braze/live/setup.ts
+++ b/test/integrations/destinations/braze/live/setup.ts
@@ -1,4 +1,4 @@
-import { RunContext } from '../../../live/types';
+import type { RunContext } from '../../../live/types';
 import { pollUntil } from '../../../live/poll';
 import { createUserWithAttributes, exportUserByExternalId } from './api';
 import { dedupExistingInitialAttrs } from './profiles';

--- a/test/integrations/destinations/braze/live/spec.ts
+++ b/test/integrations/destinations/braze/live/spec.ts
@@ -1,4 +1,4 @@
-import { LiveSpec, RunContext } from '../../../live/types';
+import type { LiveSpec, RunContext } from '../../../live/types';
 import {
   deleteAnonymousUser,
   deleteUserByExternalId,
@@ -61,7 +61,7 @@ const READBACK = { attempts: 6, delayMs: (n: number) => 1000 * 2 ** n };
 // (the ON path); every other scenario stays on the default processBatch path.
 const BRAZE_PER_JOB_DELIVERY_TEST_WORKSPACE_ID = 'braze-pjdm-ws';
 
-export const live: LiveSpec = {
+export const live = {
   enabled: true,
   authType: 'apiKey',
   // restApiKey + dataCenter are account-scoped and come from LIVE_SECRET_BRAZE.config; the rest are
@@ -894,6 +894,6 @@ export const live: LiveSpec = {
       },
     },
   ],
-};
+} satisfies LiveSpec;
 
 export default live;

--- a/test/integrations/destinations/braze/live/verify.ts
+++ b/test/integrations/destinations/braze/live/verify.ts
@@ -1,4 +1,4 @@
-import { RunContext } from '../../../live/types';
+import type { RunContext } from '../../../live/types';
 import { NESTED_ARRAY_ATTR, groupAttributeKey, nestedArrayMarker } from './profiles';
 import {
   BrazeUserProfile,

--- a/test/integrations/destinations/braze_audience/live/api.ts
+++ b/test/integrations/destinations/braze_audience/live/api.ts
@@ -1,10 +1,14 @@
 import axios from 'axios';
 import { Agent } from 'https';
 import { getEndpointFromConfig } from '../../../../../src/v0/destinations/braze/util';
-import { LiveSecret, RunContext } from '../../../live/types';
+import type { LiveSecret, RunContext } from '../../../live/types';
 
 // keepAlive:false so read-back/cleanup sockets don't linger as open handles when the suite finishes.
 const brazeAgent = new Agent({ keepAlive: false });
+
+interface BrazeAudienceExportResponse {
+  users?: Array<{ custom_attributes?: Record<string, unknown> }>;
+}
 
 const readString = (value: unknown, label: string): string => {
   if (typeof value !== 'string' || value.trim().length === 0) {
@@ -22,10 +26,10 @@ export const customAttributeName = (ctx: RunContext): string =>
 export const externalId = (ctx: RunContext): string => ctx.identity('user');
 
 const restApiKey = (ctx: RunContext): string =>
-  readString(ctx.liveSecret.config?.restApiKey, 'config.restApiKey');
+  readString(ctx.liveSecret.config.restApiKey, 'config.restApiKey');
 
 const dataCenter = (ctx: RunContext): string =>
-  readString(ctx.liveSecret.config?.dataCenter, 'config.dataCenter');
+  readString(ctx.liveSecret.config.dataCenter, 'config.dataCenter');
 
 export const restBaseUrl = (ctx: RunContext): string =>
   getEndpointFromConfig({
@@ -70,7 +74,7 @@ export const setMembership = async (ctx: RunContext, value: boolean): Promise<vo
  */
 export const fetchMembership = async (ctx: RunContext): Promise<boolean | undefined> => {
   const attr = customAttributeName(ctx);
-  const res = await axios.post(
+  const res = await axios.post<BrazeAudienceExportResponse>(
     `${restBaseUrl(ctx)}/users/export/ids`,
     {
       external_ids: [externalId(ctx)],
@@ -88,7 +92,7 @@ export const fetchMembership = async (ctx: RunContext): Promise<boolean | undefi
       `Braze export/ids failed: status=${res.status} body=${JSON.stringify(res.data)}`,
     );
   }
-  const users = res.data?.users;
+  const users = res.data.users;
   if (!Array.isArray(users) || users.length === 0) {
     return undefined;
   }

--- a/test/integrations/destinations/braze_audience/live/spec.ts
+++ b/test/integrations/destinations/braze_audience/live/spec.ts
@@ -1,4 +1,4 @@
-import { LiveSpec, RunContext } from '../../../live/types';
+import type { LiveSpec, RunContext } from '../../../live/types';
 import { pollUntil } from '../../../live/poll';
 import {
   clearMembership,
@@ -51,7 +51,7 @@ const verifyMembership =
     expect(value).toBe(expected);
   };
 
-export const live: LiveSpec = {
+export const live = {
   enabled: true,
   authType: 'apiKey',
   resolveConfig: (s) => ({
@@ -126,6 +126,6 @@ export const live: LiveSpec = {
       },
     },
   ],
-};
+} satisfies LiveSpec;
 
 export default live;

--- a/test/integrations/destinations/criteo_audience/live.ts
+++ b/test/integrations/destinations/criteo_audience/live.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import { Agent } from 'https';
 import { BASE_ENDPOINT } from '../../../../src/v0/destinations/criteo_audience/config';
-import { LiveScenario, LiveSpec, RunContext } from '../../live/types';
+import type { LiveScenario, LiveSpec, RunContext } from '../../live/types';
 
 const criteoAgent = new Agent({ keepAlive: false });
 
@@ -85,7 +85,7 @@ const audienceListSeed = (
   properties: { listData },
 });
 
-const scenarios: LiveScenario[] = [
+const scenarios = [
   {
     id: 'criteo-audience-add-email',
     description: 'Event-stream audiencelist adds email identifiers to the email audience (add)',
@@ -185,9 +185,9 @@ const scenarios: LiveScenario[] = [
       },
     ],
   },
-];
+] satisfies LiveScenario[];
 
-export const live: LiveSpec = {
+export const live = {
   enabled: true,
   authType: 'oauth',
   resolveConfig: (s) => ({
@@ -196,6 +196,6 @@ export const live: LiveSpec = {
     ...s.config,
   }),
   scenarios,
-};
+} satisfies LiveSpec;
 
 export default live;

--- a/test/integrations/destinations/criteo_audience/live.ts
+++ b/test/integrations/destinations/criteo_audience/live.ts
@@ -190,6 +190,7 @@ const scenarios = [
 export const live = {
   enabled: true,
   authType: 'oauth',
+  oauthVersion: 'v0',
   resolveConfig: (s) => ({
     audienceType: 'email',
     audienceId: s.resourceIds?.[AUDIENCE_ID_KEY.email],

--- a/test/integrations/destinations/criteo_audience/live.ts
+++ b/test/integrations/destinations/criteo_audience/live.ts
@@ -1,0 +1,201 @@
+import axios from 'axios';
+import { Agent } from 'https';
+import { BASE_ENDPOINT } from '../../../../src/v0/destinations/criteo_audience/config';
+import { LiveScenario, LiveSpec, RunContext } from '../../live/types';
+
+const criteoAgent = new Agent({ keepAlive: false });
+
+type IdentifierType = 'email' | 'madid' | 'identityLink';
+
+// resourceIds key holding the dedicated Contact List audience id for each identifier type.
+const AUDIENCE_ID_KEY: Record<IdentifierType, string> = {
+  email: 'email-audience-id',
+  madid: 'madid-audience-id',
+  identityLink: 'identity-link-audience-id',
+};
+
+const accessTokenOf = (ctx: RunContext): string | undefined => ctx.liveSecret.secret?.accessToken;
+
+const audienceIdForType = (ctx: RunContext, type: IdentifierType): string | undefined =>
+  ctx.liveSecret.resourceIds?.[AUDIENCE_ID_KEY[type]];
+
+const emailIdentifiers = (ctx: RunContext): string[] => [ctx.email('a'), ctx.email('b')];
+const madidIdentifiers = (ctx: RunContext): string[] => [
+  ctx.identity('madid-1'),
+  ctx.identity('madid-2'),
+];
+const identityLinkIdentifiers = (ctx: RunContext): string[] => [
+  ctx.identity('identitylink-1'),
+  ctx.identity('identitylink-2'),
+];
+
+const listEntries = (type: IdentifierType, values: string[]) =>
+  values.map((value) => ({ [type]: value }));
+
+// Direct Criteo contactlist PATCH used only for teardown; best-effort.
+const patchContactList = async (
+  ctx: RunContext,
+  audienceId: string,
+  attributes: Record<string, unknown>,
+): Promise<void> => {
+  await axios.request({
+    method: 'PATCH',
+    url: `${BASE_ENDPOINT}audiences/${audienceId}/contactlist`,
+    headers: {
+      Authorization: `Bearer ${accessTokenOf(ctx)}`,
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    },
+    data: { data: { type: 'ContactlistAmendment', attributes } },
+    httpsAgent: criteoAgent,
+    timeout: 15000,
+    validateStatus: () => true,
+  });
+};
+
+const cleanupRemove =
+  (
+    type: IdentifierType,
+    identifiers: (ctx: RunContext) => string[],
+    extraAttributes: Record<string, unknown> = {},
+  ) =>
+  async (ctx: RunContext): Promise<void> => {
+    const audienceId = audienceIdForType(ctx, type);
+    if (!audienceId || !accessTokenOf(ctx)) {
+      return;
+    }
+    await patchContactList(ctx, audienceId, {
+      operation: 'remove',
+      identifierType: type,
+      internalIdentifiers: false,
+      identifiers: identifiers(ctx),
+      ...extraAttributes,
+    });
+  };
+
+const audienceListSeed = (
+  ctx: RunContext,
+  listData: Record<string, unknown>,
+  context: Record<string, unknown> = {},
+): Record<string, unknown> => ({
+  type: 'audiencelist',
+  userId: ctx.identity('user'),
+  timestamp: ctx.now(),
+  context: { library: { name: 'rudder-live-integration-test' }, ...context },
+  properties: { listData },
+});
+
+const scenarios: LiveScenario[] = [
+  {
+    id: 'criteo-audience-add-email',
+    description: 'Event-stream audiencelist adds email identifiers to the email audience (add)',
+    cleanup: cleanupRemove('email', emailIdentifiers),
+    steps: [
+      {
+        stepType: 'pipeline',
+        name: 'add email identifiers',
+        expectedOutputs: 1,
+        expectedProxyRequests: 1,
+        seed: (ctx) => audienceListSeed(ctx, { add: listEntries('email', emailIdentifiers(ctx)) }),
+      },
+    ],
+  },
+  {
+    id: 'criteo-audience-add-remove-madid',
+    description:
+      'Event-stream audiencelist with both add and remove for madid -> two amendments (operation fan-out)',
+    configOverride: (base, secret) => ({
+      ...base,
+      audienceType: 'madid',
+      audienceId: secret.resourceIds?.[AUDIENCE_ID_KEY.madid],
+    }),
+    cleanup: cleanupRemove('madid', madidIdentifiers),
+    steps: [
+      {
+        stepType: 'pipeline',
+        name: 'add and remove madid identifiers',
+        expectedOutputs: 1,
+        expectedProxyRequests: 2,
+        seed: (ctx) =>
+          audienceListSeed(ctx, {
+            add: listEntries('madid', madidIdentifiers(ctx)),
+            remove: listEntries('madid', [madidIdentifiers(ctx)[0]]),
+          }),
+      },
+    ],
+  },
+  {
+    id: 'criteo-audience-add-identitylink',
+    description:
+      'Event-stream audiencelist adds identityLink identifiers (audienceType=identityLink)',
+    configOverride: (base, secret) => ({
+      ...base,
+      audienceType: 'identityLink',
+      audienceId: secret.resourceIds?.[AUDIENCE_ID_KEY.identityLink],
+    }),
+    cleanup: cleanupRemove('identityLink', identityLinkIdentifiers),
+    steps: [
+      {
+        stepType: 'pipeline',
+        name: 'add identityLink identifiers',
+        expectedOutputs: 1,
+        expectedProxyRequests: 1,
+        seed: (ctx) =>
+          audienceListSeed(ctx, { add: listEntries('identityLink', identityLinkIdentifiers(ctx)) }),
+      },
+    ],
+  },
+  {
+    id: 'criteo-audience-retl-email',
+    description:
+      'RETL (mappedToDestination) resolves the audience id from context.externalId (CRITEO_AUDIENCE-<id>) and delivers',
+    // RETL resolves the audience id from externalId, so drop audienceId from Config.
+    configOverride: (base) => {
+      const next = { ...base };
+      delete next.audienceId;
+      return next;
+    },
+    cleanup: cleanupRemove('email', emailIdentifiers),
+    steps: [
+      {
+        stepType: 'pipeline',
+        name: 'retl add email identifiers',
+        expectedOutputs: 1,
+        expectedProxyRequests: 1,
+        seed: (ctx) =>
+          audienceListSeed(
+            ctx,
+            { add: listEntries('email', emailIdentifiers(ctx)) },
+            {
+              mappedToDestination: 'true',
+              externalId: [
+                {
+                  type: `CRITEO_AUDIENCE-${audienceIdForType(ctx, 'email')}`,
+                  identifierType: 'EMAIL',
+                },
+              ],
+              sources: {
+                job_run_id: ctx.runId,
+                task_run_id: ctx.runId,
+                job_id: `live-${ctx.runId}`,
+                version: 'live',
+              },
+            },
+          ),
+      },
+    ],
+  },
+];
+
+export const live: LiveSpec = {
+  enabled: true,
+  authType: 'oauth',
+  resolveConfig: (s) => ({
+    audienceType: 'email',
+    audienceId: s.resourceIds?.[AUDIENCE_ID_KEY.email],
+    ...s.config,
+  }),
+  scenarios,
+};
+
+export default live;

--- a/test/integrations/destinations/hs/live/api.ts
+++ b/test/integrations/destinations/hs/live/api.ts
@@ -1,8 +1,21 @@
 import axios from 'axios';
 import { Agent } from 'https';
-import { RunContext } from '../../../live/types';
+import type { RunContext } from '../../../live/types';
 
 export const HS_BASE = 'https://api.hubapi.com';
+
+interface HsSearchResponse {
+  results?: Array<{ id?: string; properties?: Record<string, string> }>;
+}
+interface HsCreateResponse {
+  id?: string | number;
+}
+interface HsAssociationsResponse {
+  results?: Array<{ toObjectId: string | number }>;
+}
+interface HsContactResponse {
+  properties?: Record<string, string>;
+}
 
 // An association links two existing objects; scenarios register these types in setup.
 export const ASSOC_FROM_TYPE = 'companies';
@@ -12,8 +25,8 @@ export const ASSOC_TO_TYPE = 'contacts';
 const hsAgent = new Agent({ keepAlive: false });
 
 const bearer = (ctx: RunContext): string => {
-  const token = ctx.liveSecret.config?.accessToken;
-  if (!token) {
+  const token = ctx.liveSecret.config.accessToken;
+  if (typeof token !== 'string' || token.length === 0) {
     throw new Error('HubSpot access token missing from resolved secret');
   }
   return `Bearer ${token}`;
@@ -34,7 +47,7 @@ export const findContactIdByProperty = async (
   propertyName: string,
   value: string,
 ): Promise<string | null> => {
-  const res = await axios.post(
+  const res = await axios.post<HsSearchResponse>(
     `${HS_BASE}/crm/v3/objects/contacts/search`,
     {
       filterGroups: [{ filters: [{ propertyName, operator: 'EQ', value }] }],
@@ -47,7 +60,7 @@ export const findContactIdByProperty = async (
       timeout: 15000,
     },
   );
-  return res.data?.results?.[0]?.id ?? null;
+  return res.data.results?.[0]?.id ?? null;
 };
 
 export const findContactIdByEmail = (ctx: RunContext, email: string): Promise<string | null> =>
@@ -57,7 +70,7 @@ export const fetchContactByEmail = async (
   ctx: RunContext,
   propertyNames: string[],
 ): Promise<Record<string, string> | null> => {
-  const res = await axios.post(
+  const res = await axios.post<HsSearchResponse>(
     `${HS_BASE}/crm/v3/objects/contacts/search`,
     {
       filterGroups: [{ filters: [{ propertyName: 'email', operator: 'EQ', value: ctx.email() }] }],
@@ -70,7 +83,7 @@ export const fetchContactByEmail = async (
       timeout: 15000,
     },
   );
-  return res.data?.results?.[0]?.properties ?? null;
+  return res.data.results?.[0]?.properties ?? null;
 };
 
 export const createCrmObject = async (
@@ -78,7 +91,7 @@ export const createCrmObject = async (
   objectType: string,
   properties: Record<string, unknown>,
 ): Promise<string> => {
-  const res = await axios.post(
+  const res = await axios.post<HsCreateResponse>(
     `${HS_BASE}/crm/v3/objects/${objectType}`,
     { properties },
     {
@@ -87,7 +100,7 @@ export const createCrmObject = async (
       timeout: 15000,
     },
   );
-  const id = res.data?.id;
+  const id = res.data.id;
   if (!id) {
     throw new Error(`Setup: failed to create ${objectType} (no id in response)`);
   }
@@ -115,7 +128,7 @@ export const getAssociatedIds = async (
   fromId: string,
   toType: string,
 ): Promise<string[]> => {
-  const res = await axios.get(
+  const res = await axios.get<HsAssociationsResponse>(
     `${HS_BASE}/crm/v4/objects/${fromType}/${fromId}/associations/${toType}`,
     {
       headers: authHeaders(ctx),
@@ -123,7 +136,7 @@ export const getAssociatedIds = async (
       timeout: 15000,
     },
   );
-  return (res.data?.results ?? []).map((r: { toObjectId: unknown }) => String(r.toObjectId));
+  return (res.data.results ?? []).map((r) => String(r.toObjectId));
 };
 
 export const deleteAssociationObjects = async (ctx: RunContext): Promise<void> => {
@@ -159,13 +172,13 @@ export const fetchContactPropsById = async (
   id: string,
   propertyNames: string[],
 ): Promise<Record<string, string> | null> => {
-  const res = await axios.get(`${HS_BASE}/crm/v3/objects/contacts/${id}`, {
+  const res = await axios.get<HsContactResponse>(`${HS_BASE}/crm/v3/objects/contacts/${id}`, {
     params: { properties: propertyNames.join(',') },
     headers: authHeaders(ctx),
     httpsAgent: hsAgent,
     timeout: 15000,
   });
-  return res.data?.properties ?? null;
+  return res.data.properties ?? null;
 };
 
 // Delete any contact reachable by the run's primary or additional email. On the happy path only the

--- a/test/integrations/destinations/hs/live/profiles.ts
+++ b/test/integrations/destinations/hs/live/profiles.ts
@@ -1,4 +1,4 @@
-import { RunContext } from '../../../live/types';
+import type { RunContext } from '../../../live/types';
 
 // Firstname used as the non-unique lookupField value (must match between setup and seed/verify).
 export const lookupFirstname = (ctx: RunContext): string => `ci-${ctx.runId}`;

--- a/test/integrations/destinations/hs/live/setup.ts
+++ b/test/integrations/destinations/hs/live/setup.ts
@@ -1,4 +1,4 @@
-import { RunContext } from '../../../live/types';
+import type { RunContext } from '../../../live/types';
 import { pollUntil } from '../../../live/poll';
 import { lookupFirstname } from './profiles';
 import {

--- a/test/integrations/destinations/hs/live/spec.ts
+++ b/test/integrations/destinations/hs/live/spec.ts
@@ -1,4 +1,4 @@
-import { LiveSpec } from '../../../live/types';
+import type { LiveSpec } from '../../../live/types';
 import {
   ASSOC_FROM_TYPE,
   ASSOC_TO_TYPE,
@@ -42,7 +42,7 @@ import {
   verifyUpsertResolvesToSameContact,
 } from './verify';
 
-export const live: LiveSpec = {
+export const live = {
   enabled: true,
   authType: 'apiKey',
   resolveConfig: (s) => ({
@@ -435,6 +435,6 @@ export const live: LiveSpec = {
       verify: { check: verifyAssociationExists },
     },
   ],
-};
+} satisfies LiveSpec;
 
 export default live;

--- a/test/integrations/destinations/hs/live/verify.ts
+++ b/test/integrations/destinations/hs/live/verify.ts
@@ -1,4 +1,4 @@
-import { RunContext } from '../../../live/types';
+import type { RunContext } from '../../../live/types';
 import {
   ASSOC_FROM_TYPE,
   ASSOC_TO_TYPE,

--- a/test/integrations/live/README.md
+++ b/test/integrations/live/README.md
@@ -40,12 +40,39 @@ For anything beyond a couple of scenarios, split the spec into a `live/` folder 
 - **`live/profiles.ts`** — trait profiles + shared `(ctx) => ({ ... })` factories used by both
   seeds and verifies.
 
+### OAuth destinations (`authType: 'oauth'`)
+
+OAuth destinations don't ship a long-lived access token in their secret - one is minted at run
+time. When any enrolled destination is `authType: 'oauth'`, a suite-level `beforeAll` starts the
+**rudder-auth** container via testcontainers (`RudderAuthContainer`, `live/rudderAuthContainer.ts`)
+and returns its base URL. `OAuthTokenResolver` (`live/oauthTokenResolver.ts`), built from that URL,
+posts `{ refreshToken }` (from `LIVE_SECRET_<DEST>.oauthRefresh`) to
+`/tokens/destination/<dest>/refresh` for each OAuth destination and injects the returned token into
+`metadata.secret.accessToken`. This mirrors production, where rudder-server delegates token refresh
+to rudder-auth rather than the transformer holding credentials.
+
+The image is pulled from ECR (`422074288268.dkr.ecr.us-east-1.amazonaws.com/rudderstack/rudder-auth:develop`),
+so Docker must be running and logged in to that ECR registry. The image ships default OAuth app credentials for each integration, and the container also
+forwards credential-shaped env vars (any `*_CLIENT_ID`/`*_CLIENT_SECRET`), which override those
+defaults. So the refresh token must be issued by whichever app rudder-auth ends up using - the
+image default, or the `*_CLIENT_ID`/`*_CLIENT_SECRET` you set in `.env`.
+
+Authenticate with the AWS profile/SSO session that has ECR pull access to the account (set
+`AWS_PROFILE`, or pass `--profile`), then run:
+
+```bash
+AWS_PROFILE=<profile> aws ecr get-login-password --region us-east-1 \
+  | docker login --username AWS --password-stdin 422074288268.dkr.ecr.us-east-1.amazonaws.com
+
+LIVE_SECRET_CRITEO_AUDIENCE='{...}' LOG_LEVEL=silent \
+  npm run test:live -- --destination=criteo_audience
+```
+
 ### Deferred (not in the pilot)
 
-Vault-backed `SecretResolver`, GitHub OIDC → Vault auth, the `rudder-auth` container
-for OAuth destinations, the CI workflow, and impact-based PR subsetting. The interfaces
-here (`SecretResolver.resolve()`, `LiveSpec`) are shaped so those layer on without
-rewrites.
+Vault-backed `SecretResolver`, GitHub OIDC → Vault auth, the CI workflow, and impact-based PR
+subsetting. The interfaces here (`SecretResolver.resolve()`, `LiveSpec`) are shaped so those
+layer on without rewrites.
 
 **Scope — transform path.** The harness drives only `/routerTransform → /proxy`. rudder-server
 also runs the processor transform (`/v0/destinations/<dest>`) ahead of delivery, whose response

--- a/test/integrations/live/README.md
+++ b/test/integrations/live/README.md
@@ -66,8 +66,10 @@ so Docker must be running and logged in to that ECR registry. The image ships de
 credentials for each integration; the container also forwards credential-shaped env vars (any
 `*_CLIENT_ID`/`*_CLIENT_SECRET`/`*_CONSUMER_KEY`/`*_CONSUMER_SECRET`), which override those defaults —
 so the refresh token must be issued by whichever app rudder-auth ends up using (the image default,
-or the creds you supply). In CI those app creds come from Vault via the destination's matrix `oauth:`
-path (see the workflow); locally, set them in `.env`.
+or the creds you supply). In CI those app creds come from Vault: an OAuth job imports the whole
+`control-plane/data/external-services` set in one wildcard read, and the container forwards only the
+credential-shaped vars — so rudder-auth gets whatever it needs by its own config names, with no
+per-destination secret list in the workflow. Locally, set them in `.env`.
 
 Authenticate with the AWS profile/SSO session that has ECR pull access to the account (set
 `AWS_PROFILE`, or pass `--profile`), then run:

--- a/test/integrations/live/README.md
+++ b/test/integrations/live/README.md
@@ -50,26 +50,28 @@ refreshes each OAuth destination's secret and merges the result into `metadata.s
 production, where rudder-server delegates token refresh to rudder-auth rather than the transformer
 holding credentials.
 
-`OAuthTokenResolver` tries rudder-auth's **V1** route first — `POST /auth/v1/refresh` with
-`{ accountDefinition, account: { secret: { refreshToken }, options } }` — and falls back to the
-**legacy** per-destination route, `POST /tokens/destination/<dest>/refresh` with `{ refreshToken }`.
-rudder-auth returns each integration's own secret shape with no normalization (`criteo_audience`/
-`zoho` → `{ accessToken, refreshToken }`, `google_adwords` → `{ access_token }`), so the resolver
-merges the **whole** returned secret into `metadata.secret` rather than a single hardcoded key, and
-each transform reads its own key via `getAccessToken(metadata, 'accessToken' | 'access_token')`. If
-both routes fail it throws with each route's status/body (token-shaped fields redacted). Supply the
-token via `LIVE_SECRET_<DEST>.oauthRefresh` (`refreshToken`, plus `accountDefinition` for V1 and any
-`providerFields`).
+`OAuthTokenResolver` calls exactly the rudder-auth route the spec's `oauthVersion` declares — **v0**
+(legacy `POST /tokens/destination/<dest>/refresh` with `{ refreshToken }`, the default) or **v1**
+(`POST /auth/v1/refresh` with `{ accountDefinition, account: { secret: { refreshToken }, options } }`).
+There is no fallback between them, so a leftover legacy route can't be hit by accident. rudder-auth
+returns each integration's own secret shape with no normalization (`criteo_audience`/`zoho` →
+`{ accessToken, refreshToken }`, `google_adwords` → `{ access_token }`), so the resolver merges the
+**whole** returned secret into `metadata.secret` rather than a single hardcoded key, and each
+transform reads its own key via `getAccessToken(metadata, 'accessToken' | 'access_token')`. On failure
+it throws with the HTTP status (via `axios.isAxiosError`) — never the response body, so a token can't
+leak. Supply the token via `LIVE_SECRET_<DEST>.oauthRefresh` (`refreshToken`, plus `accountDefinition`
+for v1 and any `providerFields`).
 
 The image is pulled from ECR (`422074288268.dkr.ecr.us-east-1.amazonaws.com/rudderstack/rudder-auth:develop`),
 so Docker must be running and logged in to that ECR registry. The image ships default OAuth app
-credentials for each integration; the container also forwards credential-shaped env vars (any
-`*_CLIENT_ID`/`*_CLIENT_SECRET`/`*_CONSUMER_KEY`/`*_CONSUMER_SECRET`), which override those defaults —
-so the refresh token must be issued by whichever app rudder-auth ends up using (the image default,
-or the creds you supply). In CI those app creds come from Vault: an OAuth job imports the whole
-`control-plane/data/external-services` set in one wildcard read, and the container forwards only the
-credential-shaped vars — so rudder-auth gets whatever it needs by its own config names, with no
-per-destination secret list in the workflow. Locally, set them in `.env`.
+credentials for each integration; the container also forwards credential-shaped env vars
+(`*_CLIENT_ID`/`*_CLIENT_SECRET`/`*_CONSUMER_KEY`/`*_CONSUMER_SECRET`/`*_DEVELOPER_TOKEN`), which
+override those defaults — so the refresh token must be issued by whichever app rudder-auth ends up
+using (the image default, or the creds you supply). In CI those app creds come from Vault: an OAuth
+job imports the whole `control-plane/data/external-services` set in one wildcard read, and the
+container (`rudderAuthContainer.ts`) forwards only the **enrolled** destinations' destination-flow
+creds — scoped to `<DEST>_…` and to base/`_DESTINATION` names, never `_SOURCE` — keeping every other
+secret in the job env out of the container. Locally, set them in `.env`.
 
 Authenticate with the AWS profile/SSO session that has ECR pull access to the account (set
 `AWS_PROFILE`, or pass `--profile`), then run:

--- a/test/integrations/live/README.md
+++ b/test/integrations/live/README.md
@@ -42,20 +42,32 @@ For anything beyond a couple of scenarios, split the spec into a `live/` folder 
 
 ### OAuth destinations (`authType: 'oauth'`)
 
-OAuth destinations don't ship a long-lived access token in their secret - one is minted at run
+OAuth destinations don't ship a long-lived access token in their secret — one is minted at run
 time. When any enrolled destination is `authType: 'oauth'`, a suite-level `beforeAll` starts the
 **rudder-auth** container via testcontainers (`RudderAuthContainer`, `live/rudderAuthContainer.ts`)
 and returns its base URL. `OAuthTokenResolver` (`live/oauthTokenResolver.ts`), built from that URL,
-posts `{ refreshToken }` (from `LIVE_SECRET_<DEST>.oauthRefresh`) to
-`/tokens/destination/<dest>/refresh` for each OAuth destination and injects the returned token into
-`metadata.secret.accessToken`. This mirrors production, where rudder-server delegates token refresh
-to rudder-auth rather than the transformer holding credentials.
+refreshes each OAuth destination's secret and merges the result into `metadata.secret`. This mirrors
+production, where rudder-server delegates token refresh to rudder-auth rather than the transformer
+holding credentials.
+
+`OAuthTokenResolver` tries rudder-auth's **V1** route first — `POST /auth/v1/refresh` with
+`{ accountDefinition, account: { secret: { refreshToken }, options } }` — and falls back to the
+**legacy** per-destination route, `POST /tokens/destination/<dest>/refresh` with `{ refreshToken }`.
+rudder-auth returns each integration's own secret shape with no normalization (`criteo_audience`/
+`zoho` → `{ accessToken, refreshToken }`, `google_adwords` → `{ access_token }`), so the resolver
+merges the **whole** returned secret into `metadata.secret` rather than a single hardcoded key, and
+each transform reads its own key via `getAccessToken(metadata, 'accessToken' | 'access_token')`. If
+both routes fail it throws with each route's status/body (token-shaped fields redacted). Supply the
+token via `LIVE_SECRET_<DEST>.oauthRefresh` (`refreshToken`, plus `accountDefinition` for V1 and any
+`providerFields`).
 
 The image is pulled from ECR (`422074288268.dkr.ecr.us-east-1.amazonaws.com/rudderstack/rudder-auth:develop`),
-so Docker must be running and logged in to that ECR registry. The image ships default OAuth app credentials for each integration, and the container also
-forwards credential-shaped env vars (any `*_CLIENT_ID`/`*_CLIENT_SECRET`), which override those
-defaults. So the refresh token must be issued by whichever app rudder-auth ends up using - the
-image default, or the `*_CLIENT_ID`/`*_CLIENT_SECRET` you set in `.env`.
+so Docker must be running and logged in to that ECR registry. The image ships default OAuth app
+credentials for each integration; the container also forwards credential-shaped env vars (any
+`*_CLIENT_ID`/`*_CLIENT_SECRET`/`*_CONSUMER_KEY`/`*_CONSUMER_SECRET`), which override those defaults —
+so the refresh token must be issued by whichever app rudder-auth ends up using (the image default,
+or the creds you supply). In CI those app creds come from Vault via the destination's matrix `oauth:`
+path (see the workflow); locally, set them in `.env`.
 
 Authenticate with the AWS profile/SSO session that has ECR pull access to the account (set
 `AWS_PROFILE`, or pass `--profile`), then run:
@@ -70,9 +82,9 @@ LIVE_SECRET_CRITEO_AUDIENCE='{...}' LOG_LEVEL=silent \
 
 ### Deferred (not in the pilot)
 
-Vault-backed `SecretResolver`, GitHub OIDC → Vault auth, the CI workflow, and impact-based PR
-subsetting. The interfaces here (`SecretResolver.resolve()`, `LiveSpec`) are shaped so those
-layer on without rewrites.
+Impact-based PR subsetting (running only the destinations a PR touches). Vault-backed secrets,
+GitHub-OIDC → Vault auth, and the CI workflow are now implemented — see
+`.github/workflows/live-integration-tests.yml`.
 
 **Scope — transform path.** The harness drives only `/routerTransform → /proxy`. rudder-server
 also runs the processor transform (`/v0/destinations/<dest>`) ahead of delivery, whose response
@@ -103,11 +115,13 @@ blob matching the `LiveSecret` shape:
 
 - `config` — merged into `destination.Config` (auth for header-based destinations lives here).
 - `secret` — merged into `metadata.secret` (for destinations that read the token there).
-- `resourceIds`, `oauthRefresh`, `readback` — optional; account ids, OAuth refresh token,
-  and read-back credentials for `verify` steps.
+- `resourceIds`, `oauthRefresh`, `readback` — optional; account-scoped ids, the OAuth refresh
+  token (`oauthRefresh.refreshToken` + `accountDefinition` for the rudder-auth V1 route), and
+  read-back credentials for `verify` steps.
 
-In production these come from Vault (one path per destination); the resolver interface
-stays the same.
+`SecretResolver` validates the blob against a zod schema (`LiveSecretSchema`) and throws a
+path-scoped error if it doesn't match. In production the blob comes from Vault (one path per
+destination, stored as single-line JSON); the resolver interface stays the same.
 
 `LIVE_TEST_EMAIL_DOMAIN` overrides the sink domain used for generated test emails.
 
@@ -116,14 +130,14 @@ stays the same.
 Add `test/integrations/destinations/<dest>/live.ts` exporting a `LiveSpec`:
 
 ```ts
-export const live: LiveSpec = {
+export const live = {
   enabled: true,
   authType: 'apiKey',
   resolveConfig: (s) => ({ ...s.config }), // -> destination.Config
   scenarios: [
     /* ... */
   ],
-};
+} satisfies LiveSpec;
 ```
 
 The registry discovers it automatically. Set `enabled: false` to keep it in the tree

--- a/test/integrations/live/oauthTokenResolver.ts
+++ b/test/integrations/live/oauthTokenResolver.ts
@@ -1,18 +1,9 @@
 import axios from 'axios';
 import { z } from 'zod';
-import type { LiveSecret } from './types';
+import type { LiveSecret, OAuthVersion } from './types';
 
-// rudder-auth returns each integration's own refreshed *secret* object, with no normalization:
-// criteo_audience/zoho -> { accessToken, refreshToken }, google_adwords -> { access_token }, etc.
-// rudder-server injects that object as-is into metadata.secret, and each transform reads its own key
-// via getAccessToken(metadata, 'accessToken' | 'access_token'). So the resolver returns the whole
-// secret to merge, and only asserts that *some* access token is present to tell a successful refresh
-// from an error body. (Confirmed against rudder-auth: routes/tokens.ts, routes/auth/v1/index.ts,
-// controllers/refreshTokenMethods/criteo_audience.ts.)
 const SecretSchema = z.record(z.unknown());
 
-// Success carries the secret to merge; failure carries a reason so a total failure can report why
-// each route failed instead of an opaque "no token".
 type RefreshResult = { ok: true; secret: Record<string, string> } | { ok: false; detail: string };
 
 const stringEntries = (secret: Record<string, unknown>): Record<string, string> => {
@@ -23,29 +14,6 @@ const stringEntries = (secret: Record<string, unknown>): Record<string, string> 
     }
   }
   return out;
-};
-
-// Redact token-shaped keys before a failure body is put in an error, so a token under an
-// unrecognized key can't leak (rudder-auth responses are flat, so a shallow pass suffices).
-const redact = (data: unknown): unknown => {
-  if (data === null || typeof data !== 'object') {
-    return data;
-  }
-  const out: Record<string, unknown> = {};
-  for (const [key, value] of Object.entries(data as Record<string, unknown>)) {
-    out[key] = /token|secret|password|key/i.test(key) ? '[redacted]' : value;
-  }
-  return out;
-};
-
-// A refresh succeeded iff a token is present under either key convention; otherwise report the body.
-const toResult = (status: number, data: unknown): RefreshResult => {
-  const parsed = SecretSchema.safeParse(data);
-  const secret = parsed.success ? stringEntries(parsed.data) : {};
-  if (secret.accessToken || secret.access_token) {
-    return { ok: true, secret };
-  }
-  return { ok: false, detail: `HTTP ${status}, body=${JSON.stringify(redact(data))}` };
 };
 
 export class OAuthTokenResolver {
@@ -60,21 +28,32 @@ export class OAuthTokenResolver {
       const res = await axios.post(url, body, {
         headers: { 'Content-Type': 'application/json' },
         timeout: 20000,
-        validateStatus: () => true,
       });
-      return toResult(res.status, res.data);
+      const parsed = SecretSchema.safeParse(res.data);
+      const secret = parsed.success ? stringEntries(parsed.data) : {};
+      if (secret.accessToken || secret.access_token) {
+        return { ok: true, secret };
+      }
+      return { ok: false, detail: `HTTP ${res.status}: no access token in response` };
     } catch (err) {
-      // Machine code only — never the message/config, which can carry the request body (token).
-      const code = axios.isAxiosError(err) ? (err.code ?? 'no response') : 'unexpected error';
-      return { ok: false, detail: `unreachable (${code})` };
+      if (!axios.isAxiosError(err)) {
+        return { ok: false, detail: 'unexpected error' };
+      }
+      // err.response → the HTTP error status; otherwise a network/timeout. Report the status or
+      // machine code only — never err.message/config, which can carry the request body's token.
+      return {
+        ok: false,
+        detail: err.response
+          ? `HTTP ${err.response.status}`
+          : `unreachable (${err.code ?? 'no response'})`,
+      };
     }
   }
 
-  // V1: POST /auth/v1/refresh with { accountDefinition, account: { secret, options } }.
-  private async tryV1(secret: LiveSecret): Promise<RefreshResult> {
+  private async refreshV1(secret: LiveSecret): Promise<RefreshResult> {
     const { refreshToken, accountDefinition, providerFields } = secret.oauthRefresh ?? {};
-    if (!refreshToken || !accountDefinition) {
-      return { ok: false, detail: 'skipped (no oauthRefresh.accountDefinition)' };
+    if (!accountDefinition) {
+      return { ok: false, detail: 'oauthRefresh.accountDefinition is required for a v1 refresh' };
     }
     return this.post(`${this.baseUrl}/auth/v1/refresh`, {
       accountDefinition,
@@ -82,33 +61,33 @@ export class OAuthTokenResolver {
     });
   }
 
-  // Legacy: POST /tokens/destination/<dest>/refresh with { refreshToken }.
-  private async tryLegacy(destination: string, refreshToken: string): Promise<RefreshResult> {
+  private async refreshV0(destination: string, refreshToken: string): Promise<RefreshResult> {
     return this.post(`${this.baseUrl}/tokens/destination/${destination}/refresh`, { refreshToken });
   }
 
-  async resolveSecret(destination: string, secret: LiveSecret): Promise<Record<string, string>> {
+  // Call exactly the route the spec declares — no fallback, so a leftover legacy path can't be hit.
+  async resolveSecret(
+    destination: string,
+    secret: LiveSecret,
+    version: OAuthVersion,
+  ): Promise<Record<string, string>> {
     const refreshToken = secret.oauthRefresh?.refreshToken;
     if (!refreshToken) {
       throw new Error(
-        `[live:${destination}] authType is 'oauth' but LIVE_SECRET_${destination.toUpperCase()} ` +
-          `has no oauthRefresh.refreshToken — cannot mint a secret via rudder-auth.`,
+        `[live:${destination}] authType is 'oauth' but LIVE_SECRET_${destination.toUpperCase()} has no oauthRefresh.refreshToken.`,
       );
     }
-    const v1 = await this.tryV1(secret);
-    if (v1.ok) {
-      return v1.secret;
+    const result =
+      version === 'v0'
+        ? await this.refreshV0(destination, refreshToken)
+        : await this.refreshV1(secret);
+    if (result.ok) {
+      return result.secret;
     }
-    const legacy = await this.tryLegacy(destination, refreshToken);
-    if (legacy.ok) {
-      return legacy.secret;
-    }
+    const route =
+      version === 'v0' ? `/tokens/destination/${destination}/refresh` : '/auth/v1/refresh';
     throw new Error(
-      `[live:${destination}] rudder-auth refresh failed on both routes:\n` +
-        `  V1 (/auth/v1/refresh): ${v1.detail}\n` +
-        `  legacy (/tokens/destination/${destination}/refresh): ${legacy.detail}\n` +
-        `The refresh token must match the app whose client_id/secret rudder-auth uses ` +
-        `(image default, or *_CLIENT_ID/_SECRET in the env).`,
+      `[live:${destination}] rudder-auth ${version} refresh failed (${route}): ${result.detail}`,
     );
   }
 }

--- a/test/integrations/live/oauthTokenResolver.ts
+++ b/test/integrations/live/oauthTokenResolver.ts
@@ -1,0 +1,55 @@
+import axios from 'axios';
+import { LiveSecret } from './types';
+
+type RefreshResponse = {
+  accessToken?: string;
+  refreshToken?: string;
+  [key: string]: unknown;
+};
+
+// Mints a fresh OAuth access token for a destination via the rudder-auth refresh endpoint.
+export class OAuthTokenResolver {
+  private readonly baseUrl: string;
+
+  constructor(baseUrl: string) {
+    this.baseUrl = baseUrl.replace(/\/+$/, '');
+  }
+
+  async resolveAccessToken(destination: string, secret: LiveSecret): Promise<string> {
+    const refreshToken = secret.oauthRefresh?.refreshToken;
+    if (!refreshToken) {
+      throw new Error(
+        `[live:${destination}] authType is 'oauth' but LIVE_SECRET_${destination.toUpperCase()} ` +
+          `has no oauthRefresh.refreshToken — cannot mint an access token via rudder-auth.`,
+      );
+    }
+
+    const url = `${this.baseUrl}/tokens/destination/${destination}/refresh`;
+    const res = await axios
+      .post<RefreshResponse>(
+        url,
+        { refreshToken },
+        {
+          headers: { 'Content-Type': 'application/json' },
+          timeout: 20000,
+          validateStatus: () => true,
+        },
+      )
+      .catch((err) => {
+        throw new Error(
+          `[live:${destination}] could not reach rudder-auth at ${url}: ${String(err)}. ` +
+            `Check the rudder-auth container started (see live/rudderAuthContainer.ts).`,
+        );
+      });
+
+    const accessToken = res.data?.accessToken;
+    if (res.status !== 200 || !accessToken) {
+      throw new Error(
+        `[live:${destination}] rudder-auth refresh failed (${url}): HTTP ${res.status}, ` +
+          `body=${JSON.stringify(res.data)}. The refresh token must be issued by the app whose ` +
+          `client_id/secret rudder-auth uses (the image default, or the *_CLIENT_ID/_SECRET set in the env).`,
+      );
+    }
+    return accessToken;
+  }
+}

--- a/test/integrations/live/oauthTokenResolver.ts
+++ b/test/integrations/live/oauthTokenResolver.ts
@@ -1,13 +1,53 @@
 import axios from 'axios';
-import { LiveSecret } from './types';
+import { z } from 'zod';
+import type { LiveSecret } from './types';
 
-type RefreshResponse = {
-  accessToken?: string;
-  refreshToken?: string;
-  [key: string]: unknown;
+// rudder-auth returns each integration's own refreshed *secret* object, with no normalization:
+// criteo_audience/zoho -> { accessToken, refreshToken }, google_adwords -> { access_token }, etc.
+// rudder-server injects that object as-is into metadata.secret, and each transform reads its own key
+// via getAccessToken(metadata, 'accessToken' | 'access_token'). So the resolver returns the whole
+// secret to merge, and only asserts that *some* access token is present to tell a successful refresh
+// from an error body. (Confirmed against rudder-auth: routes/tokens.ts, routes/auth/v1/index.ts,
+// controllers/refreshTokenMethods/criteo_audience.ts.)
+const SecretSchema = z.record(z.unknown());
+
+// Success carries the secret to merge; failure carries a reason so a total failure can report why
+// each route failed instead of an opaque "no token".
+type RefreshResult = { ok: true; secret: Record<string, string> } | { ok: false; detail: string };
+
+const stringEntries = (secret: Record<string, unknown>): Record<string, string> => {
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(secret)) {
+    if (typeof value === 'string') {
+      out[key] = value;
+    }
+  }
+  return out;
 };
 
-// Mints a fresh OAuth access token for a destination via the rudder-auth refresh endpoint.
+// Redact token-shaped keys before a failure body is put in an error, so a token under an
+// unrecognized key can't leak (rudder-auth responses are flat, so a shallow pass suffices).
+const redact = (data: unknown): unknown => {
+  if (data === null || typeof data !== 'object') {
+    return data;
+  }
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(data as Record<string, unknown>)) {
+    out[key] = /token|secret|password|key/i.test(key) ? '[redacted]' : value;
+  }
+  return out;
+};
+
+// A refresh succeeded iff a token is present under either key convention; otherwise report the body.
+const toResult = (status: number, data: unknown): RefreshResult => {
+  const parsed = SecretSchema.safeParse(data);
+  const secret = parsed.success ? stringEntries(parsed.data) : {};
+  if (secret.accessToken || secret.access_token) {
+    return { ok: true, secret };
+  }
+  return { ok: false, detail: `HTTP ${status}, body=${JSON.stringify(redact(data))}` };
+};
+
 export class OAuthTokenResolver {
   private readonly baseUrl: string;
 
@@ -15,41 +55,60 @@ export class OAuthTokenResolver {
     this.baseUrl = baseUrl.replace(/\/+$/, '');
   }
 
-  async resolveAccessToken(destination: string, secret: LiveSecret): Promise<string> {
+  private async post(url: string, body: object): Promise<RefreshResult> {
+    try {
+      const res = await axios.post(url, body, {
+        headers: { 'Content-Type': 'application/json' },
+        timeout: 20000,
+        validateStatus: () => true,
+      });
+      return toResult(res.status, res.data);
+    } catch (err) {
+      // Machine code only — never the message/config, which can carry the request body (token).
+      const code = axios.isAxiosError(err) ? (err.code ?? 'no response') : 'unexpected error';
+      return { ok: false, detail: `unreachable (${code})` };
+    }
+  }
+
+  // V1: POST /auth/v1/refresh with { accountDefinition, account: { secret, options } }.
+  private async tryV1(secret: LiveSecret): Promise<RefreshResult> {
+    const { refreshToken, accountDefinition, providerFields } = secret.oauthRefresh ?? {};
+    if (!refreshToken || !accountDefinition) {
+      return { ok: false, detail: 'skipped (no oauthRefresh.accountDefinition)' };
+    }
+    return this.post(`${this.baseUrl}/auth/v1/refresh`, {
+      accountDefinition,
+      account: { secret: { refreshToken, ...(providerFields ?? {}) }, options: {} },
+    });
+  }
+
+  // Legacy: POST /tokens/destination/<dest>/refresh with { refreshToken }.
+  private async tryLegacy(destination: string, refreshToken: string): Promise<RefreshResult> {
+    return this.post(`${this.baseUrl}/tokens/destination/${destination}/refresh`, { refreshToken });
+  }
+
+  async resolveSecret(destination: string, secret: LiveSecret): Promise<Record<string, string>> {
     const refreshToken = secret.oauthRefresh?.refreshToken;
     if (!refreshToken) {
       throw new Error(
         `[live:${destination}] authType is 'oauth' but LIVE_SECRET_${destination.toUpperCase()} ` +
-          `has no oauthRefresh.refreshToken — cannot mint an access token via rudder-auth.`,
+          `has no oauthRefresh.refreshToken — cannot mint a secret via rudder-auth.`,
       );
     }
-
-    const url = `${this.baseUrl}/tokens/destination/${destination}/refresh`;
-    const res = await axios
-      .post<RefreshResponse>(
-        url,
-        { refreshToken },
-        {
-          headers: { 'Content-Type': 'application/json' },
-          timeout: 20000,
-          validateStatus: () => true,
-        },
-      )
-      .catch((err) => {
-        throw new Error(
-          `[live:${destination}] could not reach rudder-auth at ${url}: ${String(err)}. ` +
-            `Check the rudder-auth container started (see live/rudderAuthContainer.ts).`,
-        );
-      });
-
-    const accessToken = res.data?.accessToken;
-    if (res.status !== 200 || !accessToken) {
-      throw new Error(
-        `[live:${destination}] rudder-auth refresh failed (${url}): HTTP ${res.status}, ` +
-          `body=${JSON.stringify(res.data)}. The refresh token must be issued by the app whose ` +
-          `client_id/secret rudder-auth uses (the image default, or the *_CLIENT_ID/_SECRET set in the env).`,
-      );
+    const v1 = await this.tryV1(secret);
+    if (v1.ok) {
+      return v1.secret;
     }
-    return accessToken;
+    const legacy = await this.tryLegacy(destination, refreshToken);
+    if (legacy.ok) {
+      return legacy.secret;
+    }
+    throw new Error(
+      `[live:${destination}] rudder-auth refresh failed on both routes:\n` +
+        `  V1 (/auth/v1/refresh): ${v1.detail}\n` +
+        `  legacy (/tokens/destination/${destination}/refresh): ${legacy.detail}\n` +
+        `The refresh token must match the app whose client_id/secret rudder-auth uses ` +
+        `(image default, or *_CLIENT_ID/_SECRET in the env).`,
+    );
   }
 }

--- a/test/integrations/live/poll.ts
+++ b/test/integrations/live/poll.ts
@@ -1,4 +1,4 @@
-import { PollCheckResult, PollUntilOptions, RetryUntilPassesOptions } from './types';
+import type { PollCheckResult, PollUntilOptions, RetryUntilPassesOptions } from './types';
 
 const sleep = (ms: number): Promise<void> =>
   new Promise((resolve) => {

--- a/test/integrations/live/registry.ts
+++ b/test/integrations/live/registry.ts
@@ -1,6 +1,6 @@
 import { existsSync, readdirSync } from 'fs';
 import { join } from 'path';
-import { EnrolledDestination, LiveSpec } from './types';
+import type { EnrolledDestination, LiveSpec } from './types';
 
 const DESTINATIONS_DIR = join(__dirname, '..', 'destinations');
 
@@ -12,7 +12,10 @@ function loadSpec(destination: string): LiveSpec | undefined {
     return undefined;
   }
   // eslint-disable-next-line global-require, import/no-dynamic-require
-  const mod = require(join(DESTINATIONS_DIR, destination, 'live'));
+  const mod = require(join(DESTINATIONS_DIR, destination, 'live')) as {
+    live?: LiveSpec;
+    default?: LiveSpec;
+  };
   const spec: LiveSpec | undefined = mod.live || mod.default;
   return spec && spec.enabled ? spec : undefined;
 }

--- a/test/integrations/live/routerProxyRequests.ts
+++ b/test/integrations/live/routerProxyRequests.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { formatZodError } from '@rudderstack/integrations-lib';
 import { DeliveryV1ResponseSchema, ProxyMetdata, ProxyV1Request } from '../../../src/types';
 import { isRecord, readBoolean, readNumber, readString } from './coerce';
 import { BatchedRequest, LiveRouterOutputSchema, RouterOutput } from './types';
@@ -57,13 +58,25 @@ const ProxyDeliveryHttpBodySchema = z.object({
 
 /** Parse `/routerTransform` HTTP body; returns only successful (2xx) outputs. */
 export const parseSuccessfulRouterOutputs = (body: unknown): RouterOutput[] => {
-  const { output } = RouterTransformHttpBodySchema.parse(body);
-  return output.filter((o) => o.statusCode >= 200 && o.statusCode < 300);
+  const result = RouterTransformHttpBodySchema.safeParse(body);
+  if (!result.success) {
+    throw new Error(
+      `/routerTransform response did not match the expected shape: ${formatZodError(result.error)}`,
+    );
+  }
+  return result.data.output.filter((o) => o.statusCode >= 200 && o.statusCode < 300);
 };
 
 /** Parse `/v1/destinations/<dest>/proxy` HTTP body to the delivery verdict. */
-export const parseDeliveryOutput = (body: unknown) =>
-  ProxyDeliveryHttpBodySchema.parse(body).output;
+export const parseDeliveryOutput = (body: unknown): z.infer<typeof DeliveryV1ResponseSchema> => {
+  const result = ProxyDeliveryHttpBodySchema.safeParse(body);
+  if (!result.success) {
+    throw new Error(
+      `/proxy response did not match the expected delivery shape: ${formatZodError(result.error)}`,
+    );
+  }
+  return result.data.output;
+};
 
 // Maps one router-transform output item to one or more ProxyV1Requests (array batchedRequests fan out).
 export const routerOutputToProxyRequests = (item: RouterOutput): ProxyV1Request[] => {

--- a/test/integrations/live/routerTransformRequest.ts
+++ b/test/integrations/live/routerTransformRequest.ts
@@ -1,5 +1,5 @@
 import { readString } from './coerce';
-import { BuildRouterTransformBodyOptions } from './types';
+import type { BuildRouterTransformBodyOptions, RouterTransformRequestBody } from './types';
 
 export const buildRouterTransformBody = (
   destination: string,
@@ -7,7 +7,7 @@ export const buildRouterTransformBody = (
   config: Record<string, unknown>,
   jobId: number,
   options?: BuildRouterTransformBodyOptions,
-) => ({
+): RouterTransformRequestBody => ({
   input: [
     {
       message,

--- a/test/integrations/live/rudderAuthContainer.ts
+++ b/test/integrations/live/rudderAuthContainer.ts
@@ -3,27 +3,37 @@ import { GenericContainer, StartedTestContainer, Wait } from 'testcontainers';
 const IMAGE = '422074288268.dkr.ecr.us-east-1.amazonaws.com/rudderstack/rudder-auth:develop';
 const PORT = 3033;
 
+// The OAuth app-credential shapes rudder-auth reads for a token refresh (see rudder-auth
+// config/custom-environment-variables.yml). A strict allowlist, not a broad /TOKEN|SECRET|KEY/,
+// because credentialEnv() runs over the whole job env.
+const CREDENTIAL_TYPES = 'CLIENT_ID|CLIENT_SECRET|CONSUMER_KEY|CONSUMER_SECRET|DEVELOPER_TOKEN';
+
 // Manages the rudder-auth container the live suite starts for OAuth destinations.
 export class RudderAuthContainer {
+  private readonly destinations: string[];
+
   private readonly env: NodeJS.ProcessEnv;
 
   private container?: StartedTestContainer;
 
-  constructor(env: NodeJS.ProcessEnv = process.env) {
+  constructor(destinations: string[], env: NodeJS.ProcessEnv = process.env) {
+    this.destinations = destinations;
     this.env = env;
   }
 
-  // OAuth app credentials forwarded into the container, filtered from the injected env by name.
-  // These override the app creds baked into the image (needed when the refresh token was issued by
-  // a different app than the image ships). Only the destinations whose CI matrix entry supplies
-  // these vars have them in env, so the forwarding is scoped without any per-destination code.
+  // Forward only the enrolled OAuth destinations' app credentials into the container, scoped by
+  // destination (destType) and to the destination flow — base or *_DESTINATION names, never
+  // *_SOURCE. This overrides the image's default app creds; everything else in the job env (the
+  // wildcard-imported cred set, plus GITHUB_TOKEN, AWS_*, LIVE_SECRET_*, ...) stays out.
   private credentialEnv(): Record<string, string> {
     const env: Record<string, string> = {};
+    if (this.destinations.length === 0) {
+      return env;
+    }
+    const dests = this.destinations.map((d) => d.toUpperCase()).join('|');
+    const pattern = new RegExp(`^(${dests})_(${CREDENTIAL_TYPES})(_DESTINATION)?$`);
     for (const [key, value] of Object.entries(this.env)) {
-      if (value === undefined) {
-        continue;
-      }
-      if (/(CLIENT_ID|CLIENT_SECRET|CONSUMER_KEY|CONSUMER_SECRET)/.test(key)) {
+      if (value !== undefined && pattern.test(key)) {
         env[key] = value;
       }
     }

--- a/test/integrations/live/rudderAuthContainer.ts
+++ b/test/integrations/live/rudderAuthContainer.ts
@@ -20,17 +20,16 @@ export class RudderAuthContainer {
   private credentialEnv(): Record<string, string> {
     const env: Record<string, string> = {};
     for (const [key, value] of Object.entries(this.env)) {
-      if (
-        value !== undefined &&
-        /(CLIENT_ID|CLIENT_SECRET|CONSUMER_KEY|CONSUMER_SECRET)/.test(key)
-      ) {
+      if (value === undefined) {
+        continue;
+      }
+      if (/(CLIENT_ID|CLIENT_SECRET|CONSUMER_KEY|CONSUMER_SECRET)/.test(key)) {
         env[key] = value;
       }
     }
     return env;
   }
 
-  // Start the container and return its base URL.
   async start(): Promise<string> {
     try {
       // eslint-disable-next-line no-console
@@ -49,7 +48,9 @@ export class RudderAuthContainer {
       return url;
     } catch (err) {
       throw new Error(
-        `[live] failed to start the rudder-auth container from ${IMAGE}: ${String(err)}.`,
+        `[live] failed to start the rudder-auth container from ${IMAGE}: ${
+          err instanceof Error ? err.message : 'unknown error'
+        }.`,
       );
     }
   }
@@ -62,7 +63,11 @@ export class RudderAuthContainer {
       await this.container.stop();
     } catch (err) {
       // eslint-disable-next-line no-console
-      console.warn(`[live] rudder-auth container teardown failed (ignored): ${String(err)}`);
+      console.warn(
+        `[live] rudder-auth container teardown failed (ignored): ${
+          err instanceof Error ? err.message : 'unknown error'
+        }`,
+      );
     } finally {
       this.container = undefined;
     }

--- a/test/integrations/live/rudderAuthContainer.ts
+++ b/test/integrations/live/rudderAuthContainer.ts
@@ -1,0 +1,70 @@
+import { GenericContainer, StartedTestContainer, Wait } from 'testcontainers';
+
+const IMAGE = '422074288268.dkr.ecr.us-east-1.amazonaws.com/rudderstack/rudder-auth:develop';
+const PORT = 3033;
+
+// Manages the rudder-auth container the live suite starts for OAuth destinations.
+export class RudderAuthContainer {
+  private readonly env: NodeJS.ProcessEnv;
+
+  private container?: StartedTestContainer;
+
+  constructor(env: NodeJS.ProcessEnv = process.env) {
+    this.env = env;
+  }
+
+  // OAuth app credentials forwarded into the container, filtered from the injected env by name.
+  // These override the app creds baked into the image (needed when the refresh token was issued by
+  // a different app than the image ships). Only the destinations whose CI matrix entry supplies
+  // these vars have them in env, so the forwarding is scoped without any per-destination code.
+  private credentialEnv(): Record<string, string> {
+    const env: Record<string, string> = {};
+    for (const [key, value] of Object.entries(this.env)) {
+      if (
+        value !== undefined &&
+        /(CLIENT_ID|CLIENT_SECRET|CONSUMER_KEY|CONSUMER_SECRET)/.test(key)
+      ) {
+        env[key] = value;
+      }
+    }
+    return env;
+  }
+
+  // Start the container and return its base URL.
+  async start(): Promise<string> {
+    try {
+      // eslint-disable-next-line no-console
+      console.log(`[live] starting rudder-auth container from ${IMAGE}…`);
+      this.container = await new GenericContainer(IMAGE)
+        .withExposedPorts(PORT)
+        .withEnvironment(this.credentialEnv())
+        .withWaitStrategy(
+          Wait.forHttp('/health', PORT).forStatusCodeMatching((code) => code >= 200 && code < 400),
+        )
+        .withStartupTimeout(120000)
+        .start();
+      const url = `http://127.0.0.1:${this.container.getMappedPort(PORT)}`;
+      // eslint-disable-next-line no-console
+      console.log(`[live] rudder-auth is healthy at ${url}`);
+      return url;
+    } catch (err) {
+      throw new Error(
+        `[live] failed to start the rudder-auth container from ${IMAGE}: ${String(err)}.`,
+      );
+    }
+  }
+
+  async stop(): Promise<void> {
+    if (!this.container) {
+      return;
+    }
+    try {
+      await this.container.stop();
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.warn(`[live] rudder-auth container teardown failed (ignored): ${String(err)}`);
+    } finally {
+      this.container = undefined;
+    }
+  }
+}

--- a/test/integrations/live/runContext.ts
+++ b/test/integrations/live/runContext.ts
@@ -1,10 +1,16 @@
 import { randomUUID } from 'crypto';
-import { LiveResource, LiveSecret, RunContext } from './types';
+import type { LiveResource, LiveSecret, RunContext } from './types';
 
 const EMAIL_DOMAIN = process.env.LIVE_TEST_EMAIL_DOMAIN || 'ci.rudderstack-test.com';
 
 // Parses a relative time offset like '-3h' / '+1d' into milliseconds (empty -> 0).
 const OFFSET_RE = /^([+-])(\d+)([smhd])$/;
+const UNIT_MS: Record<string, number> = {
+  s: 1000,
+  m: 60 * 1000,
+  h: 60 * 60 * 1000,
+  d: 24 * 60 * 60 * 1000,
+};
 const offsetToMs = (offset?: string): number => {
   if (!offset) {
     return 0;
@@ -14,13 +20,7 @@ const offsetToMs = (offset?: string): number => {
     throw new Error(`Invalid time offset: "${offset}"`);
   }
   const [, sign, rawAmount, unit] = m;
-  const unitMs: Record<string, number> = {
-    s: 1000,
-    m: 60 * 1000,
-    h: 60 * 60 * 1000,
-    d: 24 * 60 * 60 * 1000,
-  };
-  return (sign === '-' ? -1 : 1) * Number(rawAmount) * unitMs[unit];
+  return (sign === '-' ? -1 : 1) * Number(rawAmount) * UNIT_MS[unit];
 };
 
 export class RunContextImpl implements RunContext {

--- a/test/integrations/live/runPipelineStep.ts
+++ b/test/integrations/live/runPipelineStep.ts
@@ -6,7 +6,7 @@ import {
   routerOutputToProxyRequests,
 } from './routerProxyRequests';
 import { buildRouterTransformBody } from './routerTransformRequest';
-import { DeliveryFailure, RunPipelineStepParams } from './types';
+import type { DeliveryFailure, RunPipelineStepParams } from './types';
 
 const isDelivered = (status: number): boolean =>
   (status >= HttpStatusCode.Ok && status < HttpStatusCode.MultipleChoices) ||
@@ -44,8 +44,9 @@ const attemptDelivery = async ({
   expect(routerResponse.status).toEqual(HttpStatusCode.Ok);
 
   const routerOutputs = parseSuccessfulRouterOutputs(routerResponse.body);
-  if (step.expectedOutputs !== undefined) {
-    expect(routerOutputs).toHaveLength(step.expectedOutputs);
+  const { expectedOutputs, expectedProxyRequests } = step;
+  if (expectedOutputs !== undefined) {
+    expect(routerOutputs).toHaveLength(expectedOutputs);
   } else {
     expect(routerOutputs.length).toBeGreaterThan(0);
   }
@@ -56,9 +57,9 @@ const attemptDelivery = async ({
   proxyRequestsPerOutput.forEach((proxyRequests) =>
     expect(proxyRequests.length).toBeGreaterThan(0),
   );
-  if (step.expectedProxyRequests !== undefined) {
+  if (expectedProxyRequests !== undefined) {
     const total = proxyRequestsPerOutput.reduce((n, proxyRequests) => n + proxyRequests.length, 0);
-    expect(total).toEqual(step.expectedProxyRequests);
+    expect(total).toEqual(expectedProxyRequests);
   }
 
   for (const proxyRequests of proxyRequestsPerOutput) {

--- a/test/integrations/live/secretResolver.ts
+++ b/test/integrations/live/secretResolver.ts
@@ -1,4 +1,5 @@
-import { LiveSecret } from './types';
+import { formatZodError } from '@rudderstack/integrations-lib';
+import { LiveSecret, LiveSecretSchema } from './types';
 
 const jsonEnvKey = (destination: string): string => `LIVE_SECRET_${destination.toUpperCase()}`;
 
@@ -9,27 +10,28 @@ export class SecretResolver {
     this.env = env;
   }
 
-  // Resolves a LiveSecret per destination from the LIVE_SECRET_<DEST> env var (JSON).
-  // Throws when the secret is missing or invalid; live tests require credentials.
+  // Resolve + validate a LiveSecret from the LIVE_SECRET_<DEST> env var (JSON). Validating at this
+  // boundary — never trusting JSON.parse — means a malformed secret fails here with a precise,
+  // path-scoped message instead of surfacing as a confusing failure deep inside a scenario.
   resolve(destination: string): LiveSecret {
     const key = jsonEnvKey(destination);
     const raw = this.env[key];
     if (!raw) {
       throw new Error(`${key} is not set — live tests require credentials for '${destination}'.`);
     }
-    let parsed: LiveSecret;
+    let json: unknown;
     try {
-      parsed = JSON.parse(raw);
-    } catch (e) {
-      throw new Error(`${key} is set but is not valid JSON: ${(e as Error).message}`);
+      json = JSON.parse(raw);
+    } catch {
+      // Don't include the parser message — it can echo a fragment of the raw secret (incl. tokens).
+      throw new Error(`${key} is set but is not valid JSON.`);
     }
-    return {
-      authType: parsed.authType || 'apiKey',
-      config: parsed.config,
-      secret: parsed.secret,
-      resourceIds: parsed.resourceIds,
-      oauthRefresh: parsed.oauthRefresh,
-      readback: parsed.readback,
-    };
+    const result = LiveSecretSchema.safeParse(json);
+    if (!result.success) {
+      throw new Error(
+        `${key} does not match the LiveSecret shape: ${formatZodError(result.error)}`,
+      );
+    }
+    return result.data;
   }
 }

--- a/test/integrations/live/types.ts
+++ b/test/integrations/live/types.ts
@@ -28,6 +28,7 @@ const LiveSecretSchema = z.object({
 });
 type LiveSecret = z.infer<typeof LiveSecretSchema>;
 type AuthType = LiveSecret['authType'];
+type OAuthVersion = 'v0' | 'v1';
 
 interface LiveResource {
   type: string;
@@ -151,6 +152,7 @@ interface LiveScenario {
 interface LiveSpec {
   enabled: boolean; // false parks the whole destination — the registry skips it
   authType: AuthType;
+  oauthVersion?: OAuthVersion;
   // Map the resolved secret into the destination.Config the transform expects (merge non-secret
   // defaults with the credentials in `s.config`).
   resolveConfig: (s: LiveSecret) => Record<string, unknown>;
@@ -298,6 +300,7 @@ export {
   AccountDefinition,
   AccountDefinitionSchema,
   AuthType,
+  OAuthVersion,
   LiveSecret,
   LiveSecretSchema,
   RunContext,

--- a/test/integrations/live/types.ts
+++ b/test/integrations/live/types.ts
@@ -1,23 +1,38 @@
 import { z } from 'zod';
 
-type AuthType = 'apiKey' | 'oauth' | 'basic' | 'serviceAccount' | 'custom';
-type AccountDefinition = { type: string; category: string; name: string };
+// Account definition rudder-auth uses to describe an OAuth account.
+const AccountDefinitionSchema = z.object({
+  type: z.string(),
+  category: z.string(),
+  name: z.string(),
+});
+type AccountDefinition = z.infer<typeof AccountDefinitionSchema>;
 
-// Resolved credentials for one destination.
-type LiveSecret = {
-  authType: AuthType;
-  config: Record<string, unknown>; // merged into destination.Config
-  secret?: Record<string, string>; // merged into metadata.secret
-  resourceIds?: Record<string, string>; // account-scoped: listId, pixelId, measurementId, etc.
-  oauthRefresh?: {
-    refreshToken: string; // the long-lived token: the only oauth secret stored
-    accountDefinition: AccountDefinition;
-    providerFields?: Record<string, string>; // e.g. Salesforce instance_url, Google Cloud project ID, etc.
-  };
-  readback?: Record<string, unknown>; // credentials for the optional verify() hook, e.g. API key, etc.
-};
+// Resolved credentials for one destination, validated at the LIVE_SECRET_<DEST> boundary by
+// SecretResolver. The type is inferred from the schema (z.infer) so it can never drift from what
+// is actually validated — one source of truth for the secret shape. Unknown keys are stripped;
+// unset `authType`/`config` fall back to their defaults.
+const LiveSecretSchema = z.object({
+  authType: z.enum(['apiKey', 'oauth', 'basic', 'serviceAccount', 'custom']).default('apiKey'),
+  config: z.record(z.unknown()).default({}), // merged into destination.Config
+  secret: z.record(z.string()).optional(), // merged into metadata.secret
+  resourceIds: z.record(z.string()).optional(), // account-scoped: listId, pixelId, audience ids, etc.
+  oauthRefresh: z
+    .object({
+      refreshToken: z.string(), // the long-lived token: the only oauth secret stored
+      accountDefinition: AccountDefinitionSchema.optional(),
+      providerFields: z.record(z.string()).optional(), // e.g. Salesforce instance_url, GCP project id
+    })
+    .optional(),
+  readback: z.record(z.unknown()).optional(), // credentials for the optional verify() hook
+});
+type LiveSecret = z.infer<typeof LiveSecretSchema>;
+type AuthType = LiveSecret['authType'];
 
-type LiveResource = { type: string; id: string };
+interface LiveResource {
+  type: string;
+  id: string;
+}
 
 // Run-scoped context threaded through every step of a scenario. Build data from these — never
 // from string literals — so each run is isolated and repeatable.
@@ -49,10 +64,10 @@ interface Step {
 // and workspaceId (per-workspace feature-flag gating on metadata.workspaceId, e.g. HubSpot's rETL
 // split). Add fields here as new needs arise. NOTE: destination.Config is NOT here — per-scenario
 // config is owned by resolveConfig + the scenario's configOverride.
-type MetadataOverride = {
+interface MetadataOverride {
   workspaceId?: string;
   dontBatch?: boolean;
-};
+}
 
 // Top-level fields of the /routerTransform input `destination` a scenario may override (the harness
 // always sets ID/Config/Enabled). Kept explicit — not a loose Record — so a step can only override
@@ -60,9 +75,9 @@ type MetadataOverride = {
 // on destination.WorkspaceID (e.g. Braze's per-job delivery mapping). Config is deliberately absent —
 // it's owned by resolveConfig + configOverride, so there's one clear source for per-scenario config.
 // Add fields here as new gating needs arise.
-type DestinationOverride = {
+interface DestinationOverride {
   WorkspaceID?: string;
-};
+}
 
 // A pipeline step: seed -> /routerTransform -> /proxy, asserting the event is delivered.
 interface PipelineStep extends Step {
@@ -109,10 +124,10 @@ type LiveStep = PipelineStep | ActionStep | VerifyStep;
 
 // A scenario is an ordered list of steps (pipeline | action | verify) sharing one RunContext.
 // Setup, teardown and read-back are expressed as action/verify steps — no lifecycle hooks.
-type LiveScenario = {
+interface LiveScenario {
   id: string; // stable identifier, shown in test output and used to select scenarios
   description: string; // one-line summary of the behavior under test
-  steps: LiveStep[];
+  steps: readonly LiveStep[];
 
   enabled?: boolean; // default true; set false to keep the scenario in the tree without running it
   // Run this scenario against a modified destination.Config (derived from the spec's base config).
@@ -130,10 +145,10 @@ type LiveScenario = {
   // Scenario teardown: armed at scenario start, drained after its steps finish (LIFO, best-effort),
   // and run even if a step failed. Prefer this over a trailing cleanup step.
   cleanup?: (ctx: RunContext) => void | Promise<void>;
-};
+}
 
 // Per-destination contract at test/integrations/destinations/<dest>/live.ts, loaded by the registry.
-type LiveSpec = {
+interface LiveSpec {
   enabled: boolean; // false parks the whole destination — the registry skips it
   authType: AuthType;
   // Map the resolved secret into the destination.Config the transform expects (merge non-secret
@@ -142,11 +157,14 @@ type LiveSpec = {
   // Optional: map secret → connection.config (must include `destination` for VDM audience dests).
   // When set, the harness wraps this as a full connection on each /routerTransform input.
   resolveConnection?: (s: LiveSecret) => Record<string, unknown>;
-  scenarios: LiveScenario[];
-};
+  scenarios: readonly LiveScenario[];
+}
 
 // A destination enrolled to run, paired with its spec.
-type EnrolledDestination = { destination: string; spec: LiveSpec };
+interface EnrolledDestination {
+  destination: string;
+  spec: LiveSpec;
+}
 
 // Live-local wire schemas: include `endpointPath` (stripped by the shared
 // ProcessorTransformationOutputSchema) and keep destination/metadata loose so we don't require
@@ -186,32 +204,60 @@ type RouterOutput = z.infer<typeof LiveRouterOutputSchema>;
 type BatchedRequest = z.infer<typeof LiveProcessorOutputSchema>;
 
 // Options for buildRouterTransformBody (routerTransformRequest.ts).
-type BuildRouterTransformBodyOptions = {
+interface BuildRouterTransformBodyOptions {
   secret?: Record<string, string>;
   metadataOverride?: MetadataOverride;
   destinationOverride?: DestinationOverride;
   // Full connection object for RETL / audience destinations that read connection.config
   // (e.g. customAttributeName). Absent for event-stream destinations that don't need it.
   connection?: Record<string, unknown>;
-};
+}
+
+// The /routerTransform request body the harness builds (see routerTransformRequest.ts). Declared
+// explicitly so the wire contract is a single documented type rather than an inferred literal.
+interface RouterTransformInput {
+  message: Record<string, unknown>;
+  destination: {
+    ID: string;
+    Config: Record<string, unknown>;
+    Enabled: boolean;
+  } & DestinationOverride;
+  connection?: Record<string, unknown>;
+  metadata: {
+    jobId: number;
+    attemptNum: number;
+    userId: string;
+    sourceId: string;
+    destinationId: string;
+    workspaceId: string;
+    secret: Record<string, string>;
+  } & MetadataOverride;
+}
+interface RouterTransformRequestBody {
+  input: RouterTransformInput[];
+  destType: string;
+}
 
 // Minimal HTTP client the pipeline runner drives; wraps SuperTest so the runner stays free of its types.
-type LiveHttpResponse = { status: number; body: unknown };
-type LiveHttpClient = {
-  post: (url: string, body: unknown) => Promise<LiveHttpResponse>;
-};
+interface LiveHttpResponse {
+  status: number;
+  body: unknown;
+}
+interface LiveHttpClient {
+  post: (url: string, body: object) => Promise<LiveHttpResponse>;
+}
 
 // Structured delivery failure — the retry loop and the throw site both consume this, so the
 // human-readable message is assembled once, at the throw (see runPipelineStep).
-type DeliveryFailure = {
+interface DeliveryFailure {
   proxyStatus: number;
   verdictStatus: number;
   message: string;
   jobStates: unknown[];
-};
+}
 
 // Arguments threaded into a single pipeline-step run.
-type RunPipelineStepParams = {
+interface RunPipelineStepParams {
   destination: string;
   scenarioId: string;
   step: PipelineStep;
@@ -220,13 +266,16 @@ type RunPipelineStepParams = {
   http: LiveHttpClient;
   // Optional connection for destinations that require it at transform time (audience / VDM).
   connection?: Record<string, unknown>;
-};
+}
 
 // ─── Poll helpers (poll.ts) ───
 
-type PollCheckResult<T> = { done: boolean; value: T };
+interface PollCheckResult<T> {
+  done: boolean;
+  value: T;
+}
 
-type PollUntilOptions = {
+interface PollUntilOptions {
   label: string;
   attempts: number;
   /** Delay before the next attempt; `attempt` is 0-based (after the first check). */
@@ -238,17 +287,19 @@ type PollUntilOptions = {
    * verify steps that want a jest `expect` diff of the final read-back.
    */
   soft?: boolean;
-};
+}
 
-type RetryUntilPassesOptions = {
+interface RetryUntilPassesOptions {
   attempts?: number; // default 4
   delayMs?: (attempt: number) => number; // default 1000 * 2 ** attempt
-};
+}
 
 export {
   AccountDefinition,
+  AccountDefinitionSchema,
   AuthType,
   LiveSecret,
+  LiveSecretSchema,
   RunContext,
   LiveResource,
   LiveStep,
@@ -265,6 +316,8 @@ export {
   RouterOutput,
   BatchedRequest,
   BuildRouterTransformBodyOptions,
+  RouterTransformInput,
+  RouterTransformRequestBody,
   LiveHttpResponse,
   LiveHttpClient,
   DeliveryFailure,

--- a/test/integrations/live/types.ts
+++ b/test/integrations/live/types.ts
@@ -10,7 +10,6 @@ type LiveSecret = {
   secret?: Record<string, string>; // merged into metadata.secret
   resourceIds?: Record<string, string>; // account-scoped: listId, pixelId, measurementId, etc.
   oauthRefresh?: {
-    // if authType is oauth, sent to rudder-auth /auth/v1/refresh
     refreshToken: string; // the long-lived token: the only oauth secret stored
     accountDefinition: AccountDefinition;
     providerFields?: Record<string, string>; // e.g. Salesforce instance_url, Google Cloud project ID, etc.
@@ -117,7 +116,7 @@ type LiveScenario = {
 
   enabled?: boolean; // default true; set false to keep the scenario in the tree without running it
   // Run this scenario against a modified destination.Config (derived from the spec's base config).
-  configOverride?: (base: Record<string, unknown>) => Record<string, unknown>;
+  configOverride?: (base: Record<string, unknown>, secret: LiveSecret) => Record<string, unknown>;
   // The common trailing read-back, declared on the scenario the way `cleanup` is: the framework
   // runs `check` after the steps and retries it on a thrown matcher error (jest `expect`) with
   // backoff, rethrowing the last error on exhaustion — so destination code shrinks to the


### PR DESCRIPTION
🔒 Scanned for secrets using gitleaks 8.29.1

## What are the changes introduced in this PR?

Adds a live (real-destination) integration test suite for **criteo_audience**, plus the OAuth harness the suite needs to mint real access tokens via rudder-auth, and the CI wiring to run it.

- **criteo_audience live suite** (`test/integrations/destinations/criteo_audience/live.ts`): scenarios covering the Audience Type options — `add-email`, `add/remove-madid`, `add-identityLink`, and a RETL `email` flow. Each seeds an event, drives `/routerTransform → /proxy` against the real Criteo API, and cleans up via a real remove PATCH. Audience IDs come from the secret's `resourceIds` (`emailAudienceId`, `maidAudienceId`, `identityLinkAudienceId`).
- **OAuth harness** for `authType: 'oauth'` destinations:
  - `live/rudderAuthContainer.ts` — starts the rudder-auth container via `testcontainers` (image pulled from ECR), waits on `/health`, exposes a dynamic mapped port, and forwards credential-shaped env vars (`CLIENT_ID|CLIENT_SECRET|CONSUMER_KEY|CONSUMER_SECRET`) into the container so tokens can be minted with a test app instead of the image defaults.
  - `live/oauthTokenResolver.ts` — posts the refresh token to `/tokens/destination/<dest>/refresh` and returns the access token.
  - `component.live.test.ts` — starts the container once when any enrolled destination is OAuth, mints the token per destination, and injects it into `metadata.secret.accessToken`.
- **CI** (`.github/workflows/live-integration-tests.yml`): `criteo_audience` added to the matrix. A destination opts into the rudder-auth path purely by declaring its OAuth app-cred Vault mappings in the matrix `appSecrets` field; a single Vault step pulls both the destination secret and those app creds, and the ECR login/pre-pull steps gate on `appSecrets` being set (apiKey destinations skip them).

## What is the related Linear task?

- Resolves INT-6946