### PR TITLE
fix(braze): stop router in/out mismatch from duplicated job metadata

### DIFF
--- a/src/v0/destinations/braze/braze.util.test.ts
+++ b/src/v0/destinations/braze/braze.util.test.ts
@@ -2911,3 +2911,129 @@ describe('router in/out job accounting (ON path)', () => {
     expect(outJobIdCount(result)).toBe(jobs.length);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Chunk-boundary invariant: chunking packs whole source-job groups, never
+// individual items, so a boundary can only fall between two jobs. A chunk may
+// therefore close under the per-type cap rather than split a job.
+// ---------------------------------------------------------------------------
+
+describe('chunk boundaries never split a source job', () => {
+  const destination = brazeDestFor();
+
+  type ItemSpec = { type: 'attributes' | 'events' | 'purchases'; externalId?: string };
+
+  const jobFromSpecs = (jobId: number, specs: ItemSpec[]): BrazeTransformedEvent => {
+    const bucket: Record<string, any[]> = { attributes: [], events: [], purchases: [] };
+    specs.forEach((spec, k) => {
+      const base: Record<string, unknown> = { tag: `${jobId}-${k}` };
+      if (spec.externalId !== undefined) {
+        base.external_id = spec.externalId;
+      }
+      if (spec.type === 'events') {
+        bucket.events.push({ ...base, name: 'e', time: 't' });
+      } else if (spec.type === 'purchases') {
+        bucket.purchases.push({
+          ...base,
+          product_id: `p${jobId}-${k}`,
+          price: 1,
+          currency: 'USD',
+          quantity: 1,
+          time: 't',
+        });
+      } else {
+        bucket.attributes.push(base);
+      }
+    });
+    return {
+      destination,
+      statusCode: 200,
+      batchedRequest: {
+        version: '1',
+        type: 'REST',
+        method: 'POST',
+        endpoint: '',
+        headers: {},
+        params: {},
+        body: {
+          JSON: {
+            attributes: bucket.attributes,
+            events: bucket.events,
+            purchases: bucket.purchases,
+          },
+        },
+        files: {},
+      } as any,
+      metadata: [{ jobId, workspaceId: 'workspace-non-mau' }],
+    };
+  };
+
+  const jobIdOccurrences = (result: any[]): Map<number, number> => {
+    const counts = new Map<number, number>();
+    for (const out of result) {
+      for (const jobId of new Set((out.metadata ?? []).map((m: any) => m.jobId))) {
+        counts.set(jobId as number, (counts.get(jobId as number) ?? 0) + 1);
+      }
+    }
+    return counts;
+  };
+
+  test('closes a chunk under the per-type cap rather than splitting the job that overflows it', () => {
+    // 37 two-attribute jobs fill 74 of the 75 attribute slots. The 38th job also
+    // contributes two attributes, and its two items carry different external_ids
+    // — the shape that used to be scattered by the item-level sort.
+    const jobs = Array.from({ length: 37 }, (_, i) =>
+      jobFromSpecs(i, [
+        { type: 'attributes', externalId: `u${String(i).padStart(3, '0')}` },
+        { type: 'attributes', externalId: `u${String(i).padStart(3, '0')}` },
+      ]),
+    );
+    jobs.push(
+      jobFromSpecs(37, [{ type: 'attributes', externalId: 'aaa' }, { type: 'attributes' }]),
+    );
+
+    const result = processBatchWithDeliveryMapping(jobs);
+    const tracks = onTrackOutputs(result, destination);
+
+    // The overflowing job is not split: no chunk carries 75 attributes.
+    expect(tracks.some((t) => t.batchedRequest.body.JSON.attributes.length === 75)).toBe(false);
+    for (const [, occurrences] of jobIdOccurrences(result)) {
+      expect(occurrences).toBe(1);
+    }
+  });
+
+  test('no jobId is ever emitted twice across randomised mixed-external_id batches', () => {
+    // Deterministic LCG — reproducible, no test flakiness.
+    let seed = 0x2f6e2b1;
+    const rand = (n: number) => {
+      seed = (seed * 1103515245 + 12345) & 0x7fffffff;
+      return seed % n;
+    };
+    const types: ItemSpec['type'][] = ['attributes', 'events', 'purchases'];
+    const pool = ['e0', 'e1', 'e2', 'e3', 'e4', 'e5', 'e6', 'e7'];
+
+    const jobs = Array.from({ length: 120 }, (_, i) => {
+      const specs: ItemSpec[] = [{ type: 'attributes', externalId: pool[rand(pool.length)] }];
+      const extra = rand(4);
+      for (let k = 0; k < extra; k += 1) {
+        const pick = rand(pool.length + 1);
+        specs.push({
+          type: types[rand(types.length)],
+          // pool.length means "no external_id at all" — the alias-branch shape.
+          externalId: pick === pool.length ? undefined : pool[pick],
+        });
+      }
+      return jobFromSpecs(i, specs);
+    });
+
+    const result = processBatchWithDeliveryMapping(jobs);
+    const tracks = onTrackOutputs(result, destination);
+    expect(tracks.length).toBeGreaterThanOrEqual(2);
+
+    const counts = jobIdOccurrences(result);
+    expect(counts.size).toBe(jobs.length);
+    for (const [, occurrences] of counts) {
+      expect(occurrences).toBe(1);
+    }
+  });
+});

--- a/src/v0/destinations/braze/braze.util.test.ts
+++ b/src/v0/destinations/braze/braze.util.test.ts
@@ -2830,3 +2830,84 @@ describe('isPerJobDeliveryMappingEnabled — per-workspace rollout gate', () => 
     expect(isPerJobDeliveryMappingEnabled('ws2')).toBe(true);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Router in/out job accounting — rudder-server discards the whole transformer
+// response and retries the entire batch as 500 when the number of jobIds it
+// gets back differs from the number it sent (`router_transformer_invalid_response`,
+// reason `in out mismatch`). `in` is a set of input jobIds; `out` is appended
+// once per (output element x distinct jobId in that element), so a jobId that
+// surfaces in two outputs inflates `out` even though nothing was lost.
+// ---------------------------------------------------------------------------
+
+describe('router in/out job accounting (ON path)', () => {
+  const destination = brazeDestFor();
+
+  // Mirrors rudder-server's check in router/transformer/transformer.go: `in` is a
+  // deduped set of input jobIds, `out` appends one entry per (output x distinct
+  // jobId), so cross-output duplicates make len(out) > len(in).
+  const outJobIdCount = (result: any[]): number =>
+    result.reduce((acc, r) => acc + new Set((r.metadata ?? []).map((m: any) => m.jobId)).size, 0);
+
+  const trackJob = (
+    jobId: number,
+    attributesExternalId: string | undefined,
+    eventsExternalId: string | undefined,
+  ): BrazeTransformedEvent => ({
+    destination,
+    statusCode: 200,
+    batchedRequest: {
+      version: '1',
+      type: 'REST',
+      method: 'POST',
+      endpoint: '',
+      headers: {},
+      params: {},
+      body: {
+        JSON: {
+          attributes: [
+            attributesExternalId === undefined
+              ? { name: `n${jobId}` }
+              : { external_id: attributesExternalId, name: `n${jobId}` },
+          ],
+          events: [
+            eventsExternalId === undefined
+              ? { name: 'e', time: 't' }
+              : { external_id: eventsExternalId, name: 'e', time: 't' },
+          ],
+        },
+      },
+      files: {},
+    } as any,
+    metadata: [{ jobId, workspaceId: 'workspace-non-mau' }],
+  });
+
+  test('a job whose items carry different external_ids is not emitted in two chunks', () => {
+    // 80 ordinary jobs force more than one chunk (V1 cap is 75 attributes).
+    const jobs: BrazeTransformedEvent[] = Array.from({ length: 80 }, (_, i) =>
+      trackJob(i, `u${String(i).padStart(3, '0')}`, `u${String(i).padStart(3, '0')}`),
+    );
+    // One anonymous job: traits carried an `external_id`, but the message had no
+    // userId, so setExternalIdOrAliasObject took the alias branch and left the
+    // events item without an `external_id`. Its two items therefore sort to
+    // opposite ends of the batch.
+    jobs.push(trackJob(999, 'a-anonymous-user', undefined));
+
+    const result = processBatchWithDeliveryMapping(jobs);
+    const tracks = onTrackOutputs(result, destination);
+    expect(tracks.length).toBeGreaterThanOrEqual(2);
+
+    const occurrences = tracks.filter((t) => t.metadata.some((m: any) => m.jobId === 999)).length;
+    expect(occurrences).toBe(1);
+  });
+
+  test('out jobId count equals in jobId count for a mixed-external_id batch', () => {
+    const jobs: BrazeTransformedEvent[] = Array.from({ length: 80 }, (_, i) =>
+      trackJob(i, `u${String(i).padStart(3, '0')}`, `u${String(i).padStart(3, '0')}`),
+    );
+    jobs.push(trackJob(999, 'a-anonymous-user', undefined));
+
+    const result = processBatchWithDeliveryMapping(jobs);
+    expect(outJobIdCount(result)).toBe(jobs.length);
+  });
+});

--- a/src/v0/destinations/braze/braze.util.test.ts
+++ b/src/v0/destinations/braze/braze.util.test.ts
@@ -15,10 +15,12 @@ import {
 import { isPerJobDeliveryMappingEnabled } from './config';
 import { removeUndefinedAndNullValues, removeUndefinedAndNullAndEmptyValues } from '../../util';
 import { generateRandomString } from '@rudderstack/integrations-lib';
+import type { Metadata } from '../../../types';
 import {
   BrazeDestination,
   BrazeRouterRequest,
   BrazeTransformedEvent,
+  BrazeBatchResponse,
   BrazeTrackRequestBody,
   BrazeSubscriptionBatchPayload,
   BrazeMergeBatchPayload,
@@ -2840,14 +2842,27 @@ describe('isPerJobDeliveryMappingEnabled — per-workspace rollout gate', () => 
 // surfaces in two outputs inflates `out` even though nothing was lost.
 // ---------------------------------------------------------------------------
 
+// Structural view of the ON-path track outputs the tests below assert on. The
+// shared on*/off* helpers further up predate strict typing and return `any[]`;
+// annotating once at the call site keeps every assertion properly typed.
+type OnTrackOutput = {
+  batchedRequest: { body: { JSON: BrazeTrackRequestBody } };
+  metadata: Partial<Metadata>[];
+};
+
+const jobIdsOf = (out: BrazeBatchResponse): number[] =>
+  (out.metadata ?? [])
+    .map((meta) => meta.jobId)
+    .filter((jobId): jobId is number => jobId !== undefined);
+
 describe('router in/out job accounting (ON path)', () => {
   const destination = brazeDestFor();
 
   // Mirrors rudder-server's check in router/transformer/transformer.go: `in` is a
   // deduped set of input jobIds, `out` appends one entry per (output x distinct
   // jobId), so cross-output duplicates make len(out) > len(in).
-  const outJobIdCount = (result: any[]): number =>
-    result.reduce((acc, r) => acc + new Set((r.metadata ?? []).map((m: any) => m.jobId)).size, 0);
+  const outJobIdCount = (result: BrazeBatchResponse[]): number =>
+    result.reduce((acc, out) => acc + new Set(jobIdsOf(out)).size, 0);
 
   const trackJob = (
     jobId: number,
@@ -2878,7 +2893,7 @@ describe('router in/out job accounting (ON path)', () => {
         },
       },
       files: {},
-    } as any,
+    },
     metadata: [{ jobId, workspaceId: 'workspace-non-mau' }],
   });
 
@@ -2894,10 +2909,12 @@ describe('router in/out job accounting (ON path)', () => {
     jobs.push(trackJob(999, 'a-anonymous-user', undefined));
 
     const result = processBatchWithDeliveryMapping(jobs);
-    const tracks = onTrackOutputs(result, destination);
+    const tracks: OnTrackOutput[] = onTrackOutputs(result, destination);
     expect(tracks.length).toBeGreaterThanOrEqual(2);
 
-    const occurrences = tracks.filter((t) => t.metadata.some((m: any) => m.jobId === 999)).length;
+    const occurrences = tracks.filter((track) =>
+      track.metadata.some((meta) => meta.jobId === 999),
+    ).length;
     expect(occurrences).toBe(1);
   });
 
@@ -2924,16 +2941,18 @@ describe('chunk boundaries never split a source job', () => {
   type ItemSpec = { type: 'attributes' | 'events' | 'purchases'; externalId?: string };
 
   const jobFromSpecs = (jobId: number, specs: ItemSpec[]): BrazeTransformedEvent => {
-    const bucket: Record<string, any[]> = { attributes: [], events: [], purchases: [] };
+    const attributes: Record<string, unknown>[] = [];
+    const events: Record<string, unknown>[] = [];
+    const purchases: Record<string, unknown>[] = [];
     specs.forEach((spec, k) => {
       const base: Record<string, unknown> = { tag: `${jobId}-${k}` };
       if (spec.externalId !== undefined) {
         base.external_id = spec.externalId;
       }
       if (spec.type === 'events') {
-        bucket.events.push({ ...base, name: 'e', time: 't' });
+        events.push({ ...base, name: 'e', time: 't' });
       } else if (spec.type === 'purchases') {
-        bucket.purchases.push({
+        purchases.push({
           ...base,
           product_id: `p${jobId}-${k}`,
           price: 1,
@@ -2942,7 +2961,7 @@ describe('chunk boundaries never split a source job', () => {
           time: 't',
         });
       } else {
-        bucket.attributes.push(base);
+        attributes.push(base);
       }
     });
     return {
@@ -2955,24 +2974,18 @@ describe('chunk boundaries never split a source job', () => {
         endpoint: '',
         headers: {},
         params: {},
-        body: {
-          JSON: {
-            attributes: bucket.attributes,
-            events: bucket.events,
-            purchases: bucket.purchases,
-          },
-        },
+        body: { JSON: { attributes, events, purchases } },
         files: {},
-      } as any,
+      },
       metadata: [{ jobId, workspaceId: 'workspace-non-mau' }],
     };
   };
 
-  const jobIdOccurrences = (result: any[]): Map<number, number> => {
+  const jobIdOccurrences = (result: BrazeBatchResponse[]): Map<number, number> => {
     const counts = new Map<number, number>();
     for (const out of result) {
-      for (const jobId of new Set((out.metadata ?? []).map((m: any) => m.jobId))) {
-        counts.set(jobId as number, (counts.get(jobId as number) ?? 0) + 1);
+      for (const jobId of new Set(jobIdsOf(out))) {
+        counts.set(jobId, (counts.get(jobId) ?? 0) + 1);
       }
     }
     return counts;
@@ -2993,10 +3006,12 @@ describe('chunk boundaries never split a source job', () => {
     );
 
     const result = processBatchWithDeliveryMapping(jobs);
-    const tracks = onTrackOutputs(result, destination);
+    const tracks: OnTrackOutput[] = onTrackOutputs(result, destination);
 
     // The overflowing job is not split: no chunk carries 75 attributes.
-    expect(tracks.some((t) => t.batchedRequest.body.JSON.attributes.length === 75)).toBe(false);
+    expect(
+      tracks.some((track) => (track.batchedRequest.body.JSON.attributes ?? []).length === 75),
+    ).toBe(false);
     for (const [, occurrences] of jobIdOccurrences(result)) {
       expect(occurrences).toBe(1);
     }
@@ -3027,7 +3042,7 @@ describe('chunk boundaries never split a source job', () => {
     });
 
     const result = processBatchWithDeliveryMapping(jobs);
-    const tracks = onTrackOutputs(result, destination);
+    const tracks: OnTrackOutput[] = onTrackOutputs(result, destination);
     expect(tracks.length).toBeGreaterThanOrEqual(2);
 
     const counts = jobIdOccurrences(result);

--- a/src/v0/destinations/braze/util.ts
+++ b/src/v0/destinations/braze/util.ts
@@ -1014,25 +1014,27 @@ const createTaggedTrackChunk = (): TaggedTrackChunk => ({
   byteSize: 0,
 });
 
-// Contiguous same-sourceJobIndex runs in a sorted item list. Because we
-// stable-sort by (externalId, sourceJobIndex), items from the same source job
-// end up adjacent regardless of type.
-const groupBySourceJob = (sortedItems: TaggedItem[]): TaggedItem[][] => {
-  const groups: TaggedItem[][] = [];
-  if (sortedItems.length === 0) {
-    return groups;
-  }
-  let start = 0;
-  for (let i = 1; i <= sortedItems.length; i += 1) {
-    if (
-      i === sortedItems.length ||
-      sortedItems[i].sourceJobIndex !== sortedItems[start].sourceJobIndex
-    ) {
-      groups.push(sortedItems.slice(start, i));
-      start = i;
+// All items belonging to one source job, as a single group. Keyed on
+// sourceJobIndex rather than derived from contiguous runs of a sorted list: a
+// job's items are NOT guaranteed to share one externalId, so sorting by
+// externalId can scatter them. A message with no userId but an `external_id`
+// trait, for instance, keeps that trait on its attributes item while its
+// events item falls back to `user_alias` and carries no external_id at all
+// (see setExternalIdOrAliasObject). Splitting such a job across two chunks
+// makes its jobId surface in two router outputs, which rudder-server counts
+// as an in/out mismatch and punishes by retrying the whole batch as a 500.
+// Insertion order is preserved so grouping stays deterministic.
+const groupBySourceJob = (items: TaggedItem[]): TaggedItem[][] => {
+  const groups = new Map<number, TaggedItem[]>();
+  for (const item of items) {
+    const group = groups.get(item.sourceJobIndex);
+    if (group) {
+      group.push(item);
+    } else {
+      groups.set(item.sourceJobIndex, [item]);
     }
   }
-  return groups;
+  return [...groups.values()];
 };
 
 const addGroupToChunk = (chunk: TaggedTrackChunk, group: TaggedItem[]): void => {
@@ -1096,8 +1098,15 @@ const groupFitsV2 = (chunk: TaggedTrackChunk, group: TaggedItem[]): boolean => {
 // pre-check; the exported wrappers below use per-item sourceJobIndex so no
 // group ever exceeds a single item.
 const chunkTaggedItems = (items: TaggedItem[], mode: 'v1' | 'v2'): TaggedTrackChunk[] => {
-  const sortedItems = _.orderBy(items, ['externalId', 'sourceJobIndex']);
-  const groups = groupBySourceJob(sortedItems);
+  // Group first, then order whole groups by their leading externalId. Ordering
+  // groups rather than items keeps same-user jobs adjacent (so the V1
+  // per-chunk externalId cap still bites late) while making it impossible for
+  // one job's items to land in two chunks.
+  const groups = _.orderBy(
+    groupBySourceJob(items),
+    [(group) => group[0].externalId ?? '', (group) => group[0].sourceJobIndex],
+    ['asc', 'asc'],
+  );
   const chunks: TaggedTrackChunk[] = [];
   let currentChunk = createTaggedTrackChunk();
   const fits = mode === 'v1' ? groupFitsV1 : groupFitsV2;


### PR DESCRIPTION
## What

Fixes the P0 `router-transformer-invalid-response` alert (reason `in out mismatch`, destType `braze`) firing on `multi-tenant-eu` / `proeumt`.

## Root cause

`chunkTaggedItems` sorted tagged track items by `externalId`, then recovered per-job groups from **contiguous** runs of `sourceJobIndex`. That assumes every item of a job shares one `externalId`. It doesn't:

- `getUserAttributesObject` copies traits verbatim and `external_id` is **not** in `reservedKeys` (`transform.ts:157-196`), so a `traits.external_id` lands on the attributes item.
- When the message has no `userId`, `setExternalIdOrAliasObject` (`util.ts:1512`) takes the alias branch — it sets `user_alias` and never overwrites the attributes item's `external_id`, while the events item is built fresh and gets **no** `external_id`.

So that job's two items sort to opposite ends of the batch, form two groups, and can land in two chunks. `trackChunkResponse` then emits the job's metadata once per chunk.

rudder-server (`router/transformer/transformer.go:325-366`) builds `in` as a deduped set of input jobIds and `out` by appending once per (output element x distinct jobId), so a jobId in two outputs makes `len(out) > len(in)`. On mismatch it **discards the whole transformer response** and retries every job in the batch as a 500 (`transformer.go:368-389`), with no log line — only the stat and the job status.

## Evidence

Reporting DB (`errors` table, EU TimescaleDB) for destination `xxxxxxxx`:

```
Transformer returned invalid output size: 69 for input size: 68
Transformer returned invalid output size: 75 for input size: 74
Transformer returned invalid output size: 67 for input size: 66
```

Always over by **exactly one** — one straddling job per batch, i.e. a duplicate, not a drop.

Regression correlation: workspace `xxxxxxx` was added to `BRAZE_PER_JOB_DELIVERY_MAPPING_WORKSPACE_IDS` in rudder-devops `ffbee0a84` ("enable new batching strategy of Braze for starter customers", #7628) at 2026-08-12 10:29 UTC; the first such error for this destination is 2026-08-12 ~11:34 UTC. No occurrences before that, and no other destination affected EU-wide in 45 days. The affected code (`chunkTaggedItems` / `groupBySourceJob`) came in with `b76933ce6` (2026-07-27) and is reachable only on the flagged path.

## Fix

Group by `sourceJobIndex` first (a `Map`, so grouping no longer depends on sort order), then order whole *groups* by their leading `externalId`. Same-user locality is preserved so the V1 per-chunk `externalId` cap still bites late, but a job's items can no longer be split across chunks whatever external_ids they carry.

Because `fits()` is evaluated against a whole group and `addGroupToChunk` commits the whole group, a chunk boundary can now only fall *between* jobs. A chunk may therefore close under the cap (e.g. at 74 of 75) rather than split the job that overflows it.

## Tests

Four new tests in `braze.util.test.ts`, in two blocks. All four fail on the parent commit and pass on the fix.

`router in/out job accounting (ON path)`
- a job whose items carry different `external_id`s is not emitted in two chunks;
- out-jobId count equals in-jobId count, mirroring rudder-server's exact counting rule. Pre-fix: `Expected: 81, Received: 82` — the production symptom reproduced.

`chunk boundaries never split a source job`
- a chunk closes under the per-type cap rather than splitting the overflowing job. Pre-fix this finds a 75-attribute chunk, i.e. the job really was split across the boundary;
- a deterministic randomised sweep (120 jobs, mixed and absent `external_id`s) asserts no jobId is ever emitted twice. Pre-fix a jobId appears twice.

Verification (re-run after merging `develop`):
- `npx jest src/v0/destinations/braze` — 262 passed (6 suites)
- Braze component tests — 108 passed
- `tsc --noEmit -p tsconfig.test.json` clean (the root `tsconfig.json` excludes `*.test.ts`, so it does not cover this file); prettier clean

The counts are higher than at first review because `develop` has since gained #5488's `validateDestinationConfig` tests; nothing in this branch changed.

## Packing cost

Group-atomic packing can leave slots unused, so this was measured against the old code on identical workloads (request counts out of `processBatchWithDeliveryMapping`):

| jobs/batch | mixed-id jobs | old | new | extra |
|---|---|---|---|---|
| 74 | 0-100% | 2 | 2 | +0 |
| 300 | 0-50% | 9 | 9 | +0 |
| 300 | 100% | 8 | 9 | +1 |
| 1000 | 1-100% | 27 | 28 | +1 |
| 5000 | 50-100% | 134 | 136 | +2 |

The cost is a small absolute number of extra requests, not a proportional one, so it shrinks as batches grow. At this destination's actual batch sizes (66-75 jobs) it is zero. The bound is `(max group size - 1)` unused slots per chunk — 1 of 75 (1.33%) for the standard attributes+events shape. Where all of a job's items share one `external_id` the two algorithms produce identical output, since the old sort already made them adjacent.

Separately: the group-preserving chunker has real overhead versus theoretically optimal packing for jobs with many purchases (up to ~2x at ~38 items/job). That is pre-existing from `b76933ce6` — an identical sweep over group sizes k=1..74 gives byte-identical counts on both versions.

## Notes

- Sub/merge chunking uses positional `_.chunk`, which would have the same straddle hazard — but each message yields exactly one subscription group (`transform.ts:462`) or one merge update, so it is not reachable today. Left unchanged deliberately.
- The stale `debug/braze-in-out-mismatch` branch targets *dropped* jobs (`processBatch`'s missing `else`); that is a different, real defect but not the cause of this alert, which is a duplicate.
- Third commit is test-only cleanup: removes `any` from the blocks added here (real types, a `jobId` type-predicate narrowing, and dropping two `as any` casts that turned out to be unnecessary). The file's pre-existing `any` usages are untouched.
- Fourth commit merges `develop`. The only conflict was an import line in `braze.util.test.ts`: #5488 added `ConfigurationError` where this branch had added `Metadata`; both are kept. `util.ts` auto-merged — #5488's `restApiKey` guard and this PR's chunker sit in disjoint regions of the file, and the diff of `util.ts` against `develop` is still exactly the `groupBySourceJob`/`chunkTaggedItems` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

