### PR TITLE
fix(ga4_v2): use Promise.allSettled so a single bad mapping does not drop all valid mappings

### DIFF
--- a/src/v0/destinations/ga4_v2/customMappingsHandler.js
+++ b/src/v0/destinations/ga4_v2/customMappingsHandler.js
@@ -107,7 +107,7 @@ const handleCustomMappings = async (message, Config, workspaceId) => {
     return buildDeliverablePayload(rawPayload, Config);
   }
 
-  const processedPayloads = await Promise.all(
+  const settled = await Promise.allSettled(
     validMappings.map(async (mapping) => {
       const eventName = mapping.destEventName;
       // reserved event names are not allowed
@@ -149,6 +149,22 @@ const handleCustomMappings = async (message, Config, workspaceId) => {
       return ga4MappedPayload;
     }),
   );
+
+  const processedPayloads = [];
+  for (const result of settled) {
+    if (result.status === 'fulfilled') {
+      processedPayloads.push(result.value);
+    } else if (result.reason instanceof PlatformError) {
+      throw result.reason;
+    }
+  }
+
+  if (processedPayloads.length === 0 && settled.length > 0) {
+    const firstRejected = settled.find((r) => r.status === 'rejected');
+    if (firstRejected) {
+      throw firstRejected.reason;
+    }
+  }
 
   return processedPayloads.map((processedPayload) =>
     buildDeliverablePayload(processedPayload, Config),

--- a/test/integrations/destinations/ga4_v2/processor/customMappings.ts
+++ b/test/integrations/destinations/ga4_v2/processor/customMappings.ts
@@ -928,4 +928,77 @@ export const customMappingTestCases = [
     },
     mockFns: defaultMockFns,
   },
+,
+  {
+    name: 'ga4_v2',
+    id: 'ga4_custom_mapping_allsettled_all_fail',
+    description:
+      'All custom mappings fail (both use reserved event names): first error is thrown and not short-circuited by Promise.all',
+    scenario: 'All custom mappings invalid',
+    successCriteria:
+      'Should surface an InstrumentationError for the first reserved event name, not a generic Promise rejection',
+    feature: 'processor',
+    module: 'destination',
+    version: 'v0',
+    input: {
+      request: {
+        body: [
+          {
+            message: {
+              type: 'track',
+              event: 'Purchase',
+              userId: 'root_user',
+              anonymousId: 'root_anonId',
+              context: { device, traits },
+              properties,
+              originalTimestamp: '2022-04-28T00:23:09.544Z',
+              integrations,
+            },
+            metadata: generateMetadata(1),
+            destination: {
+              ...destination,
+              Config: {
+                ...destination.Config,
+                eventsMapping: [
+                  {
+                    rsEventName: 'Purchase',
+                    destEventName: 'first_open',
+                    eventProperties: [],
+                  },
+                  {
+                    rsEventName: 'Purchase',
+                    destEventName: 'app_update',
+                    eventProperties: [],
+                  },
+                ],
+              },
+            },
+          },
+        ],
+      },
+    },
+    output: {
+      response: {
+        status: 200,
+        body: [
+          {
+            error: '[GA4]:: Reserved event name: first_open are not allowed',
+            statusCode: 400,
+            statTags: {
+              errorCategory: 'dataValidation',
+              errorType: 'instrumentation',
+              destType: 'GA4_V2',
+              module: 'destination',
+              implementation: 'native',
+              feature: 'processor',
+              destinationId: 'default-destinationId',
+              workspaceId: 'default-workspaceId',
+            },
+            metadata: generateMetadata(1),
+          },
+        ],
+      },
+    },
+    mockFns: defaultMockFns,
+  },
 ];


### PR DESCRIPTION
## Summary

Resolves #5471.

`handleCustomMappings` uses `Promise.all` to evaluate all
`validMappings` entries concurrently. If any one mapping throws
(e.g. a reserved GA4 event name, a failed name validation, or a
bad custom-mapping expression), `Promise.all` immediately rejects
and the results of every other mapping are discarded. The entire
event fails with a single-mapping error, even when the majority of
mappings are perfectly valid.

### Change

Replace `Promise.all` with `Promise.allSettled`:

- **Fulfilled** results are collected into `processedPayloads` and
  returned as GA4 events.
- **PlatformErrors** (sandbox unavailable, fail-closed) are
  rethrown immediately so the event stays retryable. This
  preserves the existing behaviour for transient infrastructure
  failures.
- **InstrumentationError / ConfigurationError** from individual
  mappings are silently dropped, allowing the rest to proceed.
- If **all** mappings fail (and none is a PlatformError), the
  first rejection is surfaced so the customer is not left with a
  silent no-op.

### Tests

Added `ga4_custom_mapping_allsettled_all_fail`: two mappings both
using reserved GA4 event names (`first_open` and `app_update`).
The test confirms the first `InstrumentationError` is surfaced when
every mapping fails, validating the all-fail path of the new logic.

harsh4vardhan