### PR TITLE
fix(google_adwords_offline_conversions): retry transient partial-failure conversions

### DIFF
--- a/src/v0/util/googleUtils/partialFailure.test.ts
+++ b/src/v0/util/googleUtils/partialFailure.test.ts
@@ -1,12 +1,12 @@
 import {
   formatGoogleAdsErrors,
   getFailedEventStatusCode,
-  isRetryableGoogleAdsError,
   parsePartialFailure,
 } from './partialFailure';
 
-// Shapes are declared locally rather than imported: the module exports only the two functions
-// under test, and nothing should be exported purely to give this file a handle on it.
+// Shapes are declared locally rather than imported: the module exports only the functions the
+// network handler calls, and nothing should be exported purely to give this file a handle on it.
+// That is why the transient-error check is exercised through getFailedEventStatusCode.
 type TestError = {
   errorCode?: Record<string, string>;
   message?: string;
@@ -234,81 +234,34 @@ describe('formatGoogleAdsErrors', () => {
   });
 });
 
-describe('classifying an error as transient', () => {
-  it.each([
-    ['internalError', 'INTERNAL_ERROR'],
-    ['internalError', 'TRANSIENT_ERROR'],
-    ['internalError', 'DEADLINE_EXCEEDED'],
-    ['quotaError', 'RESOURCE_EXHAUSTED'],
-    ['quotaError', 'RESOURCE_TEMPORARILY_EXHAUSTED'],
-    ['databaseError', 'CONCURRENT_MODIFICATION'],
-  ])('retries %s: %s, which Google documents as transient', (key, value) => {
-    expect(isRetryableGoogleAdsError({ errorCode: { [key]: value } })).toBe(true);
-  });
-
-  it.each([
-    // Permanent causes that share a namespace with a retryable one -- the value has to be
-    // checked, not just the oneof key.
-    ['internalError', 'ERROR_CODE_NOT_PUBLISHED'],
-    ['quotaError', 'ACCESS_PROHIBITED'],
-    ['quotaError', 'PAYMENTS_PROFILE_ACTIVATION_RATE_LIMIT_EXCEEDED'],
-    ['databaseError', 'REQUEST_TOO_LARGE'],
-    // Ordinary data problems.
-    ['conversionUploadError', 'NO_CONVERSION_ACTION_FOUND'],
-    ['notAllowlistedError', 'CUSTOMER_NOT_ALLOWLISTED_FOR_THIS_FEATURE'],
-  ])('aborts %s: %s', (key, value) => {
-    expect(isRetryableGoogleAdsError({ errorCode: { [key]: value } })).toBe(false);
-  });
-
-  it('does not retry a code it has never seen', () => {
-    expect(isRetryableGoogleAdsError({ errorCode: { internalError: 'SOME_FUTURE_CODE' } })).toBe(
-      false,
-    );
-    expect(isRetryableGoogleAdsError({ errorCode: { brandNewError: 'INTERNAL_ERROR' } })).toBe(
-      false,
-    );
-  });
-
-  it('survives an errorCode key that collides with Object.prototype', () => {
-    // The oneof key is destination-controlled, so a prototype key must not resolve to an
-    // inherited member and blow up the whole batch. `constructor` would otherwise return the
-    // Object function, and calling `.has` on it throws.
-    expect(() =>
-      isRetryableGoogleAdsError({ errorCode: { constructor: 'INTERNAL_ERROR' } }),
-    ).not.toThrow();
-    expect(isRetryableGoogleAdsError({ errorCode: { constructor: 'INTERNAL_ERROR' } })).toBe(false);
-    // Parsed rather than written as a literal on purpose: `{ __proto__: x }` sets the prototype
-    // and leaves no own property, so it would not exercise the lookup at all. The destination
-    // response really does arrive via JSON.parse, which does create the own property.
-    const parsed = JSON.parse('{"errorCode":{"__proto__":"INTERNAL_ERROR"}}');
-    expect(Object.keys(parsed.errorCode)).toEqual(['__proto__']);
-    expect(() => isRetryableGoogleAdsError(parsed)).not.toThrow();
-    expect(isRetryableGoogleAdsError(parsed)).toBe(false);
-  });
-
-  it('tolerates a missing or malformed errorCode', () => {
-    expect(isRetryableGoogleAdsError({})).toBe(false);
-    expect(isRetryableGoogleAdsError({ errorCode: undefined })).toBe(false);
-    expect(isRetryableGoogleAdsError({ errorCode: 'INTERNAL_ERROR' } as never)).toBe(false);
-    expect(isRetryableGoogleAdsError(undefined as never)).toBe(false);
-  });
-});
-
 describe('choosing the delivery status of a failed conversion', () => {
   const internal = { errorCode: { internalError: 'INTERNAL_ERROR' } };
   const permanent = { errorCode: { conversionUploadError: 'NO_CONVERSION_ACTION_FOUND' } };
 
-  it('retries an event whose only error is transient', () => {
+  it('retries an event Google failed with its generic internal error', () => {
     expect(getFailedEventStatusCode([internal])).toBe(500);
   });
 
-  it('retries when every attributed error is transient', () => {
-    expect(
-      getFailedEventStatusCode([internal, { errorCode: { internalError: 'TRANSIENT_ERROR' } }]),
-    ).toBe(500);
+  it('retries when every attributed error is that internal error', () => {
+    expect(getFailedEventStatusCode([internal, { ...internal }])).toBe(500);
   });
 
-  it('aborts when a permanent cause sits alongside a transient one', () => {
+  it.each([
+    // Neighbouring internalError values are deliberately NOT retried: the value is checked, not
+    // just the oneof key.
+    ['internalError', 'TRANSIENT_ERROR'],
+    ['internalError', 'DEADLINE_EXCEEDED'],
+    ['internalError', 'ERROR_CODE_NOT_PUBLISHED'],
+    ['quotaError', 'RESOURCE_EXHAUSTED'],
+    ['databaseError', 'CONCURRENT_MODIFICATION'],
+    // Ordinary data problems.
+    ['conversionUploadError', 'NO_CONVERSION_ACTION_FOUND'],
+    ['notAllowlistedError', 'CUSTOMER_NOT_ALLOWLISTED_FOR_THIS_FEATURE'],
+  ])('aborts %s: %s', (key, value) => {
+    expect(getFailedEventStatusCode([{ errorCode: { [key]: value } }])).toBe(400);
+  });
+
+  it('aborts when a permanent cause sits alongside the internal error', () => {
     // Retrying cannot clear the permanent cause, so it would only burn the TTL.
     expect(getFailedEventStatusCode([internal, permanent])).toBe(400);
     expect(getFailedEventStatusCode([permanent, internal])).toBe(400);
@@ -321,7 +274,10 @@ describe('choosing the delivery status of a failed conversion', () => {
     expect(getFailedEventStatusCode(undefined)).toBe(400);
   });
 
-  it('aborts a permanent error, preserving the existing behaviour', () => {
-    expect(getFailedEventStatusCode([permanent])).toBe(400);
+  it('aborts on a missing or malformed errorCode rather than guessing', () => {
+    expect(getFailedEventStatusCode([{}])).toBe(400);
+    expect(getFailedEventStatusCode([{ errorCode: undefined }])).toBe(400);
+    expect(getFailedEventStatusCode([{ errorCode: 'INTERNAL_ERROR' } as never])).toBe(400);
+    expect(getFailedEventStatusCode([undefined as never])).toBe(400);
   });
 });

--- a/src/v0/util/googleUtils/partialFailure.test.ts
+++ b/src/v0/util/googleUtils/partialFailure.test.ts
@@ -1,4 +1,9 @@
-import { formatGoogleAdsErrors, parsePartialFailure } from './partialFailure';
+import {
+  formatGoogleAdsErrors,
+  getFailedEventStatusCode,
+  isRetryableGoogleAdsError,
+  parsePartialFailure,
+} from './partialFailure';
 
 // Shapes are declared locally rather than imported: the module exports only the two functions
 // under test, and nothing should be exported purely to give this file a handle on it.
@@ -226,5 +231,97 @@ describe('formatGoogleAdsErrors', () => {
       message: 'An internal error has occurred.',
     }));
     expect(formatGoogleAdsErrors(errors, 'fallback').length).toBeLessThan(200);
+  });
+});
+
+describe('classifying an error as transient', () => {
+  it.each([
+    ['internalError', 'INTERNAL_ERROR'],
+    ['internalError', 'TRANSIENT_ERROR'],
+    ['internalError', 'DEADLINE_EXCEEDED'],
+    ['quotaError', 'RESOURCE_EXHAUSTED'],
+    ['quotaError', 'RESOURCE_TEMPORARILY_EXHAUSTED'],
+    ['databaseError', 'CONCURRENT_MODIFICATION'],
+  ])('retries %s: %s, which Google documents as transient', (key, value) => {
+    expect(isRetryableGoogleAdsError({ errorCode: { [key]: value } })).toBe(true);
+  });
+
+  it.each([
+    // Permanent causes that share a namespace with a retryable one -- the value has to be
+    // checked, not just the oneof key.
+    ['internalError', 'ERROR_CODE_NOT_PUBLISHED'],
+    ['quotaError', 'ACCESS_PROHIBITED'],
+    ['quotaError', 'PAYMENTS_PROFILE_ACTIVATION_RATE_LIMIT_EXCEEDED'],
+    ['databaseError', 'REQUEST_TOO_LARGE'],
+    // Ordinary data problems.
+    ['conversionUploadError', 'NO_CONVERSION_ACTION_FOUND'],
+    ['notAllowlistedError', 'CUSTOMER_NOT_ALLOWLISTED_FOR_THIS_FEATURE'],
+  ])('aborts %s: %s', (key, value) => {
+    expect(isRetryableGoogleAdsError({ errorCode: { [key]: value } })).toBe(false);
+  });
+
+  it('does not retry a code it has never seen', () => {
+    expect(isRetryableGoogleAdsError({ errorCode: { internalError: 'SOME_FUTURE_CODE' } })).toBe(
+      false,
+    );
+    expect(isRetryableGoogleAdsError({ errorCode: { brandNewError: 'INTERNAL_ERROR' } })).toBe(
+      false,
+    );
+  });
+
+  it('survives an errorCode key that collides with Object.prototype', () => {
+    // The oneof key is destination-controlled, so a prototype key must not resolve to an
+    // inherited member and blow up the whole batch. `constructor` would otherwise return the
+    // Object function, and calling `.has` on it throws.
+    expect(() =>
+      isRetryableGoogleAdsError({ errorCode: { constructor: 'INTERNAL_ERROR' } }),
+    ).not.toThrow();
+    expect(isRetryableGoogleAdsError({ errorCode: { constructor: 'INTERNAL_ERROR' } })).toBe(false);
+    // Parsed rather than written as a literal on purpose: `{ __proto__: x }` sets the prototype
+    // and leaves no own property, so it would not exercise the lookup at all. The destination
+    // response really does arrive via JSON.parse, which does create the own property.
+    const parsed = JSON.parse('{"errorCode":{"__proto__":"INTERNAL_ERROR"}}');
+    expect(Object.keys(parsed.errorCode)).toEqual(['__proto__']);
+    expect(() => isRetryableGoogleAdsError(parsed)).not.toThrow();
+    expect(isRetryableGoogleAdsError(parsed)).toBe(false);
+  });
+
+  it('tolerates a missing or malformed errorCode', () => {
+    expect(isRetryableGoogleAdsError({})).toBe(false);
+    expect(isRetryableGoogleAdsError({ errorCode: undefined })).toBe(false);
+    expect(isRetryableGoogleAdsError({ errorCode: 'INTERNAL_ERROR' } as never)).toBe(false);
+    expect(isRetryableGoogleAdsError(undefined as never)).toBe(false);
+  });
+});
+
+describe('choosing the delivery status of a failed conversion', () => {
+  const internal = { errorCode: { internalError: 'INTERNAL_ERROR' } };
+  const permanent = { errorCode: { conversionUploadError: 'NO_CONVERSION_ACTION_FOUND' } };
+
+  it('retries an event whose only error is transient', () => {
+    expect(getFailedEventStatusCode([internal])).toBe(500);
+  });
+
+  it('retries when every attributed error is transient', () => {
+    expect(
+      getFailedEventStatusCode([internal, { errorCode: { internalError: 'TRANSIENT_ERROR' } }]),
+    ).toBe(500);
+  });
+
+  it('aborts when a permanent cause sits alongside a transient one', () => {
+    // Retrying cannot clear the permanent cause, so it would only burn the TTL.
+    expect(getFailedEventStatusCode([internal, permanent])).toBe(400);
+    expect(getFailedEventStatusCode([permanent, internal])).toBe(400);
+  });
+
+  it('aborts an event Google did not attribute any error to', () => {
+    // No attributed error is no evidence of a transient fault. This is also the index-alignment
+    // fallback, where retrying could replay events Google actually accepted.
+    expect(getFailedEventStatusCode([])).toBe(400);
+    expect(getFailedEventStatusCode(undefined)).toBe(400);
+  });
+
+  it('aborts a permanent error, preserving the existing behaviour', () => {
+    expect(getFailedEventStatusCode([permanent])).toBe(400);
   });
 });

--- a/src/v0/util/googleUtils/partialFailure.ts
+++ b/src/v0/util/googleUtils/partialFailure.ts
@@ -144,6 +144,73 @@ export const parsePartialFailure = (
 };
 
 /**
+ * Google Ads error codes whose own proto documentation states the failure is transient, i.e. the
+ * identical request can succeed on a later attempt. Keyed by the `errorCode` oneof field.
+ *
+ * A Map rather than an object literal so a destination-supplied key such as `constructor` or
+ * `__proto__` cannot resolve to something inherited from Object.prototype.
+ *
+ * Ref - https://github.com/googleapis/googleapis/tree/master/google/ads/googleads/v23/errors
+ */
+const RETRYABLE_ERROR_CODES: ReadonlyMap<string, ReadonlySet<string>> = new Map([
+  [
+    'internalError',
+    // "unexpected internal error" / "The user should retry their request in these cases." /
+    // "The request took longer than a deadline."
+    new Set(['INTERNAL_ERROR', 'TRANSIENT_ERROR', 'DEADLINE_EXCEEDED']),
+  ],
+  [
+    'quotaError',
+    // "Too many requests." / "Too many requests in a short amount of time." The upload itself is
+    // fine, the account is over its rate limit right now.
+    new Set(['RESOURCE_EXHAUSTED', 'RESOURCE_TEMPORARILY_EXHAUSTED']),
+  ],
+  [
+    'databaseError',
+    // "Multiple requests were attempting to modify the same resource at once. Retry the request."
+    new Set(['CONCURRENT_MODIFICATION']),
+  ],
+]);
+
+/**
+ * Whether Google considers this individual error worth retrying.
+ *
+ * Codes absent from the map are treated as permanent, so an unrecognised or newly introduced code
+ * keeps the existing abort rather than being retried on a guess.
+ */
+export const isRetryableGoogleAdsError = (error: GoogleAdsError): boolean => {
+  const { errorCode } = error ?? {};
+  if (!errorCode || typeof errorCode !== 'object') {
+    return false;
+  }
+  return Object.entries(errorCode).some(
+    ([key, value]) => typeof value === 'string' && RETRYABLE_ERROR_CODES.get(key)?.has(value),
+  );
+};
+
+/**
+ * Picks the delivery status for a conversion Google rejected.
+ *
+ * Retry only when Google attributed at least one error to the event and *every* one of them is
+ * transient:
+ * - no attributed error is no evidence of a transient fault, and these are also the events hit by
+ *   the index-alignment fallback, so retrying them would replay events Google may well have
+ *   accepted;
+ * - a permanent cause alongside a transient one will reject the conversion on every attempt, so
+ *   retrying only burns the 24h TTL before the event dies anyway.
+ *
+ * 500 rather than 429 even for quota errors: rudder-server treats both as non-terminal, and a
+ * single status keeps the batch-level errorType honest without implying we parsed a Retry-After.
+ */
+export const getFailedEventStatusCode = (errors: GoogleAdsError[] | undefined): number => {
+  const all = errors ?? [];
+  if (all.length === 0) {
+    return 400;
+  }
+  return all.every(isRetryableGoogleAdsError) ? 500 : 400;
+};
+
+/**
  * Request-wide errors are replayed onto every failed event, so a response carrying many of them
  * would otherwise be rendered once per event — O(events x errors). These caps keep the size of
  * what we emit independent of what the destination returns.

--- a/src/v0/util/googleUtils/partialFailure.ts
+++ b/src/v0/util/googleUtils/partialFailure.ts
@@ -144,52 +144,22 @@ export const parsePartialFailure = (
 };
 
 /**
- * Google Ads error codes whose own proto documentation states the failure is transient, i.e. the
- * identical request can succeed on a later attempt. Keyed by the `errorCode` oneof field.
+ * `internalError: INTERNAL_ERROR` is Google's "Google Ads API encountered unexpected internal
+ * error" — a fault on their side that the identical conversion can clear on a later attempt.
  *
- * A Map rather than an object literal so a destination-supplied key such as `constructor` or
- * `__proto__` cannot resolve to something inherited from Object.prototype.
+ * This is deliberately the ONLY code treated as transient. Other codes documented as retryable
+ * (TRANSIENT_ERROR, DEADLINE_EXCEEDED, quota and database errors) keep the existing abort: they
+ * are not what we actually observe on this destination, and widening the set is a behaviour
+ * change for events that are being delivered fine today.
  *
- * Ref - https://github.com/googleapis/googleapis/tree/master/google/ads/googleads/v23/errors
+ * Ref - https://github.com/googleapis/googleapis/blob/master/google/ads/googleads/v23/errors/internal_error.proto
  */
-const RETRYABLE_ERROR_CODES: ReadonlyMap<string, ReadonlySet<string>> = new Map([
-  [
-    'internalError',
-    // "unexpected internal error" / "The user should retry their request in these cases." /
-    // "The request took longer than a deadline."
-    new Set(['INTERNAL_ERROR', 'TRANSIENT_ERROR', 'DEADLINE_EXCEEDED']),
-  ],
-  [
-    'quotaError',
-    // "Too many requests." / "Too many requests in a short amount of time." The upload itself is
-    // fine, the account is over its rate limit right now.
-    new Set(['RESOURCE_EXHAUSTED', 'RESOURCE_TEMPORARILY_EXHAUSTED']),
-  ],
-  [
-    'databaseError',
-    // "Multiple requests were attempting to modify the same resource at once. Retry the request."
-    new Set(['CONCURRENT_MODIFICATION']),
-  ],
-]);
+const isTransientError = (error: GoogleAdsError): boolean =>
+  error?.errorCode?.internalError === 'INTERNAL_ERROR';
 
 /**
- * Whether Google considers this individual error worth retrying.
- *
- * Codes absent from the map are treated as permanent, so an unrecognised or newly introduced code
- * keeps the existing abort rather than being retried on a guess.
- */
-export const isRetryableGoogleAdsError = (error: GoogleAdsError): boolean => {
-  const { errorCode } = error ?? {};
-  if (!errorCode || typeof errorCode !== 'object') {
-    return false;
-  }
-  return Object.entries(errorCode).some(
-    ([key, value]) => typeof value === 'string' && RETRYABLE_ERROR_CODES.get(key)?.has(value),
-  );
-};
-
-/**
- * Picks the delivery status for a conversion Google rejected.
+ * Picks the delivery status for a conversion Google rejected: 500 so rudder-server retries the
+ * job, 400 so it aborts.
  *
  * Retry only when Google attributed at least one error to the event and *every* one of them is
  * transient:
@@ -198,16 +168,13 @@ export const isRetryableGoogleAdsError = (error: GoogleAdsError): boolean => {
  *   accepted;
  * - a permanent cause alongside a transient one will reject the conversion on every attempt, so
  *   retrying only burns the 24h TTL before the event dies anyway.
- *
- * 500 rather than 429 even for quota errors: rudder-server treats both as non-terminal, and a
- * single status keeps the batch-level errorType honest without implying we parsed a Retry-After.
  */
 export const getFailedEventStatusCode = (errors: GoogleAdsError[] | undefined): number => {
   const all = errors ?? [];
   if (all.length === 0) {
     return 400;
   }
-  return all.every(isRetryableGoogleAdsError) ? 500 : 400;
+  return all.every(isTransientError) ? 500 : 400;
 };
 
 /**

--- a/src/v1/destinations/google_adwords_offline_conversions/networkHandler.js
+++ b/src/v1/destinations/google_adwords_offline_conversions/networkHandler.js
@@ -7,6 +7,7 @@ const { processAxiosResponse } = require('../../../adapters/utils/networkUtils')
 const {
   parsePartialFailure,
   formatGoogleAdsErrors,
+  getFailedEventStatusCode,
 } = require('../../../v0/util/googleUtils/partialFailure');
 const { CommonUtils } = require('../../../util/common');
 
@@ -194,8 +195,11 @@ const responseHandler = (responseParams) => {
       const eventErrors = isIndexAligned
         ? (errorsByIndex.get(i) ?? unindexedErrors)
         : unindexedErrors;
+      // Google documents several of these codes as transient. Aborting them drops the event
+      // permanently on a fault a later attempt would clear, so let the per-event status decide
+      // retry vs abort -- rudder-server reads this array, not the batch status, per job.
       return {
-        statusCode: isEventFailed ? 400 : 200,
+        statusCode: isEventFailed ? getFailedEventStatusCode(eventErrors) : 200,
         metadata,
         error: isEventFailed
           ? formatGoogleAdsErrors(eventErrors, errorMessage, requestId)
@@ -203,13 +207,17 @@ const responseHandler = (responseParams) => {
       };
     });
 
+    // Keep the batch-level classification consistent with what the events actually did, so
+    // dataDelivery error stats don't report a retry as a permanent drop.
+    const hasRetryableEvent = responseWithIndividualEvents.some((event) => event.statusCode >= 500);
+
     const data = {
-      status: 400,
+      status: hasRetryableEvent ? 500 : 400,
       message: `[Google Ads Offline Conversions]:: ${errorMessage}`,
       destinationResponse,
       statTags: {
         errorCategory: 'network',
-        errorType: 'aborted',
+        errorType: hasRetryableEvent ? 'retryable' : 'aborted',
         destType: destType && typeof destType === 'string' ? destType.toUpperCase() : '',
         module: 'destination',
         implementation: 'native',

--- a/test/integrations/destinations/google_adwords_offline_conversions/dataDelivery/business.ts
+++ b/test/integrations/destinations/google_adwords_offline_conversions/dataDelivery/business.ts
@@ -99,6 +99,7 @@ const params = {
   },
   param3: {},
   param4: {},
+  param5: {},
 };
 
 params['param3'] = { ...params.param2, customVariables: [] };
@@ -109,6 +110,8 @@ params['param4'] = {
   conversionEnvironment: 'APP',
   conversionActionId: 'customers/1234567893/conversionActions/848898417',
 };
+
+params['param5'] = { ...params.param4, customerId: '1234567895' };
 
 const validRequestPayload1 = {
   addConversionPayload: {
@@ -217,6 +220,15 @@ const notAllowedToAccessFeatureRequestPayload = {
       ...validRequestPayload2.conversions[0],
       conversionEnvironment: 'APP',
     },
+  ],
+};
+
+// One conversion Google rejects transiently, one it rejects permanently.
+const mixedPartialFailureRequestPayload = {
+  ...validRequestPayload2,
+  conversions: [
+    { ...validRequestPayload2.conversions[0], conversionEnvironment: 'APP' },
+    { ...validRequestPayload2.conversions[0], conversionEnvironment: 'APP', orderId: 'PL-123QS' },
   ],
 };
 
@@ -671,6 +683,97 @@ export const testScenariosForV1API = [
             ],
             statTags: expectedStatTags,
             status: 400,
+          },
+        },
+      },
+    },
+  },
+  {
+    id: 'gaoc_v1_scenario_7',
+    name: 'google_adwords_offline_conversions',
+    description:
+      '[Proxy v1 API] :: Partial failure mixing a transient INTERNAL_ERROR with a permanent upload error',
+    successCriteria:
+      'Should retry only the conversion Google failed transiently and abort the permanently failed one',
+    scenario: 'Business',
+    feature: 'dataDelivery',
+    module: 'destination',
+    version: 'v1',
+    input: {
+      request: {
+        body: generateProxyV1Payload(
+          {
+            headers: headers.header2,
+            params: params.param5,
+            JSON: mixedPartialFailureRequestPayload,
+            endpoint: `https://googleads.googleapis.com/${API_VERSION}/customers/1234567895:uploadClickConversions`,
+          },
+          [generateMetadata(1), generateMetadata(2)],
+        ),
+        method: 'POST',
+      },
+    },
+    output: {
+      response: {
+        status: 200,
+        body: {
+          output: {
+            message:
+              "[Google Ads Offline Conversions]:: Multiple errors in 'details'. First error: An internal error has occurred., at conversions[0]",
+            destinationResponse: {
+              response: {
+                partialFailureError: {
+                  code: 3,
+                  message:
+                    "Multiple errors in 'details'. First error: An internal error has occurred., at conversions[0]",
+                  details: [
+                    {
+                      '@type':
+                        'type.googleapis.com/google.ads.googleads.v23.errors.GoogleAdsFailure',
+                      errors: [
+                        {
+                          errorCode: { internalError: 'INTERNAL_ERROR' },
+                          message: 'An internal error has occurred.',
+                          location: {
+                            fieldPathElements: [{ fieldName: 'conversions', index: 0 }],
+                          },
+                        },
+                        {
+                          errorCode: { conversionUploadError: 'NO_CONVERSION_ACTION_FOUND' },
+                          message:
+                            "The conversion action specified in the upload request cannot be found. Make sure it's available in this account.",
+                          location: {
+                            fieldPathElements: [
+                              { fieldName: 'conversions', index: 1 },
+                              { fieldName: 'conversion_action' },
+                            ],
+                          },
+                        },
+                      ],
+                      requestId: 'FM1CP_W1g5PqesNL1oJtYQ',
+                    },
+                  ],
+                },
+                results: [{}, {}],
+              },
+              status: 200,
+            },
+            response: [
+              {
+                error:
+                  'An internal error has occurred. [internalError: INTERNAL_ERROR] at conversions[0] (requestId: FM1CP_W1g5PqesNL1oJtYQ)',
+                metadata: generateMetadata(1),
+                statusCode: 500,
+              },
+              {
+                error:
+                  "The conversion action specified in the upload request cannot be found. Make sure it's available in this account. [conversionUploadError: NO_CONVERSION_ACTION_FOUND] at conversions[1].conversion_action (requestId: FM1CP_W1g5PqesNL1oJtYQ)",
+                metadata: generateMetadata(2),
+                statusCode: 400,
+              },
+            ],
+            statTags: { ...expectedStatTags, errorType: 'retryable' },
+            status: 500,
           },
         },
       },

--- a/test/integrations/destinations/google_adwords_offline_conversions/network.ts
+++ b/test/integrations/destinations/google_adwords_offline_conversions/network.ts
@@ -32,6 +32,130 @@ const commonResponse = {
 
 export const networkCallsData = [
   {
+    // Two conversions, one rejected with a transient INTERNAL_ERROR and one with a permanent
+    // NO_CONVERSION_ACTION_FOUND, so a single batch has to produce both dispositions.
+    httpReq: {
+      url: `https://googleads.googleapis.com/${API_VERSION}/customers/1234567895:uploadClickConversions`,
+      data: {
+        conversions: [
+          {
+            gbraid: 'gbraid',
+            wbraid: 'wbraid',
+            externalAttributionData: {
+              externalAttributionCredit: 10,
+              externalAttributionModel: 'externalAttributionModel',
+            },
+            cartData: {
+              merchantId: 9876,
+              feedCountryCode: 'feedCountryCode',
+              feedLanguageCode: 'feedLanguageCode',
+              localTransactionCost: 20,
+              items: [{ productId: '507f1f77bcf86cd799439011', quantity: 2, unitPrice: 50 }],
+            },
+            userIdentifiers: [
+              {
+                userIdentifierSource: 'FIRST_PARTY',
+                hashedPhoneNumber:
+                  '04e1dabb7c1348b72bfa87da179c9697c69af74827649266a5da8cdbb367abcd',
+              },
+            ],
+            conversionEnvironment: 'APP',
+            gclid: 'gclid',
+            conversionDateTime: '2022-01-01 12:32:45-08:00',
+            conversionValue: 1,
+            currencyCode: 'GBP',
+            orderId: 'PL-123QR',
+            conversionAction: 'customers/1234567891/conversionActions/848898416',
+            customVariables: [
+              {
+                conversionCustomVariable: 'customers/1234567891/conversionCustomVariables/19131634',
+                value: 'value',
+              },
+            ],
+          },
+          {
+            gbraid: 'gbraid',
+            wbraid: 'wbraid',
+            externalAttributionData: {
+              externalAttributionCredit: 10,
+              externalAttributionModel: 'externalAttributionModel',
+            },
+            cartData: {
+              merchantId: 9876,
+              feedCountryCode: 'feedCountryCode',
+              feedLanguageCode: 'feedLanguageCode',
+              localTransactionCost: 20,
+              items: [{ productId: '507f1f77bcf86cd799439011', quantity: 2, unitPrice: 50 }],
+            },
+            userIdentifiers: [
+              {
+                userIdentifierSource: 'FIRST_PARTY',
+                hashedPhoneNumber:
+                  '04e1dabb7c1348b72bfa87da179c9697c69af74827649266a5da8cdbb367abcd',
+              },
+            ],
+            conversionEnvironment: 'APP',
+            gclid: 'gclid',
+            conversionDateTime: '2022-01-01 12:32:45-08:00',
+            conversionValue: 1,
+            currencyCode: 'GBP',
+            orderId: 'PL-123QS',
+            conversionAction: 'customers/1234567891/conversionActions/848898416',
+            customVariables: [
+              {
+                conversionCustomVariable: 'customers/1234567891/conversionCustomVariables/19131634',
+                value: 'value',
+              },
+            ],
+          },
+        ],
+        partialFailure: true,
+      },
+      headers: {
+        Authorization: authHeader1,
+        'Content-Type': 'application/json',
+        'developer-token': 'test-developer-token-12345',
+      },
+      method: 'POST',
+      params: { destination: 'google_adwords_offline_conversion' },
+    },
+    httpRes: {
+      status: 200,
+      data: {
+        partialFailureError: {
+          code: 3,
+          message:
+            "Multiple errors in 'details'. First error: An internal error has occurred., at conversions[0]",
+          details: [
+            {
+              '@type': 'type.googleapis.com/google.ads.googleads.v23.errors.GoogleAdsFailure',
+              errors: [
+                {
+                  errorCode: { internalError: 'INTERNAL_ERROR' },
+                  message: 'An internal error has occurred.',
+                  location: { fieldPathElements: [{ fieldName: 'conversions', index: 0 }] },
+                },
+                {
+                  errorCode: { conversionUploadError: 'NO_CONVERSION_ACTION_FOUND' },
+                  message:
+                    "The conversion action specified in the upload request cannot be found. Make sure it's available in this account.",
+                  location: {
+                    fieldPathElements: [
+                      { fieldName: 'conversions', index: 1 },
+                      { fieldName: 'conversion_action' },
+                    ],
+                  },
+                },
+              ],
+              requestId: 'FM1CP_W1g5PqesNL1oJtYQ',
+            },
+          ],
+        },
+        results: [{}, {}],
+      },
+    },
+  },
+  {
     httpReq: {
       url: `https://googleads.googleapis.com/${API_VERSION}/customers/11122233331/offlineUserDataJobs:create`,
       data: {


### PR DESCRIPTION
## What

Google Ads reports per-conversion partial failures with HTTP 200 and a `partialFailureError`. Every failed conversion in that payload was mapped to `statusCode: 400`, so rudder-server aborted it and never retried — including `internalError: INTERNAL_ERROR`, which is Google's own "Google Ads API encountered unexpected internal error".

This returns `500` for that one code so the job is retried, and leaves everything else exactly as it is.

## Why

`INTERNAL_ERROR` is the dominant abort reason on this destination:

- **~219K aborted events over the last 14 days (~15.7K/day)**, across **92 destinations / 67 workspaces**, present every single day (35–74 destinations/day).
- The failure *rate* co-moves in lockstep across unrelated workspaces and Google Ads accounts while delivery volume stays flat. Six independent top destinations all peaked 08-12 and cratered 08-13 together (−81% to −93%), then rebounded together on 08-18.

Unrelated customers cannot co-vary like that unless the driver is Google's. It is a Google-side transient fault, not a customer payload problem — and every one of those events is currently dropped permanently on a fault a later attempt would clear.

Config problems, by contrast, come back with their own named code *plus* a field path (`UNPARSEABLE_GCLID … .gclid`), so they remain distinguishable and keep aborting.

## Scope

**`internalError: INTERNAL_ERROR` is the only code treated as transient.**

Other codes whose protos also document them as retryable — `TRANSIENT_ERROR`, `DEADLINE_EXCEEDED`, `quotaError: RESOURCE_EXHAUSTED` / `RESOURCE_TEMPORARILY_EXHAUSTED`, `databaseError: CONCURRENT_MODIFICATION` — deliberately keep the existing abort. They are not what we actually observe here, and retrying them would be a behaviour change for events that are being delivered fine today. Tests pin each of them to 400 so widening the set is a conscious decision rather than an accident.

## When we retry

Only when Google attributed **at least one** error to the event and **every** one of them is `INTERNAL_ERROR`:

- **No attributed error → abort.** That's no evidence of a transient fault, and it's also the index-misalignment fallback, so retrying could replay conversions Google may well have accepted.
- **A permanent cause alongside it → abort.** It will reject on every attempt, so retrying only burns the 24h TTL.

## Why per-event status is the right lever

Verified against rudder-server: `router/transformer/transformer_proxy_adapter.go:169` maps our `response[].statusCode` straight into `routerJobResponseCodes[jobID]`, and `router/misc.go:23` (`isJobTerminated`) treats `>= 500` as non-terminal, i.e. retried. The batch-level `status` only feeds metrics — `deliverToDestinationV1` returns HTTP 200 regardless — so per-event codes are authoritative and mixed dispositions in one batch work correctly.

The batch-level `status`/`statTags.errorType` are updated to match so dataDelivery error stats don't report a retry as a permanent drop.

## Operational note

With `guaranteeUserEventOrder` enabled, a retried job now holds its user's event-ordering barrier where it previously terminated immediately. That is the correct semantics for a retryable failure and is bounded by the existing retry limit and 24h TTL, but it is a real behaviour change at ~15.7K events/day.

## Tests

- Unit tests covering: `INTERNAL_ERROR` alone and repeated (→ 500); each deliberately-excluded code, including the neighbouring `internalError` values, so the enum *value* is checked and not just the oneof key (→ 400); a permanent cause alongside the internal error; an unattributed event; missing/malformed `errorCode`.
- Component test `gaoc_v1_scenario_7`: one batch mixing `INTERNAL_ERROR` (→ 500) with a permanent `NO_CONVERSION_ACTION_FOUND` (→ 400), asserting both dispositions plus the batch-level `retryable` classification.
- Existing partial-failure scenarios use permanent codes and are unchanged.

No export exists purely for the tests — `getFailedEventStatusCode` is what the network handler calls, and the transient check is module-private and exercised through it.

`tsc --noEmit` and eslint clean; 75 googleUtils unit tests and 164 `google_adwords` component tests pass.

## Follow-up (not in this PR)

`google_adwords_enhanced_conversions/networkHandler.ts` has the same abort-everything behaviour with an explicit comment asserting failures are "always non-retryable data issues". It doesn't use `parsePartialFailure` at all, so bringing it onto this path is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
