### PR TITLE
feat(network): emit pre-compression delivery payload size metric (INT-7033)

### DIFF
--- a/src/adapters/network.js
+++ b/src/adapters/network.js
@@ -381,6 +381,24 @@ const extractPayloadForFormat = (payload, format) => {
   return extractor();
 };
 
+// INT-7033: uncompressed (pre-compression) byte size of the delivery body, per payload format.
+// Mirrors extractPayloadForFormat but returns the raw serialized length BEFORE any GZIP, so the
+// GZIP branch reports the pre-compression size (the compressed/wire size is Phase 1, INT-6923).
+const getUncompressedPayloadSize = (payload, format) => {
+  if (!payload) {
+    return undefined;
+  }
+  const serializers = {
+    JSON_ARRAY: () => payload?.batch,
+    JSON: () => JSON.stringify(payload),
+    XML: () => payload?.payload,
+    FORM: () => getFormData(payload).toString(),
+    GZIP: () => payload?.payload,
+  };
+  const serialized = serializers[format]?.();
+  return typeof serialized === 'string' ? Buffer.byteLength(serialized) : undefined;
+};
+
 /**
  * Prepares the proxy request
  * @param {*} request
@@ -392,11 +410,24 @@ const prepareProxyRequest = async (request) => {
     method,
     params,
     endpoint,
+    endpointPath,
+    metadata,
     headers: incomingHeaders = {},
     destinationConfig: config,
   } = request;
   const headers = { ...incomingHeaders };
   const { payload, payloadFormat } = getPayloadData(body);
+  // INT-7033: baseline pre-compression delivery payload size, keyed by destination / endpoint /
+  // workspace. Emitted for every proxy delivery independent of the rollout flag; `compressed`
+  // records whether this delivery ships gzipped (true today only for endpoints already on GZIP).
+  const uncompressedSize = getUncompressedPayloadSize(payload, payloadFormat);
+  if (uncompressedSize !== undefined) {
+    stats.histogram('delivery_payload_size_bytes', uncompressedSize, {
+      ...logger.getLogMetadata(metadata),
+      endpointPath: endpointPath ?? '',
+      compressed: payloadFormat === 'GZIP',
+    });
+  }
   if (payloadFormat && payloadFormat === 'GZIP') {
     headers['Content-Encoding'] = 'gzip';
   }

--- a/src/adapters/network.js
+++ b/src/adapters/network.js
@@ -359,44 +359,51 @@ const getZippedPayload = (payload) =>
       throw new PlatformError(`Failed to do GZIP compression: ${err}`, 400);
     });
 
+// Single source of truth for the delivery payload formats:
+//  - `extract`   -> the value handed to the HTTP client (a gzip Buffer for GZIP).
+//  - `rawString` -> the uncompressed serialized string, used only to size the body for the
+//                   pre-compression delivery-size metric (INT-7033).
+const PAYLOAD_FORMAT_HANDLERS = {
+  JSON_ARRAY: { extract: (payload) => payload?.batch, rawString: (payload) => payload?.batch },
+  JSON: { extract: (payload) => payload, rawString: (payload) => JSON.stringify(payload) },
+  XML: { extract: (payload) => payload?.payload, rawString: (payload) => payload?.payload },
+  FORM: {
+    extract: (payload) => getFormData(payload),
+    rawString: (payload) => getFormData(payload).toString(),
+  },
+  GZIP: {
+    extract: (payload) => getZippedPayload(payload?.payload),
+    rawString: (payload) => payload?.payload,
+  },
+};
+
 const extractPayloadForFormat = (payload, format) => {
   if (!payload) {
     return undefined;
   }
-
-  const extractors = {
-    JSON_ARRAY: () => payload?.batch,
-    JSON: () => payload,
-    XML: () => payload?.payload,
-    FORM: () => getFormData(payload),
-    GZIP: () => getZippedPayload(payload?.payload),
-  };
-
-  const extractor = extractors[format];
-  if (!extractor) {
+  const handler = PAYLOAD_FORMAT_HANDLERS[format];
+  if (!handler) {
     logger.debug(`Unknown payload format: ${format}`);
     return undefined;
   }
-
-  return extractor();
+  return handler.extract(payload);
 };
 
-// INT-7033: uncompressed (pre-compression) byte size of the delivery body, per payload format.
-// Mirrors extractPayloadForFormat but returns the raw serialized length BEFORE any GZIP, so the
-// GZIP branch reports the pre-compression size (the compressed/wire size is Phase 1, INT-6923).
+// INT-7033: uncompressed (pre-compression) byte size of the delivery body. Guarded on purpose --
+// a size metric must never be able to fail a delivery, so a serialization error (e.g. a body that
+// JSON.stringify rejects) yields no observation instead of throwing on the delivery hot path.
 const getUncompressedPayloadSize = (payload, format) => {
-  if (!payload) {
+  const handler = PAYLOAD_FORMAT_HANDLERS[format];
+  if (!payload || !handler) {
     return undefined;
   }
-  const serializers = {
-    JSON_ARRAY: () => payload?.batch,
-    JSON: () => JSON.stringify(payload),
-    XML: () => payload?.payload,
-    FORM: () => getFormData(payload).toString(),
-    GZIP: () => payload?.payload,
-  };
-  const serialized = serializers[format]?.();
-  return typeof serialized === 'string' ? Buffer.byteLength(serialized) : undefined;
+  try {
+    const raw = handler.rawString(payload);
+    return typeof raw === 'string' ? Buffer.byteLength(raw) : undefined;
+  } catch (err) {
+    logger.debug(`delivery_payload_size_bytes: failed to size ${format} payload: ${err}`);
+    return undefined;
+  }
 };
 
 /**
@@ -410,24 +417,11 @@ const prepareProxyRequest = async (request) => {
     method,
     params,
     endpoint,
-    endpointPath,
-    metadata,
     headers: incomingHeaders = {},
     destinationConfig: config,
   } = request;
   const headers = { ...incomingHeaders };
   const { payload, payloadFormat } = getPayloadData(body);
-  // INT-7033: baseline pre-compression delivery payload size, keyed by destination / endpoint /
-  // workspace. Emitted for every proxy delivery independent of the rollout flag; `compressed`
-  // records whether this delivery ships gzipped (true today only for endpoints already on GZIP).
-  const uncompressedSize = getUncompressedPayloadSize(payload, payloadFormat);
-  if (uncompressedSize !== undefined) {
-    stats.histogram('delivery_payload_size_bytes', uncompressedSize, {
-      ...logger.getLogMetadata(metadata),
-      endpointPath: endpointPath ?? '',
-      compressed: payloadFormat === 'GZIP',
-    });
-  }
   if (payloadFormat && payloadFormat === 'GZIP') {
     headers['Content-Encoding'] = 'gzip';
   }
@@ -485,6 +479,26 @@ const handleHttpRequest = async (requestType = 'post', ...httpArgs) => {
   return { httpResponse, processedResponse };
 };
 
+// INT-7033: baseline distribution of uncompressed delivery-body sizes, keyed by
+// destType / endpointPath / workspace. Fired from proxyRequest (the live proxy-delivery path)
+// rather than prepareProxyRequest, so it carries the authoritative destType (the proxy arg), sees
+// the request's endpointPath and per-job metadata, and never fires for the /proxyTest payload-
+// comparison route (which calls prepareProxy directly and never delivers). `compressed` marks
+// deliveries already on the GZIP format.
+const fireDeliveryPayloadSizeStats = (body, { destType, endpointPath, metadata }) => {
+  const { payload, payloadFormat } = getPayloadData(body);
+  const size = getUncompressedPayloadSize(payload, payloadFormat);
+  if (size === undefined) {
+    return;
+  }
+  stats.histogram('delivery_payload_size_bytes', size, {
+    ...logger.getLogMetadata(metadata),
+    destType,
+    endpointPath: endpointPath ?? '',
+    compressed: payloadFormat === 'GZIP',
+  });
+};
+
 /**
  * depricating: handles proxying requests to destinations from server, expects requsts in "defaultRequestConfig"
  * note: needed for test api
@@ -492,8 +506,9 @@ const handleHttpRequest = async (requestType = 'post', ...httpArgs) => {
  * @returns
  */
 const proxyRequest = async (request, destType) => {
-  const { metadata } = request;
+  const { metadata, endpointPath, body } = request;
   const { endpoint, data, method, params, headers } = await prepareProxyRequest(request);
+  fireDeliveryPayloadSizeStats(body, { destType, endpointPath, metadata });
   const requestOptions = {
     url: endpoint,
     data,

--- a/src/adapters/network.js
+++ b/src/adapters/network.js
@@ -299,12 +299,14 @@ const httpPATCH = async (url, data, options, statTags = {}, disableMetrics = fal
 const getPayloadData = (body) => {
   let payload;
   let payloadFormat;
-  Object.entries(body).forEach(([key, value]) => {
+  // for...of (not forEach) so static analysis sees payloadFormat as a string, not just its
+  // initial undefined — an assignment inside a forEach callback is invisible to that inference.
+  for (const [key, value] of Object.entries(body)) {
     if (!lodash.isEmpty(value)) {
       payload = value;
       payloadFormat = key;
     }
-  });
+  }
   return { payload, payloadFormat };
 };
 

--- a/src/adapters/network.test.js
+++ b/src/adapters/network.test.js
@@ -1312,3 +1312,79 @@ describe('proxyRequest tests', () => {
     });
   });
 });
