### PR TITLE
fix(security): override transitive deps to resolve critical/high vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4099,9 +4099,9 @@
       }
     },
     "node_modules/@rudderstack/integrations-lib/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -4144,13 +4144,13 @@
       }
     },
     "node_modules/@rudderstack/integrations-lib/node_modules/minimatch": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "license": "ISC",
       "peer": true,
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -4235,9 +4235,9 @@
       }
     },
     "node_modules/@shopify/jest-koa-mocks/node_modules/koa": {
-      "version": "2.16.3",
-      "resolved": "https://registry.npmjs.org/koa/-/koa-2.16.3.tgz",
-      "integrity": "sha512-zPPuIt+ku1iCpFBRwseMcPYQ1cJL8l60rSmKeOuGfOXyE6YnTBmf2aEFNL2HQGrD0cPcLO/t+v9RTgC+fwEh/g==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/koa/-/koa-2.16.4.tgz",
+      "integrity": "sha512-3An0GCLDSR34tsCO4H8Tef8Pp2ngtaZDAZnsWJYelqXUK5wyiHvGItgK/xcSkmHLSTn1Jcho1mRQs2ehRzvKKw==",
       "license": "MIT",
       "dependencies": {
         "accepts": "^1.3.5",
@@ -5423,7 +5423,9 @@
       }
     },
     "node_modules/@typescript-eslint/parser/node_modules/brace-expansion": {
-      "version": "2.0.2",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5431,11 +5433,13 @@
       }
     },
     "node_modules/@typescript-eslint/parser/node_modules/minimatch": {
-      "version": "9.0.5",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -5570,7 +5574,9 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils/node_modules/brace-expansion": {
-      "version": "2.0.2",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5578,11 +5584,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils/node_modules/minimatch": {
-      "version": "9.0.5",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -5706,7 +5714,9 @@
       }
     },
     "node_modules/@typescript-eslint/utils/node_modules/brace-expansion": {
-      "version": "2.0.2",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5714,11 +5724,13 @@
       }
     },
     "node_modules/@typescript-eslint/utils/node_modules/minimatch": {
-      "version": "9.0.5",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -6803,7 +6815,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -7607,6 +7621,8 @@
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "license": "MIT"
     },
     "node_modules/concat-stream": {
@@ -10039,7 +10055,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.0.6",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz",
+      "integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==",
       "funding": [
         {
           "type": "github",
@@ -10181,7 +10199,9 @@
       }
     },
     "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.0.2",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10189,7 +10209,9 @@
       }
     },
     "node_modules/filelist/node_modules/minimatch": {
-      "version": "5.1.6",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -10728,17 +10750,21 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.0.2",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
     },
     "node_modules/glob/node_modules/minimatch": {
-      "version": "9.0.5",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -15407,7 +15433,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -19834,7 +19862,9 @@
       "license": "MIT"
     },
     "node_modules/underscore": {
-      "version": "1.12.1",
+      "version": "1.13.8",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
+      "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
       "license": "MIT"
     },
     "node_modules/undici": {
@@ -20061,9 +20091,9 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/websocket-driver": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
-      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.5.tgz",
+      "integrity": "sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==",
       "license": "Apache-2.0",
       "dependencies": {
         "http-parser-js": ">=0.5.1",

--- a/package.json
+++ b/package.json
@@ -187,6 +187,19 @@
     "semver-regex": "3.1.4",
     "cacheable-request@2.1.4": {
       "http-cache-semantics": "4.1.1"
+    },
+    "websocket-driver": "0.7.5",
+    "fast-uri": "3.1.6",
+    "minimatch@^9.0.0": "9.0.9",
+    "minimatch@^5.0.0": "5.1.9",
+    "minimatch@^3.0.0": "3.1.5",
+    "brace-expansion@^2.0.0": "2.1.4",
+    "brace-expansion@^1.0.0": "1.1.18",
+    "@shopify/jest-koa-mocks": {
+      "koa": "2.16.4"
+    },
+    "rs-jsonpath": {
+      "underscore": "1.13.8"
     }
   },
   "lint-staged": {


### PR DESCRIPTION
## What are the changes introduced in this PR?

Resolves all 18 open **critical/high** vulnerabilities reported by Snyk for this project by pinning fixed versions of transitive dependencies via npm `overrides` in `package.json` (no direct dependency or source-code changes):

| Override | Fixed version | Issues resolved |
|---|---|---|
| `websocket-driver` | 0.7.5 | **1 critical** (CVE-2026-54466, length parameter inconsistency) + 1 high — via `@rudderstack/integrations-lib` → `jsforce` → `faye` |
| `fast-uri` | 3.1.6 | 7 high (directory traversal, URL-encoding handling, interpretation conflicts) — via `ajv` |
| `minimatch@^9.0.0` / `@^5.0.0` / `@^3.0.0` | 9.0.9 / 5.1.9 / 3.1.5 | 3 high (ReDoS, algorithmic complexity), per major line |
| `brace-expansion@^2.0.0` / `@^1.0.0` | 2.1.4 / 1.1.18 | 4 high (infinite loop, resource exhaustion) |
| `@shopify/jest-koa-mocks` → `koa` | 2.16.4 | 1 high (CVE-2026-27959, HTTP header injection); root `koa@3.2.0` already has the 3.x fix |
| `rs-jsonpath` → `underscore` | 1.13.8 | 1 high (CVE-2026-27601, uncontrolled recursion); `rs-jsonpath` pins `underscore` exactly, so an override is required |

`minimatch`/`brace-expansion` are version-scoped (not global) because both major lines coexist in the tree and their APIs differ; `koa` is parent-scoped to avoid conflicting with the direct `koa@^3.1.2` dependency.

## What is the related Linear task?

N/A

## Please explain the objectives of your changes below

Remediate the open critical/high findings in the Snyk `rudder-transformer` project. All overrides pin the minimum-known-safe patch of the already-resolved major version, so no consumer crosses a major/minor API boundary except `underscore` (1.12.1 → 1.13.8, exercised by the `http` destination tests which cover both `rs-jsonpath` consumers).

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

N/A — dependency patch bumps only.

### Any new dependencies introduced with this change?

No new dependencies; only transitive version pins via `overrides`.

### Any new generic utility introduced or modified. Please explain the changes.

N/A

### Any technical or performance related pointers to consider with the change?

Exact pins in `overrides` freeze these transitive deps — future patches won't flow until the override is updated (consistent with the existing overrides in this repo). Follow-up: bump `underscore` in the `rs-jsonpath` fork so its override can be dropped.

<hr>

### Developer checklist

- [x] My code follows the style guidelines of this project

- [x] **No breaking changes are being introduced.**

- [ ] All related docs linked with the PR?

- [x] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [x] Is the PR limited to 10 file changes?

- [x] Is the PR limited to one linear task?

- [ ] Are relevant unit and component test-cases added in **new readability format**?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)