### PR TITLE
chore: server_team as codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,5 @@
-* @rudderlabs/integrations
+* @rudderlabs/integrations @rudderlabs/server_team
 __tests__/ @rudderlabs/integrations @rudderlabs/data-management @rudderlabs/server_team
 src/util/ @rudderlabs/integrations @rudderlabs/data-management @rudderlabs/server_team
-**/trackingPlan.ts @rudderlabs/data-management
+**/trackingPlan.ts @rudderlabs/data-management @rudderlabs/server_team
 **/userTransform.ts @rudderlabs/server_team


### PR DESCRIPTION
## What are the changes introduced in this PR?

As per title, adding server_team as CODEOWNERS.