### PR TITLE
fix(ninetailed): backfill required context.page fields

### DIFF
--- a/src/cdk/v2/destinations/ninetailed/utils.js
+++ b/src/cdk/v2/destinations/ninetailed/utils.js
@@ -1,6 +1,38 @@
 const { BatchUtils } = require('@rudderstack/workflow-engine');
+const lodash = require('lodash');
 const config = require('./config');
-const { constructPayload } = require('../../../../v0/util');
+const { constructPayload, isDefinedAndNotNull } = require('../../../../v0/util');
+
+// Ninetailed validates context.page against a schema where every one of these is a
+// required string. A single event with a partial page object gets the whole batch
+// (up to MAX_BATCH_SIZE events) rejected, so the gaps are filled with empty strings.
+const PAGE_REQUIRED_STRING_FIELDS = ['path', 'referrer', 'search', 'url'];
+
+/**
+ * Fills in the page fields Ninetailed requires but the source may not have sent.
+ *
+ * Note this cannot be expressed as `defaultValue` in contextMapping.json: an empty
+ * string default is falsy, so `handleMetadataForValue` returns the original undefined
+ * and `constructPayload` skips the assignment entirely. Both would silently no-op.
+ *
+ * @param {*} page the mapped context.page value
+ * @returns page with all required fields present, or the input untouched if it is not an object
+ */
+const normalizePageContext = (page) => {
+  if (!lodash.isPlainObject(page)) {
+    return page;
+  }
+  const normalizedPage = { ...page };
+  PAGE_REQUIRED_STRING_FIELDS.forEach((field) => {
+    if (typeof normalizedPage[field] !== 'string') {
+      normalizedPage[field] = '';
+    }
+  });
+  if (!lodash.isPlainObject(normalizedPage.query)) {
+    normalizedPage.query = {};
+  }
+  return normalizedPage;
+};
 
 /**
  * This fucntion constructs payloads based upon mappingConfig for all calls
@@ -34,6 +66,11 @@ const constructFullPayload = (message) => {
       break;
     default:
       break;
+  }
+  // Only normalize a page the source actually sent; do not invent one for events
+  // (server-side track calls, for instance) that legitimately carry no page context.
+  if (isDefinedAndNotNull(context.page)) {
+    context.page = normalizePageContext(context.page);
   }
   payload.context = context;
   return { ...payload, ...typeSpecifcPayload }; // merge base and type-specific payloads;
@@ -101,4 +138,9 @@ const batchResponseBuilder = (events) => {
   return response;
 };
 
-module.exports = { constructFullPayload, getEndpoint, batchResponseBuilder };
+module.exports = {
+  constructFullPayload,
+  getEndpoint,
+  batchResponseBuilder,
+  normalizePageContext,
+};

--- a/src/cdk/v2/destinations/ninetailed/utils.test.js
+++ b/src/cdk/v2/destinations/ninetailed/utils.test.js
@@ -1,0 +1,139 @@
+const { normalizePageContext, constructFullPayload } = require('./utils');
+
+// Ninetailed rejects the entire batch when any event's context.page is missing one of
+// these, so every mapped page object must carry all five.
+const REQUIRED_PAGE_FIELDS = ['path', 'query', 'referrer', 'search', 'url'];
+
+describe('normalizePageContext', () => {
+  it('adds search when the source omitted it', () => {
+    // Real payload that produced "events.index[5].context.page.search: Required"
+    const page = {
+      path: '/to/ohtefCKH',
+      query: {},
+      referrer: 'https://www.tiktok.com/',
+      tab_url: 'https://koko-ai.pro.typeform.com/to/ohtefCKH',
+      title: 'Mental Health First Aid',
+      url: 'https://koko-ai.pro.typeform.com/to/ohtefCKH',
+    };
+
+    const result = normalizePageContext(page);
+
+    expect(result.search).toBe('');
+    expect(Object.keys(result)).toEqual(expect.arrayContaining(REQUIRED_PAGE_FIELDS));
+  });
+
+  it('preserves an empty search rather than dropping it', () => {
+    const result = normalizePageContext({
+      path: '/p',
+      query: {},
+      referrer: '',
+      search: '',
+      url: 'u',
+    });
+
+    expect(result).toHaveProperty('search', '');
+  });
+
+  it('preserves real values and passes through unknown keys', () => {
+    const page = {
+      path: '/lp',
+      query: { utm_campaign: 'spring' },
+      referrer: 'https://www.google.com/',
+      search: '?utm_campaign=spring',
+      url: 'https://x.com/lp?utm_campaign=spring',
+      title: 'LP',
+      tab_url: 'https://x.com/lp?utm_campaign=spring',
+    };
+
+    expect(normalizePageContext(page)).toEqual(page);
+  });
+
+  it('fills every required field for a page object that only has extras', () => {
+    const result = normalizePageContext({ title: 'Only a title' });
+
+    expect(result).toEqual({
+      title: 'Only a title',
+      path: '',
+      referrer: '',
+      search: '',
+      url: '',
+      query: {},
+    });
+  });
+
+  it('replaces non-string and non-object values with valid defaults', () => {
+    const result = normalizePageContext({
+      path: null,
+      referrer: 42,
+      search: undefined,
+      url: { nested: true },
+      query: 'not-an-object',
+    });
+
+    expect(result).toEqual({ path: '', referrer: '', search: '', url: '', query: {} });
+  });
+
+  it('does not mutate the input', () => {
+    const page = { path: '/p' };
+
+    normalizePageContext(page);
+
+    expect(page).toEqual({ path: '/p' });
+  });
+
+  it.each([
+    ['undefined', undefined],
+    ['null', null],
+    ['a string', 'not-a-page'],
+    ['an array', []],
+  ])('returns %s untouched', (_name, input) => {
+    expect(normalizePageContext(input)).toEqual(input);
+  });
+});
+
+describe('constructFullPayload page handling', () => {
+  const baseMessage = {
+    type: 'track',
+    event: 'Product Viewed',
+    anonymousId: 'anon-1',
+    messageId: 'msg-1',
+    originalTimestamp: '2026-08-13T00:00:00Z',
+  };
+
+  it('backfills search on a partial page context', () => {
+    const payload = constructFullPayload({
+      ...baseMessage,
+      context: {
+        page: { path: '/to/ohtefCKH', url: 'https://koko-ai.pro.typeform.com/to/ohtefCKH' },
+      },
+    });
+
+    expect(payload.context.page).toEqual(
+      expect.objectContaining({ path: '/to/ohtefCKH', search: '', referrer: '', query: {} }),
+    );
+  });
+
+  it('keeps an empty search present end to end', () => {
+    const payload = constructFullPayload({
+      ...baseMessage,
+      context: {
+        page: {
+          path: '/p/stainless-steel-square-eyeglass-frames/32340/3234014',
+          query: {},
+          referrer: 'https://www.zennioptical.com/men-glasses',
+          search: '',
+          url: 'https://www.zennioptical.com/p/stainless-steel-square-eyeglass-frames/32340/3234014',
+        },
+      },
+    });
+
+    expect(payload.context.page).toHaveProperty('search', '');
+    expect(JSON.stringify(payload)).toContain('"search"');
+  });
+
+  it('does not invent a page for events that carry no page context', () => {
+    const payload = constructFullPayload({ ...baseMessage, context: { locale: 'en-US' } });
+
+    expect(payload.context.page).toBeUndefined();
+  });
+});

--- a/test/integrations/destinations/ninetailed/commonConfig.ts
+++ b/test/integrations/destinations/ninetailed/commonConfig.ts
@@ -115,10 +115,20 @@ export const commonInput = {
   originalTimestamp: '2021-01-25T15:32:56.409Z',
 };
 
+// The transformer backfills the page fields Ninetailed requires, so the delivered
+// context carries a `query` that the input context does not have.
+export const expectedContext = {
+  ...context,
+  page: {
+    ...context.page,
+    query: {},
+  },
+};
+
 export const commonOutput = {
   anonymousId: 'anon_123',
   messageId: 'dummy_msg_id',
-  context,
+  context: expectedContext,
   channel: 'web',
   originalTimestamp: '2021-01-25T15:32:56.409Z',
 };

--- a/test/integrations/destinations/ninetailed/processor/identify.ts
+++ b/test/integrations/destinations/ninetailed/processor/identify.ts
@@ -68,6 +68,7 @@ export const identify = [
                       },
                       locale: 'en-US',
                       page: {
+                        query: {},
                         path: '/signup',
                         referrer: 'https://rudderstack.medium.com/',
                         search: '?type=freetrial',
@@ -166,6 +167,7 @@ export const identify = [
                       },
                       locale: 'en-US',
                       page: {
+                        query: {},
                         path: '/signup',
                         referrer: 'https://rudderstack.medium.com/',
                         search: '?type=freetrial',
@@ -254,6 +256,7 @@ export const identify = [
                       },
                       locale: 'en-US',
                       page: {
+                        query: {},
                         path: '/signup',
                         referrer: 'https://rudderstack.medium.com/',
                         search: '?type=freetrial',

--- a/test/integrations/destinations/ninetailed/processor/track.ts
+++ b/test/integrations/destinations/ninetailed/processor/track.ts
@@ -104,6 +104,7 @@ export const track = [
                       },
                       locale: 'en-US',
                       page: {
+                        query: {},
                         path: '/signup',
                         referrer: 'https://rudderstack.medium.com/',
                         search: '?type=freetrial',
@@ -196,6 +197,93 @@ export const track = [
               module: 'destination',
             },
             statusCode: 400,
+          },
+        ],
+      },
+    },
+  },
+  {
+    id: 'ninetailed-test-track-success-2',
+    name: 'ninetailed',
+    description: 'Track call whose context.page is missing fields Ninetailed requires',
+    scenario: 'Buisness',
+    successCriteria:
+      'Missing page fields should be backfilled with empty defaults so one partial page does not fail the whole batch',
+    feature: 'processor',
+    module: 'destination',
+    version: 'v0',
+    input: {
+      request: {
+        body: [
+          {
+            destination,
+            message: {
+              context: {
+                page: {
+                  path: '/to/ohtefCKH',
+                  referrer: 'https://www.tiktok.com/',
+                  title: 'Mental Health First Aid',
+                  url: 'https://koko-ai.pro.typeform.com/to/ohtefCKH',
+                },
+              },
+              type: 'track',
+              event: 'form viewed',
+              channel: 'web',
+              messageId: 'dummy_msg_id',
+              anonymousId: 'anon_123',
+              integrations: {
+                All: true,
+              },
+              originalTimestamp: '2021-01-25T15:32:56.409Z',
+            },
+            metadata,
+          },
+        ],
+      },
+    },
+    output: {
+      response: {
+        status: 200,
+        body: [
+          {
+            metadata: {
+              destinationId: 'dummyDestId',
+            },
+            output: transformResultBuilder({
+              method: 'POST',
+              endpoint:
+                'https://experience.ninetailed.co/v2/organizations/dummyOrganisationId/environments/main/events',
+              JSON: {
+                events: [
+                  {
+                    context: {
+                      library: {
+                        name: 'Rudderstack Ninetailed Destination',
+                        version: '1',
+                      },
+                      location: {},
+                      page: {
+                        path: '/to/ohtefCKH',
+                        query: {},
+                        referrer: 'https://www.tiktok.com/',
+                        search: '',
+                        title: 'Mental Health First Aid',
+                        url: 'https://koko-ai.pro.typeform.com/to/ohtefCKH',
+                      },
+                    },
+                    type: 'track',
+                    event: 'form viewed',
+                    channel: 'web',
+                    messageId: 'dummy_msg_id',
+                    properties: {},
+                    anonymousId: 'anon_123',
+                    originalTimestamp: '2021-01-25T15:32:56.409Z',
+                  },
+                ],
+              },
+              userId: '',
+            }),
+            statusCode: 200,
           },
         ],
       },


### PR DESCRIPTION
## What are the changes introduced in this PR?

Ninetailed validates `context.page` against a schema where `path`, `query`, `referrer`, `search` and `url` are **all required** (`Page` in `@ninetailed/experience.js-shared`). We map `page` → `page` as one whole object, so a partial page object from the source passes straight through and the API rejects it:

```
events.index[5].context.page.search: Required
```

This PR fills the missing fields with empty defaults before the payload is sent.

### Why this matters more than one event

`rtWorkflow.yaml` batches up to `MAX_BATCH_SIZE` (200) events per request, and Ninetailed rejects the **entire array** on one bad element. One event with an incomplete page object takes up to 199 healthy events down with it — including events from other sources on the same destination.

### Why not `defaultValue` in `contextMapping.json`

The obvious fix — per-field mappings with `defaultValue` metadata, as INT-1861 / #3197 did for `context.location` — silently does nothing here, for two independent reasons:

1. `handleMetadataForValue` does `return defaultValue || value` (`src/v0/util/index.js:976`). An empty-string default is falsy, so it returns the original `undefined`.
2. `constructPayload` only assigns when `value || value === 0 || value === false` (`src/v0/util/index.js:1132`). `''` is falsy, so the key is never set.

Verified empirically — a mapping with `defaultValue: ''` produces no `search` key whether or not the source sent one.

Worse, switching `page` → `page` to per-field mappings would be an active **regression**: `search` is `''` for any URL without a query string (the majority of pageviews), and `constructPayload` would drop it, turning currently-succeeding events into batch-killing failures. Empty string is valid to Ninetailed (`z.string()`); only an *absent* key produces `Required`.

Hence the normalization lives in `utils.js`.

### Behaviour change

Delivered payloads now always carry all five page fields when the source sent a `context.page`. Notably `query: {}` is now present — no RudderStack SDK has ever emitted `context.page.query`, so this field was previously always missing and failing validation. Existing test fixtures are updated to match.

A page the source never sent is left **absent** rather than invented, so events with no page context (server-side track calls) are unaffected.

## What is the related Linear task?

N/A — found while debugging a production destination.

## Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

Yes, see "Behaviour change" above. Payloads are strictly more schema-valid; no field that was previously populated is altered.

## Any new dependencies introduced with this change?

N/A

## Any new generic utility introduced or modified. Please explain the changes.

`normalizePageContext` in `src/cdk/v2/destinations/ninetailed/utils.js`, scoped to this destination. Exported for unit tests.

## Any technical or performance related pointers to consider with the change?

One shallow object copy per event with a page context.

## Follow-up worth considering (not in this PR)

`query` is defaulted to `{}` rather than derived from `search`. Ninetailed's own SDK builds it from the URL's search params, so campaign/UTM data still does not reach Ninetailed from cloud mode. Deriving it is a behaviour/product decision, deliberately left out of a fix PR.

### Developer checklist

- [x] My code follows the style guidelines of this project
- [x] **No breaking changes are being introduced.**
- [ ] All related docs linked with the PR?
- [x] All changes manually tested?
- [ ] Any documentation changes needed with this change?
- [x] Is the PR limited to 10 file changes?
- [x] Is the PR limited to one linear task?
- [x] Are relevant unit and component test-cases added?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?
- [ ] Verified that there are no credentials or confidential data exposed with the changes.