### PR TITLE
fix(tiktok_audience): keep batch_data aligned with id_schema

### DIFF
--- a/src/v0/destinations/tiktok_audience/recordTransform.test.ts
+++ b/src/v0/destinations/tiktok_audience/recordTransform.test.ts
@@ -234,3 +234,100 @@ describe('processTiktokAudienceRecords tiktok_audience record edge cases', () =>
     expect(id).toBe(md5('abcdef'));
   });
 });
+
+describe('processTiktokAudienceRecords batch_data / id_schema positional alignment', () => {
+  type BatchedJSON = {
+    batchedRequest: {
+      body: {
+        JSON: {
+          batch_data: ({ id: string; audience_ids: string[] } | Record<string, never>)[][];
+          id_schema: string[];
+        };
+      };
+    };
+  };
+
+  const readPayload = (response: RouterTransformationResponse) =>
+    (response as unknown as BatchedJSON).batchedRequest.body.JSON;
+
+  it('null identifiers are sent as {} placeholders so each slot lines up with id_schema', () => {
+    const event = buildBaseEvent({
+      identifiers: {
+        AAID_SHA256: null,
+        EMAIL_SHA256: 'user@example.com',
+        IDFA_SHA256: null,
+        PHONE_SHA256: null,
+      },
+    });
+
+    const { failedResponses, successfulResponses } = processTiktokAudienceRecords([event]);
+    expect(failedResponses).toHaveLength(0);
+    expect(successfulResponses).toHaveLength(1);
+
+    const { batch_data: batchData, id_schema: idSchema } = readPayload(successfulResponses[0]);
+    expect(idSchema).toEqual(['AAID_SHA256', 'EMAIL_SHA256', 'IDFA_SHA256', 'PHONE_SHA256']);
+    expect(batchData[0]).toHaveLength(idSchema.length);
+    expect(batchData[0]).toEqual([
+      {},
+      { id: sha256('user@example.com'), audience_ids: ['23856594064540489'] },
+      {},
+      {},
+    ]);
+  });
+
+  it('identifiers supplied out of alphabetical order are re-ordered to match id_schema', () => {
+    const event = buildBaseEvent({
+      identifiers: {
+        PHONE_SHA256: '+15551234567',
+        EMAIL_SHA256: 'user@example.com',
+        AAID_SHA256: 'AAID-VALUE',
+      },
+    });
+
+    const { failedResponses, successfulResponses } = processTiktokAudienceRecords([event]);
+    expect(failedResponses).toHaveLength(0);
+    expect(successfulResponses).toHaveLength(1);
+
+    const { batch_data: batchData, id_schema: idSchema } = readPayload(successfulResponses[0]);
+    expect(idSchema).toEqual(['AAID_SHA256', 'EMAIL_SHA256', 'PHONE_SHA256']);
+    expect(batchData[0]).toEqual([
+      { id: sha256('aaid-value'), audience_ids: ['23856594064540489'] },
+      { id: sha256('user@example.com'), audience_ids: ['23856594064540489'] },
+      { id: sha256('+15551234567'), audience_ids: ['23856594064540489'] },
+    ]);
+  });
+
+  it('every row in a batch has one entry per id_schema slot', () => {
+    const events = [
+      buildBaseEvent({
+        identifiers: { AAID_SHA256: null, EMAIL_SHA256: 'a@example.com', PHONE_SHA256: null },
+      }),
+      buildBaseEvent({
+        identifiers: {
+          AAID_SHA256: 'aaid-b',
+          EMAIL_SHA256: 'b@example.com',
+          PHONE_SHA256: '+15550000002',
+        },
+      }),
+      buildBaseEvent({
+        identifiers: { AAID_SHA256: null, EMAIL_SHA256: null, PHONE_SHA256: '+15550000003' },
+      }),
+    ];
+
+    const { failedResponses, successfulResponses } = processTiktokAudienceRecords(events);
+    expect(failedResponses).toHaveLength(0);
+    expect(successfulResponses).toHaveLength(1);
+
+    const { batch_data: batchData, id_schema: idSchema } = readPayload(successfulResponses[0]);
+    expect(batchData).toHaveLength(3);
+    batchData.forEach((row) => expect(row).toHaveLength(idSchema.length));
+
+    // The phone-only user must land in the PHONE_SHA256 slot, not the AAID_SHA256 slot.
+    const phoneSlot = idSchema.indexOf('PHONE_SHA256');
+    expect(batchData[2][phoneSlot]).toEqual({
+      id: sha256('+15550000003'),
+      audience_ids: ['23856594064540489'],
+    });
+    expect(batchData[2][idSchema.indexOf('AAID_SHA256')]).toEqual({});
+  });
+});

