### PR TITLE
fix(amazon_audience): await Promise.all in processRouterDest

### DIFF
--- a/src/v0/destinations/amazon_audience/transform.js
+++ b/src/v0/destinations/amazon_audience/transform.js
@@ -30,7 +30,7 @@ const processRouterDest = async (inputs, reqMetadata) => {
   const errorRespList = []; // list of error
   const { destination } = inputs[0];
   const { Config } = destination;
-  inputs.map(async (event) => {
+  await Promise.all(inputs.map(async (event) => {
     try {
       if (event.message.statusCode) {
         // already transformed event
@@ -47,7 +47,7 @@ const processRouterDest = async (inputs, reqMetadata) => {
       const errRespEvent = handleRtTfSingleEventError(event, error, reqMetadata);
       errorRespList.push(errRespEvent);
     }
-  });
+  }));
   let batchedResponseList = [];
   if (responseList.length > 0) {
     batchedResponseList = batchEvents(responseList, destination);


### PR DESCRIPTION
## Summary

Resolves #5472.

`processRouterDest` uses `inputs.map(async ...)` but discards the
returned `Promise[]`. The function works today only because
`processRecord` is synchronous, so every callback completes before
the first microtask checkpoint and `responseList` is fully populated
by the time it is read. However, if anyone adds even a single
`await` inside the callback in the future, all `Promise`s will be
unresolved when `responseList` is read, dropping every record
silently with no error.

### Change

Wrap the `map` in `await Promise.all()` so the function is correct
regardless of whether the callback is async or synchronous.

```diff
-  inputs.map(async (event) => {
+  await Promise.all(inputs.map(async (event) => {
     ...
-  });
+  }));
```

### Tests

Existing router tests in
`test/integrations/destinations/amazon_audience/router/data.ts`
fully exercise the code path (multi-record batching, error handling).
They continue to pass because the observable behavior is unchanged.

harsh4vardhan