### PR TITLE
docs(skills): reconcile batching registration and networkHandler guidance

### DIFF
--- a/.claude/skills/batching-framework-delivery/SKILL.md
+++ b/.claude/skills/batching-framework-delivery/SKILL.md
@@ -129,9 +129,56 @@ Don't set these yourself:
 
 ## Transport stays in `networkHandler.ts`
 
-Only *response handling* moves. A destination that builds its HTTP request at delivery time (SDK call, URL derived from `params`, custom `processAxiosResponse`) keeps `proxy` / `prepareProxy` / `processAxiosResponse` in its handler.
+Only *response handling* moves. A destination that **already has** a handler building its HTTP request at delivery time (SDK call, URL derived from `params`, custom `processAxiosResponse`) keeps `proxy` / `prepareProxy` / `processAxiosResponse` there — `deliver()` in `src/services/destination/nativeIntegration.ts` resolves the network handler and calls `proxy()` / `processAxiosResponse()` *before* it consults `isDestinationIntegrationEnabled`, and `DestinationIntegration` exposes no transport hook to move that into.
 
-**Keep the legacy `networkHandler.ts` until GA.** Workspaces not yet enrolled still transform through `processRouterDest` and are delivered by that handler; both are deleted together at GA.
+This whole section is about **migrations**. For a destination being built new, see "A new destination gets no `networkHandler.ts`" below — the answer there is always no.
+
+### Keeping the legacy handler
+
+**Keep the legacy `networkHandler.ts` until nothing routes to it.** `batching: true` is not the
+cutoff on its own; two things still send traffic through it:
+
+- **Pre-GA workspaces.** A workspace not named in
+  `{DEST}_BATCHING_FRAMEWORK_ENABLED_WORKSPACE_IDS` transforms through `processRouterDest` *and*
+  is delivered by that handler — the two move together, so this is one condition, not two.
+- **v0 proxy requests.** `deliver()` reaches the framework branch only via `isProxyV1Request`,
+  which requires the v1 route *and* an array `metadata`. A v0 request stays on the handler even
+  for a batching-GA destination, because the framework answers with a `DeliveryV1Response` that
+  a v0 caller cannot parse.
+
+`customerio`, `braze_audience`, `iterable_audience`, `google_adwords_enhanced_conversions` and
+`reddit_audience` are all batching-GA today and still carry both a `delivery.ts` and a
+`src/v1/destinations/<dest>/networkHandler.ts` (gaec keeps a v0 one too) — now for the **second**
+reason only. The handler is deletable once v0 proxy traffic is confirmed dead for the destination.
+
+### A new destination gets no `networkHandler.ts`
+
+**Do not write one.** A destination built new on the framework has no legacy transform and no
+unenrolled workspaces, so nothing above applies to it. Build it framework-native:
+
+- **No `networkHandler.ts`, for transport or for response handling.** `posthog` and
+  `custom_audience` have neither a `networkHandler.ts` nor a `delivery.ts` — they take the
+  framework default, which reproduces `genericNetworkHandler`. That is the shape to copy.
+- **Add a `delivery.ts` only to override the default verdicts** (see the verdict builders above).
+- Mark it `batching: true` in `src/features.ts` from the start — a new destination is GA on day
+  one, so the `{DEST}_BATCHING_FRAMEWORK_ENABLED_WORKSPACE_IDS` rollout flag is for migrations and
+  is not needed. That single entry turns on transform *and* delivery; there is nothing else to set.
+
+**If it looks like you need one, that is a framework gap — raise it, don't fork around it.** Two
+cases come up, and neither is a licence to hand-write a handler:
+
+- **Transport the framework cannot express** — an SDK call, a URL derived from `params`. Framework
+  delivery replaces response *interpretation* only, and `deliver()` runs transport before it
+  consults the predicate at all, so a handler written here would sit on the delivery path forever.
+- **OAuth on the v0 proxy path.** A v0 request bypasses `delivery.ts`, and `genericNetworkHandler`
+  throws a bare `NetworkError` with no `authErrorCategory`, so a 401 there aborts the batch without
+  requesting a token refresh. This is a **known gap in the framework**, not a reason to grow a
+  second copy of response handling — writing a handler re-forks classification across two files,
+  which is the exact thing this framework exists to remove.
+
+`reddit_audience` does ship `src/v1/destinations/reddit_audience/networkHandler.ts` despite being
+new and `batching: true` from the start. It predates this guidance and is **not a template** — if
+you are citing it to justify a handler on a new destination, raise the gap instead.
 
 ## Enabling it
 
