### PR TITLE
chore: onboard customerio to live integration test

### DIFF
--- a/test/integrations/destinations/customerio/live.ts
+++ b/test/integrations/destinations/customerio/live.ts
@@ -1,0 +1,1 @@
+export { live, default } from './live/spec';

--- a/test/integrations/destinations/customerio/live/api.ts
+++ b/test/integrations/destinations/customerio/live/api.ts
@@ -1,0 +1,279 @@
+import axios from 'axios';
+import { Agent } from 'https';
+import type { RunContext } from '../../../live/types';
+
+// keepAlive:false so read-back/cleanup sockets don't linger as open handles when the suite finishes.
+const cioAgent = new Agent({ keepAlive: false });
+const TIMEOUT_MS = 15000;
+
+// Two different APIs, two different credentials:
+//  - Track API  Basic siteID:apiKey  — what the transform delivers to. Used here only for
+//    setup/teardown side effects (create a person, delete a person/object).
+//  - App API    Bearer App API Key   — read-only; every verify reads destination state back through
+//    it, independently of the transform.
+// US hosts only: the suite runs against a US sandbox. CustomerIO's EU region uses separate hosts
+// (track-eu / api-eu), so enrolling an EU account means selecting them here too.
+const TRACK_BASE = 'https://track.customer.io';
+const APP_BASE = 'https://api.customer.io';
+
+const trackAuthHeaders = (ctx: RunContext): Record<string, string> => {
+  const { siteID, apiKey } = ctx.liveSecret.config;
+  if (typeof siteID !== 'string' || !siteID) {
+    throw new Error('CustomerIO siteID missing from LIVE_SECRET_CUSTOMERIO.config');
+  }
+  if (typeof apiKey !== 'string' || !apiKey) {
+    throw new Error('CustomerIO apiKey missing from LIVE_SECRET_CUSTOMERIO.config');
+  }
+  return {
+    'Content-Type': 'application/json',
+    Authorization: `Basic ${Buffer.from(`${siteID}:${apiKey}`).toString('base64')}`,
+    Connection: 'close',
+  };
+};
+
+const appAuthHeaders = (ctx: RunContext): Record<string, string> => {
+  const appApiKey = ctx.liveSecret.readback?.appApiKey;
+  if (typeof appApiKey !== 'string' || !appApiKey) {
+    throw new Error(
+      'CustomerIO App API key missing — set readback.appApiKey in LIVE_SECRET_CUSTOMERIO (the read-back verifies need it)',
+    );
+  }
+  return {
+    'Content-Type': 'application/json',
+    Accept: 'application/json',
+    Authorization: `Bearer ${appApiKey}`,
+    Connection: 'close',
+  };
+};
+
+// How a person is addressed in an App API path. `id`/`email` are the workspace identifiers the
+// transform writes; `cio_id` is CustomerIO's own immutable id, used when a lookup resolved it.
+export type PersonIdType = 'id' | 'email' | 'cio_id';
+
+export interface PersonIdentifiers {
+  id: string | null;
+  email: string | null;
+  cio_id: string;
+}
+
+// CustomerIO reports an activity's identity in different fields per activity type: `name` for
+// `event` and `screen` activities, `url` for `page` activities.
+export interface CustomerActivity {
+  id: string;
+  type: string;
+  name?: string;
+  url?: string;
+  timestamp?: number;
+}
+
+export interface CustomerRelationship {
+  object_type_id?: number | string;
+  identifiers?: { object_id?: string; cio_object_id?: string };
+  attributes?: Record<string, unknown>;
+}
+
+export interface CustomerDevice {
+  id: string;
+  platform?: string;
+  last_used?: number;
+}
+
+// One person record carries identifiers, attributes AND devices, so a single GET backs every
+// person-shaped read-back.
+interface PersonRecord {
+  id?: string;
+  identifiers?: PersonIdentifiers;
+  attributes?: Record<string, string>;
+  devices?: CustomerDevice[];
+}
+
+// App API GET. A 404 means "this record does not exist", which is a legitimate read-back result
+// (the merge verify asserts exactly that), so it resolves to null instead of throwing.
+const appGet = async <T>(
+  ctx: RunContext,
+  path: string,
+  params?: Record<string, unknown>,
+): Promise<T | null> => {
+  try {
+    const res = await axios.get<T>(`${APP_BASE}${path}`, {
+      params,
+      headers: appAuthHeaders(ctx),
+      httpsAgent: cioAgent,
+      timeout: TIMEOUT_MS,
+    });
+    return res.data;
+  } catch (err) {
+    if (axios.isAxiosError(err) && err.response?.status === 404) {
+      return null;
+    }
+    throw err;
+  }
+};
+
+// ─── App API: read-backs ───
+
+// GET /v1/customers/{id}/attributes — the whole person record; null when they don't exist.
+const getPerson = async (
+  ctx: RunContext,
+  customerId: string,
+  idType: PersonIdType = 'id',
+): Promise<PersonRecord | null> => {
+  const data = await appGet<{ customer?: PersonRecord }>(
+    ctx,
+    `/v1/customers/${encodeURIComponent(customerId)}/attributes`,
+    { id_type: idType },
+  );
+  return data?.customer ?? null;
+};
+
+// Null when the person doesn't exist (distinct from an existing person with no attributes).
+// CustomerIO stores every profile attribute as a string, which is why the seeded trait profiles are
+// string-valued.
+export const getPersonAttributes = async (
+  ctx: RunContext,
+  customerId: string,
+  idType: PersonIdType = 'id',
+): Promise<Record<string, string> | null> => {
+  const person = await getPerson(ctx, customerId, idType);
+  return person ? (person.attributes ?? {}) : null;
+};
+
+// GET /v1/customers?email= — resolves a person written with only an email to their identifiers.
+// Going through cio_id afterwards keeps the read-back working whether or not `email` is enabled as
+// an identifier in the workspace (id_type=email 400s in an id-only workspace).
+// Returns EVERY match, so a caller can assert how many profiles an email resolves to — a duplicate
+// profile is the failure mode this distinguishes.
+export const findPersonsByEmail = async (
+  ctx: RunContext,
+  email: string,
+): Promise<PersonIdentifiers[]> => {
+  const data = await appGet<{ results?: PersonIdentifiers[] }>(ctx, '/v1/customers', { email });
+  return data?.results ?? [];
+};
+
+export const findPersonByEmail = async (
+  ctx: RunContext,
+  email: string,
+): Promise<PersonIdentifiers | null> => (await findPersonsByEmail(ctx, email))[0] ?? null;
+
+// GET /v1/customers/{id}/activities — the person's event feed. Deliberately unfiltered by activity
+// `type`: the two transform paths record a screen differently (v1 sends it as an `event`, v2 as a
+// `screen`), so callers match on the activity NAME to stay API-version agnostic.
+export const getPersonActivities = async (
+  ctx: RunContext,
+  customerId: string,
+  idType: PersonIdType = 'id',
+): Promise<CustomerActivity[]> => {
+  const data = await appGet<{ activities?: CustomerActivity[] }>(
+    ctx,
+    `/v1/customers/${encodeURIComponent(customerId)}/activities`,
+    { id_type: idType, limit: 100 },
+  );
+  return data?.activities ?? [];
+};
+
+// GET /v1/customers/{id}/relationships — the objects (groups) a person is related to.
+export const getPersonRelationships = async (
+  ctx: RunContext,
+  customerId: string,
+  idType: PersonIdType = 'id',
+): Promise<CustomerRelationship[]> => {
+  const data = await appGet<{ cio_relationships?: CustomerRelationship[] }>(
+    ctx,
+    `/v1/customers/${encodeURIComponent(customerId)}/relationships`,
+    { id_type: idType },
+  );
+  return data?.cio_relationships ?? [];
+};
+
+// GET /v1/objects/{object_type_id}/{object_id}/attributes — null when the object doesn't exist.
+export const getObjectAttributes = async (
+  ctx: RunContext,
+  objectTypeId: string,
+  objectId: string,
+): Promise<Record<string, string> | null> => {
+  const data = await appGet<{ object?: { attributes?: Record<string, string> } }>(
+    ctx,
+    `/v1/objects/${encodeURIComponent(objectTypeId)}/${encodeURIComponent(objectId)}/attributes`,
+  );
+  return data?.object?.attributes ?? null;
+};
+
+// The person record's `devices` — each device's `id` is the device token. Null when the person
+// doesn't exist, so a caller can tell "no such person" apart from "person exists but has no
+// devices"; collapsing both to [] hides which one failed.
+export const getPersonDevices = async (
+  ctx: RunContext,
+  customerId: string,
+  idType: PersonIdType = 'id',
+): Promise<CustomerDevice[] | null> => {
+  const person = await getPerson(ctx, customerId, idType);
+  return person ? (person.devices ?? []) : null;
+};
+
+// ─── Track API: setup + teardown side effects ───
+
+// Teardown is best-effort: a failure is logged, never thrown, so one failed cleanup can't strand the
+// siblings the runner still has to drain.
+const bestEffort = async (what: string, run: () => Promise<unknown>): Promise<void> => {
+  try {
+    await run();
+  } catch (err) {
+    const status = axios.isAxiosError(err) ? err.response?.status : undefined;
+    // eslint-disable-next-line no-console
+    console.error(
+      `[live:customerio] teardown (${what}) failed${status ? ` (status ${status})` : ''}:`,
+      err instanceof Error ? err.message : 'unknown error',
+    );
+  }
+};
+
+// PUT /api/v1/customers/{id} — creates or updates a person directly, bypassing the transform. Used
+// by setup steps that need prerequisite state (e.g. the two profiles an alias merge collapses).
+export const upsertPerson = async (
+  ctx: RunContext,
+  identifier: string,
+  attributes: Record<string, unknown>,
+): Promise<void> => {
+  await axios.put(`${TRACK_BASE}/api/v1/customers/${encodeURIComponent(identifier)}`, attributes, {
+    headers: trackAuthHeaders(ctx),
+    httpsAgent: cioAgent,
+    timeout: TIMEOUT_MS,
+  });
+};
+
+// DELETE /api/v1/customers/{id} — removes a person and their data.
+export const deletePerson = (ctx: RunContext, identifier: string): Promise<void> =>
+  bestEffort(`delete person ${identifier}`, () =>
+    axios.delete(`${TRACK_BASE}/api/v1/customers/${encodeURIComponent(identifier)}`, {
+      headers: trackAuthHeaders(ctx),
+      httpsAgent: cioAgent,
+      timeout: TIMEOUT_MS,
+    }),
+  );
+
+// Objects have no REST delete route; the Track API deletes them through a v2/batch object action.
+export const deleteObject = (
+  ctx: RunContext,
+  objectTypeId: string,
+  objectId: string,
+): Promise<void> =>
+  bestEffort(`delete object ${objectTypeId}/${objectId}`, () =>
+    axios.post(
+      `${TRACK_BASE}/api/v2/batch`,
+      {
+        batch: [
+          {
+            type: 'object',
+            action: 'delete',
+            identifiers: { object_id: objectId, object_type_id: objectTypeId },
+          },
+        ],
+      },
+      { headers: trackAuthHeaders(ctx), httpsAgent: cioAgent, timeout: TIMEOUT_MS },
+    ),
+  );
+
+// The cleanup every scenario that writes the run's main person reuses.
+export const deletePersonById = (ctx: RunContext): Promise<void> =>
+  deletePerson(ctx, ctx.identity('user'));