--- a/src/v0/destinations/tiktok_audience/recordTransform.ts
+++ b/src/v0/destinations/tiktok_audience/recordTransform.ts
@@ -4,7 +4,7 @@ import validator from 'validator';
 import type {
   TiktokAudienceRecordRequest,
   IdentifiersPayload,
-  Identifier,
+  BatchIdentifier,
   SegmentMappingPayload,
   ProcessTiktokAudienceRecordsResponse,
 } from './recordTypes';
@@ -73,11 +73,22 @@ function prepareIdentifiersPayload(event: TiktokAudienceRecordRequest): Identifi
     throw new Error(`Invalid hashing method for identifier key ${fieldName} for TikTok Audience.`);
   };
 
-  const identifiersList: Identifier[] = [];
-  for (const [fieldName, value] of Object.entries(identifiers)) {
+  // TikTok reads each batch_data row positionally against id_schema, so a row must hold one
+  // entry per schema slot. Walk the schema itself rather than the identifiers object: its key
+  // order is not guaranteed to be sorted, and slots the user has no usable value for must still
+  // be occupied — by an empty object, which is how TikTok expects "this user has no such id".
+  const idSchema = Object.keys(identifiers).sort();
+  const identifiersList: BatchIdentifier[] = [];
+  let populatedIdentifiers = 0;
+
+  for (const fieldName of idSchema) {
     if (!TRAITS_SET.has(fieldName)) {
       throw new Error(`Invalid identifier key ${fieldName} for TikTok Audience.`);
     }
+
+    const value = identifiers[fieldName];
+    let identifier: BatchIdentifier = {};
+
     if (value) {
       let hashingType: HashingType = HashingType.NONE;
       if (SHA256_TRAITS.includes(fieldName)) {
@@ -101,27 +112,34 @@ function prepareIdentifiersPayload(event: TiktokAudienceRecordRequest): Identifi
       if (isHashRequired) {
         const normalizedFieldValue = normalizedValue(fieldName, value);
         if (isDefinedAndNotNullAndNotEmpty(normalizedFieldValue)) {
-          identifiersList.push({
+          identifier = {
             id: hashIdentifier(fieldName, normalizedFieldValue),
             audience_ids: [audienceId],
-          });
+          };
         }
       } else {
-        identifiersList.push({
+        identifier = {
           id: value,
           audience_ids: [audienceId],
-        });
+        };
       }
     }
+
+    identifiersList.push(identifier);
+    if ('id' in identifier) {
+      populatedIdentifiers += 1;
+    }
   }
-  if (identifiersList.length === 0) {
+
+  // A row of nothing but placeholders identifies no one, so it is still an aborted event.
+  if (populatedIdentifiers === 0) {
     throw new InstrumentationError('No identifiers found, aborting event.');
   }
 
   const payload: IdentifiersPayload = {
     event,
     batchIdentifiers: identifiersList,
-    idSchema: Object.keys(identifiers).sort(),
+    idSchema,
     advertiserId,
     action: ACTION_RECORD_MAP[action],
   };

--- a/src/v0/destinations/tiktok_audience/recordTypes.ts
+++ b/src/v0/destinations/tiktok_audience/recordTypes.ts
@@ -71,16 +71,24 @@ export type Identifier = {
   audience_ids: string[];
 };
 
+/**
+ * Placeholder for an id_schema slot this user has no value for. It keeps the row the same
+ * length as id_schema so TikTok reads every remaining id against the right identifier type.
+ */
+export type IdentifierPlaceholder = Record<string, never>;
+
+export type BatchIdentifier = Identifier | IdentifierPlaceholder;
+
 export type IdentifiersPayload = {
   event: TiktokAudienceRecordRequest;
-  batchIdentifiers: Identifier[];
+  batchIdentifiers: BatchIdentifier[];
   idSchema: string[];
   advertiserId: string;
   action: string;
 };
 
 export type SegmentMappingPayload = {
-  batch_data: Identifier[][];
+  batch_data: BatchIdentifier[][];
   id_schema: string[];
   advertiser_ids: string[];
   action: string;

--- a/test/integrations/destinations/tiktok_audience/router/data.ts
+++ b/test/integrations/destinations/tiktok_audience/router/data.ts
@@ -2706,10 +2706,14 @@ export const data = [
                   JSON: {
                     batch_data: [
                       [
+                        // AAID_SHA256 was null: an empty object holds the slot open so the
+                        // hashes below are read against EMAIL_SHA256 and PHONE_SHA256.
+                        {},
                         {
                           id: 'ac0f1baec38a9ef3cfcb56db981df7d9bab2568c7f53ef3776d1c059ec58e72b',
                           audience_ids: ['23856594064540489'],
                         },
+                        {},
                         {
                           id: 'c775e7b757ede630cd0aa1113bd102661ab38829ca52a6422ab782862f268646',
                           audience_ids: ['23856594064540489'],


### PR DESCRIPTION
> Same change as #5519, targeted at `hotfix/tiktok_ads_id_schema` instead of `develop`. Cherry-picked from `c2741212e` with the original authorship and commit message intact; the tiktok_audience files are byte-identical to that commit.

## What are the changes introduced in this PR?

TikTok reads each `batch_data` row **positionally** against `id_schema`. `prepareIdentifiersPayload` built the row by iterating the `identifiers` object and pushing only truthy values, which misaligned it in two independent ways:

1. **A missing identifier produced a shorter row**, shifting every later id left. A user with only an email was sent as a one-entry row against a four-entry schema, so TikTok read the email hash as an `AAID_SHA256`. This is the customer report.
2. **`id_schema` is sorted, the row was not.** The row followed the `identifiers` object's own key order, so even a *fully populated* user could be emitted out of order — `AAID` and `PHONE` silently swapped. This was not in the report and is the more insidious of the two, since nothing about the record looks wrong.

The fix walks the sorted schema instead of the object, and emits `{}` for any slot the user has no usable value for.

```ts
const idSchema = Object.keys(identifiers).sort();
for (const fieldName of idSchema) {
  let identifier: BatchIdentifier = {};   // holds the slot open
  if (value) { /* validate, normalize, hash */ }
  identifiersList.push(identifier);
}
```

Events whose slots are *all* placeholders still abort with `No identifiers found` — a row of nothing but placeholders identifies no one.

### Why `{}` and not a reordered `id_schema`

Two independent confirmations that the placeholder is the contract:

- **This repo already does it correctly elsewhere.** The legacy `audienceList` path in `transform.ts` maps over the schema and emits `{}` for a missing trait:
  ```js
  destinationFields.map((f) => trait[f] ? { id: hashIdentifier(f, trait[f]), audience_ids: [audienceId] } : {})
  ```
  The two paths disagreed; the older one was right. This change makes the `record` path match it.
- **Segment's TikTok Audiences destination** does the same, with a comment stating the rule: *"Even if email and advertising_id are empty we want to include them into the array as we seek to comply with the ID Schema defined outside of this function."*

## What is the related Linear task?

Not yet filed — reported by Chatbooks in a shared Slack channel and triaged in #<internal thread>. Happy to link one before merge.

## Please explain the objectives of your changes below

Restore correct identifier attribution for TikTok audiences. Any record with a missing or invalid identifier currently has its remaining ids attributed to the wrong identifier types, which corrupts audience matching silently — TikTok returns `200` either way. Customers only notice as unexplained low match rates.

The affected customer worked around it by rebuilding their connection to match on email only, which is exactly the configuration in which the bug cannot appear (a single-slot schema is always aligned). Enriching with any additional identifier re-exposes it.

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

`batch_data` rows now always have exactly `id_schema.length` entries, where previously they had only as many entries as the record had non-null identifiers. This is the fix, and it is a wire-format change for every `record`-path TikTok audience payload with a sparse or unsorted identifier set.

`test/integrations/destinations/tiktok_audience/router/data.ts` — **"Native Test 18: record events: invalid identifiers"** had frozen the old behaviour into its expected payload (two ids against a four-entry `id_schema`, i.e. the misalignment itself) and had always passed. Its fixture is updated; please sanity-check that fixture rather than assuming it was collateral damage.

### Any new dependencies introduced with this change?

N/A

### Any new generic utility introduced or modified. Please explain the changes.

N/A — one new local type, `BatchIdentifier = Identifier | IdentifierPlaceholder`, so a placeholder is representable.

### Any technical or performance related pointers to consider with the change?

Payload size grows for sparse records (an extra `{}` per unfilled slot). Grouping is unchanged: it already keys on `id_schema`, and rows are now uniformly that length.

<hr>

## Verification

**Unit** — 12/12 in `recordTransform.test.ts`, including 3 new alignment cases. All three were confirmed to **fail before the fix** (row length 1 vs schema 4; AAID/PHONE hashes swapped), so they can actually catch a regression.

**Component** — 16/16 for `tiktok_audience`. Repo-wide `tsc --noEmit`, eslint and prettier clean.

**End-to-end on a local stack, against the real TikTok API.** Transformer built from this branch and deployed into the stack, verified the patched code was actually in the running container, then drove a real rETL sync from a warehouse source into a live TikTok audience with `AAID_SHA256`, `EMAIL_SHA256`, `PHONE_SHA256` mapped and nulls seeded across every gap shape. The payload was captured off the wire between rudder-server and the transformer:

```
 20 ok                                    (every row length == id_schema length)
 11 ["AAID_SHA256","EMAIL_SHA256","PHONE_SHA256"]

  5  -           | EMAIL_SHA256 | -              both null
  5  -           | EMAIL_SHA256 | PHONE_SHA256   <- leading gap: the reported bug
  5  AAID_SHA256 | EMAIL_SHA256 | -              trailing gap
  5  AAID_SHA256 | EMAIL_SHA256 | PHONE_SHA256   fully populated
```

Sync result: **20 changed → 20 successful, 0 failed / dropped / invalid.** TikTok accepted the `{}` placeholders.

Running the identical payload against the current published transformer image reproduces both bugs:

```
                     BEFORE                          AFTER
row 0  AAID_SHA256   jared@example.com   <- bug      (no entry)
       EMAIL_SHA256  (no entry)                      jared@example.com
row 1  AAID_SHA256   marketing@example   <- bug      (no entry)
       EMAIL_SHA256  +15551234567        <- bug      marketing@example.com
       PHONE_SHA256  (no entry)                      +15551234567
row 2  AAID_SHA256   +15559998888        <- bug      aaid-value-here
       PHONE_SHA256  aaid-value-here     <- bug      +15559998888
```

Row 2 is bug #2: all identifiers present, `AAID` and `PHONE` swapped.

## Linear ticket 
[Resolve INT-7054](https://linear.app/rudderstack/issue/INT-7054/fix-tiktok-audience-identifier-schema-alignment)

### Developer checklist

- [x] My code follows the style guidelines of this project

- [ ] **No breaking changes are being introduced.** — see *changes to existing behaviour* above: the emitted `batch_data` shape changes. That is the fix, but it is a wire-format change worth a reviewer's eyes.

- [x] All related docs linked with the PR?

- [x] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [x] Is the PR limited to 10 file changes? — 4 files

- [x] Is the PR limited to one linear task?

- [x] Are relevant unit and component test-cases added in **new readability format**?

