### PR TITLE
chore(google_adwords_enhanced_conversions): add live integration tests

### DIFF
--- a/.claude/skills/live-integration-test/SKILL.md
+++ b/.claude/skills/live-integration-test/SKILL.md
@@ -52,6 +52,16 @@ merge gate; this suite is additive and asserts on the genuine delivery verdict.
 | mocked network via `network.ts` / `MockAxiosAdapter` | **no mock** — the runner boots the real app and hits real APIs |
 | a `data.ts` case = one input `message` + `destination.Config` + expected `output` | a **scenario** with a pipeline step whose `seed(ctx)` rebuilds that `message` |
 | hardcoded PII/ids in the message (email, userId, externalId, recordId, list/audience id) | `ctx.email()`, `ctx.identity(entity)`, `ctx.runId`, `ctx.now(offset?)`, `ctx.liveSecret.resourceIds`, or an id registered by a setup step — never a literal |
+
+**What that rule is and isn't about.** It targets values that must be *unique per run* or that are
+*sensitive*: identities, PII, and ids of records the run creates. It is not a ban on constants. A
+name that is fixed **configuration of the sandbox account** — a conversion action name, a list
+name — is neither secret nor run-scoped, and it must match the account character for character, so
+a literal next to the code that uses it beats a Vault key that can be forgotten. Prefer
+`resourceIds` when the value is an opaque id you'd have to look up anyway, or genuinely varies by
+environment; prefer a named constant in the spec when it's a stable label a reader can sanity-check
+against the account. Either way the failure should name the thing: a missing `resourceIds` key
+fails at collection, a wrong constant fails at the destination's own lookup.
 | config variants across cases (api version, list/object type, mapping) | a base `resolveConfig` + per-scenario `configOverride(base)` |
 | a case that asserts a specific transformed request shape | a scenario asserting the event is **delivered** (verdict 2xx / 207); the shape is the transform's job, already covered by the mocked suite |
 
@@ -64,6 +74,32 @@ the *code paths* that matter live — these differ by destination category:
 - **Conversion / event destinations**: the distinct event types and property mappings; enhanced /
   offline conversion variants.
 - **Cross-cutting** (any category): batched vs `dontBatch`; config-driven variants.
+
+**Batching is a scenario, not a side effect.** A pipeline step whose `seed` returns one event can
+never show that N events group into one delivery request. Return an ARRAY from `seed` for that
+— every event goes into a single `/routerTransform` call — and pin the result with
+`expectedOutputs`/`expectedProxyRequests`, since a grouping regression that fans events out still
+delivers 2xx on each. Worth a scenario per batching-key dimension the destination has: events that
+should group (same key), events that should fan out (different key), and `metadataOverride:
+{ dontBatch: true }`.
+
+**Partial failure is where a delivery spec earns its keep.** If the destination reports per-item
+results inside a 2xx (or a batch endpoint that 207s), add a scenario seeding one valid item next to
+one the DESTINATION rejects — not one your transform rejects, which never reaches delivery — and
+declare `expectedFailure: { items: [<seed index>] }`. The step then asserts which job was blamed,
+which is the positional mapping delivery specs implement and the thing that breaks silently. Find a field the
+transform passes through unvalidated (gaec uses a malformed `adjustmentDateTime`) so the item
+survives transform and fails at the API.
+
+**Credential branches need a bad credential, not a broken account.** For a spec's `authExpired` /
+`authRevoked` handling, use `metadataOverride: { secret: { ... } }` to hand one step a credential
+the destination rejects, and assert `expectedFailure: { category: '...' }` — the category, not
+merely that delivery failed, since a generic abort looks identical otherwise. Watch for transforms that call the
+destination BEFORE the delivery request (gaec resolves its conversion action by name first): those
+calls use the same credential and throw from inside `networkHandler.proxy()`, which the framework
+catches as a legacy-path error and never routes through the delivery spec. Where that applies, have
+the scenario perform one valid delivery first so any such lookup is cached, then fail the next
+step — and keep that warm-up inside the scenario so it does not depend on scenario order.
 
 Give each a stable `id` and a one-line `description`.
 
@@ -125,6 +161,14 @@ runs against the previous attempt's state.
 (listId, pixelId, measurementId, …); `readback` holds credentials for `verify` steps.
 `resolveConfig(s)` maps `s.config` (plus fixed non-secret defaults taken from the component
 `destination.Config`) into the real `destination.Config`.