--- a/test/integrations/destinations/customerio/live/profiles.ts
+++ b/test/integrations/destinations/customerio/live/profiles.ts
@@ -1,0 +1,121 @@
+import type { RunContext } from '../../../live/types';
+
+// The JS-SDK-style context every seeded CustomerIO event carries (mirrors the component fixtures).
+export const customerIoLibraryContext = {
+  library: { name: 'RudderLabs JavaScript SDK', version: '1.0.0' },
+  locale: 'en-US',
+};
+
+// Common envelope fields shared by every seed, built from ctx so each run is isolated. `timestamp`
+// is what the transform reads as its historical timestamp on both paths (GenericFieldMapping
+// historicalTimestamp -> timestamp | originalTimestamp).
+export const baseEvent = (ctx: RunContext, suffix: string) => ({
+  channel: 'web',
+  messageId: `${ctx.runId}-${suffix}`,
+  timestamp: ctx.now(),
+  originalTimestamp: ctx.now(),
+  sentAt: ctx.now(),
+  integrations: { All: true },
+});
+
+// ─── Trait profiles ───
+// Each is a (ctx) => ({ ... }) factory shared by a scenario's seed and its read-back verify, so the
+// seeded values and the assertion can't drift. CustomerIO maps traits 1:1 onto profile attributes
+// (only `address` is expanded) and stores every attribute as a STRING, so every value here is a
+// string — a number would read back as its string form and diff against the seed.
+
+export const identifyTraits = (ctx: RunContext): Record<string, string> => ({
+  email: ctx.email(),
+  firstName: 'CI-Identify',
+  tier: `ci-${ctx.runId}-identify`,
+});
+
+// The email-only identify carries no userId, so the person is addressed purely by this email.
+export const emailOnlyEmail = (ctx: RunContext): string => ctx.email('email-only');
+export const emailOnlyTraits = (ctx: RunContext): Record<string, string> => ({
+  email: emailOnlyEmail(ctx),
+  firstName: 'CI-EmailOnly',
+  tier: `ci-${ctx.runId}-email-only`,
+});
+
+// A userId that is itself an email address. Both paths key the person by `id` = that email (v1 puts
+// it in the URL path, v2 in identifiers.id) rather than by the `email` identifier, so the read-back
+// looks the person up by id.
+export const emailUserId = (ctx: RunContext): string => ctx.email('user-as-email');
+export const emailUserIdTraits = (ctx: RunContext): Record<string, string> => ({
+  email: emailUserId(ctx),
+  firstName: 'CI-EmailUserId',
+  tier: `ci-${ctx.runId}-email-userid`,
+});
+
+// The second identify in the identity-consistency sequence. `tier` changes and `stage` is new, so
+// the read-back can tell an applied update apart from the original create.
+export const emailUserIdUpdatedTraits = (ctx: RunContext): Record<string, string> => ({
+  ...emailUserIdTraits(ctx),
+  tier: `ci-${ctx.runId}-email-userid-updated`,
+  stage: 'post-track-update',
+});
+
+// The track between the two identifies. It carries no email of its own, so it is the step that
+// would fork a duplicate profile if the identity were resolved differently.
+export const emailUserIdEventName = (ctx: RunContext): string =>
+  `CI Email UserId Event ${ctx.runId}`;
+
+// RETL / warehouse: context.mappedToDestination makes the transform derive userId from
+// context.externalId, so these traits land on the profile keyed by that external id.
+export const retlTraits = (ctx: RunContext): Record<string, string> => ({
+  email: ctx.email(),
+  firstName: 'CI-RETL',
+  tier: `ci-${ctx.runId}-retl`,
+});
+
+// ─── Event names ───
+// Run-unique so the activity read-back matches exactly one activity. The screen name is the one the
+// transform derives (`Viewed <name> Screen`) on both paths.
+
+export const trackEventName = (ctx: RunContext): string => `CI Live Event ${ctx.runId}`;
+// A page activity's identity comes back in the App API's `url` field rather than `name`, so the page
+// name is URL-shaped — which is also what a real page event carries.
+export const pageName = (ctx: RunContext): string => `https://example.com/ci-live/${ctx.runId}`;
+export const screenName = (ctx: RunContext): string => `CI Live Screen ${ctx.runId}`;
+export const screenActivityName = (ctx: RunContext): string => `Viewed ${screenName(ctx)} Screen`;
+
+// ─── Group / object ───
+// object_type_id comes from traits.objectTypeId (defaulted to '1' by the group mapping,
+// src/v0/destinations/customerio/data/customerIoGroup.json); a sandbox whose company object is a
+// different type can override it via resourceIds.objectTypeId.
+
+export const groupId = (ctx: RunContext): string => ctx.identity('group');
+export const objectTypeId = (ctx: RunContext): string =>
+  ctx.liveSecret.resourceIds?.objectTypeId ?? '1';
+
+// The traits become the object's attributes (the mapping excludes only `action`), so the same
+// factory drives the seed and the object read-back.
+export const groupTraits = (ctx: RunContext): Record<string, string> => ({
+  name: `CI Live Account ${ctx.runId}`,
+  objectTypeId: objectTypeId(ctx),
+  tier: `ci-${ctx.runId}-group`,
+});
+
+// ─── Device ───
+// context.device.token is what both paths register/remove; `type` becomes the platform.
+
+export const deviceToken = (ctx: RunContext): string => `ci-${ctx.runId}-device-token`;
+export const deviceContext = (ctx: RunContext) => ({
+  ...customerIoLibraryContext,
+  device: { token: deviceToken(ctx), type: 'android' },
+});
+
+// ─── Alias / merge ───
+// Written directly through the Track API by the setup action, so these are already the destination's
+// attribute shape (no trait mapping in between).
+
+export const mergePrimaryAttributes = (ctx: RunContext): Record<string, string> => ({
+  email: ctx.email('merge-primary'),
+  tier: `ci-${ctx.runId}-merge-primary`,
+});
+
+export const mergeSecondaryAttributes = (ctx: RunContext): Record<string, string> => ({
+  email: ctx.email('merge-secondary'),
+  tier: `ci-${ctx.runId}-merge-secondary`,
+});

