### PR TITLE
fix(iterable): NaN guard on product price, quantity, and revenue after parseFloat/parseInt

### DIFF
--- a/src/v0/destinations/iterable/util.js
+++ b/src/v0/destinations/iterable/util.js
@@ -252,7 +252,13 @@ const prepareItemsPayload = (message) => {
     }
 
     itemPayload.price = parseFloat(itemPayload.price);
+    if (Number.isNaN(itemPayload.price)) {
+      throw new InstrumentationError('Product price must be a valid number');
+    }
     itemPayload.quantity = parseInt(itemPayload.quantity, 10);
+    if (Number.isNaN(itemPayload.quantity)) {
+      throw new InstrumentationError('Product quantity must be a valid integer');
+    }
     return { ...itemPayload };
   });
 };
@@ -276,6 +282,9 @@ const purchaseEventPayloadBuilder = (message, category, config) => {
   validateMandatoryField(rawPayload.user);
 
   rawPayload.total = parseFloat(rawPayload.total);
+  if (Number.isNaN(rawPayload.total)) {
+    throw new InstrumentationError('Revenue (total) must be a valid number');
+  }
   rawPayload.items = prepareItemsPayload(message);
   rawPayload.createdAt = new Date(rawPayload.createdAt).getTime();
   rawPayload.id = rawPayload.id ? rawPayload.id.toString() : undefined;

--- a/test/integrations/destinations/iterable/processor/trackTestData.ts
+++ b/test/integrations/destinations/iterable/processor/trackTestData.ts
@@ -1446,4 +1446,186 @@ export const trackTestData: ProcessorTestData[] = [
       },
     },
   },
