### PR TITLE
fix(slack,discord): throw ConfigurationError on invalid regex in event name config

### DIFF
--- a/src/v0/destinations/discord/transform.js
+++ b/src/v0/destinations/discord/transform.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-nested-ternary */
 /* eslint-disable no-prototype-builtins */
 const Handlebars = require('handlebars');
-const { InstrumentationError } = require('@rudderstack/integrations-lib');
+const { InstrumentationError, ConfigurationError } = require('@rudderstack/integrations-lib');
 const { EventType } = require('../../../constants');
 
 const {
@@ -104,6 +104,14 @@ const processIdentify = (message, destination) => {
   return buildResponse(response, destination);
 };
 
+const buildSafeRegex = (pattern, flags) => {
+  try {
+    return new RegExp(pattern, flags);
+  } catch (e) {
+    throw new ConfigurationError(`Invalid regex pattern in event name config: ${e.message}`);
+  }
+};
+
 const processTrack = (message, destination) => {
   const eventTemplateConfig = destination.Config.eventTemplateSettings;
 
@@ -133,8 +141,8 @@ const processTrack = (message, destination) => {
     if (configEventName && configEventTemplate) {
       if (templateConfig.eventRegex) {
         if (
-          eventName.match(new RegExp(configEventName, 'g')) &&
-          eventName.match(new RegExp(configEventName, 'g')).length > 0
+          eventName.match(buildSafeRegex(configEventName, 'g')) &&
+          eventName.match(buildSafeRegex(configEventName, 'g')).length > 0
         ) {
           templateListForThisEvent.add(configEventTemplate);
         }

--- a/src/v0/destinations/slack/transform.js
+++ b/src/v0/destinations/slack/transform.js
@@ -103,6 +103,14 @@ const processIdentify = (message, destination) => {
   return buildResponse({ text: resultText }, message, destination);
 };
 
+const buildSafeRegex = (pattern, flags) => {
+  try {
+    return new RegExp(pattern, flags);
+  } catch (e) {
+    throw new ConfigurationError(`Invalid regex pattern in event name config: ${e.message}`);
+  }
+};
+
 const isEventNameMatchesRegex = (eventName, regex) => eventName.match(regex)?.length > 0;
 
 const getChannelForEventName = (eventChannelSettings, eventName) => {
@@ -119,9 +127,9 @@ const getChannelForEventName = (eventChannelSettings, eventName) => {
           'match:: ',
           configEventName,
           eventName,
-          eventName.match(new RegExp(configEventName, 'g')),
+          eventName.match(buildSafeRegex(configEventName, 'g')),
         );
-        if (isEventNameMatchesRegex(eventName, new RegExp(configEventName, 'g'))) {
+        if (isEventNameMatchesRegex(eventName, buildSafeRegex(configEventName, 'g'))) {
           return channelWebhook;
         }
       } else if (channelConfig.eventName === eventName) {
@@ -144,9 +152,9 @@ const getChannelNameForEvent = (eventChannelSettings, eventName) => {
           'match:: ',
           configEventName,
           eventName,
-          eventName.match(new RegExp(configEventName, 'g')),
+          eventName.match(buildSafeRegex(configEventName, 'g')),
         );
-        if (isEventNameMatchesRegex(eventName, new RegExp(configEventName, 'g'))) {
+        if (isEventNameMatchesRegex(eventName, buildSafeRegex(configEventName, 'g'))) {
           return configEventChannel;
         }
       } else if (configEventName === eventName) {
@@ -168,7 +176,7 @@ const buildtemplateList = (templateListForThisEvent, eventTemplateSettings, even
       : undefined;
     if (configEventName && configEventTemplate) {
       if (templateConfig.eventRegex) {
-        if (isEventNameMatchesRegex(eventName, new RegExp(configEventName, 'g'))) {
+        if (isEventNameMatchesRegex(eventName, buildSafeRegex(configEventName, 'g'))) {
           templateListForThisEvent.add(configEventTemplate);
         }
       } else if (configEventName === eventName) {

--- a/test/integrations/destinations/discord/processor/data.ts
+++ b/test/integrations/destinations/discord/processor/data.ts
@@ -908,4 +908,90 @@ export const data = [
       },
     },
   },
+,
+  {
+    name: 'discord',
+    description: 'Track: invalid regex in eventTemplateSettings.eventName throws ConfigurationError not SyntaxError',
+    feature: 'processor',
+    module: 'destination',
+    version: 'v0',
+    input: {
+      request: {
+        body: [
+          {
+            destination: {
+              ID: '1ZQVSU9SXNg6KYgZALaqjAO3PIL',
+              Name: 'test-Discord',
+              DestinationDefinition: {
+                ID: '1ZQUiJVMlmF7lfsdfXg7KXQnlLV',
+                Name: 'DISCORD',
+                DisplayName: 'Discord',
+                Config: { excludeKeys: [], includeKeys: [] },
+              },
+              Config: {
+                webhookUrl: 'https://discord.com/api/webhooks/dummy/token',
+                whitelistedTraitsSettings: [],
+                eventTemplateSettings: [
+                  {
+                    eventName: '(',
+                    eventRegex: true,
+                    eventTemplate: '{{name}} did {{event}}',
+                  },
+                ],
+              },
+              Enabled: true,
+              Transformations: [],
+              IsProcessorEnabled: true,
+            },
+            message: {
+              anonymousId: '4de817fb-7f8e-4e23-b9be-f6736dbda20f',
+              channel: 'web',
+              context: { traits: { name: 'Test User' } },
+              event: 'Product Added',
+              integrations: { All: true },
+              messageId: '9ecc0183-89ed-48bd-87eb-b2d8e1ca6781',
+              originalTimestamp: '2024-01-01T00:00:00.000Z',
+              properties: { product_id: 'p123' },
+              type: 'track',
+            },
+            metadata: {
+              jobId: 2,
+              userId: 'u1',
+              destinationId: '1ZQVSU9SXNg6KYgZALaqjAO3PIL',
+              destinationType: 'DISCORD',
+              workspaceId: 'w1',
+            },
+          },
+        ],
+      },
+    },
+    output: {
+      response: {
+        status: 200,
+        body: [
+          {
+            metadata: {
+              jobId: 2,
+              userId: 'u1',
+              destinationId: '1ZQVSU9SXNg6KYgZALaqjAO3PIL',
+              destinationType: 'DISCORD',
+              workspaceId: 'w1',
+            },
+            statusCode: 400,
+            error: 'Invalid regex pattern in event name config: Invalid regular expression: /(/g: Unterminated group',
+            statTags: {
+              errorCategory: 'dataValidation',
+              destinationId: '1ZQVSU9SXNg6KYgZALaqjAO3PIL',
+              errorType: 'configuration',
+              destType: 'DISCORD',
+              module: 'destination',
+              implementation: 'native',
+              workspaceId: 'w1',
+              feature: 'processor',
+            },
+          },
+        ],
+      },
+    },
+  },
 ];

--- a/test/integrations/destinations/slack/processor/data.ts
+++ b/test/integrations/destinations/slack/processor/data.ts
@@ -240,4 +240,102 @@ export const data: ProcessorTestData[] = [
       return {};
     },
   },
+,
+  {
+    id: 'slack-track-invalid-regex-config-error',
+    name: 'slack',
+    description: 'Track: invalid regex in eventChannelSettings.eventName throws ConfigurationError not SyntaxError',
+    feature: 'processor',
+    module: 'destination',
+    version: 'v0',
+    scenario: 'User enters an invalid regex pattern in the event routing config',
+    successCriteria: 'Should return a 400 ConfigurationError, not a 500 SyntaxError',
+    input: {
+      request: {
+        method: 'POST',
+        body: [
+          {
+            destination: {
+              ID: '1ZQVSU9SXNg6KYgZALaqjAO3PIL',
+              Name: 'test-slack',
+              DestinationDefinition: {
+                ID: '1ZQUiJVMlmF7lfsdfXg7KXQnlLV',
+                Name: 'SLACK',
+                DisplayName: 'Slack',
+                Config: { excludeKeys: [], includeKeys: [] },
+              },
+              Enabled: true,
+              Transformations: [],
+              IsProcessorEnabled: true,
+              WorkspaceID: 'test-workspace-id',
+              Config: {
+                webhookUrl: 'https://hooks.slack.com/services/THZM86VSS/BV9HZ2UN6/demo',
+                whitelistedTraitsSettings: [],
+                eventChannelSettings: [
+                  {
+                    eventName: '(',
+                    eventRegex: true,
+                    eventChannel: '#general',
+                    webhookUrl: 'https://hooks.slack.com/services/THZM86VSS/BV9HZ2UN6/demo',
+                  },
+                ],
+              },
+            },
+            message: {
+              anonymousId: '4de817fb-7f8e-4e23-b9be-f6736dbda20f',
+              channel: 'web',
+              context: { traits: { name: 'Test User' } },
+              event: 'Product Added',
+              integrations: { All: true },
+              messageId: '9ecc0183-89ed-48bd-87eb-b2d8e1ca6782',
+              originalTimestamp: '2024-01-01T00:00:00.000Z',
+              properties: { product_id: 'p123' },
+              type: 'track',
+              userId: 'u1',
+            },
+            metadata: {
+              jobId: 3,
+              userId: 'u1',
+              messageId: '9ecc0183-89ed-48bd-87eb-b2d8e1ca6782',
+              destinationId: '1ZQVSU9SXNg6KYgZALaqjAO3PIL',
+              destinationType: 'SLACK',
+              workspaceId: 'test-workspace-id',
+            },
+          },
+        ],
+      },
+    },
+    output: {
+      response: {
+        status: 200,
+        body: [
+          {
+            metadata: {
+              jobId: 3,
+              userId: 'u1',
+              messageId: '9ecc0183-89ed-48bd-87eb-b2d8e1ca6782',
+              destinationId: '1ZQVSU9SXNg6KYgZALaqjAO3PIL',
+              destinationType: 'SLACK',
+              workspaceId: 'test-workspace-id',
+            },
+            statusCode: 400,
+            error: 'Invalid regex pattern in event name config: Invalid regular expression: /(/g: Unterminated group',
+            statTags: {
+              errorCategory: 'dataValidation',
+              destinationId: '1ZQVSU9SXNg6KYgZALaqjAO3PIL',
+              errorType: 'configuration',
+              destType: 'SLACK',
+              module: 'destination',
+              implementation: 'native',
+              workspaceId: 'test-workspace-id',
+              feature: 'processor',
+            },
+          },
+        ],
+      },
+    },
+    mockFns: () => {
+      return {};
+    },
+  },
 ];


### PR DESCRIPTION
## Summary

Resolves #5469.

Both Slack and Discord allow customers to configure regex patterns
for event-name routing. Those patterns are passed directly to
`new RegExp(pattern, 'g')` with no error handling.

An invalid pattern such as `"("` or `"[a-"` throws a `SyntaxError`
that propagates up through `processTrack` uncaught. Because there
is no catch at the Express handler level for this error type, every
subsequent track event for that destination returns a 500 until
someone notices and manually fixes the destination config.

### Changes

**Slack** `src/v0/destinations/slack/transform.js`
**Discord** `src/v0/destinations/discord/transform.js`

Both files now wrap `new RegExp()` in a `buildSafeRegex()` helper:

```js
const buildSafeRegex = (pattern, flags) => {
  try {
    return new RegExp(pattern, flags);
  } catch (e) {
    throw new ConfigurationError(
      `Invalid regex pattern in event name config: ${e.message}`
    );
  }
};
```

All five call-sites in Slack and two in Discord are updated to use
`buildSafeRegex`. An invalid pattern now produces a clean 400
`ConfigurationError` on the offending event instead of an
unhandled `SyntaxError`.

Discord also had `ConfigurationError` missing from its
`@rudderstack/integrations-lib` import; that import is added.

### Tests

One processor test case each for Discord and Slack: a `track` event
sent to a destination whose event-name regex is the invalid pattern
`"("`. Both cases assert a 400 `configuration` error, confirming the
guard fires correctly.

harsh4vardhan