--- a/test/integrations/destinations/customerio/live/setup.ts
+++ b/test/integrations/destinations/customerio/live/setup.ts
@@ -1,0 +1,47 @@
+import type { RunContext } from '../../../live/types';
+import { pollUntil } from '../../../live/poll';
+import { getPersonAttributes, upsertPerson } from './api';
+import { mergePrimaryAttributes, mergeSecondaryAttributes } from './profiles';
+
+// A Track API write is queued, so a just-created person isn't immediately readable. Merge rejects an
+// unknown secondary profile, so the precondition is made deterministic here rather than left to the
+// pipeline step's retries.
+const waitUntilReadable = (ctx: RunContext, identifier: string): Promise<unknown> =>
+  pollUntil(
+    async () => {
+      const attributes = await getPersonAttributes(ctx, identifier);
+      return { done: Boolean(attributes), value: attributes };
+    },
+    { label: `person ${identifier} readable`, attempts: 5, delayMs: (n) => 1000 * 2 ** n },
+  );
+
+const createPerson = async (
+  ctx: RunContext,
+  identifier: string,
+  attributes: Record<string, string>,
+): Promise<void> => {
+  await upsertPerson(ctx, identifier, attributes);
+  ctx.register({ type: 'person', id: identifier });
+};
+
+// The device scenario's pipeline steps only register and remove a device token, so the owning
+// profile is created here — the steps then exercise nothing but the device paths.
+export const createDeviceOwner = async (ctx: RunContext): Promise<void> => {
+  const identifier = ctx.identity('user');
+  await createPerson(ctx, identifier, { email: ctx.email() });
+  await waitUntilReadable(ctx, identifier);
+};
+
+// Both profiles an alias call collapses: the primary survives the merge, the secondary is absorbed.
+// Created through the Track API directly so the prerequisite state never depends on the transform
+// path under test.
+export const createMergeProfiles = async (ctx: RunContext): Promise<void> => {
+  const primary = ctx.identity('merge-primary');
+  const secondary = ctx.identity('merge-secondary');
+
+  await createPerson(ctx, primary, mergePrimaryAttributes(ctx));
+  await createPerson(ctx, secondary, mergeSecondaryAttributes(ctx));
+
+  await waitUntilReadable(ctx, primary);
+  await waitUntilReadable(ctx, secondary);
+};