+
+describe('prepareProxyRequest - delivery_payload_size_bytes metric (INT-7033)', () => {
+  beforeEach(() => {
+    stats.histogram.mockClear();
+  });
+
+  it('emits the uncompressed JSON body size with compressed=false and per-destination labels', async () => {
+    const jsonBody = { api_key: 'k', events: [{ event_type: 'Login', prop: 'x'.repeat(50) }] };
+    const request = {
+      body: { JSON: jsonBody },
+      endpoint: 'https://api2.amplitude.com/2/httpapi',
+      endpointPath: '/2/httpapi',
+      method: 'POST',
+      headers: {},
+      metadata: {
+        destinationId: 'dest-1',
+        workspaceId: 'ws-1',
+        destinationType: 'AM',
+        sourceId: 'src-1',
+      },
+    };
+
+    await prepareProxyRequest(request);
+
+    expect(stats.histogram).toHaveBeenCalledTimes(1);
+    expect(stats.histogram).toHaveBeenCalledWith(
+      'delivery_payload_size_bytes',
+      Buffer.byteLength(JSON.stringify(jsonBody)),
+      {
+        destType: 'AM',
+        destinationId: 'dest-1',
+        workspaceId: 'ws-1',
+        sourceId: 'src-1',
+        endpointPath: '/2/httpapi',
+        compressed: false,
+      },
+    );
+  });
+
+  it('reports the pre-compression size with compressed=true for a GZIP body', async () => {
+    const rawArray = JSON.stringify([{ $token: 't', $distinct_id: 'd', $set: { plan: 'pro' } }]);
+    const request = {
+      body: { GZIP: { payload: rawArray } },
+      endpoint: 'https://api.mixpanel.com/engage',
+      endpointPath: '/engage',
+      method: 'POST',
+      headers: {},
+      metadata: { destinationId: 'dest-2', workspaceId: 'ws-2', destinationType: 'MP' },
+    };
+
+    await prepareProxyRequest(request);
+
+    expect(stats.histogram).toHaveBeenCalledTimes(1);
+    expect(stats.histogram).toHaveBeenCalledWith(
+      'delivery_payload_size_bytes',
+      Buffer.byteLength(rawArray),
+      expect.objectContaining({
+        endpointPath: '/engage',
+        compressed: true,
+        destType: 'MP',
+        workspaceId: 'ws-2',
+      }),
+    );
+  });
+
+  it('does not emit when the body has no non-empty payload format', async () => {
+    await prepareProxyRequest({
+      body: {},
+      endpoint: 'https://example.com',
+      method: 'GET',
+      headers: {},
+    });
+
+    expect(stats.histogram).not.toHaveBeenCalled();
+  });
+});

