### PR TITLE
feat(google_adwords_offline_conversions): surface per-conversion partial-failure details

### DIFF
--- a/src/v0/util/googleUtils/partialFailure.test.ts
+++ b/src/v0/util/googleUtils/partialFailure.test.ts
@@ -1,14 +1,14 @@
-import {
-  formatGoogleAdsErrors,
-  getErrorCodeLabel,
-  getFieldPath,
-  getOperationIndex,
-  parsePartialFailure,
-  GoogleAdsError,
-  PartialFailureError,
-} from './partialFailure';
+import { formatGoogleAdsErrors, parsePartialFailure } from './partialFailure';
 
-const failureWith = (errors: GoogleAdsError[], requestId?: string): PartialFailureError => ({
+// Shapes are declared locally rather than imported: the module exports only the two functions
+// under test, and nothing should be exported purely to give this file a handle on it.
+type TestError = {
+  errorCode?: Record<string, string>;
+  message?: string;
+  location?: { fieldPathElements?: { fieldName?: string; index?: number }[] };
+};
+
+const failureWith = (errors: TestError[], requestId?: string) => ({
   code: 3,
   message: 'summary message',
   details: [
@@ -20,76 +20,48 @@ const failureWith = (errors: GoogleAdsError[], requestId?: string): PartialFailu
   ],
 });
 
-describe('getErrorCodeLabel', () => {
-  it('flattens the errorCode oneof into a label', () => {
-    expect(getErrorCodeLabel({ errorCode: { internalError: 'INTERNAL_ERROR' } })).toBe(
-      'internalError: INTERNAL_ERROR',
-    );
-  });
+/** Which conversion an error gets attributed to, observed through the public parser. */
+const attributedIndex = (error: TestError): number | undefined => {
+  const { errorsByIndex, unindexedErrors } = parsePartialFailure(failureWith([error]));
+  return unindexedErrors.length > 0 ? undefined : [...errorsByIndex.keys()][0];
+};
 
-  it('returns undefined when errorCode is absent or not an object', () => {
-    expect(getErrorCodeLabel({})).toBeUndefined();
-    expect(getErrorCodeLabel({ errorCode: 'INTERNAL_ERROR' } as never)).toBeUndefined();
-  });
+const locatedAt = (fieldPathElements: { fieldName?: string; index?: number }[]): TestError => ({
+  location: { fieldPathElements },
 });
 
-describe('getOperationIndex', () => {
+describe('attributing an error to its conversion', () => {
   it('reads the index of the named operation field', () => {
-    const error = {
-      location: { fieldPathElements: [{ fieldName: 'conversions', index: 3 }] },
-    };
-    expect(getOperationIndex(error, 'conversions')).toBe(3);
+    expect(attributedIndex(locatedAt([{ fieldName: 'conversions', index: 3 }]))).toBe(3);
   });
 
   it('resolves index 0, which is the most common case', () => {
-    const error = {
-      location: { fieldPathElements: [{ fieldName: 'conversions', index: 0 }] },
-    };
-    expect(getOperationIndex(error, 'conversions')).toBe(0);
+    expect(attributedIndex(locatedAt([{ fieldName: 'conversions', index: 0 }]))).toBe(0);
   });
 
   it('resolves nested paths where the leaf element carries no index', () => {
-    const error = {
-      location: {
-        fieldPathElements: [
-          { fieldName: 'conversions', index: 1 },
-          { fieldName: 'conversion_action' },
-        ],
-      },
-    };
-    expect(getOperationIndex(error, 'conversions')).toBe(1);
-  });
-
-  it('falls back to the first indexed element when the field name does not match', () => {
-    const error = {
-      location: { fieldPathElements: [{ fieldName: 'conversion_adjustments', index: 2 }] },
-    };
-    expect(getOperationIndex(error, 'conversions')).toBe(2);
-  });
-
-  it('returns undefined when there is no location or no index', () => {
-    expect(getOperationIndex({}, 'conversions')).toBeUndefined();
     expect(
-      getOperationIndex(
-        { location: { fieldPathElements: [{ fieldName: 'conversion_action' }] } },
-        'conversions',
+      attributedIndex(
+        locatedAt([{ fieldName: 'conversions', index: 1 }, { fieldName: 'conversion_action' }]),
       ),
-    ).toBeUndefined();
+    ).toBe(1);
+  });
+
+  it('falls back to the outermost element when the field name does not match', () => {
+    // Keeps the util usable for conversion_adjustments (GAEC) without a second code path.
+    expect(attributedIndex(locatedAt([{ fieldName: 'conversion_adjustments', index: 2 }]))).toBe(2);
+  });
+
+  it('leaves an error request-wide when there is no location or no index', () => {
+    expect(attributedIndex({})).toBeUndefined();
+    expect(attributedIndex(locatedAt([{ fieldName: 'conversion_action' }]))).toBeUndefined();
   });
 
   it('ignores an index on a nested repeated field', () => {
     // conversions.user_identifiers[2] is identifier 2 of ONE conversion, not conversion 2.
     expect(
-      getOperationIndex(
-        {
-          location: {
-            fieldPathElements: [
-              { fieldName: 'conversions' },
-              { fieldName: 'user_identifiers', index: 2 },
-            ],
-          },
-        },
-        'conversions',
+      attributedIndex(
+        locatedAt([{ fieldName: 'conversions' }, { fieldName: 'user_identifiers', index: 2 }]),
       ),
     ).toBeUndefined();
   });
@@ -153,31 +125,11 @@ describe('parsePartialFailure', () => {
 
   it('returns empty results for malformed or missing input', () => {
     [undefined, {}, { details: 'nope' }, { details: [{}] }].forEach((input) => {
-      const parsed = parsePartialFailure(input as PartialFailureError);
+      const parsed = parsePartialFailure(input as never);
       expect(parsed.errorsByIndex.size).toBe(0);
       expect(parsed.unindexedErrors).toEqual([]);
       expect(parsed.requestId).toBeUndefined();
     });
-  });
-});
-
-describe('getFieldPath', () => {
-  it('renders indexed and scalar elements as a readable path', () => {
-    expect(
-      getFieldPath({
-        location: {
-          fieldPathElements: [
-            { fieldName: 'conversions', index: 1 },
-            { fieldName: 'conversion_action' },
-          ],
-        },
-      }),
-    ).toBe('conversions[1].conversion_action');
-  });
-
-  it('returns undefined when there is no usable location', () => {
-    expect(getFieldPath({})).toBeUndefined();
-    expect(getFieldPath({ location: { fieldPathElements: [] } })).toBeUndefined();
   });
 });
 
@@ -217,6 +169,23 @@ describe('formatGoogleAdsErrors', () => {
     ).toBe(
       'The conversion action cannot be found. [conversionUploadError: NO_CONVERSION_ACTION_FOUND] at conversions[1].conversion_action',
     );
+  });
+
+  it('omits the path and the code when Google reported neither', () => {
+    expect(formatGoogleAdsErrors([{ message: 'plain' }], 'fallback')).toBe('plain');
+    expect(
+      formatGoogleAdsErrors(
+        [{ message: 'plain', location: { fieldPathElements: [] } }],
+        'fallback',
+      ),
+    ).toBe('plain');
+    // An errorCode that is not the expected oneof object contributes nothing.
+    expect(
+      formatGoogleAdsErrors(
+        [{ message: 'plain', errorCode: 'INTERNAL_ERROR' } as never],
+        'fallback',
+      ),
+    ).toBe('plain');
   });
 
   it('joins multiple errors for the same event', () => {

--- a/src/v0/util/googleUtils/partialFailure.test.ts
+++ b/src/v0/util/googleUtils/partialFailure.test.ts
@@ -1,0 +1,261 @@
+import {
+  formatGoogleAdsErrors,
+  getErrorCodeLabel,
+  getFieldPath,
+  getOperationIndex,
+  parsePartialFailure,
+  GoogleAdsError,
+  PartialFailureError,
+} from './partialFailure';
+
+const failureWith = (errors: GoogleAdsError[], requestId?: string): PartialFailureError => ({
+  code: 3,
+  message: 'summary message',
+  details: [
+    {
+      '@type': 'type.googleapis.com/google.ads.googleads.v23.errors.GoogleAdsFailure',
+      errors,
+      ...(requestId ? { requestId } : {}),
+    },
+  ],
+});
+
+describe('getErrorCodeLabel', () => {
+  it('flattens the errorCode oneof into a label', () => {
+    expect(getErrorCodeLabel({ errorCode: { internalError: 'INTERNAL_ERROR' } })).toBe(
+      'internalError: INTERNAL_ERROR',
+    );
+  });
+
+  it('returns undefined when errorCode is absent or not an object', () => {
+    expect(getErrorCodeLabel({})).toBeUndefined();
+    expect(getErrorCodeLabel({ errorCode: 'INTERNAL_ERROR' } as never)).toBeUndefined();
+  });
+});
+
+describe('getOperationIndex', () => {
+  it('reads the index of the named operation field', () => {
+    const error = {
+      location: { fieldPathElements: [{ fieldName: 'conversions', index: 3 }] },
+    };
+    expect(getOperationIndex(error, 'conversions')).toBe(3);
+  });
+
+  it('resolves index 0, which is the most common case', () => {
+    const error = {
+      location: { fieldPathElements: [{ fieldName: 'conversions', index: 0 }] },
+    };
+    expect(getOperationIndex(error, 'conversions')).toBe(0);
+  });
+
+  it('resolves nested paths where the leaf element carries no index', () => {
+    const error = {
+      location: {
+        fieldPathElements: [
+          { fieldName: 'conversions', index: 1 },
+          { fieldName: 'conversion_action' },
+        ],
+      },
+    };
+    expect(getOperationIndex(error, 'conversions')).toBe(1);
+  });
+
+  it('falls back to the first indexed element when the field name does not match', () => {
+    const error = {
+      location: { fieldPathElements: [{ fieldName: 'conversion_adjustments', index: 2 }] },
+    };
+    expect(getOperationIndex(error, 'conversions')).toBe(2);
+  });
+
+  it('returns undefined when there is no location or no index', () => {
+    expect(getOperationIndex({}, 'conversions')).toBeUndefined();
+    expect(
+      getOperationIndex(
+        { location: { fieldPathElements: [{ fieldName: 'conversion_action' }] } },
+        'conversions',
+      ),
+    ).toBeUndefined();
+  });
+
+  it('ignores an index on a nested repeated field', () => {
+    // conversions.user_identifiers[2] is identifier 2 of ONE conversion, not conversion 2.
+    expect(
+      getOperationIndex(
+        {
+          location: {
+            fieldPathElements: [
+              { fieldName: 'conversions' },
+              { fieldName: 'user_identifiers', index: 2 },
+            ],
+          },
+        },
+        'conversions',
+      ),
+    ).toBeUndefined();
+  });
+});
+
+describe('parsePartialFailure', () => {
+  it('groups errors by conversion index and picks up the request id', () => {
+    const partialFailureError = failureWith(
+      [
+        {
+          errorCode: { conversionUploadError: 'NO_CONVERSION_ACTION_FOUND' },
+          message: 'The conversion action cannot be found.',
+          location: {
+            fieldPathElements: [
+              { fieldName: 'conversions', index: 1 },
+              { fieldName: 'conversion_action' },
+            ],
+          },
+        },
+        {
+          errorCode: { internalError: 'INTERNAL_ERROR' },
+          message: 'An internal error has occurred.',
+          location: { fieldPathElements: [{ fieldName: 'conversions', index: 4 }] },
+        },
+      ],
+      'f4J_sjHfhbgNieU4pkBOqg',
+    );
+
+    const { errorsByIndex, unindexedErrors, requestId } = parsePartialFailure(partialFailureError);
+
+    expect(requestId).toBe('f4J_sjHfhbgNieU4pkBOqg');
+    expect(unindexedErrors).toEqual([]);
+    expect(errorsByIndex.get(1)?.[0]?.message).toBe('The conversion action cannot be found.');
+    expect(errorsByIndex.get(4)?.[0]?.errorCode).toEqual({ internalError: 'INTERNAL_ERROR' });
+  });
+
+  it('collects several errors reported against the same conversion', () => {
+    const partialFailureError = failureWith([
+      {
+        message: 'first',
+        location: { fieldPathElements: [{ fieldName: 'conversions', index: 0 }] },
+      },
+      {
+        message: 'second',
+        location: { fieldPathElements: [{ fieldName: 'conversions', index: 0 }] },
+      },
+    ]);
+
+    expect(parsePartialFailure(partialFailureError).errorsByIndex.get(0)).toHaveLength(2);
+  });
+
+  it('treats errors without a location as request-wide', () => {
+    const partialFailureError = failureWith([
+      { errorCode: { conversionAdjustmentUploadError: 'CONVERSION_ALREADY_ENHANCED' } },
+    ]);
+
+    const { errorsByIndex, unindexedErrors } = parsePartialFailure(partialFailureError);
+    expect(errorsByIndex.size).toBe(0);
+    expect(unindexedErrors).toHaveLength(1);
+  });
+
+  it('returns empty results for malformed or missing input', () => {
+    [undefined, {}, { details: 'nope' }, { details: [{}] }].forEach((input) => {
+      const parsed = parsePartialFailure(input as PartialFailureError);
+      expect(parsed.errorsByIndex.size).toBe(0);
+      expect(parsed.unindexedErrors).toEqual([]);
+      expect(parsed.requestId).toBeUndefined();
+    });
+  });
+});
+
+describe('getFieldPath', () => {
+  it('renders indexed and scalar elements as a readable path', () => {
+    expect(
+      getFieldPath({
+        location: {
+          fieldPathElements: [
+            { fieldName: 'conversions', index: 1 },
+            { fieldName: 'conversion_action' },
+          ],
+        },
+      }),
+    ).toBe('conversions[1].conversion_action');
+  });
+
+  it('returns undefined when there is no usable location', () => {
+    expect(getFieldPath({})).toBeUndefined();
+    expect(getFieldPath({ location: { fieldPathElements: [] } })).toBeUndefined();
+  });
+});
+
+describe('formatGoogleAdsErrors', () => {
+  it('renders the message with its error code and the request id', () => {
+    expect(
+      formatGoogleAdsErrors(
+        [
+          {
+            errorCode: { internalError: 'INTERNAL_ERROR' },
+            message: 'An internal error occurred.',
+          },
+        ],
+        'fallback',
+        'req-1',
+      ),
+    ).toBe('An internal error occurred. [internalError: INTERNAL_ERROR] (requestId: req-1)');
+  });
+
+  it('keeps the field path Google reported for the failing conversion', () => {
+    expect(
+      formatGoogleAdsErrors(
+        [
+          {
+            errorCode: { conversionUploadError: 'NO_CONVERSION_ACTION_FOUND' },
+            message: 'The conversion action cannot be found.',
+            location: {
+              fieldPathElements: [
+                { fieldName: 'conversions', index: 1 },
+                { fieldName: 'conversion_action' },
+              ],
+            },
+          },
+        ],
+        'fallback',
+      ),
+    ).toBe(
+      'The conversion action cannot be found. [conversionUploadError: NO_CONVERSION_ACTION_FOUND] at conversions[1].conversion_action',
+    );
+  });
+
+  it('joins multiple errors for the same event', () => {
+    expect(formatGoogleAdsErrors([{ message: 'a' }, { message: 'b' }], 'fallback')).toBe('a; b');
+  });
+
+  it('falls back to the summary message when there is nothing more specific', () => {
+    expect(formatGoogleAdsErrors([], 'fallback')).toBe('fallback');
+    expect(formatGoogleAdsErrors(undefined, 'fallback', 'req-1')).toBe(
+      'fallback (requestId: req-1)',
+    );
+  });
+
+  it('does not splice the batch summary next to a specific code', () => {
+    // The summary describes the FIRST error in the batch, so pairing it with another error's
+    // code would attribute the wrong cause.
+    expect(
+      formatGoogleAdsErrors([{ errorCode: { internalError: 'INTERNAL_ERROR' } }], 'summary'),
+    ).toBe('[internalError: INTERNAL_ERROR]');
+  });
+
+  it('caps how many errors are rendered per event', () => {
+    const errors = Array.from({ length: 10 }, (_, i) => ({ message: `e${i}` }));
+    expect(formatGoogleAdsErrors(errors, 'fallback')).toBe('e0; e1; e2; (+7 more)');
+  });
+
+  it('truncates without losing the request id or the dropped-error count', () => {
+    const errors = Array.from({ length: 10 }, () => ({ message: 'x'.repeat(5000) }));
+    const formatted = formatGoogleAdsErrors(errors, 'fallback', 'req-1');
+    expect(formatted.length).toBeLessThan(1200);
+    expect(formatted).toContain('(truncated)');
+    expect(formatted).toContain('(+7 more)');
+    expect(formatted.endsWith('(requestId: req-1)')).toBe(true);
+  });
+
+  it('stays bounded when a request-wide error set is replayed onto every event', () => {
+    const errors = Array.from({ length: 2000 }, () => ({
+      message: 'An internal error has occurred.',
+    }));
+    expect(formatGoogleAdsErrors(errors, 'fallback').length).toBeLessThan(200);
+  });
+});

--- a/src/v0/util/googleUtils/partialFailure.ts
+++ b/src/v0/util/googleUtils/partialFailure.ts
@@ -1,0 +1,199 @@
+/**
+ * Helpers for reading Google Ads API partial-failure responses.
+ *
+ * On a partial failure the API replies with HTTP 200 and a `partialFailureError` of type
+ * google.rpc.Status. Its `details` array carries GoogleAdsFailure payloads; each
+ * GoogleAdsError inside names the specific error enum, carries its own human-readable
+ * message, and points at the operation that failed via `location.fieldPathElements`.
+ *
+ * `partialFailureError.message` only ever summarises the FIRST error, e.g.
+ * "Multiple errors in 'details'. First error: An internal error has occurred., at conversions[15]".
+ * Stamping that single string onto every failed event loses the per-event cause, the error
+ * enum (which is what says whether Google considers the failure retryable) and the request
+ * id Google asks for when escalating.
+ *
+ * `trigger` is deliberately NOT surfaced: it echoes the value that caused the error, which
+ * for conversion uploads can be a hashed email or a click id, and these strings are persisted
+ * in error reporting.
+ *
+ * Refs:
+ * - https://developers.google.com/google-ads/api/docs/best-practices/partial-failures
+ * - https://github.com/googleapis/googleapis/blob/master/google/ads/googleads/v23/errors/errors.proto
+ */
+
+export type FieldPathElement = {
+  fieldName?: string;
+  /** Only set for repeated fields; absent for leaf scalars such as `conversion_action`. */
+  index?: number;
+};
+
+export type GoogleAdsError = {
+  /** A oneof, so exactly one key is set, e.g. `{ internalError: 'INTERNAL_ERROR' }`. */
+  errorCode?: Record<string, string>;
+  message?: string;
+  location?: {
+    fieldPathElements?: FieldPathElement[];
+  };
+};
+
+export type GoogleAdsFailure = {
+  /** e.g. `type.googleapis.com/google.ads.googleads.v23.errors.GoogleAdsFailure` */
+  '@type'?: string;
+  errors?: GoogleAdsError[];
+  requestId?: string;
+};
+
+export type PartialFailureError = {
+  code?: number;
+  message?: string;
+  details?: GoogleAdsFailure[];
+};
+
+export type ParsedPartialFailure = {
+  /** Errors keyed by the 0-based index of the operation they belong to. */
+  errorsByIndex: Map<number, GoogleAdsError[]>;
+  /** Errors carrying no operation index, so they apply to the request as a whole. */
+  unindexedErrors: GoogleAdsError[];
+  requestId?: string;
+};
+
+/**
+ * Flattens the `errorCode` oneof into an `internalError: INTERNAL_ERROR` label.
+ */
+export const getErrorCodeLabel = (error: GoogleAdsError): string | undefined => {
+  const { errorCode } = error ?? {};
+  if (!errorCode || typeof errorCode !== 'object') {
+    return undefined;
+  }
+  const entry = Object.entries(errorCode).find(([, value]) => typeof value === 'string');
+  return entry ? `${entry[0]}: ${entry[1]}` : undefined;
+};
+
+/**
+ * Resolves which operation an error belongs to. Prefers the element naming `operationField`
+ * (e.g. `conversions`) so nested paths such as `conversions[3].conversion_action` resolve to 3.
+ *
+ * The fallback only considers the FIRST element, because the operation index is always on the
+ * outermost repeated field. Scanning every element would mis-attribute an error whose outer
+ * element carries no index but whose nested one does — `conversions.user_identifiers[2]` would
+ * otherwise be read as operation 2.
+ */
+export const getOperationIndex = (
+  error: GoogleAdsError,
+  operationField: string,
+): number | undefined => {
+  const elements = error?.location?.fieldPathElements;
+  if (!Array.isArray(elements)) {
+    return undefined;
+  }
+  const named = elements.find(
+    (element) => element?.fieldName === operationField && Number.isInteger(element?.index),
+  );
+  const outermost = Number.isInteger(elements[0]?.index) ? elements[0] : undefined;
+  return named?.index ?? outermost?.index;
+};
+
+/**
+ * Renders the location as a readable field path, e.g. `conversions[1].conversion_action`, so the
+ * offending field survives alongside the error code.
+ */
+export const getFieldPath = (error: GoogleAdsError): string | undefined => {
+  const elements = error?.location?.fieldPathElements;
+  if (!Array.isArray(elements)) {
+    return undefined;
+  }
+  const path = elements
+    .filter((element) => element?.fieldName)
+    .map((element) =>
+      Number.isInteger(element?.index)
+        ? `${element.fieldName}[${element.index}]`
+        : element.fieldName,
+    )
+    .join('.');
+  return path || undefined;
+};
+
+/**
+ * Groups the individual GoogleAdsErrors of a partial failure by the operation they refer to.
+ */
+export const parsePartialFailure = (
+  partialFailureError: PartialFailureError | undefined,
+  operationField = 'conversions',
+): ParsedPartialFailure => {
+  const errorsByIndex = new Map<number, GoogleAdsError[]>();
+  const unindexedErrors: GoogleAdsError[] = [];
+  let requestId: string | undefined;
+
+  const details = Array.isArray(partialFailureError?.details) ? partialFailureError.details : [];
+  details.forEach((detail) => {
+    requestId = requestId ?? detail?.requestId;
+    const errors = Array.isArray(detail?.errors) ? detail.errors : [];
+    errors.forEach((error) => {
+      const index = getOperationIndex(error, operationField);
+      if (typeof index !== 'number') {
+        unindexedErrors.push(error);
+        return;
+      }
+      const existing = errorsByIndex.get(index);
+      if (existing) {
+        existing.push(error);
+      } else {
+        errorsByIndex.set(index, [error]);
+      }
+    });
+  });
+
+  return { errorsByIndex, unindexedErrors, requestId };
+};
+
+/**
+ * Request-wide errors are replayed onto every failed event, so a response carrying many of them
+ * would otherwise be rendered once per event — O(events x errors). These caps keep the size of
+ * what we emit independent of what the destination returns.
+ */
+export const MAX_ERRORS_PER_EVENT = 3;
+export const MAX_ERROR_LENGTH = 1024;
+
+const describeError = (error: GoogleAdsError, fallbackMessage: string): string => {
+  const code = getErrorCodeLabel(error);
+  const fieldPath = getFieldPath(error);
+  // Only fall back to the batch summary when Google gave us nothing specific at all. Splicing it
+  // in beside a code or path would describe a different error than the one being annotated.
+  const parts = [error?.message || (code || fieldPath ? '' : fallbackMessage)];
+  if (code) {
+    parts.push(`[${code}]`);
+  }
+  if (fieldPath) {
+    parts.push(`at ${fieldPath}`);
+  }
+  return parts.filter(Boolean).join(' ');
+};
+
+/**
+ * Renders the errors for a single failed event, falling back to the summary message when
+ * Google gave us nothing more specific. The request id is appended so it reaches error
+ * reporting, where it is the only handle Google support can act on.
+ */
+export const formatGoogleAdsErrors = (
+  errors: GoogleAdsError[] | undefined,
+  fallbackMessage: string,
+  requestId?: string,
+): string => {
+  const all = errors ?? [];
+  const described = all
+    .slice(0, MAX_ERRORS_PER_EVENT)
+    .map((error) => describeError(error, fallbackMessage))
+    .filter(Boolean);
+
+  let summary = described.length > 0 ? described.join('; ') : fallbackMessage;
+  if (summary.length > MAX_ERROR_LENGTH) {
+    summary = `${summary.slice(0, MAX_ERROR_LENGTH)}... (truncated)`;
+  }
+  // Appended after truncation so the dropped-error count and the request id, both of which are
+  // short and load-bearing for debugging, cannot be the parts that get cut.
+  const omitted = all.length - MAX_ERRORS_PER_EVENT;
+  if (omitted > 0) {
+    summary = `${summary}; (+${omitted} more)`;
+  }
+  return requestId ? `${summary} (requestId: ${requestId})` : summary;
+};

--- a/src/v0/util/googleUtils/partialFailure.ts
+++ b/src/v0/util/googleUtils/partialFailure.ts
@@ -21,13 +21,13 @@
  * - https://github.com/googleapis/googleapis/blob/master/google/ads/googleads/v23/errors/errors.proto
  */
 
-export type FieldPathElement = {
+type FieldPathElement = {
   fieldName?: string;
   /** Only set for repeated fields; absent for leaf scalars such as `conversion_action`. */
   index?: number;
 };
 
-export type GoogleAdsError = {
+type GoogleAdsError = {
   /** A oneof, so exactly one key is set, e.g. `{ internalError: 'INTERNAL_ERROR' }`. */
   errorCode?: Record<string, string>;
   message?: string;
@@ -36,20 +36,20 @@ export type GoogleAdsError = {
   };
 };
 
-export type GoogleAdsFailure = {
+type GoogleAdsFailure = {
   /** e.g. `type.googleapis.com/google.ads.googleads.v23.errors.GoogleAdsFailure` */
   '@type'?: string;
   errors?: GoogleAdsError[];
   requestId?: string;
 };
 
-export type PartialFailureError = {
+type PartialFailureError = {
   code?: number;
   message?: string;
   details?: GoogleAdsFailure[];
 };
 
-export type ParsedPartialFailure = {
+type ParsedPartialFailure = {
   /** Errors keyed by the 0-based index of the operation they belong to. */
   errorsByIndex: Map<number, GoogleAdsError[]>;
   /** Errors carrying no operation index, so they apply to the request as a whole. */
@@ -60,7 +60,7 @@ export type ParsedPartialFailure = {
 /**
  * Flattens the `errorCode` oneof into an `internalError: INTERNAL_ERROR` label.
  */
-export const getErrorCodeLabel = (error: GoogleAdsError): string | undefined => {
+const getErrorCodeLabel = (error: GoogleAdsError): string | undefined => {
   const { errorCode } = error ?? {};
   if (!errorCode || typeof errorCode !== 'object') {
     return undefined;
@@ -78,10 +78,7 @@ export const getErrorCodeLabel = (error: GoogleAdsError): string | undefined => 
  * element carries no index but whose nested one does — `conversions.user_identifiers[2]` would
  * otherwise be read as operation 2.
  */
-export const getOperationIndex = (
-  error: GoogleAdsError,
-  operationField: string,
-): number | undefined => {
+const getOperationIndex = (error: GoogleAdsError, operationField: string): number | undefined => {
   const elements = error?.location?.fieldPathElements;
   if (!Array.isArray(elements)) {
     return undefined;
@@ -97,7 +94,7 @@ export const getOperationIndex = (
  * Renders the location as a readable field path, e.g. `conversions[1].conversion_action`, so the
  * offending field survives alongside the error code.
  */
-export const getFieldPath = (error: GoogleAdsError): string | undefined => {
+const getFieldPath = (error: GoogleAdsError): string | undefined => {
   const elements = error?.location?.fieldPathElements;
   if (!Array.isArray(elements)) {
     return undefined;
@@ -151,8 +148,8 @@ export const parsePartialFailure = (
  * would otherwise be rendered once per event — O(events x errors). These caps keep the size of
  * what we emit independent of what the destination returns.
  */
-export const MAX_ERRORS_PER_EVENT = 3;
-export const MAX_ERROR_LENGTH = 1024;
+const MAX_ERRORS_PER_EVENT = 3;
+const MAX_ERROR_LENGTH = 1024;
 
 const describeError = (error: GoogleAdsError, fallbackMessage: string): string => {
   const code = getErrorCodeLabel(error);

--- a/src/v1/destinations/google_adwords_offline_conversions/networkHandler.js
+++ b/src/v1/destinations/google_adwords_offline_conversions/networkHandler.js
@@ -4,6 +4,10 @@ const { isHttpStatusSuccess, isEmptyObject } = require('../../../v0/util');
 const { destType } = require('../../../v0/destinations/google_adwords_offline_conversions/config');
 const { getDeveloperToken, getAuthErrCategory } = require('../../../v0/util/googleUtils');
 const { processAxiosResponse } = require('../../../adapters/utils/networkUtils');
+const {
+  parsePartialFailure,
+  formatGoogleAdsErrors,
+} = require('../../../v0/util/googleUtils/partialFailure');
 const { CommonUtils } = require('../../../util/common');
 
 /**
@@ -169,13 +173,33 @@ const responseHandler = (responseParams) => {
   // Ref - https://github.com/googleapis/googleapis/blob/master/google/rpc/code.proto
   if (partialFailureError && partialFailureError.code !== 0) {
     const errorMessage = partialFailureError.message || 'unknown error format';
+    // partialFailureError.message only summarises the first error. Google reports the cause of
+    // each individual conversion in details[].errors[], keyed by location.fieldPathElements, so
+    // resolve every failed event to its own error code and message instead of repeating the
+    // summary. Ref - https://developers.google.com/google-ads/api/docs/best-practices/partial-failures
+    const { errorsByIndex, unindexedErrors, requestId } = parsePartialFailure(partialFailureError);
+    // Google indexes its errors against the conversions array of the request it answered, which is
+    // not always this metadata array: combineBatchRequestsWithSameJobIds can merge two differently
+    // sized requests under one metadata array, and removeDuplicateMetadata sorts that metadata by
+    // jobId while the conversions keep router order.
+    // This length check catches the size mismatch only -- it cannot detect a pure reordering, so
+    // treat it as a floor on correctness rather than a guarantee. When it trips we fall back to the
+    // request-wide errors, which carry no positional claim.
+    const isIndexAligned = Array.isArray(results) && results.length === metaDataArray.length;
     const responseWithIndividualEvents = metaDataArray.map((metadata, i) => {
       const eventResponse = results?.[i] ?? {};
       const isEventFailed = isEmptyObject(eventResponse);
+      // Errors without an index apply to the request as a whole, so they stand in for events
+      // Google did not attribute individually.
+      const eventErrors = isIndexAligned
+        ? (errorsByIndex.get(i) ?? unindexedErrors)
+        : unindexedErrors;
       return {
         statusCode: isEventFailed ? 400 : 200,
         metadata,
-        error: isEventFailed ? errorMessage : 'success',
+        error: isEventFailed
+          ? formatGoogleAdsErrors(eventErrors, errorMessage, requestId)
+          : 'success',
       };
     });
 

--- a/test/integrations/destinations/google_adwords_offline_conversions/dataDelivery/business.ts
+++ b/test/integrations/destinations/google_adwords_offline_conversions/dataDelivery/business.ts
@@ -521,7 +521,7 @@ export const testScenariosForV1API = [
             response: [
               {
                 error:
-                  'Customer is not allowlisted for accessing this feature., at conversions[0].conversion_environment',
+                  'Customer is not allowlisted for accessing this feature. [notAllowlistedError: CUSTOMER_NOT_ALLOWLISTED_FOR_THIS_FEATURE] at conversions[0].conversion_environment (requestId: dummyRequestId)',
                 metadata: generateMetadata(1),
                 statusCode: 400,
               },
@@ -664,7 +664,7 @@ export const testScenariosForV1API = [
               },
               {
                 error:
-                  "The conversion action specified in the upload request cannot be found. Make sure it's available in this account., at conversions[1].conversion_action",
+                  "The conversion action specified in the upload request cannot be found. Make sure it's available in this account. [conversionUploadError: NO_CONVERSION_ACTION_FOUND] at conversions[1].conversion_action (requestId: f4J_sjHfhbgNieU4pkBOqg)",
                 metadata: generateMetadata(2),
                 statusCode: 400,
               },


### PR DESCRIPTION
## What are the changes introduced in this PR?

When Google Ads rejects some conversions in a batch it replies **HTTP 200** with a `partialFailureError` (a `google.rpc.Status`). Its `details[].errors[]` carry, per conversion: the specific `errorCode` enum, that conversion's own `message`, the `location` of the offending field, and the `requestId`.

The v1 GAOC response handler used only `partialFailureError.message` — which by construction describes just the **first** error — and stamped that one string onto **every** failed event in the batch. Everything else was dropped before it reached error reporting.

This PR parses the structured details and gives each failed event its own error:

```
before: Multiple errors in 'details'. First error: An internal error has occurred., at conversions[15]
after:  An internal error has occurred. [internalError: INTERNAL_ERROR] at conversions[15] (requestId: f4J_sjHfhbgNieU4pkBOqg)
```

New shared util `src/v0/util/googleUtils/partialFailure.ts` (`parsePartialFailure` / `formatGoogleAdsErrors`), wired into the GAOC v1 `networkHandler`.

## What is the related Linear task?

N/A — came out of a support investigation into `An internal error has occurred., at conversions[N]` on GOOGLE_ADWORDS_OFFLINE_CONVERSIONS.

## Please explain the objectives of your changes below

That error is currently **225,692 events across 92 destinations / 67 workspaces in 14 days**, and its rate co-moves across unrelated Google Ads accounts (0.51% → 6.82% of delivery attempts while traffic stayed flat), which points at Google's side rather than customer payloads.

We could not confirm that from our own data, because we discard exactly the fields needed to:

1. **Tell which documented error it is.** Google documents `InternalErrorEnum.InternalError`; `INTERNAL_ERROR` and `TRANSIENT_ERROR` are both explicitly retryable ([Error Types](https://developers.google.com/google-ads/api/docs/best-practices/error-types)). Without `errorCode` we cannot tell which we are being sent — and therefore cannot justify a retry policy.
2. **Escalate to Google.** Google asks for the request id when reporting an issue; we were dropping it.
3. **Tell events apart.** Every failed event in a batch got an identical message naming one conversion's index, so a customer debugging event #15 saw an error about event #1.

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

**Diagnostic only — delivery semantics are unchanged.** `statusCode` (400/200 per event), `status`, `statTags` and the success path are byte-for-byte identical. Only the per-event `error` **string** changes. Making these failures retryable is deliberately **not** in this PR: it would change delivery behaviour for 92 destinations and deserves its own review.

Two proxy fixtures were updated for the richer strings. The raw Google response echoed under `destinationResponse` is deliberately left untouched.

### Any new dependencies introduced with this change?

N/A

### Any new generic utility introduced or modified. Please explain the changes.

New `src/v0/util/googleUtils/partialFailure.ts`. It is destination-agnostic (`operationField` is a parameter, defaulting to `conversions`) so `google_adwords_enhanced_conversions`, which has the identical gap with `conversion_adjustments`, can adopt it without a move. Only GAOC is wired here.

### Any technical or performance related pointers to consider with the change?

Three correctness guards worth reviewer attention, all added in response to review:

- **Batch misalignment.** `combineBatches` (`src/v0/util/index.js`) can merge two differently sized requests under one deduped, re-sorted metadata array, so `metaDataArray[i]` does not always correspond to Google's `conversions[i]`. Positional attribution is therefore applied **only** when `results.length === metaDataArray.length`; otherwise we fall back to request-wide errors so no event is blamed for another's failure. (The pre-existing `results?.[i]` statusCode mapping has the same exposure; this PR does not widen it.)
- **Bounded output.** Request-wide errors are replayed onto every failed event, which is O(events x errors); with `MAX_CONVERSIONS_PER_BATCH = 2000` that is a plausible response blow-up. Capped at `MAX_ERRORS_PER_EVENT = 3` (`(+N more)`) and `MAX_ERROR_LENGTH = 1024`, with the request id appended after truncation so it always survives.
- **Index resolution.** Only the outermost path element is used as the operation index, so `conversions.user_identifiers[2]` is not misread as conversion 2.

**PII:** Google's `trigger` field echoes the value that caused the error (can be a hashed email or click id) and is deliberately **never** put into the per-event `error` string — only `message`, `errorCode`, field path and `requestId`. Verified end-to-end: a mock response carrying a sentinel `trigger` value produced error strings with no trace of it. Note for precision that `trigger` *is* still present in the raw `destinationResponse` echoed alongside the response — that is **pre-existing** behaviour, identical on the old image, and untouched here.

### E2E verification against the live Google Ads API

Run on the local `mini` stack with the transformer built from this branch, proxying to the **real** Google Ads v23 API (customer `4219454086`, real OAuth account), and compared against the stock `v1.133.2` image with the byte-identical request.

Batch of two conversions, both crafted to fail so **nothing is written to the account** (Google returned `results: [{}, {}]`, confirmed): `conversions[0]` has a valid `UPLOAD_CLICKS` conversion action but an unparseable gclid; `conversions[1]` is identifier-only.

Google's real `partialFailureError.message` names only the first error, the gclid one. Result:

```
OLD  job 201 [400] Multiple errors in 'details'. First error: The imported gclid could not be decoded...
OLD  job 202 [400] Multiple errors in 'details'. First error: The imported gclid could not be decoded...
                   ^ job 202 has NO gclid at all -- it is told to fix a field it never sent

NEW  job 201 [400] The imported gclid could not be decoded... [conversionUploadError: UNPARSEABLE_GCLID]
                   at conversions[0].gclid (requestId: DJDJHdnP4xEeAU-CvwA6zg)
NEW  job 202 [400] Make sure you've turned on enhanced conversions for leads...
                   [conversionUploadError: CUSTOMER_NOT_ENABLED_ENHANCED_CONVERSIONS_FOR_LEADS]
                   at conversions[1].user_identifiers (requestId: DJDJHdnP4xEeAU-CvwA6zg)
```

Verified in the same live run:

- **Delivery semantics unchanged** — `statusCode` identical on both images (`[400, 400]`).
- **PII holds against real data** — Google really did return a `trigger` (`{"stringValue": "THIS-IS-NOT-A-REAL-GCLID"}`); that value appears nowhere in the per-event error strings.
- **Misalignment guard** — replaying with 1 metadata entry against 2 conversions correctly fell back to the summary instead of making a wrong positional claim.
- **Cap** — 10 request-wide errors render as 3 + `(+7 more)`, 252 chars, request id preserved.

**Memory:** previously all failed events in a batch shared one string *reference*; they now each hold their own. Worst case with the caps is ~1.1 KB/event, so ~2.2 MB for a 2000-event batch — bounded, but not free.

## Known review findings (not fixed here)

Surfaced by review and consciously left out of scope:

1. **The alignment guard detects a size mismatch, not a reordering.** `removeDuplicateMetadata` sorts metadata by `jobId` while `conversions` keep router order, so if router input is ever not jobId-ascending, lengths can match while positions do not. Fully closing this needs a per-index jobId cross-check, which the Google response does not give us. The guard is a floor, not a guarantee, and the code comment says so.
2. **`statusCode` is still assigned positionally even when the guard trips.** `results?.[i]` decides 400 vs 200 regardless of alignment, so in a merged batch the wrong event can still be marked failed. This is **pre-existing** and unchanged by this PR — the new guard just makes it visible. It is the more consequential half (abort vs deliver) and probably deserves its own fix.
3. **`INTERNAL_ERROR`/`TRANSIENT_ERROR` are still aborted as 400 and never retried**, despite Google documenting them as retryable. That is the actual data-loss bug behind the 225K events; deliberately excluded here because it changes delivery behaviour fleet-wide.

### Developer checklist

- [x] My code follows the style guidelines of this project
- [x] **No breaking changes are being introduced.**
- [ ] All related docs linked with the PR?
- [x] All changes manually tested?