--- a/test/integrations/destinations/customerio/live/spec.ts
+++ b/test/integrations/destinations/customerio/live/spec.ts
@@ -1,0 +1,448 @@
+import type { LiveSpec, RunContext } from '../../../live/types';
+import { deleteObject, deletePerson, deletePersonById } from './api';
+import { createDeviceOwner, createMergeProfiles } from './setup';
+import {
+  baseEvent,
+  customerIoLibraryContext,
+  deviceContext,
+  emailOnlyEmail,
+  emailOnlyTraits,
+  emailUserId,
+  emailUserIdEventName,
+  emailUserIdTraits,
+  emailUserIdUpdatedTraits,
+  groupId,
+  groupTraits,
+  identifyTraits,
+  objectTypeId,
+  pageName,
+  retlTraits,
+  screenActivityName,
+  screenName,
+  trackEventName,
+} from './profiles';
+import {
+  verifyActivityNamed,
+  verifyDeviceRegistered,
+  verifyDeviceRemoved,
+  verifyEmailUserIdStaysOneProfile,
+  verifyObjectCreatedAndLinked,
+  verifyPersonAttributes,
+  verifyPersonAttributesByEmail,
+  verifyPersonLinkedToObject,
+  verifyProfilesMerged,
+} from './verify';
+
+// ─── API-version agnostic by construction ───
+// CustomerIO has two transform paths in this repo: the legacy per-event Track API v1 routes
+// (src/v0/destinations/customerio/transform.ts) and the batching-framework path that sends
+// everything to Track API v2 /batch (src/v0/destinations/customerio/routerTransform.ts). Which one
+// runs is decided per request by CUSTOMERIO_BATCHING_FRAMEWORK_ENABLED_WORKSPACE_IDS
+// (src/constants/batchedDestinationsMap.ts). Check before drawing conclusions from a run: a local
+// `.env` sets it, and dotenv is loaded, so a developer machine may well be exercising v2 while CI
+// (where the var is unset) exercises v1.
+//
+// Nothing below is written against either path. Every scenario asserts (a) the real delivery verdict
+// and (b) the state CustomerIO's App API reports afterwards, which is identical whichever path did
+// the writing. Concretely that means:
+//   - no scenario references a v1 endpoint or the v2 batch envelope;
+//   - each pipeline step seeds exactly ONE event, so expectedOutputs/expectedProxyRequests of 1/1
+//     hold on both paths (multi-event steps are where their batching semantics diverge);
+//   - activity read-backs match on the activity NAME, never its `type` — v1 records a screen as an
+//     `event` activity while v2 records it as a `screen`.
+// So the same suite is the acceptance gate for the v2 rollout — pin the path explicitly rather than
+// inheriting whatever the environment happens to set:
+//   CUSTOMERIO_BATCHING_FRAMEWORK_ENABLED_WORKSPACE_IDS=  npm run test:live -- --destination=customerio
+//   CUSTOMERIO_BATCHING_FRAMEWORK_ENABLED_WORKSPACE_IDS=ALL npm run test:live -- --destination=customerio
+// A failure under the second command is a v2 implementation gap, not a test that needs updating.
+//
+// rETL `record` events are deliberately absent: they exist only on the v2 path (v1 rejects
+// `type: record`), so they cannot hold across both. Enroll them once v2 is the live path.
+//
+// Credentials — LIVE_SECRET_CUSTOMERIO (single-line JSON):
+// {"authType":"basic","config":{"siteID":"<site-id>","apiKey":"<track-api-key>"},
+//  "readback":{"appApiKey":"<app-api-key>"},"resourceIds":{"objectTypeId":"1"}}
+// `config` holds the Track API credentials the transform delivers with; `readback.appApiKey` is a
+// separate App API key (bearer) that only the verifies use, and needs read scope for customers,
+// activities and objects.
+
+// Retry budget for the scenario-level read-backs. The runner wraps `verify.check` in
+// retryUntilPasses(check, { attempts, delayMs }); the checks are single-shot, so this is the ONLY
+// backoff layer. 5 attempts (waits 1,2,4,8s → reads at ~0,1,3,7,15s) covers CustomerIO's ingestion
+// lag while staying well inside the runner's per-step timeout.
+const READBACK = { attempts: 5, delayMs: (n: number) => 1000 * 2 ** n };
+
+// A multi-write sequence settles later than a single write: the final state only appears once every
+// event in the chain has been applied in order. One extra attempt (reads at ~0,1,3,7,15,31s) — an
+// observed run needed ~19s, past the standard budget's 15s.
+const SEQUENCE_READBACK = { attempts: 6, delayMs: (n: number) => 1000 * 2 ** n };
+
+// A group scenario writes both a person and an object; both are torn down.
+const deleteGroupPersonAndObject = async (ctx: RunContext): Promise<void> => {
+  await deletePersonById(ctx);
+  await deleteObject(ctx, objectTypeId(ctx), groupId(ctx));
+};
+
+// An alias merge touches two profiles. The secondary is normally absorbed by the merge, but it is
+// deleted anyway so a failed run doesn't strand it.
+const deleteMergeProfiles = async (ctx: RunContext): Promise<void> => {
+  await deletePerson(ctx, ctx.identity('merge-primary'));
+  await deletePerson(ctx, ctx.identity('merge-secondary'));
+};
+
+export const live = {
+  enabled: true,
+  authType: 'basic',
+  // siteID + apiKey are account-scoped and come from LIVE_SECRET_CUSTOMERIO.config. `datacenter` is
+  // left unset: both transform paths default to the US region without it, and the suite targets a US
+  // sandbox (api.ts pins the US hosts to match).
+  resolveConfig: (s) => ({ ...s.config }),
+  scenarios: [
+    {
+      // identify with a userId → the person is created/updated with the traits as attributes.
+      id: 'customerio-identify-userid',
+      description: 'Event-stream identify creates a person keyed by userId with its traits',
+      cleanup: deletePersonById,
+      steps: [
+        {
+          stepType: 'pipeline',
+          name: 'identify by userId',
+          expectedOutputs: 1,
+          expectedProxyRequests: 1,
+          seed: (ctx) => ({
+            ...baseEvent(ctx, 'identify-userid'),
+            type: 'identify',
+            userId: ctx.identity('user'),
+            anonymousId: ctx.identity('anon'),
+            context: { ...customerIoLibraryContext, traits: identifyTraits(ctx) },
+          }),
+        },
+      ],
+      verify: { check: verifyPersonAttributes(identifyTraits), ...READBACK },
+    },
+    {
+      // identify with NO userId: both paths fall back to the email as the person's identifier.
+      id: 'customerio-identify-email-only',
+      description: 'identify without a userId creates a person keyed by their email',
+      cleanup: (ctx) => deletePerson(ctx, emailOnlyEmail(ctx)),
+      steps: [
+        {
+          stepType: 'pipeline',
+          name: 'identify by email',
+          expectedOutputs: 1,
+          expectedProxyRequests: 1,
+          seed: (ctx) => ({
+            ...baseEvent(ctx, 'identify-email-only'),
+            type: 'identify',
+            context: { ...customerIoLibraryContext, traits: emailOnlyTraits(ctx) },
+          }),
+        },
+      ],
+      verify: {
+        check: verifyPersonAttributesByEmail(emailOnlyEmail, emailOnlyTraits),
+        ...READBACK,
+      },
+    },
+    {
+      // A userId that is itself an email address — the person is created from that address alone.
+      // Read back by email lookup rather than by id: the two paths file the address under different
+      // identifiers (see verifyEmailUserIdStaysOneProfile), so an id lookup would be path-specific.
+      id: 'customerio-identify-email-userid',
+      description:
+        'identify with an email-shaped userId creates the person addressed by that email',
+      cleanup: (ctx) => deletePerson(ctx, emailUserId(ctx)),
+      steps: [
+        {
+          stepType: 'pipeline',
+          name: 'identify with an email as userId',
+          expectedOutputs: 1,
+          expectedProxyRequests: 1,
+          seed: (ctx) => ({
+            ...baseEvent(ctx, 'identify-email-userid'),
+            type: 'identify',
+            userId: emailUserId(ctx),
+            context: { ...customerIoLibraryContext, traits: emailUserIdTraits(ctx) },
+          }),
+        },
+      ],
+      verify: { check: verifyPersonAttributesByEmail(emailUserId, emailUserIdTraits), ...READBACK },
+    },
+    {
+      // track → a named event on the person's activity feed.
+      id: 'customerio-track-event',
+      description: "A custom track event is delivered and appears on the person's activity feed",
+      cleanup: deletePersonById,
+      steps: [
+        {
+          stepType: 'pipeline',
+          name: 'track custom event',
+          expectedOutputs: 1,
+          expectedProxyRequests: 1,
+          seed: (ctx) => ({
+            ...baseEvent(ctx, 'track'),
+            type: 'track',
+            event: trackEventName(ctx),
+            userId: ctx.identity('user'),
+            context: { ...customerIoLibraryContext, traits: { email: ctx.email() } },
+            properties: { plan: 'enterprise', source: 'live-integration-test' },
+          }),
+        },
+      ],
+      verify: { check: verifyActivityNamed(trackEventName), ...READBACK },
+    },
+    {
+      // page → a page activity named after message.name.
+      id: 'customerio-page',
+      description: 'A page call is delivered as a named page activity',
+      cleanup: deletePersonById,
+      steps: [
+        {
+          stepType: 'pipeline',
+          name: 'page',
+          expectedOutputs: 1,
+          expectedProxyRequests: 1,
+          seed: (ctx) => ({
+            ...baseEvent(ctx, 'page'),
+            type: 'page',
+            name: pageName(ctx),
+            userId: ctx.identity('user'),
+            context: { ...customerIoLibraryContext, traits: { email: ctx.email() } },
+            // No `url` property: the page activity's url must then come from message.name alone,
+            // so the read-back can't accidentally match a value the event carried elsewhere.
+            properties: { path: '/ci-live', title: 'CI Live Page' },
+          }),
+        },
+      ],
+      verify: { check: verifyActivityNamed(pageName), ...READBACK },
+    },
+    {
+      // screen → an activity the transform names `Viewed <event> Screen`. This is the one place the
+      // two paths produce a different activity TYPE (v1: event, v2: screen), which is why the
+      // read-back matches on name alone.
+      id: 'customerio-screen',
+      description: 'A screen call is delivered as a "Viewed <name> Screen" activity',
+      cleanup: deletePersonById,
+      steps: [
+        {
+          stepType: 'pipeline',
+          name: 'screen',
+          expectedOutputs: 1,
+          expectedProxyRequests: 1,
+          seed: (ctx) => ({
+            ...baseEvent(ctx, 'screen'),
+            type: 'screen',
+            event: screenName(ctx),
+            userId: ctx.identity('user'),
+            context: { ...customerIoLibraryContext, traits: { email: ctx.email() } },
+            properties: { screen: 'Home' },
+          }),
+        },
+      ],
+      verify: { check: verifyActivityNamed(screenActivityName), ...READBACK },
+    },
+    {
+      // An email-shaped userId across a sequence, not just a single call. Every event keys the person
+      // by `id` = that email, but a track carries no email of its own — so if any step resolved the
+      // identity differently, CustomerIO would fork a second, unmailable profile for the same person.
+      // identify → track → identify (updating attributes) is the shortest sequence that would expose
+      // that fork, and the read-back asserts a single profile carrying both the event and the update.
+      id: 'customerio-email-userid-identity-consistency',
+      description:
+        'identify → track → identify with an email-shaped userId stays one profile and applies the update',
+      cleanup: (ctx) => deletePerson(ctx, emailUserId(ctx)),
+      steps: [
+        {
+          stepType: 'pipeline',
+          name: 'identify (create)',
+          expectedOutputs: 1,
+          expectedProxyRequests: 1,
+          seed: (ctx) => ({
+            ...baseEvent(ctx, 'email-userid-create'),
+            type: 'identify',
+            userId: emailUserId(ctx),
+            context: { ...customerIoLibraryContext, traits: emailUserIdTraits(ctx) },
+          }),
+        },
+        {
+          stepType: 'pipeline',
+          name: 'track (no email of its own)',
+          expectedOutputs: 1,
+          expectedProxyRequests: 1,
+          seed: (ctx) => ({
+            ...baseEvent(ctx, 'email-userid-track'),
+            type: 'track',
+            event: emailUserIdEventName(ctx),
+            userId: emailUserId(ctx),
+            context: customerIoLibraryContext,
+            properties: { source: 'live-integration-test' },
+          }),
+        },
+        {
+          stepType: 'pipeline',
+          name: 'identify (update attributes)',
+          expectedOutputs: 1,
+          expectedProxyRequests: 1,
+          seed: (ctx) => ({
+            ...baseEvent(ctx, 'email-userid-update'),
+            type: 'identify',
+            userId: emailUserId(ctx),
+            context: { ...customerIoLibraryContext, traits: emailUserIdUpdatedTraits(ctx) },
+          }),
+        },
+      ],
+      verify: {
+        check: verifyEmailUserIdStaysOneProfile(
+          emailUserId,
+          emailUserIdUpdatedTraits,
+          emailUserIdEventName,
+        ),
+        ...SEQUENCE_READBACK,
+      },
+    },
+    {
+      // alias → merge the previousId profile into the userId profile. Setup creates both through the
+      // Track API (a merge rejects an unknown secondary), so the prerequisite doesn't depend on the
+      // path under test. `retries` covers the ingestion race: a merge that 4xxs persists nothing.
+      id: 'customerio-alias-merge',
+      description: 'An alias call merges the previousId profile into the userId profile',
+      cleanup: deleteMergeProfiles,
+      steps: [
+        {
+          stepType: 'action',
+          name: 'setup: create primary + secondary profiles',
+          run: createMergeProfiles,
+        },
+        {
+          stepType: 'pipeline',
+          name: 'alias merge',
+          retries: 2,
+          expectedOutputs: 1,
+          expectedProxyRequests: 1,
+          seed: (ctx) => ({
+            ...baseEvent(ctx, 'alias-merge'),
+            type: 'alias',
+            userId: ctx.identity('merge-primary'),
+            previousId: ctx.identity('merge-secondary'),
+          }),
+        },
+      ],
+      verify: { check: verifyProfilesMerged, ...READBACK },
+    },
+    {
+      // group with the default `identify` action → creates the object with its attributes and
+      // relates the person to it.
+      id: 'customerio-group-object-identify',
+      description: 'A group call creates the object and relates the person to it',
+      cleanup: deleteGroupPersonAndObject,
+      steps: [
+        {
+          stepType: 'pipeline',
+          name: 'group object identify',
+          expectedOutputs: 1,
+          expectedProxyRequests: 1,
+          seed: (ctx) => ({
+            ...baseEvent(ctx, 'group-identify'),
+            type: 'group',
+            userId: ctx.identity('user'),
+            groupId: groupId(ctx),
+            traits: { ...groupTraits(ctx), action: 'identify' },
+          }),
+        },
+      ],
+      verify: { check: verifyObjectCreatedAndLinked(groupTraits), ...READBACK },
+    },
+    {
+      // The other object action worth exercising live: add_relationships only links the person to
+      // the object, so the read-back asserts the relationship rather than the object's attributes.
+      id: 'customerio-group-add-relationships',
+      description: 'A group call with add_relationships links the person to the object',
+      cleanup: deleteGroupPersonAndObject,
+      steps: [
+        {
+          stepType: 'pipeline',
+          name: 'group add_relationships',
+          expectedOutputs: 1,
+          expectedProxyRequests: 1,
+          seed: (ctx) => ({
+            ...baseEvent(ctx, 'group-add-rel'),
+            type: 'group',
+            userId: ctx.identity('user'),
+            groupId: groupId(ctx),
+            traits: { ...groupTraits(ctx), action: 'add_relationships' },
+          }),
+        },
+      ],
+      verify: { check: verifyPersonLinkedToObject(), ...READBACK },
+    },
+    {
+      // The two device routes, in the order they happen in real life. The mid-scenario verify step
+      // proves the token was registered before the uninstall removes it — without it, a device-add
+      // that silently no-ops would still pass the closing "token is gone" assertion.
+      id: 'customerio-device-add-then-delete',
+      description:
+        'Application Installed registers a device token and Application Uninstalled removes it',
+      cleanup: deletePersonById,
+      steps: [
+        { stepType: 'action', name: 'setup: create the device owner', run: createDeviceOwner },
+        {
+          stepType: 'pipeline',
+          name: 'Application Installed (register device)',
+          expectedOutputs: 1,
+          expectedProxyRequests: 1,
+          seed: (ctx) => ({
+            ...baseEvent(ctx, 'device-add'),
+            type: 'track',
+            event: 'Application Installed',
+            userId: ctx.identity('user'),
+            context: deviceContext(ctx),
+            properties: { version: '1.0.0' },
+          }),
+        },
+        verifyDeviceRegistered,
+        {
+          stepType: 'pipeline',
+          name: 'Application Uninstalled (remove device)',
+          expectedOutputs: 1,
+          expectedProxyRequests: 1,
+          seed: (ctx) => ({
+            ...baseEvent(ctx, 'device-delete'),
+            type: 'track',
+            event: 'Application Uninstalled',
+            userId: ctx.identity('user'),
+            context: deviceContext(ctx),
+          }),
+        },
+      ],
+      verify: { check: verifyDeviceRemoved, ...READBACK },
+    },
+    {
+      // RETL / warehouse: context.mappedToDestination makes both paths derive the person's id from
+      // context.externalId instead of a top-level userId, and pass the traits through as attributes.
+      id: 'customerio-retl-mapped-to-destination',
+      description:
+        'RETL (mappedToDestination) identify keys the person by context.externalId and writes its traits',
+      cleanup: deletePersonById,
+      steps: [
+        {
+          stepType: 'pipeline',
+          name: 'retl identify (mappedToDestination)',
+          expectedOutputs: 1,
+          expectedProxyRequests: 1,
+          seed: (ctx) => ({
+            ...baseEvent(ctx, 'retl-identify'),
+            type: 'identify',
+            context: {
+              ...customerIoLibraryContext,
+              mappedToDestination: true,
+              externalId: [{ identifierType: 'userId', id: ctx.identity('user') }],
+              traits: retlTraits(ctx),
+            },
+          }),
+        },
+      ],
+      verify: { check: verifyPersonAttributes(retlTraits), ...READBACK },
+    },
+  ],
+} satisfies LiveSpec;
+
+export default live;