+
+**Credentials an SDK reads from `process.env`** (not from `destination.Config` or
+`metadata.secret`) — e.g. Google Ads' shared `GOOGLE_ADS_DEVELOPER_TOKEN`: put the value in the
+secret and map it with `resolveEnv: (s) => ({ VAR: s.secret?.field })` on the spec. `envOverrides`
+is a static literal and cannot carry a secret. `resolveEnv` is applied and restored alongside
+`envOverrides` and wins on a key collision. Check `test/setup.ts` first — it seeds placeholders for
+a few such variables, and a spec that doesn't override one silently ships the placeholder to the
+real destination.
 
 **OAuth destinations** (`authType: 'oauth'`): supply `oauthRefresh` — the long-lived `refreshToken`,
 the `accountDefinition` (for rudder-auth's v1 route), and any `providerFields` (e.g. Salesforce

--- a/.claude/skills/live-integration-test/SKILL.md
+++ b/.claude/skills/live-integration-test/SKILL.md
@@ -52,6 +52,8 @@ merge gate; this suite is additive and asserts on the genuine delivery verdict.
 | mocked network via `network.ts` / `MockAxiosAdapter` | **no mock** — the runner boots the real app and hits real APIs |
 | a `data.ts` case = one input `message` + `destination.Config` + expected `output` | a **scenario** with a pipeline step whose `seed(ctx)` rebuilds that `message` |
 | hardcoded PII/ids in the message (email, userId, externalId, recordId, list/audience id) | `ctx.email()`, `ctx.identity(entity)`, `ctx.runId`, `ctx.now(offset?)`, `ctx.liveSecret.resourceIds`, or an id registered by a setup step — never a literal |
+| config variants across cases (api version, list/object type, mapping) | a base `resolveConfig` + per-scenario `configOverride(base)` |
+| a case that asserts a specific transformed request shape | a scenario asserting the event is **delivered** (verdict 2xx / 207); the shape is the transform's job, already covered by the mocked suite |
 
 **What that rule is and isn't about.** It targets values that must be *unique per run* or that are
 *sensitive*: identities, PII, and ids of records the run creates. It is not a ban on constants. A
@@ -62,8 +64,6 @@ a literal next to the code that uses it beats a Vault key that can be forgotten.
 environment; prefer a named constant in the spec when it's a stable label a reader can sanity-check
 against the account. Either way the failure should name the thing: a missing `resourceIds` key
 fails at collection, a wrong constant fails at the destination's own lookup.
-| config variants across cases (api version, list/object type, mapping) | a base `resolveConfig` + per-scenario `configOverride(base)` |
-| a case that asserts a specific transformed request shape | a scenario asserting the event is **delivered** (verdict 2xx / 207); the shape is the transform's job, already covered by the mocked suite |
 
 **One scenario per distinct behavior, not per component case.** Collapse the many mocked cases into
 the *code paths* that matter live — these differ by destination category:
@@ -170,10 +170,17 @@ is a static literal and cannot carry a secret. `resolveEnv` is applied and resto
 a few such variables, and a spec that doesn't override one silently ships the placeholder to the
 real destination.
 
-**OAuth destinations** (`authType: 'oauth'`): supply `oauthRefresh` — the long-lived `refreshToken`,
-the `accountDefinition` (for rudder-auth's v1 route), and any `providerFields` (e.g. Salesforce
-`instance_url`) — and set `oauthVersion` to the route rudder-auth uses: `'v0'` (legacy
-`/tokens/destination/<dest>/refresh`, the default) or `'v1'` (`/auth/v1/refresh`). At run time the
+**OAuth destinations** (`authType: 'oauth'`): supply `oauthRefresh` — the long-lived `refreshToken`
+and any `providerFields` (e.g. Salesforce `instance_url`) — and set `oauthVersion` to the route
+rudder-auth uses: `'v0'` (legacy
+`/tokens/destination/<dest>/refresh`, the default) or `'v1'` (`/auth/v1/refresh`). A `'v1'`
+spec must also declare `accountDefinition: { type, name }` — public metadata mirroring the control
+plane's `accounts/<dest>_oauth/db-config.json`, so it belongs on the spec, not in the secret.
+`name` is what rudder-auth lowercases to choose an implementation; `category` is always
+`'destination'` and the resolver supplies it. Nothing is derived from the destination name: the
+`DESTINATION_<DEST>_OAUTH` convention does not hold everywhere
+(`google_adwords_remarketing_lists` has a separate `_DM_OAUTH` definition), and a guess that is
+usually right surfaces as an opaque refresh failure instead of a missing declaration. At run time the
 suite starts the **rudder-auth** container (testcontainers, ECR image) and `OAuthTokenResolver` calls
 exactly that one route — no fallback — then merges the whole returned secret into `metadata.secret`,
 so the transform reads its token under whatever key rudder-auth returns (`accessToken` |

--- a/.github/scripts/live-test-matrix.js
+++ b/.github/scripts/live-test-matrix.js
@@ -15,18 +15,58 @@ const { join } = require('path');
 
 const DEST_DIR = 'test/integrations/destinations';
 
-const isOAuth = (specPath) => /authType:\s*['"]oauth['"]/.test(readFileSync(specPath, 'utf8'));
+// Drop `/* */` and `//` comments before looking for the declaration. A live spec documents its own
+// wiring at length, and `oauth: true` is not a cosmetic flag — it grants the job a WILDCARD Vault
+// import of control-plane/data/external-services plus an ECR login. A destination must earn that by
+// declaring `authType: 'oauth'`, never by mentioning it in prose.
+//
+// The line pass tracks quoting rather than taking the first `//`, so a URL in a string literal
+// ('https://…') doesn't truncate the line and cost a real declaration sharing it.
+const stripLineComment = (line) => {
+  let quote = null;
+  for (let i = 0; i < line.length; i += 1) {
+    const char = line[i];
+    if (quote) {
+      if (char === '\\') {
+        i += 1; // escaped character, never a closing quote
+      } else if (char === quote) {
+        quote = null;
+      }
+    } else if (char === '"' || char === "'" || char === '`') {
+      quote = char;
+    } else if (char === '/' && line[i + 1] === '/') {
+      return line.slice(0, i);
+    }
+  }
+  return line;
+};
+
+const stripComments = (source) =>
+  source
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .split('\n')
+    .map(stripLineComment)
+    .join('\n');
+
+// A non-trivial spec lives in a `live/` module folder with `live.ts` reduced to a one-line
+// re-export, so `authType` is declared in `live/spec.ts` and not in `live.ts` at all. Both are
+// checked: reading only `live.ts` would report an OAuth destination using the recommended layout as
+// non-OAuth, and the job would then skip the Vault cred import, the ECR login and rudder-auth.
+const isOAuth = (destinationDir) =>
+  [join(destinationDir, 'live.ts'), join(destinationDir, 'live', 'spec.ts')]
+    .filter((path) => existsSync(path))
+    .some((path) => /authType:\s*['"]oauth['"]/.test(stripComments(readFileSync(path, 'utf8'))));
 
 const include = readdirSync(DEST_DIR, { withFileTypes: true })
   .filter((entry) => entry.isDirectory())
   .map((entry) => entry.name)
   .sort()
   .flatMap((destination) => {
-    const specPath = join(DEST_DIR, destination, 'live.ts');
-    if (!existsSync(specPath)) {
+    const destinationDir = join(DEST_DIR, destination);
+    if (!existsSync(join(destinationDir, 'live.ts'))) {
       return [];
     }
-    return [{ destination, oauth: isOAuth(specPath) }];
+    return [{ destination, oauth: isOAuth(destinationDir) }];
   });
 
 if (include.length === 0) {

--- a/test/integrations/component.live.test.ts
+++ b/test/integrations/component.live.test.ts
@@ -13,7 +13,7 @@ import { runPipelineStep } from './live/runPipelineStep';
 import { retryUntilPasses } from './live/poll';
 import { OAuthTokenResolver } from './live/oauthTokenResolver';
 import { RudderAuthContainer } from './live/rudderAuthContainer';
-import { EnvManager } from './envUtils';
+import { EnvManager, EnvOverride } from './envUtils';
 import type { LiveSecret, EnrolledDestination } from './live/types';
 
 describe('Live Integration Test Suite', () => {
@@ -81,25 +81,46 @@ describe('Live Integration Test Suite', () => {
   }, 120000);
 
   // One describe per enrolled destination: resolve its credentials and base config, then run its
-  // enabled scenarios. A missing/invalid secret throws here (fail-closed), failing the destination.
+  // enabled scenarios.
+  //
+  // A missing or invalid secret throws here (fail-closed) — and note that "here" is the describe
+  // body, which jest evaluates at COLLECTION time, so the throw fails the whole suite file ("Test
+  // suite failed to run", zero tests) rather than only the destination at fault. That is fine as
+  // things stand, because CI runs one destination per matrix job (see .github/scripts/
+  // live-test-matrix.js), so a file is a destination. Anything that starts running several
+  // destinations in one jest process would need this moved into a beforeAll to keep one
+  // unprovisioned secret from taking the others down with it.
   describe.each(enrolledDestinations)('$destination', ({ destination, spec }) => {
+    const liveSecret: LiveSecret = resolver.resolve(destination);
+
     // Applied around the whole destination rather than per scenario: the flags a live spec names
     // gate the transform and delivery paths themselves, so every scenario has to run under them.
+    // `resolveEnv` contributes the secret-derived variables (a credential something reads from
+    // process.env) and is merged last, so it wins on a key collision with the static literal.
+    //
+    // A resolveEnv value is required to be non-empty, and a violation fails here at the credential
+    // boundary. Letting an empty one through would DELETE the variable (EnvOverride's semantics for
+    // undefined) and the run would fail later, once per scenario, as whatever error the consuming
+    // code raises for a missing credential — far from the secret field that is actually at fault.
     const envManager = new EnvManager();
-    beforeAll(() => {
-      if (spec.envOverrides) {
-        envManager.takeSnapshot(destination, Object.keys(spec.envOverrides));
-        envManager.applyOverrides(spec.envOverrides);
+    const resolvedEnv = spec.resolveEnv?.(liveSecret) ?? {};
+    Object.entries(resolvedEnv).forEach(([key, value]) => {
+      if (!value) {
+        throw new Error(
+          `[live:${destination}] resolveEnv returned an empty value for ${key} — the secret field ` +
+            `it maps is missing from LIVE_SECRET_${destination.toUpperCase()}.`,
+        );
       }
+    });
+    const destinationEnv: EnvOverride = { ...spec.envOverrides, ...resolvedEnv };
+    beforeAll(() => {
+      envManager.takeSnapshot(destination, Object.keys(destinationEnv));
+      envManager.applyOverrides(destinationEnv);
     });
     afterAll(() => {
-      if (spec.envOverrides) {
-        envManager.restoreSnapshot(destination);
-      }
+      envManager.restoreSnapshot(destination);
       envManager.cleanup();
     });
-
-    const liveSecret: LiveSecret = resolver.resolve(destination);
 
     beforeAll(async () => {
       if (spec.authType === 'oauth') {
@@ -114,6 +135,7 @@ describe('Live Integration Test Suite', () => {
           destination,
           liveSecret,
           spec.oauthVersion ?? 'v0',
+          spec.accountDefinition,
         );
         liveSecret.secret = { ...(liveSecret.secret ?? {}), ...secret };
       }

--- a/test/integrations/destinations/google_adwords_enhanced_conversions/live.ts
+++ b/test/integrations/destinations/google_adwords_enhanced_conversions/live.ts
@@ -1,0 +1,1 @@
+export { live, default } from './live/spec';

--- a/test/integrations/destinations/google_adwords_enhanced_conversions/live/profiles.ts
+++ b/test/integrations/destinations/google_adwords_enhanced_conversions/live/profiles.ts
@@ -1,0 +1,166 @@
+import sha256 from 'sha256';
+import type { RunContext } from '../../../live/types';
+
+// The two conversion actions the scenarios drive, named exactly as they exist in the sandbox
+// account. The SDK resolves them by name via `googleAds:searchStream`, so these are match-exact —
+// note the lower-case 'v' in 'Page view'; the mocked component fixtures say 'Page View', which is a
+// different action name and does not resolve.
+//
+// Declared here rather than in LIVE_SECRET_<DEST> because they are not credentials. The account
+// itself is already pinned by `config.customerId` in the secret, and a conversion action's name is
+// public metadata of that account — the same reasoning that moved `accountDefinition` out of the
+// secret and onto the spec. Keeping them here means the secret holds only things that must not be
+// read, and one fewer key has to be provisioned before this suite can run at all.
+//
+// Both are WEBPAGE actions, chosen because each accepts an ENHANCEMENT for a previously unseen
+// `orderId` — verified against the live account with `validateOnly: true`, so nothing was written.
+// If the sandbox's actions are ever renamed, the lookup fails with Google's "Conversion Action not
+// found" and these two literals are the only thing to update.
+export const PRIMARY_CONVERSION = 'Purchase';
+export const SECONDARY_CONVERSION = 'Page view';
+
+// ── Seed values ──
+//
+// These are the raw values a producer would put on the wire, nothing more. Deliberately no
+// normalization, formatting or hashing rules live in this file: reproducing the transform's own
+// rules here would make the suite grade the transform against a copy of itself, and any rule it
+// got wrong would be a rule the test agreed with. Everything below is either already in the shape
+// the destination accepts, or is raw input the transform is responsible for converting.
+
+// Google Ads takes date-times as `yyyy-MM-dd HH:mm:ss+|-HH:mm`. The transform does NOT convert this
+// field — trackConfig.json maps `properties.adjustmentDateTime` straight through — so an event has
+// to arrive already in that shape, and these seeds mirror what a producer must send. (If GAEC ever
+// takes over the conversion, this becomes a plain ISO timestamp and the transform is what proves
+// it; see the note in the PR description.)
+const googleDateTime = (isoTimestamp: string): string =>
+  `${isoTimestamp.slice(0, 10)} ${isoTimestamp.slice(11, 19)}+00:00`;
+
+// Raw, unnormalized identifiers — mixed case and messy phone formatting on purpose, so the
+// transform's normalize → validate → hash pipeline is what has to get them right.
+const RAW = {
+  // NANP reserves 555-0100..555-0199 for fictional use, and this number's hash is uploaded to
+  // Google as a match identifier, so it must be one that cannot belong to a real person.
+  phone: '+1 (415) 555-0171',
+  firstName: 'Alex',
+  lastName: 'Doe',
+  streetAddress: '71 Cherry Court',
+};
+
+// Plaintext address fields the transform passes through untouched. Google requires country and
+// postal code alongside a hashed name, so these travel with every address profile.
+const GEO = {
+  city: 'Southampton',
+  state: 'CA',
+  countryCode: 'US',
+  postalCode: '94105',
+};
+
+// The envelope every seeded track event shares. `orderId` is the one required mapping field
+// (trackConfig.json), so it is set here rather than per profile; it is namespaced by runId so a
+// re-run never re-uploads an adjustment Google has already accepted for the same order.
+const trackEvent = (
+  ctx: RunContext,
+  suffix: string,
+  event: string,
+  extra: { traits?: Record<string, unknown>; properties?: Record<string, unknown> },
+): Record<string, unknown> => {
+  const at = ctx.now();
+  return {
+    type: 'track',
+    event,
+    channel: 'web',
+    messageId: `${ctx.runId}-${suffix}`,
+    anonymousId: ctx.identity(`anon-${suffix}`),
+    userId: ctx.identity(`user-${suffix}`),
+    timestamp: at,
+    originalTimestamp: at,
+    sentAt: at,
+    integrations: { All: true },
+    context: {
+      library: { name: 'rudder-live-integration-test' },
+      // Maps to conversionAdjustments[0].userAgent.
+      userAgent:
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+      ...(extra.traits ? { traits: extra.traits } : {}),
+    },
+    properties: {
+      orderId: `${ctx.runId}-${suffix}`,
+      // Google rejects an adjustment stamped in the future and one older than the conversion it
+      // adjusts; an hour back sits safely inside the window for a recently uploaded conversion.
+      adjustmentDateTime: googleDateTime(ctx.now('-1h')),
+      ...(extra.properties ?? {}),
+    },
+  };
+};
+
+// ── Identifier profiles ──
+
+// Email + phone: the two standalone `userIdentifiers` entries. Both are raw — the transform
+// normalizes and SHA-256s them, and a regression there surfaces as a Google FieldError on the
+// identifier, which no mocked response can reproduce.
+export const emailPhoneTraits = (ctx: RunContext): Record<string, unknown> => ({
+  email: ctx.email(),
+  phone: RAW.phone,
+});
+
+// The addressInfo entry: raw name/street sub-fields the transform hashes, plus the plaintext geo
+// fields it passes through. `lastName` is run-scoped so concurrent runs never upload identical
+// address identifiers.
+export const addressTraits = (ctx: RunContext): Record<string, unknown> => ({
+  firstName: RAW.firstName,
+  lastName: `${RAW.lastName}-${ctx.runId.slice(-8)}`,
+  streetAddress: RAW.streetAddress,
+  ...GEO,
+});
+
+// Already-hashed identifiers, for the requireHash:false branch — which skips normalization and
+// validation and ships these to Google verbatim. The inputs are written already-normalized (lower
+// case, E.164, and `ctx.email()` is lower-case on a non-Gmail domain) so this hashes them directly
+// rather than restating the transform's normalization rules. What the scenario asserts is that
+// Google accepts the SHA-256 hex the pass-through branch forwards.
+const HASHED_INPUT = {
+  phone: '+14155550171',
+  firstName: 'alex',
+  lastName: 'doe',
+  streetAddress: '71 cherry court',
+};
+
+export const preHashedTraits = (ctx: RunContext): Record<string, unknown> => ({
+  email: sha256(ctx.email()),
+  phone: sha256(HASHED_INPUT.phone),
+  firstName: sha256(HASHED_INPUT.firstName),
+  lastName: sha256(HASHED_INPUT.lastName),
+  streetAddress: sha256(HASHED_INPUT.streetAddress),
+  ...GEO,
+});
+
+// ── Event seeds ──
+
+export const enhancementEvent = (
+  ctx: RunContext,
+  suffix: string,
+  event: string,
+  traits: Record<string, unknown>,
+): Record<string, unknown> => trackEvent(ctx, suffix, event, { traits });
+
+// An adjustment Google rejects on its own while its batch-mates are accepted — the ingredient a
+// live partial-failure scenario needs.
+//
+// It has to fail at GOOGLE, not in our transform: anything the transform rejects never reaches
+// delivery, so it would exercise the router's error path instead of delivery.ts's. This value is
+// chosen for exactly that property — trackConfig.json maps `properties.adjustmentDateTime` with no
+// type coercion and no validation, so a malformed date passes straight through and comes back as
+// `INVALID_STRING_DATE_TIME_SECONDS_WITH_OFFSET` on that one positional item, with the batch still
+// HTTP 200 and `results` carrying an empty slot where the item failed.
+const REJECTED_ADJUSTMENT_DATE_TIME = 'not-a-date';
+
+export const rejectedEnhancementEvent = (
+  ctx: RunContext,
+  suffix: string,
+  event: string,
+  traits: Record<string, unknown>,
+): Record<string, unknown> =>
+  trackEvent(ctx, suffix, event, {
+    traits,
+    properties: { adjustmentDateTime: REJECTED_ADJUSTMENT_DATE_TIME },
+  });

--- a/test/integrations/destinations/google_adwords_enhanced_conversions/live/spec.ts
+++ b/test/integrations/destinations/google_adwords_enhanced_conversions/live/spec.ts
@@ -202,10 +202,18 @@ export const live = {
   // adjustments simply fail to match any conversion and are discarded on Google's side.
   enabled: true,
   authType: 'oauth',
-  // rudder-auth's v1 route, keyed by the account definition the control plane declares for this
-  // destination (rudder-integrations-config .../accounts/google_adwords_enhanced_conversions_oauth).
-  // It answers with `{ access_token }`, which is the key transform.ts reads via getAccessToken.
+  // rudder-auth's v1 route. It answers with `{ access_token }`, which is the key transform.ts reads
+  // via getAccessToken.
   oauthVersion: 'v1',
+  // Mirrors rudder-integrations-config
+  // `destinations/google_adwords_enhanced_conversions/accounts/google_adwords_enhanced_conversions_oauth/db-config.json`.
+  // `name` is what rudder-auth lowercases to pick its implementation, so it has to match that file
+  // exactly. `category` is not declared here — it is 'destination' for every live spec and the
+  // resolver supplies it.
+  accountDefinition: {
+    type: 'google_adwords_enhanced_conversions',
+    name: 'DESTINATION_GOOGLE_ADWORDS_ENHANCED_CONVERSIONS_OAUTH',
+  },
   envOverrides: {
     // Batching-framework delivery is still behind a temporary per-destination flag; without it the
     // run would exercise the legacy networkHandler instead of delivery.ts. The transform-side flag

--- a/test/integrations/destinations/google_adwords_enhanced_conversions/live/spec.ts
+++ b/test/integrations/destinations/google_adwords_enhanced_conversions/live/spec.ts
@@ -1,0 +1,239 @@
+import { requiredSecretField } from '../../../live/secretResolver';
+import type { LiveScenario, LiveSpec } from '../../../live/types';
+import {
+  PRIMARY_CONVERSION,
+  SECONDARY_CONVERSION,
+  addressTraits,
+  emailPhoneTraits,
+  enhancementEvent,
+  preHashedTraits,
+  rejectedEnhancementEvent,
+} from './profiles';
+
+const DEST = 'google_adwords_enhanced_conversions';
+
+// What a run actually exercises, end to end, against a real Google Ads account:
+//
+//   1. rudder-auth mints an access token from the stored refresh token (authType 'oauth'),
+//   2. the batching-framework transform builds the conversion adjustments,
+//   3. the SDK resolves the conversion action by NAME via `googleAds:searchStream`, and
+//   4. uploads to `customers/<id>:uploadConversionAdjustments` on Google Ads v23.
+//
+// There is deliberately no read-back `verify`. Google Ads exposes no API for reading an uploaded
+// conversion adjustment, and matching against the underlying conversion is asynchronous (hours), so
+// a read-back would either assert nothing or be permanently flaky. The assertion is the delivery
+// verdict instead — which is meaningful here because delivery.ts maps a `partialFailureError` on a
+// 200 into a per-job abort, so any payload Google rejects fails the step rather than passing as a
+// 2xx. That covers the whole contract this suite exists to check: token, developer token, customer
+// id, conversion-action resolution, identifier hashing format and adjustment shape.
+//
+// Not ported from the component suite: every validation/error case (unconfigured conversion name,
+// missing orderId, non-track message type, missing OAuth secret, hashing-consistency aborts,
+// non-string loginCustomerId). Those never reach Google, so a live run adds nothing to what
+// component.test.ts already pins.
+
+const scenarios = [
+  {
+    id: 'gaec-enhancement-email-phone',
+    description:
+      'ENHANCEMENT with raw email + phone traits — normalized, SHA-256 hashed and uploaded as two userIdentifiers entries',
+    steps: [
+      {
+        stepType: 'pipeline',
+        name: 'enhancement with email and phone identifiers',
+        expectedOutputs: 1,
+        expectedProxyRequests: 1,
+        seed: (ctx) =>
+          enhancementEvent(ctx, 'email-phone', PRIMARY_CONVERSION, emailPhoneTraits(ctx)),
+      },
+    ],
+  },
+  {
+    id: 'gaec-enhancement-address',
+    description:
+      'ENHANCEMENT with address traits — hashed first/last name and street address alongside the plaintext city/state/countryCode/postalCode Google requires with them',
+    steps: [
+      {
+        stepType: 'pipeline',
+        name: 'enhancement with addressInfo identifiers',
+        expectedOutputs: 1,
+        expectedProxyRequests: 1,
+        seed: (ctx) => enhancementEvent(ctx, 'address', PRIMARY_CONVERSION, addressTraits(ctx)),
+      },
+    ],
+  },
+  {
+    id: 'gaec-enhancement-prehashed',
+    description:
+      'requireHash=false — pre-hashed traits skip normalization and validation and reach Google exactly as sent, proving the hex format is one Google accepts',
+    configOverride: (base) => ({ ...base, requireHash: false }),
+    steps: [
+      {
+        stepType: 'pipeline',
+        name: 'enhancement with pre-hashed identifiers',
+        expectedOutputs: 1,
+        expectedProxyRequests: 1,
+        seed: (ctx) => enhancementEvent(ctx, 'prehashed', PRIMARY_CONVERSION, preHashedTraits(ctx)),
+      },
+    ],
+  },
+  {
+    id: 'gaec-batched-same-conversion',
+    description:
+      'Two events on the same conversion action collapse into ONE upload carrying two conversionAdjustments, and both jobs are attributed the delivery verdict',
+    steps: [
+      {
+        stepType: 'pipeline',
+        name: 'two same-conversion events batch into one upload',
+        // The whole point of the scenario: one router output, one proxy request, two adjustments.
+        // Pinned exactly, because a grouping regression that fanned these out would still deliver
+        // 2xx twice and otherwise pass unnoticed.
+        expectedOutputs: 1,
+        expectedProxyRequests: 1,
+        seed: (ctx) => [
+          enhancementEvent(ctx, 'batch-a', PRIMARY_CONVERSION, emailPhoneTraits(ctx)),
+          enhancementEvent(ctx, 'batch-b', PRIMARY_CONVERSION, addressTraits(ctx)),
+        ],
+      },
+    ],
+  },
+  {
+    id: 'gaec-partial-failure',
+    description:
+      'A batch where one adjustment is rejected — Google 200s with partialFailureError and an empty results slot, and delivery.ts blames exactly that job while its batch-mate is delivered',
+    steps: [
+      {
+        stepType: 'pipeline',
+        name: 'one rejected adjustment alongside a valid one',
+        // Both events share a conversion action, so they must land in ONE upload — the partial
+        // failure only exists inside a multi-item request.
+        expectedOutputs: 1,
+        expectedProxyRequests: 1,
+        // The whole point: the SECOND event is the invalid one, so this pins the positional
+        // attribution in delivery.ts. Blaming index 0, or blaming both, still yields "one success
+        // and one failure" and would pass a weaker check.
+        expectedFailure: { items: [1] },
+        seed: (ctx) => [
+          enhancementEvent(ctx, 'partial-ok', PRIMARY_CONVERSION, emailPhoneTraits(ctx)),
+          rejectedEnhancementEvent(ctx, 'partial-bad', PRIMARY_CONVERSION, emailPhoneTraits(ctx)),
+        ],
+      },
+    ],
+  },
+  {
+    id: 'gaec-grouping-fan-out',
+    description:
+      'Two events on DIFFERENT conversion actions fan out to two uploads — the conversion name is part of the batching key, and each resolves its own conversionActionId',
+    steps: [
+      {
+        stepType: 'pipeline',
+        name: 'two different-conversion events fan out to two uploads',
+        expectedOutputs: 2,
+        expectedProxyRequests: 2,
+        seed: (ctx) => [
+          enhancementEvent(ctx, 'fanout-primary', PRIMARY_CONVERSION, emailPhoneTraits(ctx)),
+          enhancementEvent(ctx, 'fanout-secondary', SECONDARY_CONVERSION, emailPhoneTraits(ctx)),
+        ],
+      },
+    ],
+  },
+  {
+    id: 'gaec-auth-expired',
+    description:
+      "A credential Google rejects — delivery.ts's 4xx override reads the body and reports REFRESH_TOKEN, so rudder-server refreshes the grant instead of just aborting the job",
+    steps: [
+      // Deliberately two steps, and the order is load-bearing.
+      //
+      // networkHandler resolves the conversion action by NAME before uploading, and that lookup
+      // uses the same access token. With a bad token the LOOKUP fails first, and it fails by
+      // THROWING from inside networkHandler.proxy() — which the framework's try/catch turns into a
+      // legacy-path error, never reaching the delivery spec's 4xx override. The test would go red
+      // for the right-looking reason while proving nothing about delivery.ts.
+      //
+      // The lookup is memoised per (conversion name, customerId), so a valid delivery first warms
+      // that cache; the bad-token step then skips the lookup and fails on the upload, which IS a
+      // response the framework hands to the override. Warming it inside the scenario rather than
+      // relying on an earlier one keeps this independent of scenario order and of running this
+      // scenario alone.
+      {
+        stepType: 'pipeline',
+        name: 'warm the conversion-action cache with a valid delivery',
+        expectedOutputs: 1,
+        expectedProxyRequests: 1,
+        seed: (ctx) =>
+          enhancementEvent(ctx, 'auth-warm', PRIMARY_CONVERSION, emailPhoneTraits(ctx)),
+      },
+      {
+        stepType: 'pipeline',
+        name: 'delivery with a credential Google rejects',
+        expectedOutputs: 1,
+        expectedProxyRequests: 1,
+        // A syntactically valid token that is not a real grant. It has to reach the transform —
+        // getAccessToken throws on an absent one — so this replaces the value rather than removing
+        // it. Google answers 401 UNAUTHENTICATED with no `authenticationError` code, which
+        // getAuthErrCategory maps to REFRESH_TOKEN.
+        metadataOverride: { secret: { access_token: 'live-test-deliberately-invalid-token' } },
+        expectedFailure: { category: 'REFRESH_TOKEN' },
+        seed: (ctx) => enhancementEvent(ctx, 'auth-bad', PRIMARY_CONVERSION, emailPhoneTraits(ctx)),
+      },
+    ],
+  },
+] satisfies LiveScenario[];
+
+export const live = {
+  // Credentials come from the LIVE_SECRET_GOOGLE_ADWORDS_ENHANCED_CONVERSIONS field on
+  // engineering_shared/data/integrations_team/e2e_test/rudder-transformer (single-line LiveSecret
+  // JSON):
+  //
+  //   {"authType":"oauth",
+  //    "config":{"customerId":"<10-digit customer id>"},
+  //    "secret":{"developerToken":"<google ads developer token>"},
+  //    "oauthRefresh":{"refreshToken":"<google refresh token>"}}
+  //
+  // Credentials only — nothing static lives in there. Two things that are *about* the account but
+  // are not secret live in code instead: the rudder-auth account definition, derived from the
+  // destination name by the resolver (DESTINATION_GOOGLE_ADWORDS_ENHANCED_CONVERSIONS_OAUTH), and
+  // the two conversion action names (PRIMARY_CONVERSION / SECONDARY_CONVERSION in ./profiles).
+  // Every key that has to be provisioned before this suite can run at all is a key that can be
+  // forgotten, and a missing one fails the whole file at collection.
+  //
+  // Every run uploads real conversion adjustments to that account. Nothing is created that can be
+  // deleted — Google exposes no delete for an uploaded adjustment — so there is no `cleanup`; the
+  // adjustments simply fail to match any conversion and are discarded on Google's side.
+  enabled: true,
+  authType: 'oauth',
+  // rudder-auth's v1 route, keyed by the account definition the control plane declares for this
+  // destination (rudder-integrations-config .../accounts/google_adwords_enhanced_conversions_oauth).
+  // It answers with `{ access_token }`, which is the key transform.ts reads via getAccessToken.
+  oauthVersion: 'v1',
+  envOverrides: {
+    // Batching-framework delivery is still behind a temporary per-destination flag; without it the
+    // run would exercise the legacy networkHandler instead of delivery.ts. The transform-side flag
+    // is deliberately absent — GAEC is already batching-GA in features.ts.
+    GOOGLE_ADWORDS_ENHANCED_CONVERSIONS_BATCHING_FRAMEWORK_DELIVERY_ENABLED_WORKSPACE_IDS: 'ALL',
+  },
+  // The Google Ads SDK reads the developer token from process.env (googleUtils.getDeveloperToken),
+  // not from destination.Config or metadata.secret — it is a deployment-wide credential rather than
+  // a per-workspace one — so it can't travel through resolveConfig.
+  resolveEnv: (s) => ({
+    GOOGLE_ADS_DEVELOPER_TOKEN: requiredSecretField(
+      s,
+      DEST,
+      'developerToken',
+      'the Google Ads API developer token the sandbox account is approved under',
+    ),
+  }),
+  // Only the fields the transform actually reads. customerId arrives from the secret;
+  // listOfConversions is built from the same two constants the scenarios seed, so the config and
+  // the events can't drift — the transform rejects an event whose conversion name is not listed
+  // here before it ever reaches Google.
+  resolveConfig: (s) => ({
+    subAccount: false,
+    requireHash: true,
+    listOfConversions: [{ conversions: PRIMARY_CONVERSION }, { conversions: SECONDARY_CONVERSION }],
+    ...s.config,
+  }),
+  scenarios,
+} satisfies LiveSpec;
+
+export default live;

--- a/test/integrations/live/README.md
+++ b/test/integrations/live/README.md
@@ -147,6 +147,14 @@ export const live = {
 The registry discovers it automatically. Set `enabled: false` to keep it in the tree
 without running it.
 
+`envOverrides` is a static literal, so it can't carry a credential. When a transform or an SDK
+reads one from `process.env` rather than from `destination.Config` or `metadata.secret` — e.g.
+Google Ads' shared `GOOGLE_ADS_DEVELOPER_TOKEN` — declare `resolveEnv: (s) => ({ ... })` on the
+spec instead. It is applied and restored alongside `envOverrides` (and wins on a key collision),
+which keeps every live credential inside the one `LIVE_SECRET_<DEST>` blob. Note that
+`test/setup.ts` seeds placeholder values for a few such variables, so a spec that needs the real
+one must name it here or the placeholder is what reaches the destination.
+
 Batching-framework delivery is still behind a temporary per-destination flag. For live specs that
 need to exercise framework delivery, explicitly set
 `{DEST}_BATCHING_FRAMEWORK_DELIVERY_ENABLED_WORKSPACE_IDS: 'ALL'` in `envOverrides`. Do not set
@@ -161,7 +169,25 @@ scenario-level `cleanup`. There are no lifecycle hooks. Each step declares a req
 
 - **pipeline**: `{ stepType: 'pipeline', name, seed, metadataOverride?, retries? }` —
   `seed(ctx)` builds the raw event; the runner transforms, delivers, and asserts it was
-  delivered. `retries` re-runs seed → transform → deliver with backoff when delivery fails — for
+  delivered. Return an **array** of events instead of one to put them all in a single
+  `/routerTransform` call (one `input[]` entry each) — the only way to exercise router-level
+  batching live: whether N events collapse into one delivery request, and whether a batch response
+  is attributed back to every job. Pin the outcome with `expectedOutputs`/`expectedProxyRequests`,
+  since a grouping regression that fans events out still delivers 2xx on each.
+  The runner fails the step on any output that failed to _transform_ (a non-2xx entry in
+  `output[]`) rather than counting only the survivors, and on any seeded job that comes back with
+  no delivery verdict at all.
+  `expectedFailure` declares that the step is expected to fail, and how — one field for every
+  kind of failure rather than a flag per error class. `items` names seed indices whose jobs must
+  come back NOT delivered (omit for a whole-batch failure); `category` asserts the error category
+  the delivery reported. A step declaring it no longer requires the batch's top-level status to be
+  2xx. Both halves matter: for a partial failure, naming the index asserts **which** job the
+  destination blamed — blaming the wrong one still yields one success and one failure — and for a
+  credential failure, asserting the category is what separates a specific branch from the generic
+  one, since both abort the job. To reach a credential branch live, `metadataOverride.secret`
+  replaces the resolved secret for that step, because a real account's grant cannot be revoked on
+  demand.
+  `retries` re-runs seed → transform → deliver with backoff when delivery fails — for
   routes that decide create-vs-update via an eventually-consistent search (a just-created record
   can be missed and 409 on the first try). Only use it where a failed attempt persists nothing, so
   repeating is safe.

--- a/test/integrations/live/README.md
+++ b/test/integrations/live/README.md
@@ -59,8 +59,15 @@ returns each integration's own secret shape with no normalization (`criteo_audie
 **whole** returned secret into `metadata.secret` rather than a single hardcoded key, and each
 transform reads its own key via `getAccessToken(metadata, 'accessToken' | 'access_token')`. On failure
 it throws with the HTTP status (via `axios.isAxiosError`) — never the response body, so a token can't
-leak. Supply the token via `LIVE_SECRET_<DEST>.oauthRefresh` (`refreshToken`, plus `accountDefinition`
-for v1 and any `providerFields`).
+leak. Supply the token via `LIVE_SECRET_<DEST>.oauthRefresh` (`refreshToken` and any
+`providerFields`). The **v1** route also needs an `accountDefinition`, which is declared on the
+SPEC, not in the secret — it is public metadata, not a credential. State `{ type, name }`, where
+`name` is the control plane's account-definition name that rudder-auth lowercases to pick its
+implementation (`accounts/<dest>_oauth/db-config.json`); `category` is always `'destination'` and
+the resolver adds it. Nothing is derived from the destination name: the
+`DESTINATION_<DEST>_OAUTH` convention holds for most destinations but not all
+(`google_adwords_remarketing_lists` has a separate `_DM_OAUTH` definition), and a guess that is
+usually right fails as an opaque refresh error rather than as the missing declaration it is.
 
 The image is pulled from ECR (`422074288268.dkr.ecr.us-east-1.amazonaws.com/rudderstack/rudder-auth:develop`),
 so Docker must be running and logged in to that ECR registry. The image ships default OAuth app
@@ -120,8 +127,8 @@ blob matching the `LiveSecret` shape:
 - `config` — merged into `destination.Config` (auth for header-based destinations lives here).
 - `secret` — merged into `metadata.secret` (for destinations that read the token there).
 - `resourceIds`, `oauthRefresh`, `readback` — optional; account-scoped ids, the OAuth refresh
-  token (`oauthRefresh.refreshToken` + `accountDefinition` for the rudder-auth V1 route), and
-  read-back credentials for `verify` steps.
+  token (`oauthRefresh.refreshToken`), and read-back credentials for `verify` steps. The V1
+  route's `accountDefinition` is NOT here — it lives on the spec (see above).
 
 `SecretResolver` validates the blob against a zod schema (`LiveSecretSchema`) and throws a
 path-scoped error if it doesn't match. In production the blob comes from Vault (one path per

--- a/test/integrations/live/oauthTokenResolver.test.ts
+++ b/test/integrations/live/oauthTokenResolver.test.ts
@@ -5,11 +5,14 @@ import type { LiveSecret } from './types';
 jest.mock('axios');
 const mockedPost = axios.post as jest.MockedFunction<typeof axios.post>;
 
-const ACCOUNT_DEFINITION = {
+// What a spec declares: type + name, no category.
+const SPEC_DEFINITION = {
   type: 'google_adwords_enhanced_conversions',
-  category: 'destination',
   name: 'DESTINATION_GOOGLE_ADWORDS_ENHANCED_CONVERSIONS_OAUTH',
 };
+
+// What should reach rudder-auth: the same, with the framework's category filled in.
+const ACCOUNT_DEFINITION = { ...SPEC_DEFINITION, category: 'destination' };
 
 const oauthSecret = (overrides: Partial<LiveSecret['oauthRefresh']> = {}): LiveSecret => ({
   authType: 'oauth',
@@ -36,6 +39,7 @@ describe('OAuthTokenResolver — v1', () => {
       'google_adwords_enhanced_conversions',
       oauthSecret(),
       'v1',
+      SPEC_DEFINITION,
     );
 
     expect(secret).toEqual({
@@ -53,7 +57,12 @@ describe('OAuthTokenResolver — v1', () => {
       data: { secret: { access_token: 'at' } },
     } as never);
 
-    await resolver.resolveSecret('google_adwords_enhanced_conversions', oauthSecret(), 'v1');
+    await resolver.resolveSecret(
+      'google_adwords_enhanced_conversions',
+      oauthSecret(),
+      'v1',
+      SPEC_DEFINITION,
+    );
 
     expect(lastBody().account.secret).toMatchObject({
       refreshToken: 'rt-123',
@@ -72,43 +81,58 @@ describe('OAuthTokenResolver — v1', () => {
       'google_adwords_enhanced_conversions',
       oauthSecret({ providerFields: { instance_url: 'https://x.test' } }),
       'v1',
+      SPEC_DEFINITION,
     );
 
     expect(lastBody().account.secret.instance_url).toEqual('https://x.test');
   });
 
-  // An account definition is public metadata, not a credential, so it is never read from the
-  // secret. With no spec declaration either, the resolver derives the control plane's convention.
-  it('derives the conventional account definition when the spec does not declare one', async () => {
+  // `category` is 'destination' for every live spec, so the framework supplies it rather than
+  // making each spec repeat a constant it cannot vary. The spec states only type + name.
+  it('fills in the destination category the spec does not declare', async () => {
     mockedPost.mockResolvedValue({
       status: 200,
       data: { secret: { access_token: 'at' } },
     } as never);
 
-    await resolver.resolveSecret('google_adwords_enhanced_conversions', oauthSecret(), 'v1');
+    await resolver.resolveSecret(
+      'google_adwords_enhanced_conversions',
+      oauthSecret(),
+      'v1',
+      SPEC_DEFINITION,
+    );
 
     expect(lastBody().accountDefinition).toEqual(ACCOUNT_DEFINITION);
   });
 
-  it('prefers the spec-declared account definition over the derived one', async () => {
+  // Nothing is derived from the destination name. google_adwords_remarketing_lists is the case that
+  // makes derivation wrong: its DM account definition is not DESTINATION_<DEST>_OAUTH, so a guess
+  // would send a plausible name that rudder-auth resolves to nothing.
+  it('sends a non-conventional name through untouched', async () => {
     mockedPost.mockResolvedValue({
       status: 200,
       data: { secret: { access_token: 'at' } },
     } as never);
-    const specDefinition = {
+
+    await resolver.resolveSecret('google_adwords_remarketing_lists', oauthSecret(), 'v1', {
+      type: 'google_adwords_remarketing_lists',
+      name: 'DESTINATION_GOOGLE_ADWORDS_REMARKETING_LISTS_DM_OAUTH',
+    });
+
+    expect(lastBody().accountDefinition).toEqual({
       type: 'google_adwords_remarketing_lists',
       category: 'destination',
       name: 'DESTINATION_GOOGLE_ADWORDS_REMARKETING_LISTS_DM_OAUTH',
-    };
+    });
+  });
 
-    await resolver.resolveSecret(
-      'google_adwords_remarketing_lists',
-      oauthSecret(),
-      'v1',
-      specDefinition,
-    );
-
-    expect(lastBody().accountDefinition).toEqual(specDefinition);
+  // A v1 spec with no accountDefinition is a spec bug. Say that, rather than posting a definition
+  // with a missing name and reporting back whatever rudder-auth makes of it.
+  it('refuses a v1 refresh with no spec-declared account definition, without calling out', async () => {
+    await expect(
+      resolver.resolveSecret('google_adwords_enhanced_conversions', oauthSecret(), 'v1'),
+    ).rejects.toThrow('no accountDefinition on the live spec');
+    expect(mockedPost).not.toHaveBeenCalled();
   });
 });
 
@@ -150,7 +174,12 @@ describe('OAuthTokenResolver — failures', () => {
     } as never);
 
     await expect(
-      resolver.resolveSecret('google_adwords_enhanced_conversions', oauthSecret(), 'v1'),
+      resolver.resolveSecret(
+        'google_adwords_enhanced_conversions',
+        oauthSecret(),
+        'v1',
+        SPEC_DEFINITION,
+      ),
     ).rejects.toThrow('no access token in response');
   });
 
@@ -163,7 +192,12 @@ describe('OAuthTokenResolver — failures', () => {
     mockedPost.mockRejectedValue(err);
 
     await expect(
-      resolver.resolveSecret('google_adwords_enhanced_conversions', oauthSecret(), 'v1'),
+      resolver.resolveSecret(
+        'google_adwords_enhanced_conversions',
+        oauthSecret(),
+        'v1',
+        SPEC_DEFINITION,
+      ),
     ).rejects.toThrow(
       expect.objectContaining({
         message: expect.not.stringContaining('LEAKED'),

--- a/test/integrations/live/oauthTokenResolver.test.ts
+++ b/test/integrations/live/oauthTokenResolver.test.ts
@@ -1,0 +1,173 @@
+import axios from 'axios';
+import { OAuthTokenResolver } from './oauthTokenResolver';
+import type { LiveSecret } from './types';
+
+jest.mock('axios');
+const mockedPost = axios.post as jest.MockedFunction<typeof axios.post>;
+
+const ACCOUNT_DEFINITION = {
+  type: 'google_adwords_enhanced_conversions',
+  category: 'destination',
+  name: 'DESTINATION_GOOGLE_ADWORDS_ENHANCED_CONVERSIONS_OAUTH',
+};
+
+const oauthSecret = (overrides: Partial<LiveSecret['oauthRefresh']> = {}): LiveSecret => ({
+  authType: 'oauth',
+  config: {},
+  oauthRefresh: { refreshToken: 'rt-123', ...overrides },
+});
+
+const resolver = new OAuthTokenResolver('http://rudder-auth.test');
+
+beforeEach(() => mockedPost.mockReset());
+
+const lastBody = () => mockedPost.mock.calls[0][1] as Record<string, any>;
+
+describe('OAuthTokenResolver — v1', () => {
+  // rudder-auth's v1 route res.json()s `implementation.refreshToken()`'s return verbatim, and that
+  // return is `{ secret: {...} }`. Reading the token off the top level finds nothing.
+  it('unwraps the { secret } envelope the v1 route returns', async () => {
+    mockedPost.mockResolvedValue({
+      status: 200,
+      data: { secret: { access_token: 'at-1', refresh_token: 'rt-1', developer_token: 'dt-1' } },
+    } as never);
+
+    const secret = await resolver.resolveSecret(
+      'google_adwords_enhanced_conversions',
+      oauthSecret(),
+      'v1',
+    );
+
+    expect(secret).toEqual({
+      access_token: 'at-1',
+      refresh_token: 'rt-1',
+      developer_token: 'dt-1',
+    });
+  });
+
+  // The v1 route hands account.secret to the implementation with no key mapping, and rudder-auth's
+  // Google implementation destructures `refresh_token`, not `refreshToken`.
+  it('sends the refresh token under both spellings', async () => {
+    mockedPost.mockResolvedValue({
+      status: 200,
+      data: { secret: { access_token: 'at' } },
+    } as never);
+
+    await resolver.resolveSecret('google_adwords_enhanced_conversions', oauthSecret(), 'v1');
+
+    expect(lastBody().account.secret).toMatchObject({
+      refreshToken: 'rt-123',
+      refresh_token: 'rt-123',
+    });
+    expect(lastBody().accountDefinition).toEqual(ACCOUNT_DEFINITION);
+  });
+
+  it('lets providerFields override either spelling and carry extras', async () => {
+    mockedPost.mockResolvedValue({
+      status: 200,
+      data: { secret: { access_token: 'at' } },
+    } as never);
+
+    await resolver.resolveSecret(
+      'google_adwords_enhanced_conversions',
+      oauthSecret({ providerFields: { instance_url: 'https://x.test' } }),
+      'v1',
+    );
+
+    expect(lastBody().account.secret.instance_url).toEqual('https://x.test');
+  });
+
+  // An account definition is public metadata, not a credential, so it is never read from the
+  // secret. With no spec declaration either, the resolver derives the control plane's convention.
+  it('derives the conventional account definition when the spec does not declare one', async () => {
+    mockedPost.mockResolvedValue({
+      status: 200,
+      data: { secret: { access_token: 'at' } },
+    } as never);
+
+    await resolver.resolveSecret('google_adwords_enhanced_conversions', oauthSecret(), 'v1');
+
+    expect(lastBody().accountDefinition).toEqual(ACCOUNT_DEFINITION);
+  });
+
+  it('prefers the spec-declared account definition over the derived one', async () => {
+    mockedPost.mockResolvedValue({
+      status: 200,
+      data: { secret: { access_token: 'at' } },
+    } as never);
+    const specDefinition = {
+      type: 'google_adwords_remarketing_lists',
+      category: 'destination',
+      name: 'DESTINATION_GOOGLE_ADWORDS_REMARKETING_LISTS_DM_OAUTH',
+    };
+
+    await resolver.resolveSecret(
+      'google_adwords_remarketing_lists',
+      oauthSecret(),
+      'v1',
+      specDefinition,
+    );
+
+    expect(lastBody().accountDefinition).toEqual(specDefinition);
+  });
+});
+
+describe('OAuthTokenResolver — v0', () => {
+  // criteo_audience's v0 method returns the secret flat; unwrapping must not disturb that.
+  it('reads a flat v0 response and posts only refreshToken', async () => {
+    mockedPost.mockResolvedValue({
+      status: 200,
+      data: { accessToken: 'at-0', refreshToken: 'rt-0' },
+    } as never);
+
+    const secret = await resolver.resolveSecret('criteo_audience', oauthSecret(), 'v0');
+
+    expect(secret).toEqual({ accessToken: 'at-0', refreshToken: 'rt-0' });
+    expect(mockedPost.mock.calls[0][0]).toContain('/tokens/destination/criteo_audience/refresh');
+    expect(lastBody()).toEqual({ refreshToken: 'rt-123' });
+  });
+
+  // A v0 body is whatever the destination's own refresh method returns, so a nested `secret` in it
+  // is not the v1 envelope. Unwrapping by body shape rather than by route would descend into it and
+  // drop the top-level token, reporting a successful refresh as 'no access token in response'.
+  it('does not unwrap a nested `secret` on the flat v0 route', async () => {
+    mockedPost.mockResolvedValue({
+      status: 200,
+      data: { accessToken: 'at-0', secret: { clientSecret: 'not-a-token' } },
+    } as never);
+
+    const secret = await resolver.resolveSecret('criteo_audience', oauthSecret(), 'v0');
+
+    expect(secret.accessToken).toEqual('at-0');
+  });
+});
+
+describe('OAuthTokenResolver — failures', () => {
+  it('reports a refresh that returned no access token', async () => {
+    mockedPost.mockResolvedValue({
+      status: 200,
+      data: { secret: { refresh_token: 'only' } },
+    } as never);
+
+    await expect(
+      resolver.resolveSecret('google_adwords_enhanced_conversions', oauthSecret(), 'v1'),
+    ).rejects.toThrow('no access token in response');
+  });
+
+  it('never puts the response body — which carries tokens — into the thrown message', async () => {
+    const err = Object.assign(new Error('boom'), {
+      isAxiosError: true,
+      response: { status: 401, data: { secret: { access_token: 'LEAKED-TOKEN' } } },
+      config: { data: JSON.stringify({ refreshToken: 'LEAKED-REFRESH' }) },
+    });
+    mockedPost.mockRejectedValue(err);
+
+    await expect(
+      resolver.resolveSecret('google_adwords_enhanced_conversions', oauthSecret(), 'v1'),
+    ).rejects.toThrow(
+      expect.objectContaining({
+        message: expect.not.stringContaining('LEAKED'),
+      }) as never,
+    );
+  });
+});

--- a/test/integrations/live/oauthTokenResolver.ts
+++ b/test/integrations/live/oauthTokenResolver.ts
@@ -1,10 +1,40 @@
 import axios from 'axios';
 import { z } from 'zod';
-import type { LiveSecret, OAuthVersion } from './types';
+import type { AccountDefinition, LiveSecret, OAuthVersion } from './types';
+
+// The account-definition shape the control plane uses for a destination with a single OAuth
+// account: rudder-integrations-config stores it under
+// `destinations/<dest>/accounts/<dest>_oauth/db-config.json` as
+// `{ name: 'DESTINATION_<DEST>_OAUTH', type: '<dest>', category: 'destination' }`, and rudder-auth
+// resolves its implementation from `name.toLowerCase()`. Deriving it keeps the common case free of
+// boilerplate; a spec can still declare its own for a destination with more than one variant.
+const defaultAccountDefinition = (destination: string): AccountDefinition => ({
+  type: destination,
+  category: 'destination',
+  name: `DESTINATION_${destination.toUpperCase()}_OAUTH`,
+});
 
 const SecretSchema = z.record(z.unknown());
 
 type RefreshResult = { ok: true; secret: Record<string, string> } | { ok: false; detail: string };
+
+// The two routes answer with different envelopes. v0 returns the secret flat
+// (`{ accessToken, refreshToken }` / `{ access_token, … }`), while v1 wraps it —
+// `implementation.refreshToken()` returns `{ secret: {...} }` and the route `res.json`s that
+// verbatim. Without unwrapping, a v1 refresh reads no access token at the top level and is
+// reported as a failed refresh even though it succeeded.
+//
+// Applied per ROUTE rather than by sniffing the body, because the two shapes are not reliably
+// distinguishable: a v0 response is whatever the destination's own refresh method returns, and one
+// that happened to carry a nested `secret` object alongside its top-level `accessToken` would be
+// unwrapped into the inner object and the token silently lost. The route is known at the call
+// site, so there is nothing to guess at.
+const unwrapSecret = (body: Record<string, unknown>): Record<string, unknown> => {
+  const inner = body.secret;
+  return typeof inner === 'object' && inner !== null && !Array.isArray(inner)
+    ? (inner as Record<string, unknown>)
+    : body;
+};
 
 const stringEntries = (secret: Record<string, unknown>): Record<string, string> => {
   const out: Record<string, string> = {};
@@ -23,14 +53,21 @@ export class OAuthTokenResolver {
     this.baseUrl = baseUrl.replace(/\/+$/, '');
   }
 
-  private async post(url: string, body: object): Promise<RefreshResult> {
+  // `envelope` names the shape the route answers with: 'wrapped' for v1's `{ secret: {...} }`,
+  // 'flat' for v0's bare secret. See unwrapSecret for why this is a parameter and not a sniff.
+  private async post(
+    url: string,
+    body: object,
+    envelope: 'flat' | 'wrapped',
+  ): Promise<RefreshResult> {
     try {
       const res = await axios.post(url, body, {
         headers: { 'Content-Type': 'application/json' },
         timeout: 20000,
       });
       const parsed = SecretSchema.safeParse(res.data);
-      const secret = parsed.success ? stringEntries(parsed.data) : {};
+      const payload = parsed.success ? parsed.data : {};
+      const secret = stringEntries(envelope === 'wrapped' ? unwrapSecret(payload) : payload);
       if (secret.accessToken || secret.access_token) {
         return { ok: true, secret };
       }
@@ -50,19 +87,40 @@ export class OAuthTokenResolver {
     }
   }
 
-  private async refreshV1(secret: LiveSecret): Promise<RefreshResult> {
-    const { refreshToken, accountDefinition, providerFields } = secret.oauthRefresh ?? {};
-    if (!accountDefinition) {
-      return { ok: false, detail: 'oauthRefresh.accountDefinition is required for a v1 refresh' };
-    }
-    return this.post(`${this.baseUrl}/auth/v1/refresh`, {
-      accountDefinition,
-      account: { secret: { refreshToken, ...(providerFields ?? {}) }, options: {} },
-    });
+  private async refreshV1(
+    destination: string,
+    secret: LiveSecret,
+    specAccountDefinition?: AccountDefinition,
+  ): Promise<RefreshResult> {
+    const { refreshToken, providerFields } = secret.oauthRefresh ?? {};
+    // An account definition is public metadata, never a credential, so it is not read from the
+    // secret at all: a spec declares it, or the convention below is derived. That keeps
+    // LIVE_SECRET_<DEST> to credentials only.
+    const accountDefinition = specAccountDefinition ?? defaultAccountDefinition(destination);
+    // `account.secret` is handed to the resolved implementation verbatim — the v1 route does no key
+    // mapping — and implementations disagree on the casing they destructure: rudder-auth's Google
+    // implementation reads `refresh_token`, others read `refreshToken`. Sending both spellings of
+    // the same token keeps this resolver agnostic; `providerFields` is spread last so a spec can
+    // still override either, alongside extras like Salesforce's instance_url.
+    return this.post(
+      `${this.baseUrl}/auth/v1/refresh`,
+      {
+        accountDefinition,
+        account: {
+          secret: { refreshToken, refresh_token: refreshToken, ...(providerFields ?? {}) },
+          options: {},
+        },
+      },
+      'wrapped',
+    );
   }
 
   private async refreshV0(destination: string, refreshToken: string): Promise<RefreshResult> {
-    return this.post(`${this.baseUrl}/tokens/destination/${destination}/refresh`, { refreshToken });
+    return this.post(
+      `${this.baseUrl}/tokens/destination/${destination}/refresh`,
+      { refreshToken },
+      'flat',
+    );
   }
 
   // Call exactly the route the spec declares — no fallback, so a leftover legacy path can't be hit.
@@ -70,6 +128,7 @@ export class OAuthTokenResolver {
     destination: string,
     secret: LiveSecret,
     version: OAuthVersion,
+    specAccountDefinition?: AccountDefinition,
   ): Promise<Record<string, string>> {
     const refreshToken = secret.oauthRefresh?.refreshToken;
     if (!refreshToken) {
@@ -80,7 +139,7 @@ export class OAuthTokenResolver {
     const result =
       version === 'v0'
         ? await this.refreshV0(destination, refreshToken)
-        : await this.refreshV1(secret);
+        : await this.refreshV1(destination, secret, specAccountDefinition);
     if (result.ok) {
       return result.secret;
     }

--- a/test/integrations/live/oauthTokenResolver.ts
+++ b/test/integrations/live/oauthTokenResolver.ts
@@ -2,17 +2,16 @@ import axios from 'axios';
 import { z } from 'zod';
 import type { AccountDefinition, LiveSecret, OAuthVersion } from './types';
 
-// The account-definition shape the control plane uses for a destination with a single OAuth
-// account: rudder-integrations-config stores it under
-// `destinations/<dest>/accounts/<dest>_oauth/db-config.json` as
-// `{ name: 'DESTINATION_<DEST>_OAUTH', type: '<dest>', category: 'destination' }`, and rudder-auth
-// resolves its implementation from `name.toLowerCase()`. Deriving it keeps the common case free of
-// boilerplate; a spec can still declare its own for a destination with more than one variant.
-const defaultAccountDefinition = (destination: string): AccountDefinition => ({
-  type: destination,
-  category: 'destination',
-  name: `DESTINATION_${destination.toUpperCase()}_OAUTH`,
-});
+// Every account definition this suite sends is a destination's. rudder-integrations-config stores
+// them under `destinations/<dest>/accounts/<dest>_oauth/db-config.json`, and the live registry only
+// ever enrols destinations — there is no source-side live spec and no way for one to reach here. So
+// `category` is the framework's to supply, not a constant for each spec to repeat and get wrong.
+//
+// `type` and `name` are the spec's, because only the spec knows them: `name` is what rudder-auth
+// lowercases to pick an implementation, and the `DESTINATION_<DEST>_OAUTH` convention that would
+// let us guess it does not hold everywhere (google_adwords_remarketing_lists has both a legacy and
+// a `_DM_OAUTH` definition).
+const ACCOUNT_CATEGORY = 'destination';
 
 const SecretSchema = z.record(z.unknown());
 
@@ -94,9 +93,19 @@ export class OAuthTokenResolver {
   ): Promise<RefreshResult> {
     const { refreshToken, providerFields } = secret.oauthRefresh ?? {};
     // An account definition is public metadata, never a credential, so it is not read from the
-    // secret at all: a spec declares it, or the convention below is derived. That keeps
-    // LIVE_SECRET_<DEST> to credentials only.
-    const accountDefinition = specAccountDefinition ?? defaultAccountDefinition(destination);
+    // secret at all — the spec declares it, which keeps LIVE_SECRET_<DEST> to credentials only.
+    // Missing is a spec bug, and saying so beats posting a half-built definition and reading back
+    // whatever rudder-auth makes of it.
+    if (!specAccountDefinition) {
+      return {
+        ok: false,
+        detail:
+          `no accountDefinition on the live spec for '${destination}' — a v1 refresh needs ` +
+          `{ type, name }, where name is the control plane's account definition (usually ` +
+          `DESTINATION_${destination.toUpperCase()}_OAUTH)`,
+      };
+    }
+    const accountDefinition = { ...specAccountDefinition, category: ACCOUNT_CATEGORY };
     // `account.secret` is handed to the resolved implementation verbatim — the v1 route does no key
     // mapping — and implementations disagree on the casing they destructure: rudder-auth's Google
     // implementation reads `refresh_token`, others read `refreshToken`. Sending both spellings of

--- a/test/integrations/live/routerProxyRequests.ts
+++ b/test/integrations/live/routerProxyRequests.ts
@@ -56,15 +56,23 @@ const ProxyDeliveryHttpBodySchema = z.object({
   output: DeliveryV1ResponseSchema,
 });
 
-/** Parse `/routerTransform` HTTP body; returns only successful (2xx) outputs. */
-export const parseSuccessfulRouterOutputs = (body: unknown): RouterOutput[] => {
+/**
+ * Parse a `/routerTransform` HTTP body into its outputs, successful and failed alike.
+ *
+ * Failed outputs are deliberately NOT filtered out here. /routerTransform answers 200 with a
+ * per-event verdict, so a transform error is just another entry in `output[]`; dropping those
+ * silently would let a multi-event step whose events partly failed to transform still satisfy an
+ * `expectedOutputs` count built from the survivors. The caller separates them and fails on any
+ * non-2xx (see runPipelineStep).
+ */
+export const parseRouterOutputs = (body: unknown): RouterOutput[] => {
   const result = RouterTransformHttpBodySchema.safeParse(body);
   if (!result.success) {
     throw new Error(
       `/routerTransform response did not match the expected shape: ${formatZodError(result.error)}`,
     );
   }
-  return result.data.output.filter((o) => o.statusCode >= 200 && o.statusCode < 300);
+  return result.data.output;
 };
 
 /** Parse `/v1/destinations/<dest>/proxy` HTTP body to the delivery verdict. */

--- a/test/integrations/live/routerTransformRequest.ts
+++ b/test/integrations/live/routerTransformRequest.ts
@@ -1,34 +1,39 @@
 import { readString } from './coerce';
-import type { BuildRouterTransformBodyOptions, RouterTransformRequestBody } from './types';
+import type {
+  BuildRouterTransformBodyOptions,
+  RouterTransformRequestBody,
+  SeededEvent,
+} from './types';
 
+// Assembles the /routerTransform body from the events a pipeline step seeded — one `input[]` entry
+// per event, all in one call. A step whose `seed` returns a single event passes a one-element
+// array; one that returns several passes the whole batch, which is what lets the router group (or
+// fan out) them for real.
 export const buildRouterTransformBody = (
   destination: string,
-  message: Record<string, unknown>,
+  events: SeededEvent[],
   config: Record<string, unknown>,
-  jobId: number,
   options?: BuildRouterTransformBodyOptions,
 ): RouterTransformRequestBody => ({
-  input: [
-    {
-      message,
-      destination: {
-        ID: `live-${destination}`,
-        Config: config,
-        Enabled: true,
-        ...(options?.destinationOverride ?? {}),
-      },
-      ...(options?.connection ? { connection: options.connection } : {}),
-      metadata: {
-        jobId,
-        attemptNum: 0,
-        userId: readString(message.userId, 'live-user'),
-        sourceId: 'live-sourceId',
-        destinationId: `live-${destination}`,
-        workspaceId: 'live-workspaceId',
-        secret: options?.secret ?? {},
-        ...(options?.metadataOverride ?? {}),
-      },
+  input: events.map(({ message, jobId }) => ({
+    message,
+    destination: {
+      ID: `live-${destination}`,
+      Config: config,
+      Enabled: true,
+      ...(options?.destinationOverride ?? {}),
     },
-  ],
+    ...(options?.connection ? { connection: options.connection } : {}),
+    metadata: {
+      jobId,
+      attemptNum: 0,
+      userId: readString(message.userId, 'live-user'),
+      sourceId: 'live-sourceId',
+      destinationId: `live-${destination}`,
+      workspaceId: 'live-workspaceId',
+      secret: options?.secret ?? {},
+      ...(options?.metadataOverride ?? {}),
+    },
+  })),
   destType: destination,
 });

--- a/test/integrations/live/runPipelineStep.test.ts
+++ b/test/integrations/live/runPipelineStep.test.ts
@@ -1,0 +1,420 @@
+import { runPipelineStep } from './runPipelineStep';
+import { RunContextImpl } from './runContext';
+import { buildRouterTransformBody } from './routerTransformRequest';
+import type {
+  LiveHttpClient,
+  LiveHttpResponse,
+  PipelineStep,
+  RouterTransformRequestBody,
+  RunContext,
+  SeededEvent,
+} from './types';
+
+const ctx = (): RunContext =>
+  new RunContextImpl({ liveSecret: { authType: 'apiKey', config: {} } });
+
+// A /routerTransform output carrying one delivery request, echoing back the jobIds it covers.
+const routerOutput = (jobIds: number[], statusCode = 200) => ({
+  batchedRequest: {
+    version: '1',
+    type: 'REST',
+    method: 'POST',
+    endpoint: 'https://example.test/collect',
+    body: { JSON: { jobIds } },
+  },
+  metadata: jobIds.map((jobId) => ({ jobId })),
+  destination: { ID: 'live-dest', Config: {} },
+  batched: true,
+  statusCode,
+});
+
+const failedRouterOutput = (jobIds: number[]) => ({
+  ...routerOutput(jobIds, 400),
+  batchedRequest: undefined,
+  error: 'event is missing a required field',
+  statTags: { errorCategory: 'transformation' },
+});
+
+// A delivered /proxy verdict for the jobIds in the request it answers.
+const deliveredProxyOutput = (jobIds: number[]) => ({
+  output: {
+    status: 200,
+    message: 'delivered',
+    response: jobIds.map((jobId) => ({
+      error: '',
+      statusCode: 200,
+      metadata: {
+        jobId,
+        attemptNum: 0,
+        userId: 'u',
+        sourceId: 'live-sourceId',
+        destinationId: 'live-dest',
+        workspaceId: 'live-workspaceId',
+        secret: {},
+        dontBatch: false,
+      },
+    })),
+  },
+});
+
+// Records every request the runner makes, and answers /routerTransform by grouping the inputs the
+// way `groupInto` says — so a test can model batching without a real transform.
+const stubHttp = (
+  calls: { url: string; body: unknown }[],
+  // Default: every seeded event groups into one delivery request.
+  groupInto: (jobIds: number[]) => number[][] = (jobIds) => [jobIds],
+): LiveHttpClient => ({
+  post: async (url: string, body: object): Promise<LiveHttpResponse> => {
+    calls.push({ url, body });
+    if (url === '/routerTransform') {
+      const jobIds = (body as RouterTransformRequestBody).input.map((i) => i.metadata.jobId);
+      return { status: 200, body: { output: groupInto(jobIds).map((g) => routerOutput(g)) } };
+    }
+    const proxyJobIds = (body as { metadata: { jobId: number }[] }).metadata.map((m) => m.jobId);
+    return { status: 200, body: deliveredProxyOutput(proxyJobIds) };
+  },
+});
+
+const run = (step: PipelineStep, http: LiveHttpClient) =>
+  runPipelineStep({
+    destination: 'dest',
+    scenarioId: 'scenario',
+    step,
+    ctx: ctx(),
+    config: {},
+    http,
+  });
+
+const event = (name: string) => ({ type: 'track', event: name, userId: 'u' });
+
+describe('buildRouterTransformBody', () => {
+  it('builds one input per seeded event, each carrying its own jobId and the shared config', () => {
+    const events: SeededEvent[] = [
+      { message: event('a'), jobId: 11 },
+      { message: event('b'), jobId: 22 },
+    ];
+
+    const body = buildRouterTransformBody('dest', events, { apiKey: 'k' });
+
+    expect(body.destType).toEqual('dest');
+    expect(body.input).toHaveLength(2);
+    expect(body.input.map((i) => i.metadata.jobId)).toEqual([11, 22]);
+    expect(body.input.map((i) => i.message)).toEqual([event('a'), event('b')]);
+    body.input.forEach((i) => expect(i.destination.Config).toEqual({ apiKey: 'k' }));
+  });
+
+  it('applies metadataOverride to every input, not just the first', () => {
+    const events: SeededEvent[] = [
+      { message: event('a'), jobId: 11 },
+      { message: event('b'), jobId: 22 },
+    ];
+
+    const body = buildRouterTransformBody(
+      'dest',
+      events,
+      {},
+      { metadataOverride: { dontBatch: true } },
+    );
+
+    expect(body.input.map((i) => i.metadata.dontBatch)).toEqual([true, true]);
+  });
+});
+
+describe('runPipelineStep — seeding', () => {
+  it('sends a single-seed step as one /routerTransform input', async () => {
+    const calls: { url: string; body: unknown }[] = [];
+    await run(
+      {
+        stepType: 'pipeline',
+        name: 'single',
+        expectedOutputs: 1,
+        expectedProxyRequests: 1,
+        seed: () => event('a'),
+      },
+      stubHttp(calls, (jobIds) => [jobIds]),
+    );
+
+    const routerBody = calls[0].body as RouterTransformRequestBody;
+    expect(calls[0].url).toEqual('/routerTransform');
+    expect(routerBody.input).toHaveLength(1);
+  });
+
+  it('sends every event an array seed returns in ONE /routerTransform call, with distinct jobIds', async () => {
+    const calls: { url: string; body: unknown }[] = [];
+    await run(
+      {
+        stepType: 'pipeline',
+        name: 'batched',
+        expectedOutputs: 1,
+        expectedProxyRequests: 1,
+        seed: () => [event('a'), event('b'), event('c')],
+      },
+      // All three collapse into one delivery request — the batching case the step asserts.
+      stubHttp(calls, (jobIds) => [jobIds]),
+    );
+
+    const routerCalls = calls.filter((c) => c.url === '/routerTransform');
+    expect(routerCalls).toHaveLength(1);
+    const jobIds = (routerCalls[0].body as RouterTransformRequestBody).input.map(
+      (i) => i.metadata.jobId,
+    );
+    expect(jobIds).toHaveLength(3);
+    expect(new Set(jobIds).size).toEqual(3);
+  });
+
+  it('fails an array-seed step whose events fan out beyond expectedProxyRequests', async () => {
+    const calls: { url: string; body: unknown }[] = [];
+    await expect(
+      run(
+        {
+          stepType: 'pipeline',
+          name: 'batched',
+          expectedOutputs: 1,
+          expectedProxyRequests: 1,
+          seed: () => [event('a'), event('b')],
+        },
+        // The regression this scenario shape exists to catch: two events that should have grouped
+        // are delivered as two separate requests.
+        stubHttp(calls, (jobIds) => jobIds.map((id) => [id])),
+      ),
+    ).rejects.toThrow();
+  });
+
+  it('rejects a step that seeds no events', async () => {
+    const calls: { url: string; body: unknown }[] = [];
+    await expect(
+      run(
+        { stepType: 'pipeline', name: 'empty', seed: () => [] },
+        stubHttp(calls, (jobIds) => [jobIds]),
+      ),
+    ).rejects.toThrow('seeded no events');
+    expect(calls).toHaveLength(0);
+  });
+});
+
+describe('runPipelineStep — delivery attribution', () => {
+  it('fails the step when a seeded job comes back without a delivery verdict', async () => {
+    const http: LiveHttpClient = {
+      post: async (url, body) => {
+        if (url === '/routerTransform') {
+          const jobIds = (body as RouterTransformRequestBody).input.map((i) => i.metadata.jobId);
+          return { status: 200, body: { output: [routerOutput(jobIds)] } };
+        }
+        // Both jobs were delivered in one request, but the verdict only accounts for the first —
+        // the second job is left with no outcome at all, which a 2xx-only check would wave through.
+        const [firstJobId] = (body as { metadata: { jobId: number }[] }).metadata.map(
+          (m) => m.jobId,
+        );
+        return { status: 200, body: deliveredProxyOutput([firstJobId]) };
+      },
+    };
+
+    await expect(
+      run(
+        {
+          stepType: 'pipeline',
+          name: 'partly attributed',
+          expectedOutputs: 1,
+          expectedProxyRequests: 1,
+          seed: () => [event('a'), event('b')],
+        },
+        http,
+      ),
+    ).rejects.toThrow();
+  });
+});
+
+// A delivery that blames specific items, the way a partial-failure response does. `failedIndex`
+// is the position within the request's job list that comes back non-2xx.
+const partialProxyOutput = (jobIds: number[], failedIndex: number) => ({
+  output: {
+    status: 200,
+    message: 'partial failure',
+    response: jobIds.map((jobId, i) => ({
+      error: i === failedIndex ? 'rejected by destination' : '',
+      statusCode: i === failedIndex ? 400 : 200,
+      metadata: {
+        jobId,
+        attemptNum: 0,
+        userId: 'u',
+        sourceId: 'live-sourceId',
+        destinationId: 'live-dest',
+        workspaceId: 'live-workspaceId',
+        secret: {},
+        dontBatch: false,
+      },
+    })),
+  },
+});
+
+const partialHttp = (failedIndex: number): LiveHttpClient => ({
+  post: async (url, body) => {
+    if (url === '/routerTransform') {
+      const jobIds = (body as RouterTransformRequestBody).input.map((i) => i.metadata.jobId);
+      return { status: 200, body: { output: [routerOutput(jobIds)] } };
+    }
+    const jobIds = (body as { metadata: { jobId: number }[] }).metadata.map((m) => m.jobId);
+    return { status: 200, body: partialProxyOutput(jobIds, failedIndex) };
+  },
+});
+
+// `items` omitted entirely declares no expectedFailure at all — the "an undeclared failure still
+// fails the step" case — which is a different step from one declaring `items: []`.
+const partialStep = (items?: number[]): PipelineStep => ({
+  stepType: 'pipeline',
+  name: 'partial failure',
+  expectedOutputs: 1,
+  expectedProxyRequests: 1,
+  ...(items ? { expectedFailure: { items } } : {}),
+  seed: () => [event('a'), event('b')],
+});
+
+describe('runPipelineStep — expected per-item failures', () => {
+  it('passes when exactly the declared item fails', async () => {
+    await expect(run(partialStep([1]), partialHttp(1))).resolves.toBeUndefined();
+  });
+
+  // The point of the assertion: one success + one failure is not enough — it has to be the RIGHT
+  // one. A delivery spec that mapped results to jobs backwards would still produce 1 and 1.
+  it('fails when the wrong item is blamed', async () => {
+    await expect(run(partialStep([1]), partialHttp(0))).rejects.toThrow();
+  });
+
+  it('fails when a job declared as an expected failure was actually delivered', async () => {
+    const allGood: LiveHttpClient = {
+      post: async (url, body) => {
+        if (url === '/routerTransform') {
+          const jobIds = (body as RouterTransformRequestBody).input.map((i) => i.metadata.jobId);
+          return { status: 200, body: { output: [routerOutput(jobIds)] } };
+        }
+        const jobIds = (body as { metadata: { jobId: number }[] }).metadata.map((m) => m.jobId);
+        return { status: 200, body: deliveredProxyOutput(jobIds) };
+      },
+    };
+    await expect(run(partialStep([1]), allGood)).rejects.toThrow('expectedToFailButDelivered');
+  });
+
+  it('still fails on a failure that was not declared', async () => {
+    await expect(run(partialStep(), partialHttp(1))).rejects.toThrow('not delivered');
+  });
+
+  it('rejects an index the step never seeded', async () => {
+    await expect(run(partialStep([5]), partialHttp(1))).rejects.toThrow('expectedFailure.items');
+  });
+
+  // `[]` read literally is "expected to fail, but no job may fail" — the same assertions as
+  // declaring nothing. Without this it is an unfinished edit that passes as a green step.
+  it('rejects an empty items list rather than reading it as no expectation', async () => {
+    await expect(run(partialStep([]), partialHttp(1))).rejects.toThrow(
+      'expectedFailure.items is empty',
+    );
+  });
+});
+
+const authProxyOutput = (jobIds: number[], authErrorCategory?: string) => ({
+  output: {
+    status: 401,
+    message: 'auth failed',
+    ...(authErrorCategory ? { authErrorCategory } : {}),
+    statTags: { errorCategory: 'network' },
+    response: jobIds.map((jobId) => ({
+      error: 'auth failed',
+      statusCode: 401,
+      metadata: {
+        jobId,
+        attemptNum: 0,
+        userId: 'u',
+        sourceId: 'live-sourceId',
+        destinationId: 'live-dest',
+        workspaceId: 'live-workspaceId',
+        secret: {},
+        dontBatch: false,
+      },
+    })),
+  },
+});
+
+const authHttp = (authErrorCategory?: string): LiveHttpClient => ({
+  post: async (url, body) => {
+    if (url === '/routerTransform') {
+      const jobIds = (body as RouterTransformRequestBody).input.map((i) => i.metadata.jobId);
+      return { status: 200, body: { output: [routerOutput(jobIds)] } };
+    }
+    const jobIds = (body as { metadata: { jobId: number }[] }).metadata.map((m) => m.jobId);
+    return { status: 200, body: authProxyOutput(jobIds, authErrorCategory) };
+  },
+});
+
+const authStep = (category: string): PipelineStep => ({
+  stepType: 'pipeline',
+  name: 'auth',
+  expectedOutputs: 1,
+  expectedProxyRequests: 1,
+  expectedFailure: { category },
+  seed: () => event('a'),
+});
+
+describe('runPipelineStep — expected failure categories', () => {
+  it('passes when the delivery reports the declared auth category', async () => {
+    await expect(
+      run(authStep('REFRESH_TOKEN'), authHttp('REFRESH_TOKEN')),
+    ).resolves.toBeUndefined();
+  });
+
+  // The distinction that matters: both categories abort the job, but only REFRESH_TOKEN tells
+  // rudder-server the grant is worth refreshing.
+  it('fails when the delivery reports a different auth category', async () => {
+    await expect(
+      run(authStep('REFRESH_TOKEN'), authHttp('AUTH_STATUS_INACTIVE')),
+    ).rejects.toThrow();
+  });
+
+  // Without this, deleting a delivery spec's auth branch would still leave the step green: the job
+  // fails either way, just without the category.
+  it('fails when the delivery reports no auth category at all', async () => {
+    await expect(run(authStep('REFRESH_TOKEN'), authHttp(undefined))).rejects.toThrow();
+  });
+
+  it('treats an auth failure as a whole-batch expectation, so no index list is needed', async () => {
+    const step: PipelineStep = {
+      stepType: 'pipeline',
+      name: 'auth batch',
+      expectedFailure: { category: 'REFRESH_TOKEN' },
+      seed: () => [event('a'), event('b')],
+    };
+    await expect(run(step, authHttp('REFRESH_TOKEN'))).resolves.toBeUndefined();
+  });
+});
+
+describe('runPipelineStep — transform failures', () => {
+  it('fails the step when an output failed to transform, even if the survivors match expectedOutputs', async () => {
+    const http: LiveHttpClient = {
+      post: async (url, body) => {
+        if (url === '/routerTransform') {
+          const [okJobId, badJobId] = (body as RouterTransformRequestBody).input.map(
+            (i) => i.metadata.jobId,
+          );
+          return {
+            status: 200,
+            body: { output: [routerOutput([okJobId]), failedRouterOutput([badJobId])] },
+          };
+        }
+        return { status: 200, body: deliveredProxyOutput([1]) };
+      },
+    };
+
+    await expect(
+      run(
+        {
+          stepType: 'pipeline',
+          name: 'partly transformed',
+          // Counting only the successful output would make this pass; the failed one must not be
+          // silently dropped.
+          expectedOutputs: 1,
+          seed: () => [event('a'), event('b')],
+        },
+        http,
+      ),
+    ).rejects.toThrow('failed to transform');
+  });
+});

--- a/test/integrations/live/runPipelineStep.ts
+++ b/test/integrations/live/runPipelineStep.ts
@@ -2,20 +2,49 @@ import { HttpStatusCode } from 'axios';
 import { randomInt } from 'crypto';
 import {
   parseDeliveryOutput,
-  parseSuccessfulRouterOutputs,
+  parseRouterOutputs,
   routerOutputToProxyRequests,
 } from './routerProxyRequests';
 import { buildRouterTransformBody } from './routerTransformRequest';
-import type { DeliveryFailure, RunPipelineStepParams } from './types';
+import type {
+  DeliveryFailure,
+  PipelineStep,
+  RunContext,
+  RunPipelineStepParams,
+  SeededEvent,
+} from './types';
+
+// Deliberately local rather than `isHttpStatusSuccess` from src/v0/util: that is a barrel which
+// transitively loads sandboxClient -> scriptRunner -> isolated-vm, a native module, and a 2xx range
+// check is not worth pulling that in for.
+//
+// Note this does NOT on its own make the harness loadable without isolated-vm — routerProxyRequests
+// imports `DeliveryV1ResponseSchema` (a runtime value, so not erasable) from src/types, which
+// reaches the same barrel via src/types/zodTypes. That chain predates this file and untangling it
+// is a separate job; the point here is just not to add a second one gratuitously.
+const isSuccessStatus = (status: number): boolean =>
+  status >= HttpStatusCode.Ok && status < HttpStatusCode.MultipleChoices;
 
 const isDelivered = (status: number): boolean =>
-  (status >= HttpStatusCode.Ok && status < HttpStatusCode.MultipleChoices) ||
-  status === HttpStatusCode.MultiStatus;
+  isSuccessStatus(status) || status === HttpStatusCode.MultiStatus;
 
 const sleep = (ms: number): Promise<void> =>
   new Promise((resolve) => {
     setTimeout(resolve, ms);
   });
+
+// Seed the step's events and pair each with a jobId. Ids are numbered from one random base so they
+// are unique by construction across the call — a duplicate would make a per-item delivery verdict
+// unattributable to the job it belongs to.
+const seedEvents = (step: PipelineStep, ctx: RunContext): SeededEvent[] => {
+  const seeded = step.seed(ctx);
+  const messages = Array.isArray(seeded) ? seeded : [seeded];
+  if (messages.length === 0) {
+    throw new Error(`[live] step "${step.name}" seeded no events`);
+  }
+  const base = randomInt(1, 2_147_483_647 - messages.length);
+  return messages.map((message, index) => ({ message, jobId: base + index }));
+};
 
 // One seed -> transform -> deliver attempt. Returns a structured failure if the event wasn't
 // delivered, or undefined on success. Structural problems (transform non-200, wrong output count)
@@ -28,12 +57,22 @@ const attemptDelivery = async ({
   connection,
   http,
 }: RunPipelineStepParams): Promise<DeliveryFailure | undefined> => {
-  const jobId = randomInt(1, 2_147_483_647);
-  const message = step.seed(ctx);
+  const events = seedEvents(step, ctx);
+  // An empty `items` is a declaration mistake, not an expectation. Omitting `items` already means
+  // "the whole batch fails", so `[]` can only be an unfinished edit — and read literally it means
+  // "expected to fail, but no job may fail", which is indistinguishable from declaring no
+  // expectedFailure at all. Rejected here, before any network call, rather than silently passing
+  // as the step the author didn't write.
+  if (step.expectedFailure?.items?.length === 0) {
+    throw new Error(
+      `[live:${destination}:${step.name}] expectedFailure.items is empty — omit \`items\` to ` +
+        `expect the whole batch to fail, or name the seed indices that must not be delivered.`,
+    );
+  }
   // TODO: this drives only the /routerTransform -> /proxy path. rudder-server also runs
   // the processor transform (/v0/destinations/<dest>) ahead of delivery, whose response shape
   // differs — that chaining is not exercised here (see live/README.md "Deferred").
-  const routerBody = buildRouterTransformBody(destination, message, config, jobId, {
+  const routerBody = buildRouterTransformBody(destination, events, config, {
     secret: ctx.liveSecret.secret,
     metadataOverride: step.metadataOverride,
     connection,
@@ -43,10 +82,38 @@ const attemptDelivery = async ({
   const routerResponse = await http.post('/routerTransform', routerBody);
   expect(routerResponse.status).toEqual(HttpStatusCode.Ok);
 
-  const routerOutputs = parseSuccessfulRouterOutputs(routerResponse.body);
+  const routerOutputs = parseRouterOutputs(routerResponse.body);
+  // /routerTransform reports a per-event transform failure as a non-2xx entry in `output[]`, not as
+  // an HTTP error. Fail on those here, before any count assertion: a step that seeded several
+  // events would otherwise satisfy `expectedOutputs` from the survivors alone and report a partly
+  // transformed batch as a pass.
+  const failedOutputs = routerOutputs.filter((o) => !isSuccessStatus(o.statusCode));
+  if (failedOutputs.length > 0) {
+    throw new Error(
+      `[live:${destination}:${step.name}] ${failedOutputs.length} of ${routerOutputs.length} ` +
+        `/routerTransform output(s) failed to transform: ` +
+        `${JSON.stringify(
+          failedOutputs.map((o) => ({
+            statusCode: o.statusCode,
+            error: o.error,
+            statTags: o.statTags,
+          })),
+          null,
+          2,
+        )}`,
+    );
+  }
   const { expectedOutputs, expectedProxyRequests } = step;
+  // Assert on the COUNT, never on the array. `toHaveLength` prints the whole received array into
+  // the jest failure message, and a router output carries live credentials in three places at once
+  // — batchedRequest.headers.Authorization, batchedRequest.params (GAEC puts the raw accessToken
+  // there) and metadata[].secret — plus destination.Config, which is where every apiKey spec keeps
+  // its credentials. That output is not maskable: an OAuth token is minted at run time by the
+  // rudder-auth container, so it never passes through vault-action's ::add-mask::, and LOG_LEVEL
+  // doesn't apply to jest's own reporter. A count mismatch is exactly what a batching regression
+  // looks like, so this is the failure path most likely to actually fire.
   if (expectedOutputs !== undefined) {
-    expect(routerOutputs).toHaveLength(expectedOutputs);
+    expect(routerOutputs.length).toEqual(expectedOutputs);
   } else {
     expect(routerOutputs.length).toBeGreaterThan(0);
   }
@@ -62,6 +129,38 @@ const attemptDelivery = async ({
     expect(total).toEqual(expectedProxyRequests);
   }
 
+  // Every seeded job must come back carrying a delivery verdict. Checking only that the verdicts
+  // present are 2xx would pass a response covering 1 of 2 seeded jobs — exactly the attribution bug
+  // a batched delivery can have, where a destination maps a batch response back to the wrong number
+  // of jobs and the rest are silently left without an outcome.
+  const verdictByJobId = new Map<number, number>();
+  // Distinct error categories seen across the step's proxy calls, so the assertion below can show
+  // both "none reported" and "reported the wrong one" as a readable diff.
+  const errorCategories: string[] = [];
+
+  // `expectedFailure` with no `items` means the whole batch failed (a bad credential is bad for
+  // every item), so it expands to every seeded index.
+  const { expectedFailure } = step;
+  const expectedFailureIndices =
+    expectedFailure && !expectedFailure.items
+      ? events.map((_event, index) => index)
+      : (expectedFailure?.items ?? []);
+
+  // Seed indices the step says should fail, resolved to the jobIds they were assigned. Jobs are
+  // numbered in seed order, so "index 1 failed" is precisely the positional claim under test.
+  const expectedFailureJobIds = new Set(
+    expectedFailureIndices.map((index) => {
+      const event = events[index];
+      if (!event) {
+        throw new Error(
+          `[live:${destination}:${step.name}] expectedFailure.items names index ${index}, ` +
+            `but the step seeded ${events.length} event(s)`,
+        );
+      }
+      return event.jobId;
+    }),
+  );
+
   for (const proxyRequests of proxyRequestsPerOutput) {
     for (const proxyRequest of proxyRequests) {
       // eslint-disable-next-line no-await-in-loop -- deliver sequentially; order matches transform output
@@ -74,9 +173,21 @@ const attemptDelivery = async ({
       expect(deliveryOutput).toBeDefined();
 
       const jobStates = deliveryOutput.response ?? [];
-      const delivered =
-        isDelivered(deliveryOutput.status) && jobStates.every((js) => isDelivered(js.statusCode));
-      if (!delivered) {
+      jobStates.forEach((js) => verdictByJobId.set(js.metadata.jobId, js.statusCode));
+      const category = deliveryOutput.authErrorCategory;
+      if (category && !errorCategories.includes(category)) {
+        errorCategories.push(category);
+      }
+
+      // A job the step declared as an expected failure is not a delivery failure — it is the
+      // outcome under test. Everything else still has to be delivered, and when nothing is expected
+      // to fail the batch's own status must be 2xx as well (a partial failure carries the
+      // destination's status, which may legitimately not be).
+      const unexpectedFailures = jobStates.filter(
+        (js) => !isDelivered(js.statusCode) && !expectedFailureJobIds.has(js.metadata.jobId),
+      );
+      const batchFailed = expectedFailureJobIds.size === 0 && !isDelivered(deliveryOutput.status);
+      if (unexpectedFailures.length > 0 || batchFailed) {
         const redactedJobStates = jobStates.map((js) => ({
           ...js,
           metadata: { ...js.metadata, secret: '[redacted]' },
@@ -90,6 +201,24 @@ const attemptDelivery = async ({
       }
     }
   }
+
+  const unaccounted = events.filter((e) => !verdictByJobId.has(e.jobId)).map((e) => e.jobId);
+  expect({ unaccountedJobIds: unaccounted }).toEqual({ unaccountedJobIds: [] });
+
+  // The other half of the attribution claim: a job the step expected to fail must actually have
+  // failed. Without this, a delivery spec that blamed every item — or none — would still satisfy
+  // the "no unexpected failures" check above.
+  const survived = expectedFailureIndices.filter((index) =>
+    isDelivered(verdictByJobId.get(events[index].jobId) ?? 0),
+  );
+  expect({ expectedToFailButDelivered: survived }).toEqual({ expectedToFailButDelivered: [] });
+
+  if (expectedFailure?.category) {
+    expect({ errorCategory: errorCategories }).toEqual({
+      errorCategory: [expectedFailure.category],
+    });
+  }
+
   return undefined;
 };
 

--- a/test/integrations/live/secretResolver.ts
+++ b/test/integrations/live/secretResolver.ts
@@ -3,6 +3,34 @@ import { LiveSecret, LiveSecretSchema } from './types';
 
 const jsonEnvKey = (destination: string): string => `LIVE_SECRET_${destination.toUpperCase()}`;
 
+// Read a mandatory field out of a resolved secret, or say precisely which one is missing and what
+// it has to hold. LiveSecretSchema validates the secret's *shape*, but `secret` is an open record —
+// which fields a given destination needs is the spec's business. A missing value is an onboarding
+// mistake, so the error names the env var and the field rather than letting an undefined reach the
+// destination and come back as an opaque API error.
+const requiredField = (
+  value: string | undefined,
+  destination: string,
+  path: string,
+  mustBe: string,
+): string => {
+  if (!value) {
+    throw new Error(
+      `[live:${destination}] ${path} is missing from ${jsonEnvKey(destination)} — ` +
+        `it must be ${mustBe}.`,
+    );
+  }
+  return value;
+};
+
+/** A mandatory `secret` entry: a credential the transform (or an SDK) reads at run time. */
+export const requiredSecretField = (
+  s: LiveSecret,
+  destination: string,
+  field: string,
+  mustBe: string,
+): string => requiredField(s.secret?.[field], destination, `secret.${field}`, mustBe);
+
 export class SecretResolver {
   private readonly env: NodeJS.ProcessEnv;
 

--- a/test/integrations/live/types.ts
+++ b/test/integrations/live/types.ts
@@ -21,7 +21,6 @@ const LiveSecretSchema = z.object({
   oauthRefresh: z
     .object({
       refreshToken: z.string(), // the long-lived token: the only oauth secret stored
-      accountDefinition: AccountDefinitionSchema.optional(),
       providerFields: z.record(z.string()).optional(), // e.g. Salesforce instance_url, GCP project id
     })
     .optional(),
@@ -69,6 +68,12 @@ interface Step {
 interface MetadataOverride {
   workspaceId?: string;
   dontBatch?: boolean;
+  // Replaces the secret the harness would otherwise pass (the resolved credentials, refreshed by
+  // rudder-auth for OAuth destinations). Its purpose is negative testing: handing a transform a
+  // credential the destination will reject is the only way to reach a delivery spec's auth branch
+  // live, since a real account's grant cannot be revoked on demand without breaking every other
+  // scenario. Pair it with `expectedFailure.category`.
+  secret?: Record<string, string>;
 }
 
 // Top-level fields of the /routerTransform input `destination` a scenario may override (the harness
@@ -81,10 +86,15 @@ interface DestinationOverride {
   WorkspaceID?: string;
 }
 
-// A pipeline step: seed -> /routerTransform -> /proxy, asserting the event is delivered.
+// A pipeline step: seed -> /routerTransform -> /proxy, asserting the events are delivered.
 interface PipelineStep extends Step {
   stepType: 'pipeline';
-  seed: (ctx: RunContext) => Record<string, unknown>;
+  // The event to drive through the pipeline — or SEVERAL, returned as an array, which the runner
+  // puts in a single /routerTransform call as one `input[]` entry each. The array form is the only
+  // way to exercise router-level batching live: whether N events collapse into one delivery request
+  // (pin it with expectedOutputs/expectedProxyRequests — a grouping regression that fans them out
+  // still delivers 2xx on each) and whether every job comes back with a delivery verdict.
+  seed: (ctx: RunContext) => Record<string, unknown> | Record<string, unknown>[];
   // Merged into the /routerTransform input metadata, overriding defaults — e.g. { dontBatch: true }.
   metadataOverride?: MetadataOverride;
   // Merged into the /routerTransform input `destination` object, overriding defaults — e.g.
@@ -97,6 +107,26 @@ interface PipelineStep extends Step {
   // Exact number of proxy requests across all outputs (where a dontBatch regression would slip
   // through). Omit to keep the loose per-output `> 0` assertion.
   expectedProxyRequests?: number;
+  // Declares that this step is expected to fail, and how. One field for every kind of failure —
+  // a rejected item, a bad credential, a throttled batch — so the step API does not grow a
+  // separate flag per error class.
+  //
+  //   items    seed indices whose jobs must come back NOT delivered; every other seeded job must
+  //            be delivered. Omit to mean the whole batch — an EMPTY array is rejected, since it
+  //            would otherwise read as "declared a failure, expect none" and pass silently.
+  //            Naming the index is the point for a partial failure: it asserts WHICH job the
+  //            destination's delivery spec blamed, and blaming the wrong one still yields one
+  //            success and one failure.
+  //   category the error category the delivery reported, when it reports one (rudder-server reads
+  //            it to decide whether a credential is worth refreshing). Asserting it is what
+  //            separates a specific failure branch from the generic one — both abort the job.
+  //
+  // A step declaring this no longer requires the batch's top-level status to be 2xx, because a
+  // partial or auth failure legitimately isn't.
+  expectedFailure?: {
+    items?: readonly number[];
+    category?: string;
+  };
   // Re-run seed -> transform -> deliver up to this many extra times (backoff) if delivery fails.
   // For routes that decide create-vs-update by searching an eventually-consistent index: a
   // freshly set-up record can be missed on the first try and 409, then found on a retry. Only use
@@ -160,12 +190,26 @@ interface LiveSpec {
   enabled: boolean; // false parks the whole destination — the registry skips it
   authType: AuthType;
   oauthVersion?: OAuthVersion;
+  // The rudder-auth account definition for a `v1` refresh, which resolves the implementation from
+  // `name.toLowerCase()`. This is static, public metadata (it mirrors the control plane's
+  // `accounts/<dest>_oauth/db-config.json`), NOT a credential — so it is declared here rather than
+  // stored in LIVE_SECRET_<DEST>. Optional: when omitted the resolver derives the conventional
+  // `DESTINATION_<DEST>_OAUTH` shape, which is right for every destination with a single OAuth
+  // account definition. Set it only where that convention doesn't hold — e.g. a destination with
+  // more than one variant, like google_adwords_remarketing_lists' legacy vs `_DM_OAUTH` accounts.
+  accountDefinition?: AccountDefinition;
   // Environment variables set for the duration of this destination's scenarios and restored after.
   // Use this for destination/scenario-specific switches, including the temporary
   // batching-framework delivery rollout flag when a live spec must exercise framework delivery.
   // Do not set the batching-framework transform rollout flag for destinations already marked
   // batching-GA in features.ts.
   envOverrides?: EnvOverride;
+  // Secret-derived environment variables, applied and restored alongside `envOverrides` (and
+  // winning over them on a key collision). For transforms or SDKs that read a *credential* from
+  // process.env rather than from destination.Config or metadata.secret — e.g. Google Ads' shared
+  // `GOOGLE_ADS_DEVELOPER_TOKEN`. `envOverrides` is a static literal and so can't carry a secret;
+  // this keeps every live credential inside the one LIVE_SECRET_<DEST> blob.
+  resolveEnv?: (s: LiveSecret) => EnvOverride;
   // Map the resolved secret into the destination.Config the transform expects (merge non-secret
   // defaults with the credentials in `s.config`).
   resolveConfig: (s: LiveSecret) => Record<string, unknown>;
@@ -253,6 +297,13 @@ interface RouterTransformRequestBody {
   destType: string;
 }
 
+// One seeded event paired with the jobId its /routerTransform input carries. Built by the runner so
+// jobIds are unique across a multi-event step and stay stable for the whole call.
+interface SeededEvent {
+  message: Record<string, unknown>;
+  jobId: number;
+}
+
 // Minimal HTTP client the pipeline runner drives; wraps SuperTest so the runner stays free of its types.
 interface LiveHttpResponse {
   status: number;
@@ -334,6 +385,7 @@ export {
   BuildRouterTransformBodyOptions,
   RouterTransformInput,
   RouterTransformRequestBody,
+  SeededEvent,
   LiveHttpResponse,
   LiveHttpClient,
   DeliveryFailure,

--- a/test/integrations/live/types.ts
+++ b/test/integrations/live/types.ts
@@ -1,13 +1,18 @@
 import { z } from 'zod';
 import { EnvOverride } from '../envUtils';
 
-// Account definition rudder-auth uses to describe an OAuth account.
-const AccountDefinitionSchema = z.object({
-  type: z.string(),
-  category: z.string(),
-  name: z.string(),
-});
-type AccountDefinition = z.infer<typeof AccountDefinitionSchema>;
+// The part of rudder-auth's account definition an integration has to state for itself: the
+// destination `type` and the account-definition `name` rudder-auth resolves its implementation
+// from (`name.toLowerCase()`). `category` is not here — it is 'destination' for every live spec,
+// so the resolver supplies it rather than making each spec repeat a constant it cannot vary.
+//
+// A plain type, not a zod schema: this is declared in TypeScript by the spec, so the compiler
+// already checks it. Zod earns its place at the LIVE_SECRET_<DEST> boundary, where the input is
+// untrusted JSON — this is not that.
+interface AccountDefinition {
+  type: string;
+  name: string;
+}
 
 // Resolved credentials for one destination, validated at the LIVE_SECRET_<DEST> boundary by
 // SecretResolver. The type is inferred from the schema (z.infer) so it can never drift from what
@@ -191,12 +196,16 @@ interface LiveSpec {
   authType: AuthType;
   oauthVersion?: OAuthVersion;
   // The rudder-auth account definition for a `v1` refresh, which resolves the implementation from
-  // `name.toLowerCase()`. This is static, public metadata (it mirrors the control plane's
-  // `accounts/<dest>_oauth/db-config.json`), NOT a credential — so it is declared here rather than
-  // stored in LIVE_SECRET_<DEST>. Optional: when omitted the resolver derives the conventional
-  // `DESTINATION_<DEST>_OAUTH` shape, which is right for every destination with a single OAuth
-  // account definition. Set it only where that convention doesn't hold — e.g. a destination with
-  // more than one variant, like google_adwords_remarketing_lists' legacy vs `_DM_OAUTH` accounts.
+  // `name.toLowerCase()`. Static, public metadata mirroring the control plane's
+  // `accounts/<dest>_oauth/db-config.json`, NOT a credential — hence declared here rather than
+  // stored in LIVE_SECRET_<DEST>.
+  //
+  // Required for `oauthVersion: 'v1'` and stated outright, never derived from the destination name.
+  // The `DESTINATION_<DEST>_OAUTH` convention holds for most destinations but not all — see
+  // google_adwords_remarketing_lists, which has both a legacy and a `_DM_OAUTH` definition — and a
+  // derivation that is usually right is worse than none: where it guesses wrong it sends a
+  // plausible name that rudder-auth resolves to nothing, and the failure surfaces as a refresh
+  // error rather than as the missing declaration it actually is.
   accountDefinition?: AccountDefinition;
   // Environment variables set for the duration of this destination's scenarios and restored after.
   // Use this for destination/scenario-specific switches, including the temporary
@@ -362,7 +371,6 @@ interface RetryUntilPassesOptions {
 
 export {
   AccountDefinition,
-  AccountDefinitionSchema,
   AuthType,
   OAuthVersion,
   LiveSecret,


### PR DESCRIPTION
## What

Enrolls **`google_adwords_enhanced_conversions`** in the live (real-destination) integration suite, and extends the shared live harness with the things GAEC needed that it couldn't express.

A run drives events through the real `transform → deliver` path against a real Google Ads account:

1. rudder-auth mints an access token from the stored refresh token (`authType: 'oauth'`, `oauthVersion: 'v1'`),
2. the batching-framework transform builds the conversion adjustments,
3. the SDK resolves the conversion action **by name** via `googleAds:searchStream`, and
4. uploads to `customers/<id>:uploadConversionAdjustments` on Google Ads v23.

Batching-framework **delivery** is enabled for the whole spec via `envOverrides`, so the run exercises `delivery.ts` rather than the legacy `networkHandler`. The transform-side flag is deliberately absent — GAEC is already `batching: true` in `features.ts`.

## Conversion action names live in code, not in Vault

The two conversion actions the scenarios drive are `Purchase` and `Page view`, declared as `PRIMARY_CONVERSION` / `SECONDARY_CONVERSION` in `live/profiles.ts` rather than read from `resourceIds`.

They aren't credentials. The account is already pinned by `config.customerId` in the secret, and an action's name is public metadata of that account — the same reasoning that moved `accountDefinition` out of the secret and onto the spec. Every key that must be provisioned before the suite can run is a key that can be forgotten, and a missing one fails the whole file at collection with zero tests run, which is exactly what was happening: the provisioned blob had everything *except* `resourceIds`.

`resolveConfig` builds `listOfConversions` from the same two constants the scenarios seed, so config and events can't drift apart. Note the lower-case **v** in `Page view` — the mocked component fixtures say `Page View`, a different action name that doesn't resolve via `googleAds:searchStream`.

`requiredResourceId` is removed along with it; GAEC was its only caller.

## Scenarios

| id | what it proves |
| --- | --- |
| `gaec-enhancement-email-phone` | raw email + messy-format phone are normalized, SHA-256'd and accepted as two `userIdentifiers` entries |
| `gaec-enhancement-address` | hashed first/last name + street address alongside the plaintext geo fields Google requires with them |
| `gaec-enhancement-prehashed` | `requireHash: false` — pre-hashed traits skip normalization/validation and reach Google verbatim |
| `gaec-batched-same-conversion` | two same-conversion events collapse into **one** upload with two adjustments, and **both** jobs get a verdict |
| `gaec-partial-failure` | one adjustment Google rejects next to one it accepts — 200 + `partialFailureError`, and `delivery.ts` blames **exactly** the right job |
| `gaec-grouping-fan-out` | two different-conversion events fan out to two uploads, each resolving its own `conversionActionId` |
| `gaec-auth-expired` | a credential Google rejects surfaces as `REFRESH_TOKEN`, so rudder-server refreshes the grant instead of just aborting |

`gaec-partial-failure` seeds the **second** event as the bad one, so it pins positional attribution: blaming index 0, or blaming both, still yields "one success and one failure" and would satisfy a weaker check. The rejected item is a malformed `adjustmentDateTime` — `trackConfig.json` maps that field through with no coercion and no validation, so it survives transform and fails at the API, which is the only way to reach `delivery.ts`'s partial-failure path rather than the router's error path.

`gaec-auth-expired` is deliberately **two steps, and the order is load-bearing**. `networkHandler` resolves the conversion action by name *before* uploading, using the same access token; with a bad token that lookup fails first, and it fails by throwing from inside `networkHandler.proxy()`, which the framework catches as a legacy-path error that never reaches the delivery spec's 4xx override. The lookup is memoised per (conversion name, customerId) in `conversionActionIdCache`, so a valid delivery first warms it and the bad-token step then fails on the upload itself. The warm-up lives inside the scenario so it doesn't depend on scenario order.

**No read-back `verify`.** Google Ads exposes no API for reading an uploaded conversion adjustment, and matching is asynchronous. The assertion is the delivery verdict — which is meaningful here because `delivery.ts` maps a `partialFailureError` on a 200 into a per-job abort, so anything Google rejects fails the step instead of passing as a 2xx.

Validation/error cases (unconfigured conversion name, missing `orderId`, non-track type, missing OAuth secret, hashing-consistency aborts) are **not** ported — they never reach Google, so the mocked suite already owns them.

## Harness changes

- **`PipelineStep.seed` may return an array.** All events go into a single `/routerTransform` call, one `input[]` entry each. This is the only way to exercise router-level batching live; a single-event step can't show that N events group into one request. Backwards compatible — every existing spec returns one event.
- **`PipelineStep.expectedFailure`** declares that a step is expected to fail, and how — one field for every kind of failure rather than a flag per error class. `items` names seed indices whose jobs must come back NOT delivered (omit for a whole-batch failure; an **empty** array is rejected, since it would otherwise read as "declared a failure, expect none" and pass silently). `category` asserts the error category the delivery reported, which is what separates a specific auth branch from the generic abort — both abort the job otherwise.
- **`MetadataOverride.secret`** replaces the resolved credentials for one step. Handing a transform a credential the destination rejects is the only way to reach a delivery spec's auth branch live, since a real account's grant can't be revoked on demand.
- **`LiveSpec.resolveEnv`** maps secret fields into `process.env`, for credentials read from the environment rather than from `destination.Config`/`metadata.secret` (Google Ads' deployment-wide `GOOGLE_ADS_DEVELOPER_TOKEN`). `envOverrides` is a static literal and can't carry a secret. Empty values are rejected at the credential boundary rather than silently deleting the variable. This is also what keeps `test/setup.ts`'s `GOOGLE_ADS_DEVELOPER_TOKEN = 'test-developer-token-12345'` placeholder from reaching a real Google Ads account.
- **`accountDefinition` moved from the secret to the spec**, and is derived when absent. It is public metadata mirroring the control plane's `accounts/<dest>_oauth/db-config.json`, not a credential, so `LIVE_SECRET_<DEST>` stays credentials-only. The conventional `DESTINATION_<DEST>_OAUTH` shape is derived for the common case; a spec declares its own only where a destination has more than one variant.
- **The v1 refresh envelope is unwrapped per route, not by body shape.** rudder-auth's v1 route returns `{ secret: {...} }`; v0 returns the secret flat. Sniffing for a nested `secret` would descend into a v0 body that happened to carry one and drop its top-level token, so the route decides.
- **The runner now fails on partly-transformed batches** — a per-event transform failure comes back as a non-2xx entry in `output[]`, and counting only the survivors would let a multi-event step satisfy `expectedOutputs` while half its events never transformed.
- **The runner now fails on unattributed jobs** — every seeded jobId must come back carrying a delivery verdict. Checking only that the verdicts *present* are 2xx would pass a response covering 1 of 2 jobs, which is exactly the batch-attribution bug these scenarios exist to catch.
- **A shared `requiredSecretField`** in `secretResolver.ts`, so "read this secret field or name exactly which one is missing" isn't hand-rolled again. (The pre-existing hand-rolled copies in the criteo/braze specs are left alone — migrating them isn't this PR's business.)

## Bugs found and fixed along the way

- **Credential leak into CI logs.** `expect(routerOutputs).toHaveLength(n)` printed the entire router-output array into the jest failure message, and each output carries the live OAuth token three times over (`batchedRequest.headers.Authorization`, `batchedRequest.params.accessToken`, `metadata[].secret`) plus `destination.Config`, which is where every apiKey spec keeps its credentials. That output is unmaskable — an OAuth token is minted at run time by the rudder-auth container, so it never passes through `vault-action`'s `::add-mask::`, and `LOG_LEVEL` doesn't apply to jest's own reporter. Now asserts on `.length` only. Pre-existing and affecting all live specs; the multi-event scenarios here are what made a count mismatch a likely failure path.
- **`.github/scripts/live-test-matrix.js` only read `live.ts` for `authType`** — but the documented layout for a non-trivial spec puts it in `live/spec.ts` with `live.ts` reduced to a re-export. GAEC was being classified `oauth: false`, which would have skipped the Vault credential import, the ECR login and the rudder-auth container. It now checks both paths, and strips `//` and `/* */` comments first: `oauth: true` grants a *wildcard* Vault import of `control-plane/data/external-services` plus an ECR login, so a spec that merely documents `authType: 'oauth'` in prose must not trip it. The line pass is quote-aware, so a URL in a string literal doesn't truncate a declaration sharing its line. Latent for any OAuth destination using the recommended layout.
- **Non-reserved phone number in the seed.** `555-2671` sits outside the NANP fictional block, and its SHA-256 is uploaded to Google as a match identifier against their user graph. Now `555-0171`.

## Review fixes applied

- `unwrapSecret` is gated on the route (`'wrapped'`/`'flat'`) instead of sniffing the body, so a v0 response carrying a nested `secret` can't lose its top-level token. New v0 regression test.
- `runPipelineStep.ts` no longer imports `isHttpStatusSuccess` from the `src/v0/util` barrel — that barrel transitively loads `sandboxClient → scriptRunner → isolated-vm`, a native module, which is a lot to pull in for a 2xx range check. Uses a local check that `isDelivered` now shares. Note this does *not* by itself make the harness loadable without `isolated-vm`: `routerProxyRequests.ts` imports `DeliveryV1ResponseSchema` (a runtime value, so not erasable) from `src/types`, which reaches the same barrel via `src/types/zodTypes`. That chain predates this PR and untangling it is a separate job — the point here is only not to add a second one.
- `expectedFailure.items: []` is rejected before any network call rather than silently reading as no expectation.
- `live-test-matrix.js` actually strips comments now (it previously only claimed to), with a quote-aware line pass.
- The `fail-closed` comment in `component.live.test.ts` no longer overstates its isolation: the throw is in the `describe` body, so it fails the whole suite file at collection, which is fine only because CI runs one destination per matrix job.

## Verification

- `npx tsc --noEmit -p tsconfig.test.json` — clean
- `npx prettier --check` on every touched file — clean
- `node .github/scripts/live-test-matrix.js` reports GAEC and criteo_audience as `oauth: true`, every other destination's flag unchanged; prose (line and block comment) forms of `authType: 'oauth'` verified not to match, and a declaration sharing a line with a `https://` string literal verified to still match
- **All scenario seeds driven through the real `processRouterDest`** with the spec's own `resolveConfig`/`configOverride` — every one transforms without error
- Harness unit tests in `test/integrations/live/runPipelineStep.test.ts` and `test/integrations/live/oauthTokenResolver.test.ts` cover array seeds, jobId uniqueness, fan-out detection, unattributed jobs, partly-transformed batches, per-item failure attribution, expected-failure categories, the empty-`items` rejection, and both refresh envelopes
- Full mocked component suite unchanged; `src/services/destination/nativeBatching` unchanged
- The existing `vero` live spec run with a **canary** credential value: 0 occurrences of the secret anywhere in the suite's output, and the run reaches delivery and fails only on the expected auth error — confirming the single-event path and the new assertions don't misfire
- Every other live destination (`braze`, `braze_audience`, `criteo_audience`, `customerio`, `hs`, `vero`) passes on this branch, which answers one of the open questions below: the new "every seeded job gets a verdict" assertion does not misfire on a successful delivery

**Live coverage confirmed in CI.** `live (google_adwords_enhanced_conversions)` is green on the real Google Ads account — all 7 scenarios, 8 steps, ~20s:

```
scenario: gaec-enhancement-email-phone   ✓ enhancement with email and phone identifiers
scenario: gaec-enhancement-address       ✓ enhancement with addressInfo identifiers
scenario: gaec-enhancement-prehashed     ✓ enhancement with pre-hashed identifiers
scenario: gaec-batched-same-conversion   ✓ two same-conversion events batch into one upload
scenario: gaec-partial-failure           ✓ one rejected adjustment alongside a valid one
scenario: gaec-grouping-fan-out          ✓ two different-conversion events fan out to two uploads
scenario: gaec-auth-expired              ✓ warm the conversion-action cache with a valid delivery
                                         ✓ delivery with a credential Google rejects
Test Suites: 1 passed   Tests: 8 passed, 8 total
```

This is the first run covering the full set: an earlier six-scenario revision had passed live (that run is what established `Purchase`/`Page view` and confirmed Google accepts an ENHANCEMENT for a not-yet-seen `orderId`), while `gaec-partial-failure` and `gaec-auth-expired` had only been probed against the API by hand. Both now pass as scenarios, which means Google's real `partialFailureError` response does blame the second item positionally, and a rejected credential really does surface as `REFRESH_TOKEN` through `delivery.ts`'s 4xx override.

## Onboarding checklist

- **Vault** — `LIVE_SECRET_GOOGLE_ADWORDS_ENHANCED_CONVERSIONS` (single-line JSON) under `engineering_shared/data/integrations_team/e2e_test/rudder-transformer`. Shape is documented at the top of `live/spec.ts`; it needs `config.customerId`, `secret.developerToken` and `oauthRefresh.refreshToken` — and nothing else. Neither `accountDefinition` nor `resourceIds` is stored in the secret any more: the first is derived, the second is now the two constants in `live/profiles.ts`. This entry is already provisioned.
- **Vault (OAuth app creds)** — `GOOGLE_ADWORDS_ENHANCED_CONVERSIONS_CLIENT_ID(_DESTINATION)` / `_CLIENT_SECRET(_DESTINATION)` under `control-plane/data/external-services`, which the OAuth job wildcard-imports and `rudderAuthContainer` forwards.
- **Sandbox account** — account `4219454086` needs its `Purchase` and `Page view` conversion actions present and enabled for enhanced conversions. Both were verified against the live API with `validateOnly: true` (nothing written); each accepts an ENHANCEMENT for a previously unseen `orderId`. If either is ever renamed, the two constants in `live/profiles.ts` are the only thing to update. Every run uploads real conversion adjustments; nothing is created that can be deleted (Google exposes no delete for an uploaded adjustment), so unmatched adjustments are simply discarded on Google's side. `gaec-auth-expired` also sends one deliberately invalid bearer token per run — worth watching for Google-side rate limiting once this runs on every PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