@@ -140,11 +187,13 @@ Delivery has **no flag of its own**. It is gated on `isDestinationIntegrationEna
 - **GA:** the destination is marked `batching: true` in `features.ts` (surfaced as `destinationIntegrationsMap`), which enables both halves everywhere.
 - **Pre-GA:** the workspace is named in `{DEST_NAME_UPPER}_BATCHING_FRAMEWORK_ENABLED_WORKSPACE_IDS` (comma-separated workspace IDs or `ALL`).
 
-One predicate for both halves is deliberate. The delivery path interprets a payload built by the matching transform path; an unenrolled workspace's events are still built by `processRouterDest`, and pairing those with framework response handling would misread them. Deciding both from one call makes that mismatch unrepresentable.
+One predicate for both halves is deliberate. The delivery path interprets a payload built by the matching transform path; an unenrolled workspace's events are still built by `processRouterDest`, and pairing those with framework response handling would misread them. Deciding both from one call makes that mismatch unrepresentable. See `.claude/skills/batching-framework/SKILL.md#one-gate-both-halves` for the predicate and the v0-proxy carve-out.
 
 Nothing extra is needed in your `dataDelivery` component tests or `live.ts` specs for a destination
 already marked batching-GA in `features.ts`; a pre-GA destination needs the transform flag set via
-`envOverrides`, or CI keeps exercising the legacy handler.
+`envOverrides`, or CI keeps exercising the legacy handler. If you are reading an older spec that
+still sets `{DEST}_BATCHING_FRAMEWORK_DELIVERY_ENABLED_WORKSPACE_IDS`, that flag no longer exists —
+delete the override rather than porting it.
 
 ## Testing
 

--- a/.claude/skills/batching-framework/SKILL.md
+++ b/.claude/skills/batching-framework/SKILL.md
@@ -36,7 +36,7 @@ RouterTransformationResponse[]
 Delivery is a separate service call, over the same class:
 
 ```
-deliver()                            [nativeIntegration, same predicate as transform]
+deliver()                            [nativeIntegration; isProxyV1Request && same predicate as transform]
     |
 handleDeliveryResponse(Class, ctx)   [framework-owned]
     |--- delivery.statusOverrides[status] ?? [class] ?? classify by status
@@ -211,26 +211,55 @@ type BatchGroup = {
 
 ## Enabling the Framework
 
-Mark the destination `batching: true` in `src/features.ts`:
+**`src/features.ts` is the only registration surface. Do not hand-edit
+`src/constants/destinationIntegrationsMap.ts`** — it is derived, not authored:
 
 ```typescript