--- a/test/integrations/destinations/customerio/live/verify.ts
+++ b/test/integrations/destinations/customerio/live/verify.ts
@@ -1,0 +1,167 @@
+import type { LiveStep, RunContext } from '../../../live/types';
+import { pollUntil } from '../../../live/poll';
+import {
+  findPersonByEmail,
+  findPersonsByEmail,
+  getObjectAttributes,
+  getPersonActivities,
+  getPersonAttributes,
+  getPersonDevices,
+  getPersonRelationships,
+} from './api';
+import { deviceToken, groupId, mergePrimaryAttributes, objectTypeId } from './profiles';
+
+// Everything exported as a scenario-level `verify.check` here is a SINGLE-SHOT assertion: the
+// framework wraps it in retryUntilPasses and owns the backoff, so a check must not also poll
+// internally (nesting the two compounds the waits and blows past the runner's per-step timeout).
+// The one exception is `verifyDeviceRegistered`, a mid-scenario VerifyStep — steps are NOT retried,
+// so that one polls itself.
+
+// Read the profile back by its `id` and assert it carries the seeded traits. CustomerIO maps traits
+// straight onto attributes, so the seed profile is also the expected shape.
+const verifyPersonAttributesById =
+  (identifier: (ctx: RunContext) => string, traits: (ctx: RunContext) => Record<string, string>) =>
+  async (ctx: RunContext): Promise<void> => {
+    const attributes = await getPersonAttributes(ctx, identifier(ctx));
+    expect(attributes).not.toBeNull();
+    expect(attributes).toMatchObject(traits(ctx));
+  };
+
+// The common case: the person is keyed by a ctx identity rather than an arbitrary identifier.
+export const verifyPersonAttributes = (
+  traits: (ctx: RunContext) => Record<string, string>,
+  entity = 'user',
+) => verifyPersonAttributesById((ctx) => ctx.identity(entity), traits);
+
+// The email-only identify writes a person addressed solely by email. Resolve them by email first,
+// then read attributes through cio_id — that works whether or not `email` is enabled as an
+// identifier in the workspace (id_type=email 400s in an id-only workspace).
+export const verifyPersonAttributesByEmail =
+  (email: (ctx: RunContext) => string, traits: (ctx: RunContext) => Record<string, string>) =>
+  async (ctx: RunContext): Promise<void> => {
+    const person = await findPersonByEmail(ctx, email(ctx));
+    expect(person?.cio_id).toBeDefined();
+    const attributes = person ? await getPersonAttributes(ctx, person.cio_id, 'cio_id') : null;
+    expect(attributes).not.toBeNull();
+    expect(attributes).toMatchObject(traits(ctx));
+  };
+
+// Assert the event landed on the person's activity feed. CustomerIO reports the activity's identity
+// in `name` for `event`/`screen` activities but in `url` for `page` activities, so both fields are
+// searched. Matched by that identity and never by activity `type`: v1 records a screen as an `event`
+// activity while v2 records it as a `screen`, so pinning the type would make this path-specific.
+export const verifyActivityNamed =
+  (activityName: (ctx: RunContext) => string, entity = 'user') =>
+  async (ctx: RunContext): Promise<void> => {
+    const activities = await getPersonActivities(ctx, ctx.identity(entity));
+    const identities = activities
+      .flatMap((activity) => [activity.name, activity.url])
+      .filter((identity): identity is string => typeof identity === 'string');
+    expect(identities).toContain(activityName(ctx));
+  };
+
+// An email-shaped userId must resolve to ONE profile across a whole event sequence, which then
+// carries the email-less track event and the second identify's update.
+//
+// Written against v1, the current production path. A live comparison found the two paths file the
+// address under DIFFERENT identifiers: v1 addresses the person as `PUT /customers/<email>` and
+// CustomerIO stores it as the email identifier (`id` reads back empty), while v2 declares
+// `identifiers.id = <email>` so the id becomes the email string. That is a real divergence — the
+// same event stream keys profiles differently before and after the batching rollout — and the
+// intent is to fix v2, not to encode both behaviours here.
+//
+// The reads below go through `cio_id` because it is the one handle both paths agree on, so a v2
+// regression surfaces as a duplicate-profile or missing-update failure rather than as an unrelated
+// lookup 404 that obscures it.
+export const verifyEmailUserIdStaysOneProfile =
+  (
+    email: (ctx: RunContext) => string,
+    updatedTraits: (ctx: RunContext) => Record<string, string>,
+    activityName: (ctx: RunContext) => string,
+  ) =>
+  async (ctx: RunContext): Promise<void> => {
+    const address = email(ctx);
+
+    // A forked duplicate is the failure this scenario exists to catch, so assert the count first —
+    // it fails printing the actual matches rather than as an opaque attribute mismatch.
+    const matches = await findPersonsByEmail(ctx, address);
+    expect(matches).toHaveLength(1);
+
+    const cioId = matches[0]?.cio_id;
+    expect(cioId).toBeDefined();
+
+    const attributes = cioId ? await getPersonAttributes(ctx, cioId, 'cio_id') : null;
+    expect(attributes).not.toBeNull();
+    expect(attributes).toMatchObject(updatedTraits(ctx));
+
+    const activities = cioId ? await getPersonActivities(ctx, cioId, 'cio_id') : [];
+    expect(activities.map((activity) => activity.name)).toContain(activityName(ctx));
+  };
+
+// The person must be linked to the object the group call addressed (the cio_relationship half).
+export const verifyPersonLinkedToObject =
+  (entity = 'user') =>
+  async (ctx: RunContext): Promise<void> => {
+    const relationships = await getPersonRelationships(ctx, ctx.identity(entity));
+    expect(
+      relationships.map((relationship) => ({
+        objectTypeId: String(relationship.object_type_id),
+        objectId: relationship.identifiers?.object_id,
+      })),
+    ).toContainEqual({ objectTypeId: objectTypeId(ctx), objectId: groupId(ctx) });
+  };
+
+// A group `identify` writes both halves — the object with its attributes, and the relationship. A
+// v2/batch response can be a 207 whose per-item error the delivery verdict already surfaces, but
+// only this read-back proves both halves actually landed.
+export const verifyObjectCreatedAndLinked =
+  (attributes: (ctx: RunContext) => Record<string, string>, entity = 'user') =>
+  async (ctx: RunContext): Promise<void> => {
+    const objectAttributes = await getObjectAttributes(ctx, objectTypeId(ctx), groupId(ctx));
+    expect(objectAttributes).not.toBeNull();
+    expect(objectAttributes).toMatchObject(attributes(ctx));
+
+    await verifyPersonLinkedToObject(entity)(ctx);
+  };
+
+// Mid-scenario read-back between the device-add and device-delete pipeline steps. A VerifyStep is
+// not retried by the framework, so it polls internally (soft:true so the closing expect still
+// prints a real diff once attempts are exhausted).
+export const verifyDeviceRegistered: LiveStep = {
+  stepType: 'verify',
+  name: 'verify device token is registered',
+  check: async (ctx: RunContext): Promise<void> => {
+    const token = deviceToken(ctx);
+    // 6 attempts (reads at ~0,1,3,7,15,31s): device ingestion lags further behind than attribute
+    // and activity ingestion do.
+    const devices = await pollUntil(
+      async () => {
+        const found = await getPersonDevices(ctx, ctx.identity('user'));
+        return { done: Boolean(found?.some((device) => device.id === token)), value: found };
+      },
+      { label: 'device registration', attempts: 6, delayMs: (n) => 1000 * 2 ** n, soft: true },
+    );
+    // null means the person itself wasn't returned — a different failure from "no devices yet".
+    expect(devices).not.toBeNull();
+    expect(devices ?? []).toContainEqual(expect.objectContaining({ id: token }));
+  },
+};
+
+// The closing half of the device scenario: the uninstall event must have removed the token again.
+export const verifyDeviceRemoved = async (ctx: RunContext): Promise<void> => {
+  const devices = await getPersonDevices(ctx, ctx.identity('user'));
+  expect(devices).not.toBeNull();
+  expect(devices ?? []).not.toContainEqual(expect.objectContaining({ id: deviceToken(ctx) }));
+};
+
+// The merge's contract-guaranteed effect: the secondary profile stops resolving and the primary
+// survives with its own attributes. CustomerIO doesn't define how conflicting attributes are
+// reconciled across a merge, so this deliberately doesn't assert attribute transfer.
+export const verifyProfilesMerged = async (ctx: RunContext): Promise<void> => {
+  const secondary = await getPersonAttributes(ctx, ctx.identity('merge-secondary'));
+  expect(secondary).toBeNull();
+
+  const primary = await getPersonAttributes(ctx, ctx.identity('merge-primary'));
+  expect(primary).not.toBeNull();
+  expect(primary).toMatchObject(mergePrimaryAttributes(ctx));
+};


