### PR TITLE
fix(discord,slack): null guard on eventTemplateSettings and eventChannelSettings

### DIFF
--- a/src/v0/destinations/discord/transform.js
+++ b/src/v0/destinations/discord/transform.js
@@ -105,7 +105,7 @@ const processIdentify = (message, destination) => {
 };
 
 const processTrack = (message, destination) => {
-  const eventTemplateConfig = destination.Config.eventTemplateSettings;
+  const eventTemplateConfig = destination.Config.eventTemplateSettings ?? [];
 
   if (!message.event) {
     throw new InstrumentationError('Event name is required');

--- a/src/v0/destinations/slack/transform.js
+++ b/src/v0/destinations/slack/transform.js
@@ -181,8 +181,9 @@ const buildtemplateList = (templateListForThisEvent, eventTemplateSettings, even
 const processTrack = (message, destination) => {
   // logger.debug(JSON.stringify(destination));
   const { Config } = destination;
-  const { eventChannelSettings, eventTemplateSettings, incomingWebhooksType, denyListOfEvents } =
-    Config;
+  const eventChannelSettings = Config.eventChannelSettings ?? [];
+  const eventTemplateSettings = Config.eventTemplateSettings ?? [];
+  const { incomingWebhooksType, denyListOfEvents } = Config;
   const eventName = message.event;
 
   if (!eventName) {

--- a/test/integrations/destinations/discord/processor/data.ts
+++ b/test/integrations/destinations/discord/processor/data.ts
@@ -908,4 +908,98 @@ export const data = [
       },
     },
   },
+,
+  {
+    name: 'discord',
+    description: 'Track: missing eventTemplateSettings in config does not throw TypeError',
+    feature: 'processor',
+    module: 'destination',
+    version: 'v0',
+    input: {
+      request: {
+        body: [
+          {
+            destination: {
+              ID: '1ZQVSU9SXNg6KYgZALaqjAO3PIL',
+              Name: 'test-Discord',
+              DestinationDefinition: {
+                ID: '1ZQUiJVMlmF7lfsdfXg7KXQnlLV',
+                Name: 'DISCORD',
+                DisplayName: 'Discord',
+                Config: {
+                  excludeKeys: [],
+                  includeKeys: [],
+                },
+              },
+              Config: {
+                // eventTemplateSettings intentionally absent to reproduce the bug
+                webhookUrl: 'https://discord.com/api/webhooks/dummy/token',
+                whitelistedTraitsSettings: [],
+              },
+              Enabled: true,
+              Transformations: [],
+              IsProcessorEnabled: true,
+            },
+            message: {
+              anonymousId: '4de817fb-7f8e-4e23-b9be-f6736dbda20f',
+              channel: 'web',
+              context: {
+                traits: {
+                  name: 'Test User',
+                },
+              },
+              event: 'Product Added',
+              integrations: { All: true },
+              messageId: '9ecc0183-89ed-48bd-87eb-b2d8e1ca6780',
+              originalTimestamp: '2024-01-01T00:00:00.000Z',
+              properties: { product_id: 'p123', price: 9.99 },
+              type: 'track',
+            },
+            metadata: {
+              jobId: 1,
+              userId: 'u1',
+              destinationId: '1ZQVSU9SXNg6KYgZALaqjAO3PIL',
+              destinationType: 'DISCORD',
+              workspaceId: 'w1',
+            },
+          },
+        ],
+      },
+    },
+    output: {
+      response: {
+        status: 200,
+        body: [
+          {
+            output: {
+              version: '1',
+              type: 'REST',
+              method: 'POST',
+              endpoint: 'https://discord.com/api/webhooks/dummy/token',
+              headers: { 'Content-Type': 'application/json' },
+              params: {},
+              body: {
+                JSON: {
+                  content: 'Test User did Product Added with {"product_id":"p123","price":9.99}',
+                },
+                JSON_ARRAY: {},
+                XML: {},
+                FORM: {},
+              },
+              files: {},
+              userId: '',
+            },
+            metadata: {
+              jobId: 1,
+              userId: 'u1',
+              destinationId: '1ZQVSU9SXNg6KYgZALaqjAO3PIL',
+              destinationType: 'DISCORD',
+              workspaceId: 'w1',
+            },
+            statusCode: 200,
+          },
+        ],
+      },
+    },
+  },
 ];

--- a/test/integrations/destinations/slack/processor/data.ts
+++ b/test/integrations/destinations/slack/processor/data.ts
@@ -240,4 +240,106 @@ export const data: ProcessorTestData[] = [
       return {};
     },
   },
+,
+  {
+    id: 'slack-track-missing-template-settings',
+    name: 'slack',
+    description: 'Track: missing eventTemplateSettings and eventChannelSettings falls back to default template and webhook',
+    feature: 'processor',
+    module: 'destination',
+    version: 'v0',
+    scenario: 'Config migration left eventTemplateSettings undefined',
+    successCriteria: 'Should not throw TypeError and should use the default template with the global webhook',
+    input: {
+      request: {
+        method: 'POST',
+        body: [
+          {
+            destination: {
+              ID: '1ZQVSU9SXNg6KYgZALaqjAO3PIL',
+              Name: 'test-slack',
+              DestinationDefinition: {
+                ID: '1ZQUiJVMlmF7lfsdfXg7KXQnlLV',
+                Name: 'SLACK',
+                DisplayName: 'Slack',
+                Config: { excludeKeys: [], includeKeys: [] },
+              },
+              Enabled: true,
+              Transformations: [],
+              IsProcessorEnabled: true,
+              WorkspaceID: 'test-workspace-id',
+              Config: {
+                // eventTemplateSettings and eventChannelSettings intentionally absent
+                webhookUrl: 'https://hooks.slack.com/services/THZM86VSS/BV9HZ2UN6/demo',
+                whitelistedTraitsSettings: [],
+              },
+            },
+            message: {
+              anonymousId: '4de817fb-7f8e-4e23-b9be-f6736dbda20f',
+              channel: 'web',
+              context: { traits: { name: 'Test User' } },
+              event: 'Product Added',
+              integrations: { All: true },
+              messageId: '9ecc0183-89ed-48bd-87eb-b2d8e1ca6780',
+              originalTimestamp: '2024-01-01T00:00:00.000Z',
+              properties: { product_id: 'p123' },
+              type: 'track',
+              userId: 'u1',
+            },
+            metadata: {
+              jobId: 2,
+              userId: 'u1',
+              messageId: '9ecc0183-89ed-48bd-87eb-b2d8e1ca6780',
+              destinationId: '1ZQVSU9SXNg6KYgZALaqjAO3PIL',
+              destinationType: 'SLACK',
+              workspaceId: 'test-workspace-id',
+            },
+          },
+        ],
+      },
+    },
+    output: {
+      response: {
+        status: 200,
+        body: [
+          {
+            output: {
+              version: '1',
+              type: 'REST',
+              method: 'POST',
+              endpoint: 'https://hooks.slack.com/services/THZM86VSS/BV9HZ2UN6/demo',
+              headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+              params: {},
+              body: {
+                JSON: {},
+                JSON_ARRAY: {},
+                XML: {},
+                FORM: {
+                  payload: JSON.stringify({
+                    text: 'Test User did Product Added with {"product_id":"p123"}',
+                    username: 'RudderStack',
+                    icon_url: 'https://cdn.rudderlabs.com/rudderstack.png',
+                  }),
+                },
+              },
+              files: {},
+              userId: '',
+            },
+            metadata: {
+              jobId: 2,
+              userId: 'u1',
+              messageId: '9ecc0183-89ed-48bd-87eb-b2d8e1ca6780',
+              destinationId: '1ZQVSU9SXNg6KYgZALaqjAO3PIL',
+              destinationType: 'SLACK',
+              workspaceId: 'test-workspace-id',
+            },
+            statusCode: 200,
+          },
+        ],
+      },
+    },
+    mockFns: () => {
+      return {};
+    },
+  },
 ];


### PR DESCRIPTION
## Summary

Resolves #5473.

When a Discord or Slack destination is created without
`eventTemplateSettings` (or without `eventChannelSettings` for Slack)
in its config, the transformer throws a `TypeError` at the
`.forEach()` call because those fields are `undefined`.

This can happen on older destinations where the arrays were never
persisted to the config (before the feature was introduced) or on
configs that have been partially migrated.

### Changes

- **Discord** `src/v0/destinations/discord/transform.js`: read
  `eventTemplateSettings` with `?? []` so a missing field defaults to
  an empty array instead of `undefined`.
- **Slack** `src/v0/destinations/slack/transform.js`: destructure
  `eventChannelSettings` and `eventTemplateSettings` separately with
  `?? []` before passing them to downstream helpers.

### Tests

Added one processor test case each for Discord and Slack that sends a
`track` event against a config where the optional array fields are
absent. Both cases assert a 200 response with the default template
output, confirming the null guard works end-to-end.

harsh4vardhan