--- a/src/adapters/network.test.js
+++ b/src/adapters/network.test.js
@@ -1313,12 +1313,14 @@ describe('proxyRequest tests', () => {
   });
 });
 
-describe('prepareProxyRequest - delivery_payload_size_bytes metric (INT-7033)', () => {
+describe('proxyRequest - delivery_payload_size_bytes metric (INT-7033)', () => {
   beforeEach(() => {
+    axios.mockClear();
     stats.histogram.mockClear();
+    axios.mockResolvedValue({ status: 200, data: {} });
   });
 
-  it('emits the uncompressed JSON body size with compressed=false and per-destination labels', async () => {
+  it('emits the uncompressed JSON body size, with destType from the proxy arg (not metadata)', async () => {
     const jsonBody = { api_key: 'k', events: [{ event_type: 'Login', prop: 'x'.repeat(50) }] };
     const request = {
       body: { JSON: jsonBody },
@@ -1326,15 +1328,11 @@ describe('prepareProxyRequest - delivery_payload_size_bytes metric (INT-7033)', 
       endpointPath: '/2/httpapi',
       method: 'POST',
       headers: {},
-      metadata: {
-        destinationId: 'dest-1',
-        workspaceId: 'ws-1',
-        destinationType: 'AM',
-        sourceId: 'src-1',
-      },
+      // No destType/destinationType in metadata: destType must come from the proxyRequest arg.
+      metadata: { destinationId: 'dest-1', workspaceId: 'ws-1', sourceId: 'src-1' },
     };
 
-    await prepareProxyRequest(request);
+    await proxyRequest(request, 'AM');
 
     expect(stats.histogram).toHaveBeenCalledTimes(1);
     expect(stats.histogram).toHaveBeenCalledWith(
@@ -1359,32 +1357,44 @@ describe('prepareProxyRequest - delivery_payload_size_bytes metric (INT-7033)', 
       endpointPath: '/engage',
       method: 'POST',
       headers: {},
-      metadata: { destinationId: 'dest-2', workspaceId: 'ws-2', destinationType: 'MP' },
+      metadata: { destinationId: 'dest-2', workspaceId: 'ws-2' },
     };
 
-    await prepareProxyRequest(request);
+    await proxyRequest(request, 'MP');
 
     expect(stats.histogram).toHaveBeenCalledTimes(1);
     expect(stats.histogram).toHaveBeenCalledWith(
       'delivery_payload_size_bytes',
       Buffer.byteLength(rawArray),
       expect.objectContaining({
+        destType: 'MP',
         endpointPath: '/engage',
         compressed: true,
-        destType: 'MP',
         workspaceId: 'ws-2',
       }),
     );
   });
 
-  it('does not emit when the body has no non-empty payload format', async () => {
+  it('does not fire from prepareProxyRequest (the /proxyTest path never delivers)', async () => {
     await prepareProxyRequest({
-      body: {},
+      body: { JSON: { a: 1 } },
       endpoint: 'https://example.com',
-      method: 'GET',
+      endpointPath: '/x',
+      method: 'POST',
       headers: {},
+      metadata: { workspaceId: 'ws-1' },
     });
 
+    expect(stats.histogram).not.toHaveBeenCalled();
+  });
+
+  it('does not emit or throw when the body has no non-empty payload format', async () => {
+    const response = await proxyRequest(
+      { body: {}, endpoint: 'https://example.com', method: 'POST', headers: {} },
+      'AM',
+    );
+
+    expect(response).toBeDefined();
     expect(stats.histogram).not.toHaveBeenCalled();
   });
 });

--- a/src/util/prometheus.js
+++ b/src/util/prometheus.js
@@ -767,6 +767,27 @@ class Prometheus {
         ],
         buckets: [10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 150, 200],
       },
+      {
+        name: 'delivery_payload_size_bytes',
+        help: 'Uncompressed (pre-compression) size in bytes of the outbound delivery request body',
+        type: 'histogram',
+        labelNames: [
+          'destType',
+          'endpointPath',
+          'destinationId',
+          'workspaceId',
+          'sourceId',
+          'feature',
+          'module',
+          'implementation',
+          'compressed',
+        ],
+        // Small-end-weighted so sub-1KB payloads are legible; the default Prometheus buckets are
+        // latency-scaled and collapse everything under 1KB into a single bucket.
+        buckets: [
+          64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 65536, 262144, 1048576, 4194304,
+        ],
+      },
 
       // tracking plan metrics:
       // counter

--- a/src/util/prometheus.js
+++ b/src/util/prometheus.js
@@ -782,10 +782,13 @@ class Prometheus {
           'implementation',
           'compressed',
         ],
-        // Small-end-weighted so sub-1KB payloads are legible; the default Prometheus buckets are
-        // latency-scaled and collapse everything under 1KB into a single bucket.
+        // Small-end-weighted so sub-1KB payloads are legible (default Prometheus buckets are
+        // latency-scaled and collapse everything under 1KB), extended to 50MB so the large-batch
+        // tail this metric exists to size (destination body limits run to tens of MB) is not lost
+        // in a single +Inf bucket.
         buckets: [
           64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 65536, 262144, 1048576, 4194304,
+          16777216, 52428800,
         ],
       },
 


### PR DESCRIPTION
## What & why

Adds `transformer_delivery_payload_size_bytes`, a histogram of the **uncompressed (pre-compression) size of the delivery request body**, emitted on the proxy-delivery path.

This is **Phase 0** of the delivery-gzip rollout ([INT-7033]): before enabling compression we need the size distribution of delivery traffic **per destination/endpoint/workspace** (payload sizes are non-uniform across Amplitude's 4 and Mixpanel's 3 endpoints) to set rollout order and confirm whether a size floor is needed, plus a latency/error baseline (already emitted via `outgoing_request_*`) to compare the ramp against.

## The metric

- **Name:** `transformer_delivery_payload_size_bytes` (histogram)
- **Value:** uncompressed body size in bytes, computed per payload format (`JSON` → `JSON.stringify`, `JSON_ARRAY` → `.batch`, `XML` → `.payload`, `FORM` → form string, `GZIP` → the raw pre-compression `.payload`).
- **Buckets:** small-end weighted **and** extended to 50 MB — `64, 128, 256, 512, 1K, 2K, 4K, 8K, 16K, 64K, 256K, 1M, 4M, 16M, 50M` — so both the sub-1 KB detail and the large-batch tail (destination limits run to tens of MB) are legible.
- **Labels:** `destType`, `endpointPath`, `destinationId`, `workspaceId`, `sourceId`, `feature`, `module`, `implementation`, plus **`compressed`** (`true` only for endpoints already on the `GZIP` format, e.g. Mixpanel `/import`).

## Emission point (revised after review)

Emitted from **`proxyRequest`** (the live proxy-delivery path), **not** `prepareProxyRequest`, so the sample:
- carries the **authoritative `destType`** (the proxy argument — proxy metadata does not reliably carry it),
- sees the request's `endpointPath` and per-job `metadata`,
- **never fires from the `/proxyTest`** payload-comparison route (which calls `prepareProxy` directly and never delivers),
- reflects the body that is actually sent.

Sizing is **guarded** — a `JSON.stringify` failure yields no observation rather than throwing on the delivery hot path; a metric must never be able to fail a delivery. Extraction and sizing now share one `PAYLOAD_FORMAT_HANDLERS` map (no duplicated dispatch table).

## Reuse (not rebuilt)

Delivery latency & 4xx (`outgoing_request_*`, already per-endpoint + per-workspace), batch/event counts (`dest_transform_*_events`), and event-loop lag / process CPU (`collectDefaultMetrics`) already exist and are reused.

## Scope & known limitations

**Metric only.** Post-compression wire size / ratio / bytes-saved and `compression_duration` are **Phase 1** (INT-6923). The monitoring dashboard is tracked separately in **INT-7033**.

- Destinations that assign a **custom `this.proxy`** bypassing `proxyRequest` (some audience/bulk uploaders) are not covered. Amplitude & Mixpanel — the current rollout targets — both use the shared `proxyRequest`.
- Sizing JSON needs one `JSON.stringify` (unavoidable to size pre-send); low-volume FORM rebuilds the form string once more. Can add sampling if CPU shows up.
- `metadata` is an array for batched proxy requests; `getLogMetadata` uses element `[0]` (as every `outgoing_request_*` metric does). Proxy batches are per-destination, so `workspaceId`/`destinationId` are uniform and correct; only `sourceId` may be imprecise.

## Testing

- `network.test.js`: **46/46 pass**. New `proxyRequest` cases assert `destType` comes from the proxy arg (real metadata, no fabricated `destinationType`), the GZIP pre-compression size with `compressed=true`, that `prepareProxyRequest` emits nothing, and that an empty/unsizable body neither emits nor throws. Prettier + ESLint clean.

## Refs

- Linear: **INT-7033**
- Spec: rudderlabs/rudder-specs#94 (HLD §7.2/§7.4, implementation.md §5)