### PR DESCRIPTION
## What are the changes introduced in this PR?

Enrolls `customerio` in the live (real-destination) integration suite —
`test/integrations/destinations/customerio/live.ts` plus a `live/` module
(`spec` / `api` / `setup` / `verify` / `profiles`). The registry and the CI matrix
discover it automatically, so no workflow changes are needed.

12 scenarios, each asserting the real delivery verdict **and** a field-level read-back
of the resulting destination state:

| Scenario | Read-back |
| --- | --- |
| identify by userId | person attributes |
| identify by email only | attributes via email → cio_id |
| identify with an email-shaped userId | attributes via email → cio_id |
| identify → track → identify (email-shaped userId) | one profile, update applied, event present |
| track / page / screen | activity by name |
| alias merge | secondary gone, primary intact |
| group object identify | object attributes + person→object relationship |
| group add_relationships | relationship exists |
| device register then delete | device token present, then absent |
| RETL (mappedToDestination) | attributes on the externalId-keyed person |

## What is the related Linear task?

Resolves INT-6981

## Please explain the objectives of your changes below

The mocked component suite verifies the request the transformer builds; it cannot
verify that CustomerIO accepts it. These scenarios drive seeded events through the
real `/routerTransform → /proxy` path against a live account and assert both the
delivery verdict and the resulting destination state, read back independently
through CustomerIO's App API.

