### PR TITLE
fix: garl data manager address info

### DIFF
--- a/src/v0/destinations/google_adwords_remarketing_lists/dataManager/types.ts
+++ b/src/v0/destinations/google_adwords_remarketing_lists/dataManager/types.ts
@@ -50,7 +50,7 @@ export interface AddressInfo {
 export interface UserIdentifier {
   emailAddress?: string;
   phoneNumber?: string;
-  addressInfo?: AddressInfo;
+  address?: AddressInfo;
 }
 
 export interface UserData {

--- a/src/v0/destinations/google_adwords_remarketing_lists/dataManager/util.test.ts
+++ b/src/v0/destinations/google_adwords_remarketing_lists/dataManager/util.test.ts
@@ -191,7 +191,7 @@ describe('filterFieldsBySchema (via buildAudienceMemberFromProcessedFields)', ()
           userIdentifiers: [
             { emailAddress: 'hashed_email' },
             { phoneNumber: 'hashed_phone' },
-            { addressInfo: fullAddress },
+            { address: fullAddress },
           ],
         },
       },
@@ -205,7 +205,7 @@ describe('filterFieldsBySchema (via buildAudienceMemberFromProcessedFields)', ()
           userIdentifiers: [
             { emailAddress: 'hashed_email' },
             { phoneNumber: 'hashed_phone' },
-            { addressInfo: fullAddress },
+            { address: fullAddress },
           ],
         },
       },