-const destinationCapabilities = {
-  <DEST_NAME_UPPER>: { routerTransform: true, batching: true }, // Add your destination here
+// src/constants/destinationIntegrationsMap.ts
+export const destinationIntegrationsMap: Record<string, true> = getGaDestinationIntegrations();
+```
+
+`getGaDestinationIntegrations()` filters `destinationCapabilities` in `src/features.ts`
+on `batching: true`, so adding an entry to that map by hand is either a no-op or a conflict.
+
+Register the destination by adding the `batching` capability alongside `routerTransform`:
+
+```typescript
+// src/features.ts — destinationCapabilities
+const destinationCapabilities: Record<string, DestinationCapabilities> = {
+  POSTHOG: { routerTransform: true, batching: true },
+  CUSTOM_AUDIENCE: { routerTransform: true, batching: true },
+  <DEST_NAME_UPPER>: { routerTransform: true, batching: true },  // Add your destination here
 };
 ```
 
-`destinationIntegrationsMap` (`src/constants/destinationIntegrationsMap.ts`) is **derived** from this
-via `getGaDestinationIntegrations()` — there is nothing to hand-edit there.
+`routerTransform: true` puts the destination on the router-transform path at all;
+`batching: true` marks it **batching-GA**. For the current roster, grep `batching: true` in
+`src/features.ts` — it changes as destinations migrate, so a list copied into a doc goes stale.
 
-To enable destination on routerTransform, feature.ts also needs to be updated with definitionName under defaultFeaturesConfig `src/features.ts`
+### One gate, both halves
 
-When enabled, the platform routes events through `processDestinationIntegration()` instead of the legacy `processRouterDest()`.
+`isDestinationIntegrationEnabled(destType, workspaceId)`
+(`src/constants/destinationIntegrationsMap.ts`) is the **only** predicate, and it answers for the
+router transform *and* delivery:
 
-For gradual rollout before GA, use the env var pattern:
-`{DEST_NAME_UPPER}_BATCHING_FRAMEWORK_ENABLED_WORKSPACE_IDS` (comma-separated workspace IDs or `ALL`).
+- **batching-GA** (`batching: true` in `features.ts`) → true for every workspace, always.
+- **otherwise** → true only for a workspace named in
+  `{DEST_NAME_UPPER}_BATCHING_FRAMEWORK_ENABLED_WORKSPACE_IDS` (comma-separated workspace IDs or
+  `ALL`) — the pre-GA rollout knob.
 
-Delivery is gated by the **same** predicate — there is no separate delivery flag
-— see `.claude/skills/batching-framework-delivery/SKILL.md`.
+`doRouterTransformation` calls it to route events through `processDestinationIntegration()` instead
+of the legacy `processRouterDest()`; `deliver()` calls it to read the response through the
+framework's delivery bridge instead of the destination's `networkHandler`.
+
+There is **no separate delivery flag.** The delivery path interprets a payload built by the matching
+transform path, so deciding both from one call makes the mismatch unrepresentable — where a separate
+flag made it a configuration mistake anyone could make. Enrolling a workspace moves both halves
+together, and so does going GA. See `.claude/skills/batching-framework-delivery/SKILL.md`.
+
+One thing is *not* gated on the predicate: a **v0 proxy request** stays on the legacy handler
+whatever it returns, because the framework produces a `DeliveryV1Response` natively and a v0 caller
+cannot parse one. See `isProxyV1Request` in `src/services/destination/nativeIntegration.ts`.
 
 ## Delivery (response handling)
 
@@ -242,8 +271,9 @@ throws.
 **Most destinations need nothing** — the default reproduces `genericNetworkHandler`. `posthog` and
 `custom_audience` declare no overrides at all.
 
-**See `.claude/skills/batching-framework-delivery/SKILL.md`** for the contract, the verdict builders,
-the `perItem` rules and the delivery flag.
+**See `.claude/skills/batching-framework-delivery/SKILL.md`** for the contract, the verdict builders
+and the `perItem` rules. Enabling it is not separate — it rides on the same registration and the
+same predicate as the transform, per "One gate, both halves" above.
 
 ### If you just batched a destination that had a network handler
 
@@ -256,8 +286,10 @@ URL from `params`. If instead it reads the endpoint from the payload, set it nor
   and often hard-codes index `0` (e.g. `set(body.JSON, 'items[0].field', ...)`). Once batched,
   `items` is an array of N — iterate the whole array. The single-item case collapses to an array of
   one, so legacy traffic is unaffected (a safe, ungated change).
-- The proxy layer runs in a later service call than the transform and **does not see the workspace
-  batching flag**, so don't gate transport changes on it; make them correct for both 1 and N items.
+- **Don't gate transport changes on the batching predicate**; make them correct for both 1 and N
+  items. `deliver()` does read `isDestinationIntegrationEnabled`, but only *after* `proxy()` and
+  `processAxiosResponse()` have already run — transport is chosen by `networkHandlerFactory`, not by
+  the predicate — and the same handler still serves v0 proxy requests and any pre-GA workspace.
 
 Cover this with a focused unit test that mocks the delivery SDK/client and asserts the per-item field
 is set on **every** item (cheaper and more direct than a full dataDelivery mock).
@@ -270,10 +302,40 @@ it only covers the rules you knew about when you wrote it. A partner that adds a
 rule, or one whose docs are incomplete, will reject a batch of N on one event you believed
 was fine, and the retry re-sends the same batch and fails again.
 
-The fallback belongs in the **networkHandler**, where the partner's actual rejection is
-visible. On a 4xx **when more than one event was sent**, mark every job `dontBatch: true` and
-return **500** so the router re-delivers them individually; the offending event then fails
+Whether you need this at all: if the partner documents a per-item result array (partial
+success), you don't — parse it and mark only the failed items. If one bad item fails the
+request, you do.
+
+The fallback: on a 4xx **when more than one event was sent**, mark every job `dontBatch: true`
+and return **500** so the router re-delivers them individually; the offending event then fails
 alone and the rest succeed.
+
+**On the framework this is a `delivery.ts` verdict, not a `networkHandler`.** Return
+`retry(..., { dontBatch: true })` from a `'4xx'` status override:
+
+```ts
+static delivery = {
+  statusOverrides: {
+    // Exact keys win over the class key. Without this, '4xx' would also swallow 429 and turn a
+    // rate limit — transient, and a whole-batch problem — into a permanent per-job dontBatch.
+    429: (ctx, fallback) => fallback(),
+    '4xx': (ctx, fallback) => retry(reasonOf(fallback()), { dontBatch: true }),
+  },
+};
+```
+
+The framework then applies the three rules below for you: a `retry` verdict yields **500** and
+stamps `dontBatch: true` on every job's metadata; when the batch is already a **single** job it
+rewrites that verdict to an **abort** (400), so a permanently-bad event terminates instead of
+looping; and retryable 5xx never reaches a `'4xx'` override at all. See `retry` and the
+`dontBatchAbortCount` rewrite in `src/services/destination/destinationIntegration/delivery.ts`, and
+`.claude/skills/batching-framework-delivery/SKILL.md#dontbatch-softens-an-abort-it-never-hardens-a-retry`
+for why `dontBatch` must never be paired with a transient status.
+
+### The legacy shape — non-framework destinations only
+
+A destination **not** on the framework does this in its `networkHandler`, where the partner's
+actual rejection is visible. Do not write this for a new destination:
 
 ```ts
 const populateResponseWithDontBatch = (rudderJobMetadata, errorMessage) =>
@@ -329,10 +391,6 @@ unconditionally — take Amplitude's version of that line. Also
 Network handlers live at `src/v1/destinations/<dest>/networkHandler.{ts,js}` and are
 auto-discovered by `src/adapters/networkHandlerFactory.js` from the directory name — export
 them as `networkHandler` or `NetworkHandler`; no registration step.
-
-Whether you need this: if the partner documents a per-item result array (partial success),
-you don't — parse it and mark only the failed items. If one bad item fails the request, you
-do.
 
 ## Testing
 

--- a/.claude/skills/live-integration-test/SKILL.md
+++ b/.claude/skills/live-integration-test/SKILL.md
@@ -217,7 +217,7 @@ spec.
    delivery has no flag of its own — it is gated on the same predicate as the transform, so a
    pre-GA destination only needs `{DEST}_BATCHING_FRAMEWORK_ENABLED_WORKSPACE_IDS: 'ALL'`. Do not
    add it for destinations already marked batching-GA in `features.ts`; both sides are enabled
-   there.
+   there. See `.claude/skills/batching-framework/SKILL.md#one-gate-both-halves`.
 7. **CI is automatic.** The `discover` job builds the workflow matrix from `destinations/*/live.ts`,
    so a new spec runs in CI with no workflow edit. `LIVE_SECRET_<DEST>` is derived from the
    destination code; an **OAuth** spec (`authType: 'oauth'`) additionally wildcard-imports the whole
@@ -299,7 +299,8 @@ const agent = new Agent({ keepAlive: false });
 export const live = {
   enabled: true,
   authType: 'apiKey', // apiKey | oauth | basic | serviceAccount | custom
-  // Optional: env applied around this destination's scenarios and restored after.
+  // Optional: env applied around this destination's scenarios and restored after. Only needed for a
+  // destination-specific rollout flag, e.g. a pre-GA batching enrolment:
   // envOverrides: { <DEST>_BATCHING_FRAMEWORK_ENABLED_WORKSPACE_IDS: 'ALL' },
   // Non-secret Config defaults from the component test's destination.Config; real creds via s.config.
   resolveConfig: (s) => ({ ...s.config }),

--- a/.claude/skills/vdm-next-audience-integration/SKILL.md
+++ b/.claude/skills/vdm-next-audience-integration/SKILL.md
@@ -28,7 +28,6 @@ src/v0/destinations/<dest_name>/
 ├── utils.ts                  # (Optional) Normalization, hashing, field processing, API helpers
 ├── delivery.ts               # (Optional) the `delivery` spec — only if response handling
 │                             #            differs from the framework default
-├── networkHandler.ts         # (Optional) Transport only (SDK/proxy/processAxiosResponse)
 ├── routerTransform.test.ts   # Unit tests for router transform
 └── utils.test.ts             # (Optional) Unit tests for utilities
 ```
@@ -390,15 +389,12 @@ export const Integration = AudienceIntegration;
 
 ### Enabling the Batching Framework
 
-Register the destination in `src/constants/destinationIntegrationsMap.ts`:
+Add `<DEST_NAME_UPPER>: { routerTransform: true, batching: true }` to `destinationCapabilities` in
+`src/features.ts`. That one entry enables the framework transform *and* delivery.
 
-```typescript
-export const destinationIntegrationsMap: Record<string, true> = {
-  POSTHOG: true,
-  CUSTOM_AUDIENCE: true,
-  <DEST_NAME_UPPER>: true,  // Add your destination here
-};
-```
+**See `.claude/skills/batching-framework/SKILL.md#enabling-the-framework`** for why
+`src/constants/destinationIntegrationsMap.ts` must not be hand-edited, and for the pre-GA rollout
+flag.
 
 **Reference:**
 
@@ -480,7 +476,8 @@ Response handling lives on your `DestinationIntegration` class as a static `deli
 `networkHandler.ts`. **Most audience destinations need nothing** — the framework default reproduces
 `genericNetworkHandler`.
 
-**See `.claude/skills/batching-framework-delivery/SKILL.md`** for the contract, verdicts and flag.
+**See `.claude/skills/batching-framework-delivery/SKILL.md`** for the contract, the verdict builders
+and the `perItem` rules. There is no delivery flag — it rides on the same predicate as the transform.
 
 What is audience-specific: these APIs commonly report failures by **identity** rather than index —
 a `failedUpdates` object naming the emails/userIds that failed, with no positional information.
@@ -490,15 +487,13 @@ than aborted, and `notFound` on an unsubscribe is a no-op success. Reproduce tha
 destination-specific semantics in `delivery.statusOverrides`, or the default will abort them as
 plain failures.
 
-`networkHandler.ts` remains the place for **transport** — a shared platform proxy, custom
-`processAxiosResponse`, SDK-based delivery:
+**Do not add a `networkHandler.ts`.** A new audience destination is framework-native: transport
+comes from the framework default and response handling from `delivery.ts`. If the destination
+appears to need transport the framework cannot express, or OAuth refresh on the v0 proxy path,
+that is a gap in the framework — raise it rather than hand-writing a handler. See
+`.claude/skills/batching-framework-delivery/SKILL.md#a-new-destination-gets-no-networkhandlerts`.
 
-```typescript
-export { networkHandler, errorResponseHandler } from '../../util/<platform>Utils/networkHandler';
-```
-
-**Reference:** `src/v0/destinations/iterable_audience/delivery.ts` (identity-keyed),
-`src/v0/destinations/fb_custom_audience/networkHandler.ts` (transport re-export)
+**Reference:** `src/v0/destinations/iterable_audience/delivery.ts` (identity-keyed)
 
 ---
 
@@ -770,8 +765,8 @@ export const data = [
    - `getBatchStrategy()` — return `ChunkBatchStrategy` with `maxItems`/`maxPayloadSize` and `wrapBody` that builds the destination-specific request body
    - `getInputSchema()` — return the Zod schema for input validation
    - Export the class as `Integration`
-5. Register in `src/constants/destinationIntegrationsMap.ts` — add `<DEST_NAME_UPPER>: true`
-6. Create `delivery.ts` (optional) — only if the API reports failures the framework default cannot read (partial failures, identity-keyed errors); `networkHandler.ts` only if transport itself is custom
+5. Register in `src/features.ts` — see "Enabling the Batching Framework" above
+6. Handle delivery (optional) — see "Delivery — response handling" above; the framework default covers most audience destinations
 7. Create `routerTransform.test.ts` — unit tests using `processDestinationIntegration(inputs, Integration, {})` covering: valid insert/update/delete, invalid identifiers, null identifiers, hashing on/off, batch overflow, mixed actions, missing auth
 8. Create `test/integrations/destinations/<dest_name>/router/data.ts` — integration test cases covering: successful operations, validation errors, unsupported types, batching, audience subtypes, pre-hashed values
 9. Run verification:

--- a/.claude/skills/vdm-v2-object-destination/SKILL.md
+++ b/.claude/skills/vdm-v2-object-destination/SKILL.md
@@ -109,9 +109,13 @@ Object destinations declare both `recordSchema` and `eventStreamSchema`. Overrid
 
 ## Enabling the Framework
 
-Mark the destination `batching: true` in `src/features.ts` (and `routerTransform: true`). `destinationIntegrationsMap` is derived from this — nothing to hand-edit there.
+Add `<DEST_NAME_UPPER>: { routerTransform: true, batching: true }` to `destinationCapabilities` in
+`src/features.ts`. That one entry enables the framework transform *and* delivery — there is no
+separate delivery flag.
 
-Delivery is gated by the same predicate -- see `.claude/skills/batching-framework-delivery/SKILL.md`.
+**See `.claude/skills/batching-framework/SKILL.md#enabling-the-framework`** for why
+`src/constants/destinationIntegrationsMap.ts` must not be hand-edited, and for the pre-GA rollout
+flag. For the delivery *contract*, see `.claude/skills/batching-framework-delivery/SKILL.md`.
 
 ## Steps
 
@@ -123,7 +127,7 @@ Delivery is gated by the same predicate -- see `.claude/skills/batching-framewor
    - `getBatchStrategy()` -- return `ChunkBatchStrategy` with `maxPayloadSize`/`maxItems` and `wrapBody`
    - (Optional) `transformEventStream(input)` -- handle non-record events
    - Export as `Integration`
-4. Mark `batching: true` in `src/features.ts`
+4. Register in `src/features.ts` -- see "Enabling the Framework" above
 5. (Optional) Create `delivery.ts` -- the `delivery` spec, only if the API reports failures the
    framework default cannot read; add a `delivery.test.ts` that compares it against the legacy handler
 6. Create `src/v0/destinations/<dest_name>/routerTransform.test.ts` -- unit tests

--- a/memory-bank/llds/batching-framework/01-overview.md
+++ b/memory-bank/llds/batching-framework/01-overview.md
@@ -41,7 +41,7 @@ Provide a **generic batching framework** that:
 | **getBatchStrategy**           | Returns a `BatchStrategy` (`chunk` or `customBatch`) for a given endpoint                                               |
 | **TransformedPayload**         | One transformed event payload with endpoint, method, headers, and body                                                  |
 | **BatchStrategy**              | Describes how to combine payloads within a group — either `chunk(...)` or `customBatch(...)`                            |
-| **destinationIntegrationsMap** | Registry (`src/constants/destinationIntegrationsMap.ts`) that opts a destination into the framework                     |
+| **destinationIntegrationsMap** | Derived map of batching-GA destinations, built from `batching: true` in `src/features.ts` — not hand-authored           |
 
 ## Architecture — Block Diagram
 
@@ -56,10 +56,13 @@ Provide a **generic batching framework** that:
                           └──────────────┬───────────────┘
                                          │
                      ┌───────────────────┴────────────────────┐
-                     │  destinationIntegrationsMap lookup     │
+                     │ isDestinationIntegrationEnabled(       │
+                     │   destType, workspaceId)               │
+                     │ = batching-GA OR env-var rollout       │
+                     │ (same predicate gates deliver())       │
                      └──────────┬──────────────────┬──────────┘
                                 │                  │
-                     dest IS in map          dest NOT in map
+                              true               false
                                 │                  │
                  ┌──────────────▼───────────┐  ┌───▼───────────────┐
                  │ NEW FRAMEWORK PATH       │  │ LEGACY PATH       │
@@ -131,7 +134,8 @@ Provide a **generic batching framework** that:
 
 A destination opts in by:
 
-1. Marking itself `batching: true` in `src/features.ts`
+1. Adding `batching: true` to its `destinationCapabilities` entry in `src/features.ts` — which
+   enables the framework's **transform and delivery together**, there being one predicate for both
 2. Creating `src/v0/destinations/{dest}/routerTransform.ts` that exports `Integration` (the class, not an instance)
 
 ```typescript
@@ -141,7 +145,10 @@ const destinationCapabilities = {
 };
 ```
 
-`destinationIntegrationsMap` (`src/constants/destinationIntegrationsMap.ts`) is derived from that capability via `getGaDestinationIntegrations()`; it is not hand-edited.
+`destinationIntegrationsMap` (`src/constants/destinationIntegrationsMap.ts`) is **derived** from
+that capability via `getGaDestinationIntegrations()` and must not be hand-edited. The registration
+mechanics, the pre-GA rollout env var and the v0-proxy carve-out are documented once, in
+`.claude/skills/batching-framework/SKILL.md#enabling-the-framework` — not repeated here.
 
 The framework caches the **constructor** (not an instance) in `FetchHandler.destinationIntegrationHandlerMap` and creates a **new instance per request** to avoid race conditions with mutable instance state.
 
@@ -150,7 +157,7 @@ The framework caches the **constructor** (not an instance) in `FetchHandler.dest
 ```
 doRouterTransformation(events, destType, version, reqMetadata)
   │
-  ├─ if isDestinationIntegrationEnabled(destType, workspaceId):
+  ├─ if isDestinationIntegrationEnabled(destType, workspaceId):   // GA map OR per-workspace env var
   │    IntegrationClass = FetchHandler.getDestinationIntegrationHandler(destType)
   │    results = processDestinationIntegration(events, IntegrationClass, reqMetadata)
   │    return handleRouterTransformSuccessEvents(results, ...)

--- a/memory-bank/llds/batching-framework/04-reference-implementations.md
+++ b/memory-bank/llds/batching-framework/04-reference-implementations.md
@@ -276,5 +276,5 @@ To migrate a destination to the framework:
    - Call `super.batchTransform()` to delegate iteration
 7. **Add Zod schema** via `getIntegrationSchema` for destination-specific rules
 8. **Export `const Integration = YourClass`** (class, not instance)
-9. **Add destination to `destinationIntegrationsMap`**
+9. **Add `batching: true` to the destination's entry in `destinationCapabilities`** (`src/features.ts`) — see `.claude/skills/batching-framework/SKILL.md#enabling-the-framework`
 10. **Update/add component tests** — output format changes from legacy to framework envelope


### PR DESCRIPTION
## What are the changes introduced in this PR?

Skill guidance for the batching framework had drifted from the code and was producing wrong destination specs. Documentation-only — no runtime code is touched.

**Rebased onto `develop` at `14ae170cf`.** #5543 (`BatchDestination` → `DestinationIntegration`) landed mid-review and, beyond the rename, independently reconciled part of what this PR set out to fix. Scope is reduced accordingly — see "Absorbed by #5543" below. What remains is the guidance #5543 did not cover.

### 1. A new destination never gets a `networkHandler.ts`

The largest surviving change, and a **reversal** of what this PR originally proposed. The section said only *"Keep the legacy `networkHandler.ts` until GA"*, which was being read as applying to new destinations too. It is now scoped explicitly to **migrations**, and new destinations are told the opposite:

- New section **"A new destination gets no `networkHandler.ts`"** — build it framework-native. `posthog` and `custom_audience` (neither file) are the shape to copy; `delivery.ts` only to override the default verdicts.
- The two cases that look like they need one — transport the framework cannot express, and OAuth refresh on the v0 proxy path (`genericNetworkHandler` throws a bare `NetworkError` with no `authErrorCategory`, so a 401 there never requests a refresh) — are documented as **framework gaps to raise**, not as licence to hand-write a handler. Growing a second copy of response handling is the thing this framework exists to remove.
- `reddit_audience` does carry one despite being new; it is now labelled explicitly as predating this guidance and **not a template**.

Also removed from `vdm-next-audience-integration`: `networkHandler.ts` in the file-structure tree, and the *"`networkHandler.ts` remains the place for transport"* block with its `fb_custom_audience` re-export example.

### 1b. "Partners that reject the whole batch" now leads with the framework

While scoping the above I found this section still routing authors to a `networkHandler` for the all-or-nothing `dontBatch` split (naming OpenAI Ads, Reddit, Amplitude). **The framework already expresses it natively** — `retry(reason, { dontBatch: true })` from a `'4xx'` status override — and applies all three "easy to get wrong" rules itself: `retry` yields 500 and stamps `dontBatch` on every job; a batch already down to **one** job has that verdict rewritten to an `abort` (400), which is the `dontBatch ? 400 : 500` termination rule; and retryable 5xx never reaches a `'4xx'` override.

The example also pins the trap that `'4xx'` is a *class* key which would otherwise swallow **429** and turn a rate limit into a permanent per-job `dontBatch` — exact keys win, so `429: (ctx, fallback) => fallback()` is required alongside it. The hand-written recipe is kept but demoted to *"The legacy shape — non-framework destinations only"*.

### 2. "One gate, both halves"

#5543 states in passing that delivery shares the transform's predicate. This adds the named section that says how, and points the other five docs at it rather than restating it:

- `batching: true` → framework transform **and** delivery, every workspace.
- Otherwise → `{DEST_NAME_UPPER}_BATCHING_FRAMEWORK_ENABLED_WORKSPACE_IDS`, which moves both halves together.
- Carve-out: a **v0 proxy request** stays on the legacy handler regardless, because the framework answers with a `DeliveryV1Response` a v0 caller cannot parse.

Also corrects the transport-gating bullet: the old text claimed the proxy layer "does not see the workspace batching flag". It does — `deliver()` reads `isDestinationIntegrationEnabled`, just *after* `proxy()` / `processAxiosResponse()` have already run. The advice survives; the reason is now right.

### 3. Registration surface — the spots #5543 left behind

- `batching-framework/SKILL.md` still carried `To enable destination on routerTransform, feature.ts also needs to be updated with definitionName under defaultFeaturesConfig`. **`defaultFeaturesConfig` no longer exists** in `src/features.ts`. Removed, and replaced with the `destinationCapabilities` shape.
- `vdm-next-audience-integration/SKILL.md` still told authors to hand-author `destinationIntegrationsMap` as an object literal — #5543 renamed that block but did not correct it. It is derived via `getGaDestinationIntegrations()`; hand-editing is a no-op or a conflict.
- `04-reference-implementations.md` step 9 still said *"Add destination to `destinationIntegrationsMap`"*.
- `01-overview.md`: the terminology row still described the map as the *registry that opts a destination in*; the block diagram still showed a **map lookup** rather than the predicate. Both corrected.

### 4. Deduplication

`batching-framework/SKILL.md#enabling-the-framework` and `#one-gate-both-halves` are the single source; `vdm-next-audience-integration`, `vdm-v2-object-destination`, `live-integration-test`, `01-overview.md` and `04-reference-implementations.md` link to them instead of re-explaining. Restating this in five places is what let the docs drift in the first place.

## Absorbed by #5543

Dropped from this PR — already correct on `develop`:

| Was in this PR | Status |
| --- | --- |
| Delete `{DEST}_BATCHING_FRAMEWORK_DELIVERY_ENABLED_WORKSPACE_IDS` from the delivery skill | Already done |
| "Enabling it" rewritten to say delivery has no flag of its own | Already done (kept develop's wording; added the cross-ref and a note to *delete* the stale override rather than port it) |
| `live-integration-test` no longer setting a delivery-side flag | Already done (only the cross-ref added) |
| `vdm-v2-object-destination` "Enabling the Framework" pointing at `features.ts` | Already done (cross-refs added) |
| `01-overview.md` entry-point flow using the predicate | Already done |
| Renames throughout | Superseded by #5543's own rename |

The four original commits were squashed into one; they were iterative self-corrections of the same paragraphs, and the merge commit among them would not survive a rebase.

## Grounding

Every claim re-verified against `origin/develop` at `14ae170cf`, after the rename:

- `deliver()` (`src/services/destination/nativeIntegration.ts`): `networkHandler.proxy()` / `processAxiosResponse()` at L248-249 run **before** `isDestinationIntegrationEnabled` at L259-260; `isProxyV1Request` at L61.
- `posthog` / `custom_audience`: neither a `networkHandler.ts` nor a `delivery.ts` — framework default.
- `customerio`, `braze_audience`, `iterable_audience`, `google_adwords_enhanced_conversions`, `reddit_audience`: `delivery.ts` + `src/v1/destinations/<dest>/networkHandler.ts` (gaec also keeps a v0 one); `reddit_audience/classify.ts` present.
- `src/features.ts`: no `defaultFeaturesConfig`; `destinationCapabilities` at L17, seven `batching: true` entries plus the `TEST_DESTINATION` dev fixture. No roster is hard-coded into the docs — they say to grep.
- `destinationIntegrationsMap = getGaDestinationIntegrations()` and `isDestinationIntegrationEnabled` confirmed in `src/constants/destinationIntegrationsMap.ts`.
- The `dontBatch` claims in §1b read off `destinationIntegration/delivery.ts`: `retry`/`dontBatch` at L65-71, the singleton→`abort` rewrite and `batch_delivery_dont_batch_aborted` at L397-413, `statusCode = 500`/`429` and the metadata stamp at L467-481, `StatusOverride` signature at L155-158, `statusClassOf` mapping 429 into `'4xx'` at L165-170. Matches what `batching-framework-delivery/SKILL.md:90,98-102` already documents.
- `FetchHandler.destinationIntegrationHandlerMap` / `getDestinationIntegrationHandler` confirmed at `src/helpers/fetchHandlers.ts:13,48`.

`docs/superpowers/specs/2026-07-30-network-handler-abstraction-design.md` is deliberately left alone — it is a dated design doc.

## Notes for reviewers

- §1 reverses the original draft of this PR, which proposed writing a `networkHandler.ts` for new OAuth destinations. Per review, new destinations get none; the OAuth 401/refresh hazard is recorded as a framework gap instead.
- §1b touches a section this PR did not originally set out to change. It was proposing the legacy shape to new destinations, which is the same defect as §1.
- All four anchor targets resolve to real headings (`#enabling-the-framework`, `#one-gate-both-halves`, `#a-new-destination-gets-no-networkhandlerts`, `#dontbatch-softens-an-abort-it-never-hardens-a-retry`).
- `prettier --check` passes (`.claude/` is prettier-ignored; both `memory-bank/` files checked). No logic changed, so the code/security review loop was skipped per repo convention for docs-only changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CG2jakDYPLCz9ecEotgthy