The suite is written to be agnostic to which transform path runs, so it doubles as
the acceptance gate for the batching-framework (v2) rollout:

- no scenario references a v1 endpoint or the v2 batch envelope;
- each pipeline step seeds exactly one event, so `expectedOutputs` /
  `expectedProxyRequests` of 1/1 hold on both paths;
- activity read-backs match on the event **name**, never the activity `type` — v1
  records a screen as an `event`, v2 as a `screen`.

Both paths were exercised by pinning `CUSTOMERIO_BATCHING_FRAMEWORK_ENABLED_WORKSPACE_IDS`;
all 14 seeds transform to 1 output / 1 proxy request on each, and the scenarios were
run end to end against a live sandbox.

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

None. Test-only; no `src/` changes.

### Any new dependencies introduced with this change?

N/A

### Any new generic utility introduced or modified. Please explain the changes.

N/A — every helper is scoped to this destination's `live/` folder.

### Any technical or performance related pointers to consider with the change?

- Requires `LIVE_SECRET_CUSTOMERIO` in Vault under
  `engineering_shared/data/integrations_team/e2e_test/rudder-transformer` (single-line
  JSON). It needs **two** credentials: the Track API `siteID`/`apiKey` the transform
  delivers with, and a separate App API bearer key under `readback.appApiKey`
  (read scope: customers, activities, objects) used only by the read-backs.
- US region only; an EU account would additionally need the `track-eu` / `api-eu` hosts.
- rETL `record` events are deliberately excluded: they exist only on the v2 path, so
  they cannot hold across both.