@@ -226,7 +226,7 @@ describe('filterFieldsBySchema (via buildAudienceMemberFromProcessedFields)', ()
       description: "userSchema ['addressInfo'] → only address identifier",
       fields: allFields,
       userSchema: ['addressInfo'],
-      expected: { userData: { userIdentifiers: [{ addressInfo: fullAddress }] } },
+      expected: { userData: { userIdentifiers: [{ address: fullAddress }] } },
     },
     {
       description: "userSchema ['email', 'phone'] → email and phone, no address",
@@ -244,7 +244,7 @@ describe('filterFieldsBySchema (via buildAudienceMemberFromProcessedFields)', ()
       userSchema: ['email', 'addressInfo'],
       expected: {
         userData: {
-          userIdentifiers: [{ emailAddress: 'hashed_email' }, { addressInfo: fullAddress }],
+          userIdentifiers: [{ emailAddress: 'hashed_email' }, { address: fullAddress }],
         },
       },
     },
@@ -253,7 +253,7 @@ describe('filterFieldsBySchema (via buildAudienceMemberFromProcessedFields)', ()
         "individual address field in userSchema (e.g. ['firstName']) triggers needsAddress → all address fields included, email/phone excluded",
       fields: allFields,
       userSchema: ['firstName'],
-      expected: { userData: { userIdentifiers: [{ addressInfo: fullAddress }] } },
+      expected: { userData: { userIdentifiers: [{ address: fullAddress }] } },
     },
     {
       description: 'empty userSchema → all fields filtered out → null',

--- a/src/v0/destinations/google_adwords_remarketing_lists/dataManager/util.ts
+++ b/src/v0/destinations/google_adwords_remarketing_lists/dataManager/util.ts
@@ -139,7 +139,9 @@ export const buildAudienceMemberFromProcessedFields = (
       // AddressInfo requires all 4 fields per Google DM API spec
       const { givenName, familyName, regionCode, postalCode } = mapped.addressInfo;
       if (givenName && familyName && regionCode && postalCode) {
-        userIdentifiers.push({ addressInfo: { givenName, familyName, regionCode, postalCode } });
+        // Data Manager API UserIdentifier uses `address` (the legacy Google Ads API used
+        // `addressInfo`); sub-fields stay givenName/familyName/regionCode/postalCode.
+        userIdentifiers.push({ address: { givenName, familyName, regionCode, postalCode } });
       }
     }
 

--- a/test/integrations/destinations/google_adwords_remarketing_lists/processor/dataManager/index.ts
+++ b/test/integrations/destinations/google_adwords_remarketing_lists/processor/dataManager/index.ts
@@ -69,7 +69,7 @@ const testMemberFullAddress = {
       { emailAddress: EMAIL_HASH_TEST },
       { phoneNumber: PHONE_HASH },
       {
-        addressInfo: {
+        address: {
           givenName: GIVEN_TEST,
           familyName: FAMILY_RUDDERLABS,
           regionCode: 'US',
@@ -94,7 +94,7 @@ const ghiMemberWithAddress = {
       { emailAddress: EMAIL_HASH_GHI },
       { phoneNumber: PHONE_HASH },
       {
-        addressInfo: {
+        address: {
           givenName: GIVEN_GHI,
           familyName: FAMILY_JKL,
           regionCode: 'US',

--- a/test/integrations/destinations/google_adwords_remarketing_lists/router/dataManager/index.ts
+++ b/test/integrations/destinations/google_adwords_remarketing_lists/router/dataManager/index.ts
@@ -77,7 +77,7 @@ export const dmRouterData = [
                                 phoneNumber: sha256('+09876543210'),
                               },
                               {
-                                addressInfo: {
+                                address: {
                                   givenName:
                                     '9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08',
                                   familyName:
@@ -174,7 +174,7 @@ export const dmRouterData = [
                                 phoneNumber: sha256('+09876543210'),
                               },
                               {
-                                addressInfo: {
+                                address: {
                                   givenName:
                                     '9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08',
                                   familyName:
@@ -272,7 +272,7 @@ export const dmRouterData = [
                                 phoneNumber: sha256('+09876543210'),
                               },
                               {
-                                addressInfo: {
+                                address: {
                                   givenName:
                                     '9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08',
                                   familyName:
@@ -350,7 +350,7 @@ export const dmRouterData = [
                                 phoneNumber: sha256('+09876543210'),
                               },
                               {
-                                addressInfo: {
+                                address: {
                                   givenName:
                                     '9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08',
                                   familyName:
@@ -423,7 +423,7 @@ export const dmRouterData = [
                                 phoneNumber: sha256('+09876543210'),
                               },
                               {
-                                addressInfo: {
+                                address: {
                                   givenName:
                                     '9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08',
                                   familyName:
@@ -481,7 +481,7 @@ export const dmRouterData = [
                                 phoneNumber: sha256('+09876543210'),
                               },
                               {
-                                addressInfo: {
+                                address: {
                                   givenName:
                                     '9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08',
                                   familyName:
@@ -575,7 +575,7 @@ export const dmRouterData = [
                                 phoneNumber: sha256('+09876543210'),
                               },
                               {
-                                addressInfo: {
+                                address: {
                                   givenName:
                                     '9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08',
                                   familyName:
@@ -648,7 +648,7 @@ export const dmRouterData = [
                                 phoneNumber: sha256('+09876543210'),
                               },
                               {
-                                addressInfo: {
+                                address: {
                                   givenName:
                                     '9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08',
                                   familyName:
@@ -675,7 +675,7 @@ export const dmRouterData = [
                                 phoneNumber: sha256('+09876543210'),
                               },
                               {
-                                addressInfo: {
+                                address: {
                                   givenName:
                                     '9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08',
                                   familyName:
@@ -763,7 +763,7 @@ export const dmRouterData = [
                                 phoneNumber: sha256('+09876543210'),
                               },
                               {
-                                addressInfo: {
+                                address: {
                                   givenName:
                                     '9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08',
                                   familyName:
@@ -888,7 +888,7 @@ export const dmRouterData = [
                                 phoneNumber: sha256('+09876543210'),
                               },
                               {
-                                addressInfo: {
+                                address: {
                                   givenName:
                                     '9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08',
                                   familyName:
@@ -1212,7 +1212,7 @@ export const dmRouterData = [
                                   '249c99278be4d0470583fd6d232247e8befeccc5f086a488f245d712d9d0078b',
                               },
                               {
-                                addressInfo: {
+                                address: {
                                   givenName:
                                     '9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08',
                                   familyName:
@@ -1359,7 +1359,7 @@ export const dmRouterData = [
                                 phoneNumber: sha256('+09876543210'),
                               },
                               {
-                                addressInfo: {
+                                address: {
                                   givenName:
                                     '9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08',
                                   familyName:
@@ -1432,7 +1432,7 @@ export const dmRouterData = [
                                 phoneNumber: sha256('+09876543210'),
                               },
                               {
-                                addressInfo: {
+                                address: {
                                   givenName:
                                     '9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08',
                                   familyName:
@@ -1459,7 +1459,7 @@ export const dmRouterData = [
                                 phoneNumber: sha256('+09876543210'),
                               },
                               {
-                                addressInfo: {
+                                address: {
                                   givenName:
                                     '9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08',
                                   familyName:
@@ -1547,7 +1547,7 @@ export const dmRouterData = [
                                 phoneNumber: sha256('+09876543210'),
                               },
                               {
-                                addressInfo: {
+                                address: {
                                   givenName:
                                     '9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08',
                                   familyName:


### PR DESCRIPTION
🔒 Scanned for secrets using gitleaks 8.29.1

## What are the changes introduced in this PR?

- For Google DM api, send address instead of addressInfo.

## What is the related Linear task?

Resolves INT-6948