### PR TITLE
fix(braze): scope 296 to ecommerce schema rejections on /users/track

### DIFF
--- a/src/util/prometheus.js
+++ b/src/util/prometheus.js
@@ -630,7 +630,7 @@ class Prometheus {
         name: 'braze_partial_failure',
         help: 'braze_partial_failure',
         type: 'counter',
-        labelNames: [],
+        labelNames: ['destinationId', 'workspaceId'],
       },
       {
         name: 'braze_audience_partial_failure',

--- a/src/v0/destinations/braze/ecommerceUtil.ts
+++ b/src/v0/destinations/braze/ecommerceUtil.ts
@@ -65,6 +65,18 @@ const ECOMMERCE_ROUTED_ENTRIES: readonly EcommerceRoutedEntry[] = Object.values(
   ConfigCategory,
 ).filter((entry): entry is EcommerceRoutedCategory => 'brazeEvent' in entry);
 
+// Braze event names emitted by the recommended-ecommerce path. Derived from
+// ECOMMERCE_ROUTED_ENTRIES so a new ConfigCategory entry extends this for free.
+const BRAZE_ECOMMERCE_EVENT_NAMES: ReadonlySet<string> = new Set(
+  ECOMMERCE_ROUTED_ENTRIES.map((entry) => entry.brazeEvent),
+);
+
+// True when `name` is one of those event names. Read by the v1 networkHandler to
+// tell a recommended-ecommerce event apart from a legacy custom event sharing the
+// same `/users/track` `events[]` array.
+export const isBrazeEcommerceEventName = (name: unknown): boolean =>
+  typeof name === 'string' && BRAZE_ECOMMERCE_EVENT_NAMES.has(name);
+
 // Case-insensitive RS event name (lowercased, trimmed) → Braze mapping.
 const EVENT_NAME_TO_BRAZE: Record<string, EcommerceMapping> = Object.fromEntries(
   ECOMMERCE_ROUTED_ENTRIES.flatMap((entry) =>

--- a/src/v0/destinations/braze/types.ts
+++ b/src/v0/destinations/braze/types.ts
@@ -176,6 +176,18 @@ export interface BrazeDestInfo {
   purchasesIndices?: number[];
 }
 
+// The proxy request as Braze's own handler reads it: a ProxyV1Request whose
+// JSON body is narrowed to the /users/track chunk this destination built, so
+// the network handler can reach `events[]` without re-describing the shape.
+// `Omit<..., 'JSON'>` keeps the sibling body formats in sync with the base type.
+// The value still arrives unvalidated over the wire, so the handler keeps its
+// runtime guards rather than trusting this declaration.
+export interface BrazeProxyV1Request extends Omit<ProxyV1Request, 'body'> {
+  body?: Omit<NonNullable<ProxyV1Request['body']>, 'JSON'> & {
+    JSON?: BrazeTrackRequestBody;
+  };
+}
+
 export interface BrazeResponseHandlerParams {
   destinationResponse: {
     response?: {
@@ -186,13 +198,14 @@ export interface BrazeResponseHandlerParams {
   };
   rudderJobMetadata: ProxyMetdata[];
   // The framework's `deliver` step (nativeIntegration.ts) always forwards the
-  // original ProxyV1Request as `destinationRequest`. The v1 networkHandler
-  // uses its `endpointPath` (e.g. `'users/track'`) to decide whether to run
-  // the 296 per-item correlation logic — Braze's `/users/track` is the only
-  // endpoint that returns per-entry `errors[]`. Optional so unit-test call
-  // sites that don't need endpoint-dispatch can omit it; when absent the
+  // original proxy request as `destinationRequest`. The v1 networkHandler uses
+  // its `endpointPath` (e.g. `'users/track'`) to decide whether to run the
+  // per-item correlation logic — Braze's `/users/track` is the only endpoint
+  // that returns per-entry `errors[]` — and its `body.JSON.events` to tell
+  // recommended-ecommerce events apart from legacy custom ones. Optional so
+  // unit-test call sites that need neither can omit it; when absent the
   // handler skips correlation and falls back to uniform per-job outcomes.
-  destinationRequest?: ProxyV1Request;
+  destinationRequest?: BrazeProxyV1Request;
 }
 
 export interface BrazeUser extends BrazeUserAttributes {

--- a/src/v1/destinations/braze/networkHandler.test.ts
+++ b/src/v1/destinations/braze/networkHandler.test.ts
@@ -6,7 +6,8 @@ jest.mock('../../../util/stats', () => ({
 
 import stats from '../../../util/stats';
 import { TransformerProxyError } from '../../../v0/util/errorTypes';
-import type { ProxyMetdata, ProxyV1Request } from '../../../types';
+import type { ProxyMetdata } from '../../../types';
+import type { BrazeEvent, BrazeProxyV1Request } from '../../../v0/destinations/braze/types';
 import { responseHandler } from './networkHandler';
 
 const createMetadata = (jobId: number, destInfo?: Record<string, unknown>): ProxyMetdata => ({
@@ -21,9 +22,38 @@ const createMetadata = (jobId: number, destInfo?: Record<string, unknown>): Prox
   ...(destInfo !== undefined ? { destInfo } : {}),
 });
 
-// Minimal ProxyV1Request stub carrying just the endpointPath — the handler
-// only reads endpointPath to dispatch its 296-correlation branch.
-const buildRequestFor = (endpointPath: string, metadata: ProxyMetdata[]): ProxyV1Request => ({
+// Braze event names emitted by the recommended-ecommerce path. Only these mark
+// an item in the sent events[] as eligible for 296.
+const ECOM_ORDER_PLACED = 'ecommerce.order_placed';
+const ECOM_PRODUCT_VIEWED = 'ecommerce.product_viewed';
+// A legacy custom event — reaches the same events[] after chunking, but never 296.
+const LEGACY_EVENT = 'Some Custom Event';
+// BrazeEvent requires `time`; the handler never reads it, so one value serves all.
+const EVENT_TIME = '2026-08-18T00:00:00.000Z';
+const eventNamed = (name: string): BrazeEvent => ({ name, time: EVENT_TIME });
+
+// Verbatim ecommerce schema rejections observed on real /users/track responses.
+const SCHEMA_ERRORS = {
+  additionalProperty:
+    'The property \'#/\' contains additional properties ["sku_abcd"] outside of the schema when none are allowed',
+  typeMismatchProductId:
+    "The property '#/product_id' of type integer did not match the following type: string",
+  missingRequired: "The property '#/' did not contain a required property of 'product_id'",
+  typeMismatchPrice:
+    "The property '#/price' of type string did not match the following type: number",
+};
+// A track failure that is not a schema rejection — always aborts, whatever it hit.
+const NON_SCHEMA_ERROR = "'external_id' is required";
+
+const METRIC_LABELS = { destinationId: 'dest-1', workspaceId: 'workspace-1' };
+
+// Minimal proxy-request stub. The handler reads endpointPath to dispatch its
+// correlation branch and body.JSON.events to identify ecommerce items by name.
+const buildRequestFor = (
+  endpointPath: string,
+  metadata: ProxyMetdata[],
+  events: BrazeEvent[] = [],
+): BrazeProxyV1Request => ({
   version: '1',
   type: 'REST',
   method: 'POST',
@@ -32,12 +62,25 @@ const buildRequestFor = (endpointPath: string, metadata: ProxyMetdata[]): ProxyV
   userId: '',
   metadata,
   destinationConfig: {},
+  body: { JSON: { partner: 'RudderStack', ...(events.length > 0 ? { events } : {}) } },
 });
 
-const trackRequestFor = (metadata: ProxyMetdata[]) => buildRequestFor('users/track', metadata);
+const trackRequestFor = (metadata: ProxyMetdata[], events: BrazeEvent[] = []) =>
+  buildRequestFor('users/track', metadata, events);
 const mergeRequestFor = (metadata: ProxyMetdata[]) => buildRequestFor('users/merge', metadata);
 
+// A sent events[] of `count` items all carrying the same Braze event name.
+const eventsNamed = (name: string, count: number): BrazeEvent[] =>
+  Array.from({ length: count }, () => eventNamed(name));
+
 const mockStats = stats as jest.Mocked<typeof stats>;
+
+const expectNoCounter = (metricName: string) =>
+  expect(mockStats.counter).not.toHaveBeenCalledWith(
+    metricName,
+    expect.anything(),
+    expect.anything(),
+  );
 
 describe('Braze v1 networkHandler responseHandler', () => {
   beforeEach(() => {
@@ -86,11 +129,14 @@ describe('Braze v1 networkHandler responseHandler', () => {
       const response = {
         message: 'success',
         events_processed: 1,
-        errors: [{ type: "'external_id' is required", input_array: 'events', index: 1 }],
+        errors: [{ type: SCHEMA_ERRORS.missingRequired, input_array: 'events', index: 1 }],
       };
       const destinationResponse = { response, status: 200 };
       const rudderJobMetadata = [createMetadata(10), createMetadata(20)];
-      const destinationRequest = trackRequestFor(rudderJobMetadata);
+      const destinationRequest = trackRequestFor(
+        rudderJobMetadata,
+        eventsNamed(ECOM_ORDER_PLACED, 2),
+      );
 
       const result = responseHandler({
         destinationResponse,
@@ -106,16 +152,10 @@ describe('Braze v1 networkHandler responseHandler', () => {
           { statusCode: 200, metadata: createMetadata(20), error: JSON.stringify(response) },
         ],
       });
-      expect(mockStats.increment).toHaveBeenCalledWith('braze_partial_failure', {
-        destination_id: 'dest-1',
-        workspace_id: 'workspace-1',
-      });
-      // No warnings correlated → braze_delivered_with_warning counter never fires.
-      expect(mockStats.counter).not.toHaveBeenCalledWith(
-        'braze_delivered_with_warning',
-        expect.anything(),
-        expect.anything(),
-      );
+      expect(mockStats.increment).toHaveBeenCalledWith('braze_partial_failure', METRIC_LABELS);
+      // Nothing correlated → neither per-outcome counter fires.
+      expectNoCounter('braze_delivered_with_warning');
+      expectNoCounter('braze_delivery_aborted');
     });
 
     it('when SOME metadata lack destInfo (mixed batch), correlated jobs get 296 and uncorrelated jobs get 200', () => {
@@ -126,11 +166,14 @@ describe('Braze v1 networkHandler responseHandler', () => {
       const response = {
         message: 'success',
         events_processed: 1,
-        errors: [{ type: "'external_id' is required", input_array: 'events', index: 0 }],
+        errors: [{ type: SCHEMA_ERRORS.missingRequired, input_array: 'events', index: 0 }],
       };
       const destinationResponse = { response, status: 200 };
       const rudderJobMetadata = [createMetadata(10, { eventsIndices: [0] }), createMetadata(20)];
-      const destinationRequest = trackRequestFor(rudderJobMetadata);
+      const destinationRequest = trackRequestFor(
+        rudderJobMetadata,
+        eventsNamed(ECOM_ORDER_PLACED, 1),
+      );
 
       const result = responseHandler({
         destinationResponse,
@@ -141,28 +184,30 @@ describe('Braze v1 networkHandler responseHandler', () => {
       expect(result.response[0]).toEqual({
         statusCode: 296,
         metadata: rudderJobMetadata[0],
-        error: "'external_id' is required",
+        error: SCHEMA_ERRORS.missingRequired,
       });
       expect(result.response[1]).toEqual({
         statusCode: 200,
         metadata: rudderJobMetadata[1],
         error: JSON.stringify(response),
       });
-      expect(mockStats.counter).toHaveBeenCalledWith('braze_delivered_with_warning', 1, {
-        destination_id: 'dest-1',
-        workspace_id: 'workspace-1',
-      });
+      expect(mockStats.counter).toHaveBeenCalledWith(
+        'braze_delivered_with_warning',
+        1,
+        METRIC_LABELS,
+      );
+      expectNoCounter('braze_delivery_aborted');
     });
 
     it('when the delivery endpoint is NOT /users/track (e.g. alias-merge), falls back to uniform-200 without inspecting destInfo', () => {
       // Merge/subscription responses can also surface an `errors[]` array,
-      // but 296 correlation is reserved for /users/track only. Dispatch on
+      // but per-item correlation is reserved for /users/track only. Dispatch on
       // endpointPath, not error.input_array, so this case is handled
       // regardless of what Braze uses for the merge error shape.
       const response = {
         message: 'success',
         aliases_processed: 0,
-        errors: [{ type: "'external_id' is required", input_array: 'user_identifiers', index: 0 }],
+        errors: [{ type: NON_SCHEMA_ERROR, input_array: 'user_identifiers', index: 0 }],
       };
       const destinationResponse = { response, status: 200 };
       const rudderJobMetadata = [createMetadata(10, {}), createMetadata(20, {})];
@@ -177,21 +222,15 @@ describe('Braze v1 networkHandler responseHandler', () => {
       for (const state of result.response) {
         expect(state.statusCode).toBe(200);
       }
-      expect(mockStats.increment).toHaveBeenCalledWith('braze_partial_failure', {
-        destination_id: 'dest-1',
-        workspace_id: 'workspace-1',
-      });
-      expect(mockStats.counter).not.toHaveBeenCalledWith(
-        'braze_delivered_with_warning',
-        expect.anything(),
-        expect.anything(),
-      );
+      expect(mockStats.increment).toHaveBeenCalledWith('braze_partial_failure', METRIC_LABELS);
+      expectNoCounter('braze_delivered_with_warning');
+      expectNoCounter('braze_delivery_aborted');
     });
 
     it('when destinationRequest is missing entirely (framework contract broken), falls back to uniform-200', () => {
       const response = {
         message: 'success',
-        errors: [{ type: 'oops', input_array: 'events', index: 0 }],
+        errors: [{ type: SCHEMA_ERRORS.missingRequired, input_array: 'events', index: 0 }],
       };
       const destinationResponse = { response, status: 200 };
       const rudderJobMetadata = [createMetadata(10, { eventsIndices: [0] })];
@@ -199,29 +238,29 @@ describe('Braze v1 networkHandler responseHandler', () => {
       const result = responseHandler({ destinationResponse, rudderJobMetadata });
 
       expect(result.response[0].statusCode).toBe(200);
-      expect(mockStats.counter).not.toHaveBeenCalledWith(
-        'braze_delivered_with_warning',
-        expect.anything(),
-        expect.anything(),
-      );
+      expectNoCounter('braze_delivered_with_warning');
+      expectNoCounter('braze_delivery_aborted');
     });
   });
 
-  describe('partial failure — 2xx, message=success, errors present (296 correlation)', () => {
+  describe('partial failure — per-job correlation', () => {
     it('emits 296 only for jobs whose destInfo indices intersect a warned events index; other jobs get 200', () => {
       const response = {
         message: 'success',
         events_processed: 1,
-        errors: [{ type: "'external_id' is required", input_array: 'events', index: 1 }],
+        errors: [{ type: SCHEMA_ERRORS.typeMismatchPrice, input_array: 'events', index: 1 }],
       };
       const destinationResponse = { response, status: 200 };
-      // Chunk contains 2 events at positions [0, 1]. Job 10 owns index 0
-      // (clean), job 20 owns index 1 (warned).
+      // Chunk contains 2 ecommerce events at positions [0, 1]. Job 10 owns
+      // index 0 (clean), job 20 owns index 1 (warned).
       const rudderJobMetadata = [
         createMetadata(10, { eventsIndices: [0] }),
         createMetadata(20, { eventsIndices: [1] }),
       ];
-      const destinationRequest = trackRequestFor(rudderJobMetadata);
+      const destinationRequest = trackRequestFor(
+        rudderJobMetadata,
+        eventsNamed(ECOM_ORDER_PLACED, 2),
+      );
 
       const result = responseHandler({
         destinationResponse,
@@ -231,25 +270,27 @@ describe('Braze v1 networkHandler responseHandler', () => {
 
       expect(result.response).toEqual([
         { statusCode: 200, metadata: rudderJobMetadata[0], error: JSON.stringify(response) },
-        { statusCode: 296, metadata: rudderJobMetadata[1], error: "'external_id' is required" },
+        {
+          statusCode: 296,
+          metadata: rudderJobMetadata[1],
+          error: SCHEMA_ERRORS.typeMismatchPrice,
+        },
       ]);
-      expect(mockStats.increment).toHaveBeenCalledWith('braze_partial_failure', {
-        destination_id: 'dest-1',
-        workspace_id: 'workspace-1',
-      });
-      expect(mockStats.counter).toHaveBeenCalledWith('braze_delivered_with_warning', 1, {
-        destination_id: 'dest-1',
-        workspace_id: 'workspace-1',
-      });
+      expect(mockStats.increment).toHaveBeenCalledWith('braze_partial_failure', METRIC_LABELS);
+      expect(mockStats.counter).toHaveBeenCalledWith(
+        'braze_delivered_with_warning',
+        1,
+        METRIC_LABELS,
+      );
     });
 
-    it('handles warnings across multiple input_arrays — events, attributes, and purchases', () => {
+    it('warns only the ecommerce events hit — attributes and purchases hits abort their jobs', () => {
       const response = {
         message: 'success',
         errors: [
-          { type: 'attributes error', input_array: 'attributes', index: 0 },
-          { type: 'events error', input_array: 'events', index: 0 },
-          { type: 'purchases error', input_array: 'purchases', index: 2 },
+          { type: SCHEMA_ERRORS.missingRequired, input_array: 'attributes', index: 0 },
+          { type: SCHEMA_ERRORS.missingRequired, input_array: 'events', index: 0 },
+          { type: SCHEMA_ERRORS.missingRequired, input_array: 'purchases', index: 2 },
         ],
       };
       const destinationResponse = { response, status: 200 };
@@ -259,7 +300,10 @@ describe('Braze v1 networkHandler responseHandler', () => {
         createMetadata(30, { purchasesIndices: [0, 1, 2] }),
         createMetadata(40, { attributesIndices: [1] }),
       ];
-      const destinationRequest = trackRequestFor(rudderJobMetadata);
+      const destinationRequest = trackRequestFor(
+        rudderJobMetadata,
+        eventsNamed(ECOM_ORDER_PLACED, 1),
+      );
 
       const result = responseHandler({
         destinationResponse,
@@ -267,46 +311,55 @@ describe('Braze v1 networkHandler responseHandler', () => {
         destinationRequest,
       });
 
-      // Jobs 10, 20, 30 each intersect a warned index → 296 with their
-      // matching Braze error.type verbatim. Job 40 owns attributes[1] which
-      // is not warned → 200.
+      // Only job 20's hit is an ecommerce schema rejection in events[]; jobs
+      // 10 and 30 hit other sub-arrays and abort. Job 40 owns attributes[1],
+      // which is not warned at all → 200.
       expect(result.response[0]).toEqual({
-        statusCode: 296,
+        statusCode: 400,
         metadata: rudderJobMetadata[0],
-        error: 'attributes error',
+        error: SCHEMA_ERRORS.missingRequired,
       });
       expect(result.response[1]).toEqual({
         statusCode: 296,
         metadata: rudderJobMetadata[1],
-        error: 'events error',
+        error: SCHEMA_ERRORS.missingRequired,
       });
       expect(result.response[2]).toEqual({
-        statusCode: 296,
+        statusCode: 400,
         metadata: rudderJobMetadata[2],
-        error: 'purchases error',
+        error: SCHEMA_ERRORS.missingRequired,
       });
       expect(result.response[3]).toEqual({
         statusCode: 200,
         metadata: rudderJobMetadata[3],
         error: JSON.stringify(response),
       });
+      expect(mockStats.counter).toHaveBeenCalledWith(
+        'braze_delivered_with_warning',
+        1,
+        METRIC_LABELS,
+      );
+      expect(mockStats.counter).toHaveBeenCalledWith('braze_delivery_aborted', 2, METRIC_LABELS);
     });
 
     it('emits a single 296 (not multiple) when one job spans multiple warned indices; concatenates all matching error.type strings', () => {
-      // Order-completed contributing 3 purchases; two of them get warned.
-      // The job emits exactly ONE 296 entry whose `error` is a semicolon-
-      // separated join of every matching Braze error.type verbatim (encounter
-      // order across the job's declared indices, no deduplication).
+      // One job contributing 3 ecommerce events; two of them get warned. The
+      // job emits exactly ONE entry whose `error` is a semicolon-separated join
+      // of every matching Braze error.type verbatim (encounter order across the
+      // job's declared indices, no deduplication).
       const response = {
         message: 'success',
         errors: [
-          { type: 'first hit', input_array: 'purchases', index: 0 },
-          { type: 'second hit', input_array: 'purchases', index: 2 },
+          { type: SCHEMA_ERRORS.missingRequired, input_array: 'events', index: 0 },
+          { type: SCHEMA_ERRORS.typeMismatchPrice, input_array: 'events', index: 2 },
         ],
       };
       const destinationResponse = { response, status: 200 };
-      const rudderJobMetadata = [createMetadata(10, { purchasesIndices: [0, 1, 2] })];
-      const destinationRequest = trackRequestFor(rudderJobMetadata);
+      const rudderJobMetadata = [createMetadata(10, { eventsIndices: [0, 1, 2] })];
+      const destinationRequest = trackRequestFor(
+        rudderJobMetadata,
+        eventsNamed(ECOM_PRODUCT_VIEWED, 3),
+      );
 
       const result = responseHandler({
         destinationResponse,
@@ -316,18 +369,22 @@ describe('Braze v1 networkHandler responseHandler', () => {
 
       expect(result.response).toHaveLength(1);
       expect(result.response[0].statusCode).toBe(296);
-      expect(result.response[0].error).toBe('first hit; second hit');
+      expect(result.response[0].error).toBe(
+        `${SCHEMA_ERRORS.missingRequired}; ${SCHEMA_ERRORS.typeMismatchPrice}`,
+      );
     });
 
-    it('concatenates matches across events + attributes + purchases when a single job spans all three', () => {
+    it('concatenates matches across events + attributes + purchases when a single job spans all three, and aborts', () => {
       // Job 10 contributes to every track sub-array and each contribution is
-      // warned. Verify the concatenation order: events → attributes → purchases.
+      // warned. Only the events hit qualifies for 296, so abort wins — but the
+      // `error` field still carries every hit in order: events → attributes →
+      // purchases.
       const response = {
         message: 'success',
         errors: [
-          { type: 'events err', input_array: 'events', index: 0 },
-          { type: 'attributes err', input_array: 'attributes', index: 0 },
-          { type: 'purchases err', input_array: 'purchases', index: 0 },
+          { type: SCHEMA_ERRORS.missingRequired, input_array: 'events', index: 0 },
+          { type: NON_SCHEMA_ERROR, input_array: 'attributes', index: 0 },
+          { type: SCHEMA_ERRORS.typeMismatchPrice, input_array: 'purchases', index: 0 },
         ],
       };
       const destinationResponse = { response, status: 200 };
@@ -338,7 +395,10 @@ describe('Braze v1 networkHandler responseHandler', () => {
           purchasesIndices: [0],
         }),
       ];
-      const destinationRequest = trackRequestFor(rudderJobMetadata);
+      const destinationRequest = trackRequestFor(
+        rudderJobMetadata,
+        eventsNamed(ECOM_ORDER_PLACED, 1),
+      );
 
       const result = responseHandler({
         destinationResponse,
@@ -346,23 +406,28 @@ describe('Braze v1 networkHandler responseHandler', () => {
         destinationRequest,
       });
 
-      expect(result.response[0].statusCode).toBe(296);
-      expect(result.response[0].error).toBe('events err; attributes err; purchases err');
+      expect(result.response[0].statusCode).toBe(400);
+      expect(result.response[0].error).toBe(
+        `${SCHEMA_ERRORS.missingRequired}; ${NON_SCHEMA_ERROR}; ${SCHEMA_ERRORS.typeMismatchPrice}`,
+      );
     });
 
     it('does NOT deduplicate identical error.type strings across a job’s warned indices', () => {
-      // Same error type on two purchase indices — both hits kept so the
+      // Same error type on two ecommerce event indices — both hits kept so the
       // downstream count remains informative.
       const response = {
         message: 'success',
         errors: [
-          { type: "'external_id' is required", input_array: 'purchases', index: 0 },
-          { type: "'external_id' is required", input_array: 'purchases', index: 1 },
+          { type: SCHEMA_ERRORS.additionalProperty, input_array: 'events', index: 0 },
+          { type: SCHEMA_ERRORS.additionalProperty, input_array: 'events', index: 1 },
         ],
       };
       const destinationResponse = { response, status: 200 };
-      const rudderJobMetadata = [createMetadata(10, { purchasesIndices: [0, 1] })];
-      const destinationRequest = trackRequestFor(rudderJobMetadata);
+      const rudderJobMetadata = [createMetadata(10, { eventsIndices: [0, 1] })];
+      const destinationRequest = trackRequestFor(
+        rudderJobMetadata,
+        eventsNamed(ECOM_ORDER_PLACED, 2),
+      );
 
       const result = responseHandler({
         destinationResponse,
@@ -371,13 +436,15 @@ describe('Braze v1 networkHandler responseHandler', () => {
       });
 
       expect(result.response[0].statusCode).toBe(296);
-      expect(result.response[0].error).toBe("'external_id' is required; 'external_id' is required");
+      expect(result.response[0].error).toBe(
+        `${SCHEMA_ERRORS.additionalProperty}; ${SCHEMA_ERRORS.additionalProperty}`,
+      );
     });
 
     it('preserves order and identity of rudderJobMetadata in the output response', () => {
       const response = {
         message: 'success',
-        errors: [{ type: 'oops', input_array: 'events', index: 1 }],
+        errors: [{ type: SCHEMA_ERRORS.missingRequired, input_array: 'events', index: 1 }],
       };
       const destinationResponse = { response, status: 200 };
       const rudderJobMetadata = [
@@ -385,7 +452,10 @@ describe('Braze v1 networkHandler responseHandler', () => {
         createMetadata(20, { eventsIndices: [1] }),
         createMetadata(30, { eventsIndices: [2] }),
       ];
-      const destinationRequest = trackRequestFor(rudderJobMetadata);
+      const destinationRequest = trackRequestFor(
+        rudderJobMetadata,
+        eventsNamed(ECOM_ORDER_PLACED, 3),
+      );
 
       const result = responseHandler({
         destinationResponse,
@@ -397,10 +467,10 @@ describe('Braze v1 networkHandler responseHandler', () => {
       expect(result.response.map((r) => r.statusCode)).toEqual([200, 296, 200]);
     });
 
-    it('when destInfo has malformed indices field (non-array), that field is ignored and no 296 is emitted for that job', () => {
+    it('when destInfo has malformed indices field (non-array), that field is ignored and no outcome is emitted for that job', () => {
       const response = {
         message: 'success',
-        errors: [{ type: 'oops', input_array: 'events', index: 0 }],
+        errors: [{ type: SCHEMA_ERRORS.missingRequired, input_array: 'events', index: 0 }],
       };
       const destinationResponse = { response, status: 200 };
       // Job 10's destInfo has a garbage `eventsIndices`; we must not throw
@@ -410,7 +480,10 @@ describe('Braze v1 networkHandler responseHandler', () => {
         createMetadata(10, { eventsIndices: 'not-an-array' }),
         createMetadata(20, { eventsIndices: [0] }),
       ];
-      const destinationRequest = trackRequestFor(rudderJobMetadata);
+      const destinationRequest = trackRequestFor(
+        rudderJobMetadata,
+        eventsNamed(ECOM_ORDER_PLACED, 1),
+      );
 
       const result = responseHandler({
         destinationResponse,
@@ -420,6 +493,153 @@ describe('Braze v1 networkHandler responseHandler', () => {
 
       expect(result.response[0].statusCode).toBe(200);
       expect(result.response[1].statusCode).toBe(296);
+    });
+  });
+
+  describe('296 vs 400 classification', () => {
+    // A hit warns only when it is a schema rejection (error.type prefixed with
+    // the JSON pointer) of a recommended-ecommerce event in the sent events[].
+    const warningCases = [
+      { name: 'additional properties outside schema', type: SCHEMA_ERRORS.additionalProperty },
+      { name: 'integer where string expected', type: SCHEMA_ERRORS.typeMismatchProductId },
+      { name: 'missing required property', type: SCHEMA_ERRORS.missingRequired },
+      { name: 'string where number expected', type: SCHEMA_ERRORS.typeMismatchPrice },
+    ];
+
+    const abortCases = [
+      {
+        name: 'schema rejection of a legacy custom event',
+        sentEvents: [eventNamed(LEGACY_EVENT)],
+        errors: [{ type: SCHEMA_ERRORS.missingRequired, input_array: 'events', index: 0 }],
+        destInfo: { eventsIndices: [0] },
+        expectedError: SCHEMA_ERRORS.missingRequired,
+      },
+      {
+        name: 'non-schema failure on an ecommerce event',
+        sentEvents: [eventNamed(ECOM_ORDER_PLACED)],
+        errors: [{ type: NON_SCHEMA_ERROR, input_array: 'events', index: 0 }],
+        destInfo: { eventsIndices: [0] },
+        expectedError: NON_SCHEMA_ERROR,
+      },
+      {
+        name: 'schema rejection when events[] is absent from the sent body',
+        sentEvents: [],
+        errors: [{ type: SCHEMA_ERRORS.missingRequired, input_array: 'events', index: 0 }],
+        destInfo: { eventsIndices: [0] },
+        expectedError: SCHEMA_ERRORS.missingRequired,
+      },
+      {
+        name: 'schema rejection in the attributes array',
+        sentEvents: [eventNamed(ECOM_ORDER_PLACED)],
+        errors: [{ type: SCHEMA_ERRORS.missingRequired, input_array: 'attributes', index: 0 }],
+        destInfo: { attributesIndices: [0] },
+        expectedError: SCHEMA_ERRORS.missingRequired,
+      },
+      {
+        name: 'schema rejection in the purchases array',
+        sentEvents: [eventNamed(ECOM_ORDER_PLACED)],
+        errors: [{ type: SCHEMA_ERRORS.typeMismatchPrice, input_array: 'purchases', index: 0 }],
+        destInfo: { purchasesIndices: [0] },
+        expectedError: SCHEMA_ERRORS.typeMismatchPrice,
+      },
+    ];
+
+    it.each(warningCases)('emits 296 for an ecommerce schema rejection: $name', ({ type }) => {
+      const response = {
+        message: 'success',
+        errors: [{ type, input_array: 'events', index: 0 }],
+      };
+      const rudderJobMetadata = [createMetadata(10, { eventsIndices: [0] })];
+
+      const result = responseHandler({
+        destinationResponse: { response, status: 200 },
+        rudderJobMetadata,
+        destinationRequest: trackRequestFor(rudderJobMetadata, [eventNamed(ECOM_ORDER_PLACED)]),
+      });
+
+      expect(result.response).toEqual([
+        { statusCode: 296, metadata: rudderJobMetadata[0], error: type },
+      ]);
+      expect(mockStats.counter).toHaveBeenCalledWith(
+        'braze_delivered_with_warning',
+        1,
+        METRIC_LABELS,
+      );
+      expectNoCounter('braze_delivery_aborted');
+    });
+
+    it.each(abortCases)(
+      'emits 400 for $name',
+      ({ sentEvents, errors, destInfo, expectedError }) => {
+        const response = { message: 'success', errors };
+        const rudderJobMetadata = [createMetadata(10, destInfo)];
+
+        const result = responseHandler({
+          destinationResponse: { response, status: 200 },
+          rudderJobMetadata,
+          destinationRequest: trackRequestFor(rudderJobMetadata, sentEvents),
+        });
+
+        expect(result.response).toEqual([
+          { statusCode: 400, metadata: rudderJobMetadata[0], error: expectedError },
+        ]);
+        expect(mockStats.counter).toHaveBeenCalledWith('braze_delivery_aborted', 1, METRIC_LABELS);
+        expectNoCounter('braze_delivered_with_warning');
+      },
+    );
+
+    it('aborts a job that mixes a qualifying and a non-qualifying hit, keeping both error types', () => {
+      const response = {
+        message: 'success',
+        errors: [
+          { type: SCHEMA_ERRORS.missingRequired, input_array: 'events', index: 0 },
+          { type: NON_SCHEMA_ERROR, input_array: 'events', index: 1 },
+        ],
+      };
+      const rudderJobMetadata = [createMetadata(10, { eventsIndices: [0, 1] })];
+
+      const result = responseHandler({
+        destinationResponse: { response, status: 200 },
+        rudderJobMetadata,
+        destinationRequest: trackRequestFor(rudderJobMetadata, eventsNamed(ECOM_ORDER_PLACED, 2)),
+      });
+
+      expect(result.response[0].statusCode).toBe(400);
+      expect(result.response[0].error).toBe(
+        `${SCHEMA_ERRORS.missingRequired}; ${NON_SCHEMA_ERROR}`,
+      );
+    });
+
+    it('emits both counters when a batch produces warned and aborted jobs together', () => {
+      const response = {
+        message: 'success',
+        errors: [
+          { type: SCHEMA_ERRORS.missingRequired, input_array: 'events', index: 0 },
+          { type: SCHEMA_ERRORS.missingRequired, input_array: 'events', index: 1 },
+        ],
+      };
+      // Index 0 holds an ecommerce event (warns); index 1 a legacy one (aborts).
+      const rudderJobMetadata = [
+        createMetadata(10, { eventsIndices: [0] }),
+        createMetadata(20, { eventsIndices: [1] }),
+      ];
+
+      const result = responseHandler({
+        destinationResponse: { response, status: 200 },
+        rudderJobMetadata,
+        destinationRequest: trackRequestFor(rudderJobMetadata, [
+          eventNamed(ECOM_ORDER_PLACED),
+          eventNamed(LEGACY_EVENT),
+        ]),
+      });
+
+      expect(result.response.map((r) => r.statusCode)).toEqual([296, 400]);
+      expect(mockStats.counter).toHaveBeenCalledWith(
+        'braze_delivered_with_warning',
+        1,
+        METRIC_LABELS,
+      );
+      expect(mockStats.counter).toHaveBeenCalledWith('braze_delivery_aborted', 1, METRIC_LABELS);
     });
   });
 
@@ -453,7 +673,7 @@ describe('Braze v1 networkHandler responseHandler', () => {
     it('throws TransformerProxyError with per-job entries at the 2xx HTTP status', () => {
       const response = {
         message: "Valid data must be provided in the 'attributes' field.",
-        errors: [{ type: "'external_id' is required", input_array: 'events', index: 0 }],
+        errors: [{ type: NON_SCHEMA_ERROR, input_array: 'events', index: 0 }],
       };
       const destinationResponse = { response, status: 200 };
       const rudderJobMetadata = [createMetadata(10)];

--- a/src/v1/destinations/braze/networkHandler.ts
+++ b/src/v1/destinations/braze/networkHandler.ts
@@ -5,19 +5,26 @@ import { TAG_NAMES } from '../../../v0/util/tags';
 import { isHttpStatusSuccess } from '../../../v0/util/index';
 import { HTTP_STATUS_CODES } from '../../../v0/util/constant';
 import stats from '../../../util/stats';
-import type {
-  DeliveryJobState,
-  DeliveryV1Response,
-  ProxyMetdata,
-  ProxyV1Request,
-} from '../../../types';
-import { BrazeError, BrazeResponseHandlerParams } from '../../../v0/destinations/braze/types';
+import type { DeliveryJobState, DeliveryV1Response, ProxyMetdata } from '../../../types';
+import {
+  BrazeError,
+  BrazeEvent,
+  BrazeProxyV1Request,
+  BrazeResponseHandlerParams,
+} from '../../../v0/destinations/braze/types';
+import { isBrazeEcommerceEventName } from '../../../v0/destinations/braze/ecommerceUtil';
 
 const DESTINATION = 'braze';
 
 const SUCCESS_MESSAGE = `Request for ${DESTINATION} Processed Successfully`;
 const failureMessage = (status: number): string =>
   `Request failed for ${DESTINATION} with status: ${status}`;
+
+// Ops-facing metric names — kept as constants so dashboards and alerts have a
+// single definition site to grep for.
+const METRIC_PARTIAL_FAILURE = 'braze_partial_failure';
+const METRIC_DELIVERED_WITH_WARNING = 'braze_delivered_with_warning';
+const METRIC_DELIVERY_ABORTED = 'braze_delivery_aborted';
 
 // Braze's `endpointPath` value for the /users/track endpoint — the only
 // endpoint whose response carries per-entry `errors[]` correlatable back to
@@ -44,11 +51,21 @@ const DEST_INFO_KEY: Record<TrackInputArray, string> = {
   purchases: 'purchasesIndices',
 };
 
+// Braze validates each recommended-ecommerce event against its ecommerce event
+// schema and reports violations in `errors[i].type`, prefixed with the failing
+// item's JSON pointer. Observed forms:
+//   The property '#/' did not contain a required property of 'product_id'
+//   The property '#/price' of type string did not match the following type: number
+// These are per-item payload defects — Braze kept the rest of the batch and
+// dropped only the offending item — so the owning job is delivered-with-warning
+// rather than aborted.
+const ECOMMERCE_SCHEMA_ERROR_TYPE = /^The property '#\//;
+
 // True when the delivery request was aimed at /users/track. Uses the
 // framework-populated `endpointPath` on the ProxyV1Request. Absence of the
 // field (or a request the framework didn't attach) is treated as non-track:
 // the handler falls back to uniform-per-job outcomes rather than mis-attributing.
-const isTrackEndpoint = (destinationRequest: ProxyV1Request | undefined): boolean =>
+const isTrackEndpoint = (destinationRequest: BrazeProxyV1Request | undefined): boolean =>
   destinationRequest?.endpointPath === TRACK_ENDPOINT_PATH;
 
 /**
@@ -103,54 +120,105 @@ const buildWarnedIndexMaps = (errors: BrazeError[]): Record<TrackInputArray, War
   return maps;
 };
 
+// A single warned position matched back to a job: which track sub-array it came
+// from, its index within that array, and Braze's verbatim `error.type`.
+type WarnedHit = {
+  inputArray: TrackInputArray;
+  index: number;
+  type: string;
+};
+
 // Correlate a single metadata against the warned index maps. Returns every
-// matching Braze `error.type` (verbatim) across the job's contributions to
-// events/attributes/purchases, preserving encounter order. Duplicates are
-// intentionally kept — each hit reflects a distinct warned payload item,
-// so the count carries information for downstream consumers.
-const collectMatchingErrorTypes = (
+// matching entry across the job's contributions to events/attributes/purchases,
+// preserving encounter order. Duplicates are intentionally kept — each hit
+// reflects a distinct warned payload item, so the count carries information for
+// downstream consumers.
+const collectWarnedHits = (
   metadata: ProxyMetdata,
   warned: Record<TrackInputArray, WarnedIndexMap>,
-): string[] => {
-  const hits: string[] = [];
+): WarnedHit[] => {
+  const hits: WarnedHit[] = [];
   for (const inputArray of TRACK_INPUT_ARRAYS) {
     const indices = readIndicesFor(metadata, inputArray);
     if (indices) {
-      for (const idx of indices) {
-        const errorType = warned[inputArray].get(idx);
-        if (errorType) hits.push(errorType);
+      for (const index of indices) {
+        const type = warned[inputArray].get(index);
+        if (type) hits.push({ inputArray, index, type });
       }
     }
   }
   return hits;
 };
 
+// The `events[]` we sent on this chunk, positionally aligned with Braze's
+// `errors[i].index`. `cleanTrackChunk` omits empty sub-arrays when building the
+// body, so an absent `events` is normal rather than a broken contract.
+const readSentEvents = (destinationRequest: BrazeProxyV1Request | undefined): BrazeEvent[] => {
+  const events = destinationRequest?.body?.JSON?.events;
+  // The body is an unvalidated echo of what we sent, so the declared type is a
+  // statement of intent rather than a guarantee — check before trusting it.
+  return Array.isArray(events) ? events : [];
+};
+
+// True when the item we sent at `index` was built by the recommended-ecommerce
+// path, identified by its Braze event name — only that path emits those names,
+// so it separates ecommerce events from the legacy custom events that share the
+// same `events[]` array after chunking.
+const isEcommerceEventAt = (sentEvents: BrazeEvent[], index: number): boolean =>
+  isBrazeEcommerceEventName(sentEvents[index]?.name);
+
+// A hit is delivered-with-warning only when it is a schema rejection of a
+// recommended-ecommerce event. Every other correlated failure aborts its job.
+const isEcommerceSchemaWarning = (hit: WarnedHit, sentEvents: BrazeEvent[]): boolean =>
+  hit.inputArray === 'events' &&
+  isEcommerceEventAt(sentEvents, hit.index) &&
+  ECOMMERCE_SCHEMA_ERROR_TYPE.test(hit.type);
+
 // Separator for concatenating multiple warned error.type strings on a single
-// 296 job — chosen for readability when the field is logged verbatim.
+// job — chosen for readability when the field is logged verbatim.
 const ERROR_TYPE_JOIN = '; ';
 
-// Map every metadata to its DeliveryJobState. Jobs that intersect at least
-// one warned index get 296 with all matching Braze error.type strings
-// concatenated (separated by `; `); others get 200 with the full response
-// body (matching the happy-path shape). Pure — the caller aggregates and
-// emits the delivered-with-warning metric after inspecting the result.
+// Map every metadata to its DeliveryJobState. Jobs that intersect no warned
+// index get 200 with the full response body (matching the happy-path shape);
+// the rest get 296 when every hit is an ecommerce schema rejection and 400
+// otherwise, carrying all matching Braze error.type strings concatenated.
+// Pure — the caller aggregates and emits the counters after inspecting the result.
 const buildTrackPartialFailureStates = (
   response: unknown,
   rudderJobMetadata: ProxyMetdata[],
   warned: Record<TrackInputArray, WarnedIndexMap>,
+  sentEvents: BrazeEvent[],
 ): DeliveryJobState[] => {
   const successBody = JSON.stringify(response) ?? '';
   return rudderJobMetadata.map((metadata) => {
-    const errorTypes = collectMatchingErrorTypes(metadata, warned);
-    if (errorTypes.length > 0) {
-      return {
-        statusCode: HTTP_STATUS_CODES.DELIVERED_WITH_WARNING,
-        metadata,
-        error: errorTypes.join(ERROR_TYPE_JOIN),
-      };
+    const hits = collectWarnedHits(metadata, warned);
+    if (hits.length === 0) {
+      return { statusCode: 200, metadata, error: successBody };
     }
-    return { statusCode: 200, metadata, error: successBody };
+    // Abort outranks warning: one non-ecommerce-schema hit aborts the whole
+    // job, though `error` still carries every hit that matched it.
+    const statusCode = hits.every((hit) => isEcommerceSchemaWarning(hit, sentEvents))
+      ? HTTP_STATUS_CODES.DELIVERED_WITH_WARNING
+      : HTTP_STATUS_CODES.BAD_REQUEST;
+    return { statusCode, metadata, error: hits.map((hit) => hit.type).join(ERROR_TYPE_JOIN) };
   });
+};
+
+type MetricLabels = { destinationId: string; workspaceId: string };
+
+// Emit `metricName` with the number of states carrying `statusCode`, skipping
+// the call entirely when nothing matched so the series stays absent rather than
+// reporting a zero.
+const countStatesByStatus = (
+  states: DeliveryJobState[],
+  statusCode: number,
+  metricName: string,
+  labels: MetricLabels,
+): void => {
+  const count = states.filter((state) => state.statusCode === statusCode).length;
+  if (count > 0) {
+    stats.counter(metricName, count, labels);
+  }
 };
 
 const responseHandler = (params: BrazeResponseHandlerParams): DeliveryV1Response => {
@@ -196,10 +264,8 @@ const responseHandler = (params: BrazeResponseHandlerParams): DeliveryV1Response
   if (hasErrors) {
     const destinationId = rudderJobMetadata[0]?.destinationId ?? '';
     const workspaceId = rudderJobMetadata[0]?.workspaceId ?? '';
-    stats.increment('braze_partial_failure', {
-      destination_id: destinationId,
-      workspace_id: workspaceId,
-    });
+    const labels: MetricLabels = { destinationId, workspaceId };
+    stats.increment(METRIC_PARTIAL_FAILURE, labels);
 
     // Only /users/track responses carry per-item errors correlatable back to
     // originating jobs. Subscription-groups and alias-merge responses surface
@@ -211,16 +277,19 @@ const responseHandler = (params: BrazeResponseHandlerParams): DeliveryV1Response
     // destInfo default to 200 inside the builder (nothing to correlate).
     if (isTrackEndpoint(destinationRequest)) {
       const warned = buildWarnedIndexMaps(errors);
-      const states = buildTrackPartialFailureStates(response, rudderJobMetadata, warned);
-      const warnedCount = states.filter(
-        (s) => s.statusCode === HTTP_STATUS_CODES.DELIVERED_WITH_WARNING,
-      ).length;
-      if (warnedCount > 0) {
-        stats.counter('braze_delivered_with_warning', warnedCount, {
-          destination_id: destinationId,
-          workspace_id: workspaceId,
-        });
-      }
+      const states = buildTrackPartialFailureStates(
+        response,
+        rudderJobMetadata,
+        warned,
+        readSentEvents(destinationRequest),
+      );
+      countStatesByStatus(
+        states,
+        HTTP_STATUS_CODES.DELIVERED_WITH_WARNING,
+        METRIC_DELIVERED_WITH_WARNING,
+        labels,
+      );
+      countStatesByStatus(states, HTTP_STATUS_CODES.BAD_REQUEST, METRIC_DELIVERY_ABORTED, labels);
       return { status, message: SUCCESS_MESSAGE, response: states };
     }
     // Non-track endpoint (sub/merge) — fall through to the uniform-200

--- a/src/v1/destinations/braze/networkHandler.ts
+++ b/src/v1/destinations/braze/networkHandler.ts
@@ -160,18 +160,14 @@ const readSentEvents = (destinationRequest: BrazeProxyV1Request | undefined): Br
   return Array.isArray(events) ? events : [];
 };
 
-// True when the item we sent at `index` was built by the recommended-ecommerce
-// path, identified by its Braze event name — only that path emits those names,
-// so it separates ecommerce events from the legacy custom events that share the
-// same `events[]` array after chunking.
-const isEcommerceEventAt = (sentEvents: BrazeEvent[], index: number): boolean =>
-  isBrazeEcommerceEventName(sentEvents[index]?.name);
-
 // A hit is delivered-with-warning only when it is a schema rejection of a
-// recommended-ecommerce event. Every other correlated failure aborts its job.
+// recommended-ecommerce event. The item is identified by its Braze event name:
+// only the recommended-ecommerce path emits those names, so it separates them
+// from the legacy custom events sharing the same `events[]` after chunking.
+// Every other correlated failure aborts its job.
 const isEcommerceSchemaWarning = (hit: WarnedHit, sentEvents: BrazeEvent[]): boolean =>
   hit.inputArray === 'events' &&
-  isEcommerceEventAt(sentEvents, hit.index) &&
+  isBrazeEcommerceEventName(sentEvents[hit.index]?.name) &&
   ECOMMERCE_SCHEMA_ERROR_TYPE.test(hit.type);
 
 // Separator for concatenating multiple warned error.type strings on a single

--- a/test/integrations/destinations/braze/common.ts
+++ b/test/integrations/destinations/braze/common.ts
@@ -120,3 +120,44 @@ export const buildProcessorInput = (message: Record<string, unknown>) => ({
     body: [{ destination: ecommerceDestination, message }],
   },
 });
+
+/**
+ * Shared fixtures for the v1 proxy (dataDelivery) scenarios that exercise the
+ * networkHandler's per-item correlation on /users/track. The response bodies
+ * live here so the network mock and the expected `error` strings in
+ * dataDelivery/business.ts are built from the same object — key order matters,
+ * since an uncorrelated job echoes `JSON.stringify(response)` verbatim.
+ */
+
+// Verbatim Braze error types. Only a schema rejection (prefixed with the failing
+// item's JSON pointer) of a recommended-ecommerce event in `events[]` yields a
+// 296; every other correlated failure aborts its job.
+export const BRAZE_ECOMMERCE_SCHEMA_ERROR =
+  "The property '#/' did not contain a required property of 'product_id'";
+export const BRAZE_PURCHASE_ERROR = "'quantity' is not valid";
+export const BRAZE_IDENTIFIER_ERROR =
+  "'external_id', 'braze_id', 'user_alias', 'email' or 'phone' is required";
+
+// A schema rejection of an ecommerce event alongside an unrelated purchase failure.
+export const ecommerceMixedResponse = {
+  message: 'success',
+  events_processed: 1,
+  errors: [
+    { type: BRAZE_ECOMMERCE_SCHEMA_ERROR, input_array: 'events', index: 0 },
+    { type: BRAZE_PURCHASE_ERROR, input_array: 'purchases', index: 0 },
+  ],
+};
+
+// The same schema rejection, but the item at events[0] is a legacy custom event.
+export const legacyEventSchemaResponse = {
+  message: 'success',
+  events_processed: 0,
+  errors: [{ type: BRAZE_ECOMMERCE_SCHEMA_ERROR, input_array: 'events', index: 0 }],
+};
+
+// A non-schema failure on a recommended-ecommerce event.
+export const ecommerceNonSchemaResponse = {
+  message: 'success',
+  events_processed: 0,
+  errors: [{ type: BRAZE_IDENTIFIER_ERROR, input_array: 'events', index: 0 }],
+};

--- a/test/integrations/destinations/braze/dataDelivery/business.ts
+++ b/test/integrations/destinations/braze/dataDelivery/business.ts
@@ -2,6 +2,14 @@ import { ProxyMetdata } from '../../../../../src/types';
 import { ProxyV1TestData } from '../../../testTypes';
 import { generateMetadata, generateProxyV1Payload } from '../../../testUtils';
 import { authHeader1 } from '../maskedSecrets';
+import {
+  BRAZE_ECOMMERCE_SCHEMA_ERROR,
+  BRAZE_IDENTIFIER_ERROR,
+  BRAZE_PURCHASE_ERROR,
+  ecommerceMixedResponse,
+  ecommerceNonSchemaResponse,
+  legacyEventSchemaResponse,
+} from '../common';
 
 const BRAZE_USERS_TRACK_ENDPOINT = 'https://rest.iad-03.braze.com/users/track';
 
@@ -125,6 +133,50 @@ const BrazePurchaseEvent = {
     alias_label: 'rudder_id',
   },
 };
+
+const STANDARD_USER_ALIAS = {
+  alias_name: 'ab7de609-9bec-8e1c-42cd-084a1cd93a4e',
+  alias_label: 'rudder_id',
+};
+
+// Recommended-ecommerce events, shaped as the `useEcommerceRecommendedEvents`
+// transform path emits them (see processor scenario T-I-06). Their `name` is
+// what lets the v1 networkHandler tell them apart from legacy custom events
+// sharing the same events[] after chunking.
+const BrazeEcommerceOrderPlaced = {
+  name: 'ecommerce.order_placed',
+  time: '2023-11-30T21:48:45.634Z',
+  properties: {
+    order_id: 'order-1',
+    total: 129.98,
+    currency: 'USD',
+    source: 'web',
+    products: [{ product_id: 'sku_42', price: 97.99, quantity: 1 }],
+  },
+  _update_existing_only: false,
+  user_alias: STANDARD_USER_ALIAS,
+};
+
+const BrazeEcommerceProductViewed = {
+  name: 'ecommerce.product_viewed',
+  time: '2023-11-30T21:48:45.634Z',
+  properties: {
+    product_id: 'sku_42',
+    product_name: 'Widget',
+    price: 9.99,
+    currency: 'USD',
+    source: 'web',
+  },
+  _update_existing_only: false,
+  user_alias: STANDARD_USER_ALIAS,
+};
+
+// generateMetadata takes no destInfo; the v1 networkHandler reads it to map
+// Braze's per-item errors back to the job that contributed that position.
+const metadataWithDestInfo = (jobId: number, destInfo: Record<string, number[]>): ProxyMetdata => ({
+  ...generateMetadata(jobId),
+  destInfo,
+});
 
 const metadataArray = [generateMetadata(1), generateMetadata(2), generateMetadata(3)];
 
@@ -370,6 +422,162 @@ export const testScenariosForV1API: ProxyV1TestData[] = [
             statTags: expectedStatTags,
             message: 'Request failed for braze with status: 401',
             status: 401,
+          },
+        },
+      },
+    },
+  },
+  {
+    id: 'braze_v1_scenario_5',
+    name: 'braze',
+    description:
+      '[Proxy v1 API] :: /users/track partial failure where Braze rejects a recommended-ecommerce event on schema grounds and a purchase separately',
+    successCriteria:
+      'Should return 296 for the job owning the rejected ecommerce event, 400 for the job owning the failed purchase, and 200 for the job whose event was accepted',
+    scenario: 'Business',
+    feature: 'dataDelivery',
+    module: 'destination',
+    version: 'v1',
+    input: {
+      request: {
+        body: generateProxyV1Payload(
+          {
+            JSON: {
+              partner,
+              events: [BrazeEcommerceOrderPlaced, BrazeEcommerceProductViewed],
+              purchases: [BrazePurchaseEvent],
+            },
+            headers,
+            endpoint: `${BRAZE_USERS_TRACK_ENDPOINT}/ecommerce_schema_mixed`,
+            endpointPath: 'users/track',
+          },
+          [
+            metadataWithDestInfo(1, { eventsIndices: [0] }),
+            metadataWithDestInfo(2, { purchasesIndices: [0] }),
+            metadataWithDestInfo(3, { eventsIndices: [1] }),
+          ],
+        ),
+        method: 'POST',
+      },
+    },
+    output: {
+      response: {
+        status: 200,
+        body: {
+          output: {
+            response: [
+              {
+                error: BRAZE_ECOMMERCE_SCHEMA_ERROR,
+                statusCode: 296,
+                metadata: metadataWithDestInfo(1, { eventsIndices: [0] }),
+              },
+              {
+                error: BRAZE_PURCHASE_ERROR,
+                statusCode: 400,
+                metadata: metadataWithDestInfo(2, { purchasesIndices: [0] }),
+              },
+              {
+                error: JSON.stringify(ecommerceMixedResponse),
+                statusCode: 200,
+                metadata: metadataWithDestInfo(3, { eventsIndices: [1] }),
+              },
+            ],
+            status: 200,
+            message: 'Request for braze Processed Successfully',
+          },
+        },
+      },
+    },
+  },
+  {
+    id: 'braze_v1_scenario_6',
+    name: 'braze',
+    description:
+      '[Proxy v1 API] :: /users/track schema rejection at events[0], where that item is a legacy custom event rather than a recommended-ecommerce one',
+    successCriteria:
+      'Should return 400, not 296 — the schema error only warrants a warning for recommended-ecommerce events',
+    scenario: 'Business',
+    feature: 'dataDelivery',
+    module: 'destination',
+    version: 'v1',
+    input: {
+      request: {
+        body: generateProxyV1Payload(
+          {
+            JSON: {
+              partner,
+              events: [BrazeEvent2],
+            },
+            headers,
+            endpoint: `${BRAZE_USERS_TRACK_ENDPOINT}/ecommerce_legacy_event`,
+            endpointPath: 'users/track',
+          },
+          [metadataWithDestInfo(1, { eventsIndices: [0] })],
+        ),
+        method: 'POST',
+      },
+    },
+    output: {
+      response: {
+        status: 200,
+        body: {
+          output: {
+            response: [
+              {
+                error: BRAZE_ECOMMERCE_SCHEMA_ERROR,
+                statusCode: 400,
+                metadata: metadataWithDestInfo(1, { eventsIndices: [0] }),
+              },
+            ],
+            status: 200,
+            message: 'Request for braze Processed Successfully',
+          },
+        },
+      },
+    },
+  },
+  {
+    id: 'braze_v1_scenario_7',
+    name: 'braze',
+    description:
+      '[Proxy v1 API] :: /users/track failure on a recommended-ecommerce event that is not a schema rejection',
+    successCriteria:
+      'Should return 400, not 296 — only schema rejections of ecommerce events are treated as delivered-with-warning',
+    scenario: 'Business',
+    feature: 'dataDelivery',
+    module: 'destination',
+    version: 'v1',
+    input: {
+      request: {
+        body: generateProxyV1Payload(
+          {
+            JSON: {
+              partner,
+              events: [BrazeEcommerceOrderPlaced],
+            },
+            headers,
+            endpoint: `${BRAZE_USERS_TRACK_ENDPOINT}/ecommerce_non_schema`,
+            endpointPath: 'users/track',
+          },
+          [metadataWithDestInfo(1, { eventsIndices: [0] })],
+        ),
+        method: 'POST',
+      },
+    },
+    output: {
+      response: {
+        status: 200,
+        body: {
+          output: {
+            response: [
+              {
+                error: BRAZE_IDENTIFIER_ERROR,
+                statusCode: 400,
+                metadata: metadataWithDestInfo(1, { eventsIndices: [0] }),
+              },
+            ],
+            status: 200,
+            message: 'Request for braze Processed Successfully',
           },
         },
       },

--- a/test/integrations/destinations/braze/network.ts
+++ b/test/integrations/destinations/braze/network.ts
@@ -1,4 +1,9 @@
 import { authHeader1, authHeader2 } from './maskedSecrets';
+import {
+  ecommerceMixedResponse,
+  ecommerceNonSchemaResponse,
+  legacyEventSchemaResponse,
+} from './common';
 const dataDeliveryMocksData = [
   {
     httpReq: {
@@ -617,6 +622,42 @@ const updatedDataDeliveryMocksData = [
         message: 'Invalid API Key',
       },
       status: 401,
+    },
+  },
+  {
+    description:
+      'Mock response depicting a /users/track partial failure: Braze rejects the recommended-ecommerce event at events[0] on schema grounds, and the purchase at purchases[0] separately',
+    httpReq: {
+      url: `${BRAZE_USERS_TRACK_ENDPOINT}/ecommerce_schema_mixed`,
+      method: 'POST',
+    },
+    httpRes: {
+      data: ecommerceMixedResponse,
+      status: 200,
+    },
+  },
+  {
+    description:
+      'Mock response depicting a /users/track schema rejection at events[0], where that item is a legacy custom event rather than a recommended-ecommerce one',
+    httpReq: {
+      url: `${BRAZE_USERS_TRACK_ENDPOINT}/ecommerce_legacy_event`,
+      method: 'POST',
+    },
+    httpRes: {
+      data: legacyEventSchemaResponse,
+      status: 200,
+    },
+  },
+  {
+    description:
+      'Mock response depicting a /users/track failure at events[0] that is not a schema rejection, on a recommended-ecommerce event',
+    httpReq: {
+      url: `${BRAZE_USERS_TRACK_ENDPOINT}/ecommerce_non_schema`,
+      method: 'POST',
+    },
+    httpRes: {
+      data: ecommerceNonSchemaResponse,
+      status: 200,
     },
   },
 ];


### PR DESCRIPTION
## What are the changes introduced in this PR?

The v1 Braze networkHandler emitted `296` (delivered-with-warning) for **any** per-item error it
could correlate back to a job on a `/users/track` partial-failure response. This narrows it.

A correlated hit now warrants 296 only when all three hold:

1. `errors[i].input_array === 'events'`
2. the item we sent at `errors[i].index` is a recommended-ecommerce event (matched on its Braze event name)
3. `errors[i].type` is a JSON-pointer schema rejection (`/^The property '#\//`)

| Correlated hits | Status |
| --- | --- |
| none | 200, full response body |
| all qualify | 296, joined `error.type` strings |
| any does not | 400, joined `error.type` strings |

Abort outranks warning on a mixed job; `error` still carries every hit, joined with `; `.

Also fixes `braze_partial_failure`, which was registered in `prometheus.js` with `labelNames: []`.
prom-client throws on undeclared labels and the stats wrapper swallows the throw into an error log,
so that counter has never incremented at all. It now declares `destinationId`/`workspaceId`.

## What is the related Linear task?

Resolves INT-7010

## Please explain the objectives of your changes below

Braze validates recommended-ecommerce events against its ecommerce event schema and rejects
individual items:

```
The property '#/' contains additional properties ["sku_abcd"] outside of the schema when none are allowed
The property '#/product_id' of type integer did not match the following type: string
The property '#/' did not contain a required property of 'product_id'
The property '#/price' of type string did not match the following type: number
```

For these Braze accepts the batch and drops only the offending item — a genuine
delivered-with-warning. Every other correlated failure (missing identifier, bad attribute, invalid
purchase) is a real drop and should abort the job so it surfaces as a failure.

The event-name check is what makes this precise: `events[]` is not purely ecommerce. Unmapped track
events fall through to the legacy path, and chunking merges several jobs' events into one array — so
gating on the `useEcommerceRecommendedEvents` config alone would mis-classify legacy events as
warnings.

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

Two:

1. **Jobs previously receiving 296 for non-ecommerce failures now abort with 400.** This covers
   `'external_id' is required` and every `attributes`/`purchases` failure. Reason: those are
   permanent per-item drops, and reporting them as delivered-with-warning hid real data loss.
2. **`braze_delivered_with_warning` label names move from snake_case to camelCase**
   (`destinationId`/`workspaceId`), matching the neighbouring `braze_audience_*` metrics. Existing
   queries on that metric need updating. `braze_partial_failure` never emitted and
   `braze_delivery_aborted` is new, so neither has dependants.

### Any new dependencies introduced with this change?

N/A

### Any new generic utility introduced or modified. Please explain the changes.

- `isBrazeEcommerceEventName` (`src/v0/destinations/braze/ecommerceUtil.ts`) — derived from the
  existing `ECOMMERCE_ROUTED_ENTRIES`, so adding an event to `ConfigCategory` extends it for free.
- `BrazeProxyV1Request` (`src/v0/destinations/braze/types.ts`) — narrows the proxy request's
  `body.JSON` to `BrazeTrackRequestBody`. Braze-local, not a framework change.
- `src/util/prometheus.js` is shared, but the edit is confined to the `braze_partial_failure`
  entry's `labelNames`.

### Any technical or performance related pointers to consider with the change?

Correlation reads `body.JSON.events[index]` off the proxy request, relying on the same positional
alignment that `destInfo` correlation already assumes. If alignment ever failed, the item would read
as non-ecommerce and the job would abort with 400 rather than be mis-attributed a 296 — the safe
failure direction.

The body is unvalidated wire input, so runtime guards stay in place (`Array.isArray` on `events`,
`typeof name === 'string'` inside the predicate). `BrazeProxyV1Request` documents intent; it does
not prove shape.

<hr>

### Developer checklist

- [x] My code follows the style guidelines of this project

- [ ] **No breaking changes are being introduced.**

- [ ] All related docs linked with the PR?

- [ ] All changes manually tested?

- [x] Is the PR limited to 10 file changes?

- [x] Is the PR limited to one linear task?

- [x] Are relevant unit and component test-cases added in **new readability format**?