+,
+  {
+    id: 'iterable-track-nan-total',
+    name: 'iterable',
+    description: 'Order Completed: non-numeric revenue throws InstrumentationError instead of sending null to Iterable API',
+    scenario: 'Business',
+    successCriteria: 'Should return 400 InstrumentationError for non-numeric revenue',
+    feature: 'processor',
+    module: 'destination',
+    version: 'v0',
+    input: {
+      request: {
+        method: 'POST',
+        body: [
+          {
+            message: {
+              type: 'track',
+              userId: 'userId',
+              anonymousId: 'anonId',
+              event: 'order completed',
+              originalTimestamp: '2020-08-28T16:26:06.468Z',
+              properties: {
+                orderId: 99999,
+                total: 'free',
+                products: [
+                  {
+                    product_id: 'p1',
+                    name: 'Widget',
+                    price: 10,
+                    quantity: 1,
+                  },
+                ],
+              },
+              context: {
+                traits: { email: 'test@example.com' },
+              },
+            },
+            metadata: baseMetadata,
+            destination: {
+              hasDynamicConfig: false,
+              ID: '123',
+              Name: 'iterable',
+              DestinationDefinition: {
+                ID: '123',
+                Name: 'iterable',
+                DisplayName: 'Iterable',
+                Config: {},
+              },
+              Config: {
+                apiKey: 'testApiKey',
+                dataCenter: 'USDC',
+                preferUserId: false,
+                trackAllPages: true,
+                trackNamedPages: false,
+                mapToSingleEvent: false,
+                trackCategorisedPages: false,
+              },
+              Enabled: true,
+              WorkspaceID: '123',
+              Transformations: [],
+              RevisionID: 'default-revision',
+              IsProcessorEnabled: true,
+              IsConnectionEnabled: true,
+            },
+          },
+        ],
+      },
+    },
+    output: {
+      response: {
+        status: 200,
+        body: [
+          {
+            error: 'Revenue (total) must be a valid number',
+            statusCode: 400,
+            statTags: {
+              errorCategory: 'dataValidation',
+              errorType: 'instrumentation',
+              destType: 'ITERABLE',
+              module: 'destination',
+              implementation: 'native',
+              feature: 'processor',
+              destinationId: 'default-destinationId',
+              workspaceId: 'default-workspaceId',
+            },
+            metadata: baseMetadata,
+          },
+        ],
+      },
+    },
+  },
+,
+  {
+    id: 'iterable-track-nan-price',
+    name: 'iterable',
+    description: 'Order Completed: non-numeric product price throws InstrumentationError instead of sending null to Iterable API',
+    scenario: 'Business',
+    successCriteria: 'Should return 400 InstrumentationError for non-numeric product price',
+    feature: 'processor',
+    module: 'destination',
+    version: 'v0',
+    input: {
+      request: {
+        method: 'POST',
+        body: [
+          {
+            message: {
+              type: 'track',
+              userId: 'userId',
+              anonymousId: 'anonId',
+              event: 'order completed',
+              originalTimestamp: '2020-08-28T16:26:06.468Z',
+              properties: {
+                orderId: 88888,
+                total: 100,
+                products: [
+                  {
+                    product_id: 'p2',
+                    name: 'Widget Pro',
+                    price: 'free',
+                    quantity: 1,
+                  },
+                ],
+              },
+              context: {
+                traits: { email: 'test@example.com' },
+              },
+            },
+            metadata: baseMetadata,
+            destination: {
+              hasDynamicConfig: false,
+              ID: '123',
+              Name: 'iterable',
+              DestinationDefinition: {
+                ID: '123',
+                Name: 'iterable',
+                DisplayName: 'Iterable',
+                Config: {},
+              },
+              Config: {
+                apiKey: 'testApiKey',
+                dataCenter: 'USDC',
+                preferUserId: false,
+                trackAllPages: true,
+                trackNamedPages: false,
+                mapToSingleEvent: false,
+                trackCategorisedPages: false,
+              },
+              Enabled: true,
+              WorkspaceID: '123',
+              Transformations: [],
+              RevisionID: 'default-revision',
+              IsProcessorEnabled: true,
+              IsConnectionEnabled: true,
+            },
+          },
+        ],
+      },
+    },
+    output: {
+      response: {
+        status: 200,
+        body: [
+          {
+            error: 'Product price must be a valid number',
+            statusCode: 400,
+            statTags: {
+              errorCategory: 'dataValidation',
+              errorType: 'instrumentation',
+              destType: 'ITERABLE',
+              module: 'destination',
+              implementation: 'native',
+              feature: 'processor',
+              destinationId: 'default-destinationId',
+              workspaceId: 'default-workspaceId',
+            },
+            metadata: baseMetadata,
+          },
+        ],
+      },
+    },
+  },
 ];


### PR DESCRIPTION
## Summary

Resolves #5470.

Three `parseFloat`/`parseInt` calls in the Iterable transformer are
not guarded against `NaN`:

| Location | Field |
|----------|-------|
| `prepareItemsPayload` | `itemPayload.price` |
| `prepareItemsPayload` | `itemPayload.quantity` |
| `purchaseEventPayloadBuilder` | `rawPayload.total` |

When a non-numeric value such as `"free"` or `"two"` is passed:

1. `parseFloat("free")` returns `NaN`.
2. `NaN` passes `removeUndefinedAndNullValues` (NaN is neither
   `undefined` nor `null`).
3. `JSON.stringify({ price: NaN })` produces `{"price":null}`.
4. Iterable's API rejects the `trackPurchase` call with a 400.
5. The event is permanently lost with no actionable error for the
   customer.

### Change

Add `Number.isNaN()` guards immediately after each parse. An invalid
value now throws an `InstrumentationError` with a clear message
(`"Product price must be a valid number"`, etc.) before any request
is built.

### Tests

Added two processor test cases to
`test/integrations/destinations/iterable/processor/trackTestData.ts`:

- `iterable-track-nan-total`: `Order Completed` with
  `revenue: "free"` expects a 400 InstrumentationError on total.
- `iterable-track-nan-price`: `Order Completed` with
  `products[0].price: "free"` expects a 400 InstrumentationError on
  product price.

harsh4vardhan