### PR TITLE
fix(openai_ads): reject events older than OpenAI's ingest window

### DIFF
--- a/src/v0/destinations/openai_ads/config.ts
+++ b/src/v0/destinations/openai_ads/config.ts
@@ -4,6 +4,20 @@ export const ENDPOINT_PATH = '/v1/events';
 export const ENDPOINT = `${BASE_URL}${ENDPOINT_PATH}`;
 export const MAX_BATCH_SIZE = 1000;
 export const MAX_PAYLOAD_SIZE = '4MB';
+// OpenAI rejects the *whole batch* when any event falls outside these bounds, and — unlike its
+// 400s — the 422 it answers with carries no event index, so the batch can only be split blindly
+// one event at a time. Checking here keeps a single stale event from costing a full isolation
+// cycle.
+//
+// Both bounds are OpenAI's own, quoted back by its 422s: `event_timestamp_ms must be within the
+// last 7 days` (recorded in test/integrations/destinations/openai_ads/network.ts) and
+// `event_timestamp_ms must not be more than 600 seconds in the future`.
+export const MAX_EVENT_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+export const MAX_EVENT_FUTURE_SKEW_MS = 600 * 1000;
+// OpenAI re-evaluates the window when it *receives* the batch, which is later than when we build
+// the event by the batch-assembly and network delay. Without a margin an event at 6d23h59m59s
+// passes here and still 422s the whole batch — exactly what this check exists to prevent.
+export const EVENT_AGE_SAFETY_MARGIN_MS = 60 * 1000;
 export const CUSTOM_EVENT_SENTINEL = 'custom';
 const CONTENTS_DATA_TYPE = 'contents';
 export const CUSTOMER_ACTION_DATA_TYPE = 'customer_action';

--- a/src/v0/destinations/openai_ads/config.ts
+++ b/src/v0/destinations/openai_ads/config.ts
@@ -4,13 +4,17 @@ export const ENDPOINT_PATH = '/v1/events';
 export const ENDPOINT = `${BASE_URL}${ENDPOINT_PATH}`;
 export const MAX_BATCH_SIZE = 1000;
 export const MAX_PAYLOAD_SIZE = '4MB';
-// OpenAI rejects the *whole batch* when any event is older than this, and — unlike its 400s —
-// the 422 it answers with carries no event index, so the batch can only be split blindly one
-// event at a time. Checking here keeps a single stale event from costing a full isolation cycle.
+// OpenAI's ingest window, both bounds quoted from its Conversions API reference: "The timestamp
+// must be within the last 7 days and no more than 10 minutes in the future."
 //
-// The bound is OpenAI's own, quoted back by its 422: `event_timestamp_ms must be within the last
-// 7 days` (recorded in test/integrations/destinations/openai_ads/network.ts).
+// OpenAI enforces the window per batch, atomically — one violating event 422s the entire request
+// (see `staleTimestampResponse` in test/integrations/destinations/openai_ads/network.ts). The
+// delivery spec cannot attribute that 422 to a single job: it maps 400 and 422 alike to
+// `retry({ dontBatch: true })`, which re-sends every job in the batch on its own. At
+// MAX_BATCH_SIZE = 1000, one bad event turns a single request into 1001 — and is aborted at the
+// end of that anyway. Checking here costs one InstrumentationError against the one bad event.
 export const MAX_EVENT_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+export const MAX_EVENT_FUTURE_SKEW_MS = 10 * 60 * 1000;
 export const CUSTOM_EVENT_SENTINEL = 'custom';
 const CONTENTS_DATA_TYPE = 'contents';
 export const CUSTOMER_ACTION_DATA_TYPE = 'customer_action';

--- a/src/v0/destinations/openai_ads/config.ts
+++ b/src/v0/destinations/openai_ads/config.ts
@@ -4,20 +4,13 @@ export const ENDPOINT_PATH = '/v1/events';
 export const ENDPOINT = `${BASE_URL}${ENDPOINT_PATH}`;
 export const MAX_BATCH_SIZE = 1000;
 export const MAX_PAYLOAD_SIZE = '4MB';
-// OpenAI rejects the *whole batch* when any event falls outside these bounds, and — unlike its
-// 400s — the 422 it answers with carries no event index, so the batch can only be split blindly
-// one event at a time. Checking here keeps a single stale event from costing a full isolation
-// cycle.
+// OpenAI rejects the *whole batch* when any event is older than this, and — unlike its 400s —
+// the 422 it answers with carries no event index, so the batch can only be split blindly one
+// event at a time. Checking here keeps a single stale event from costing a full isolation cycle.
 //
-// Both bounds are OpenAI's own, quoted back by its 422s: `event_timestamp_ms must be within the
-// last 7 days` (recorded in test/integrations/destinations/openai_ads/network.ts) and
-// `event_timestamp_ms must not be more than 600 seconds in the future`.
+// The bound is OpenAI's own, quoted back by its 422: `event_timestamp_ms must be within the last
+// 7 days` (recorded in test/integrations/destinations/openai_ads/network.ts).
 export const MAX_EVENT_AGE_MS = 7 * 24 * 60 * 60 * 1000;
-export const MAX_EVENT_FUTURE_SKEW_MS = 600 * 1000;
-// OpenAI re-evaluates the window when it *receives* the batch, which is later than when we build
-// the event by the batch-assembly and network delay. Without a margin an event at 6d23h59m59s
-// passes here and still 422s the whole batch — exactly what this check exists to prevent.
-export const EVENT_AGE_SAFETY_MARGIN_MS = 60 * 1000;
 export const CUSTOM_EVENT_SENTINEL = 'custom';
 const CONTENTS_DATA_TYPE = 'contents';
 export const CUSTOMER_ACTION_DATA_TYPE = 'customer_action';

--- a/src/v0/destinations/openai_ads/routerTransform.test.ts
+++ b/src/v0/destinations/openai_ads/routerTransform.test.ts
@@ -10,6 +10,10 @@ import type {
 import type { Destination } from '../../../types';
 import type { OpenAIAdsEventPayload } from './types';
 import { Integration } from './routerTransform';
+// OpenAI only ingests events from the last 7 days, so fixtures are stamped relative to now
+// rather than at a fixed date that would age out of the window.
+const EVENT_TIMESTAMP = new Date(Date.now() - 60_000).toISOString();
+const EVENT_TIMESTAMP_MS = new Date(EVENT_TIMESTAMP).getTime();
 const destination: Destination = {
   ID: 'openai-ads-dest-1',
   Config: {
@@ -47,7 +51,7 @@ const makeInput = (
     event,
     messageId: `msg-${jobId}`,
     userId: `User-${jobId}`,
-    timestamp: '2024-01-01T00:00:00.000Z',
+    timestamp: EVENT_TIMESTAMP,
     properties: { amount: jobId, currency: 'USD', ...properties },
   },
   metadata: {
@@ -108,7 +112,7 @@ describe('OpenAIAdsIntegration', () => {
         event: 'Product Viewed',
         messageId: 'msg-1',
         userId: 'User-1',
-        timestamp: '2024-01-01T00:00:00.000Z',
+        timestamp: EVENT_TIMESTAMP,
         context: {
           ip: '203.0.113.10',
           userAgent: 'Mozilla/5.0',
@@ -152,7 +156,7 @@ describe('OpenAIAdsIntegration', () => {
     expect(event).toEqual({
       id: 'msg-1',
       type: 'contents_viewed',
-      timestamp_ms: 1704067200000,
+      timestamp_ms: EVENT_TIMESTAMP_MS,
       opt_out: true,
       action_source: 'web',
       source_url: 'https://example.com/path?secret=1#hash',
@@ -201,7 +205,7 @@ describe('OpenAIAdsIntegration', () => {
         type: 'track',
         event: 'Trial Started',
         messageId: 'msg-custom',
-        timestamp: '2024-01-01T00:00:00.000Z',
+        timestamp: EVENT_TIMESTAMP,
         properties: {
           value: 1,
           source_url: 'https://example.com/custom',
@@ -234,7 +238,7 @@ describe('OpenAIAdsIntegration', () => {
         type: 'page',
         name: 'Docs Page',
         messageId: 'msg-page',
-        timestamp: '2024-01-01T00:00:00.000Z',
+        timestamp: EVENT_TIMESTAMP,
         properties: { pageId: 'page-dedupe', source_url: 'https://example.com/docs' },
       },
     } as RouterTransformationRequestData).body;
@@ -248,7 +252,7 @@ describe('OpenAIAdsIntegration', () => {
         type: 'track',
         event: 'Subscription Created',
         messageId: 'msg-subscription',
-        timestamp: '2024-01-01T00:00:00.000Z',
+        timestamp: EVENT_TIMESTAMP,
         properties: {
           amount: '25.00',
           currency: 'USD',
@@ -375,7 +379,7 @@ describe('OpenAIAdsIntegration', () => {
           type: 'track',
           event: 'Signup',
           messageId: 'msg-err',
-          timestamp: '2024-01-01T00:00:00.000Z',
+          timestamp: EVENT_TIMESTAMP,
         },
       },
       error: 'event mapping not found',
@@ -383,7 +387,7 @@ describe('OpenAIAdsIntegration', () => {
     {
       input: {
         ...makeInput(1),
-        message: { type: 'page', messageId: 'msg-err', timestamp: '2024-01-01T00:00:00.000Z' },
+        message: { type: 'page', messageId: 'msg-err', timestamp: EVENT_TIMESTAMP },
       },
       error: 'source event name is required for page events',
     },
@@ -418,7 +422,7 @@ describe('OpenAIAdsIntegration', () => {
           type: 'track',
           event: 'Product Viewed',
           messageId: 'msg-err',
-          timestamp: '2024-01-01T00:00:00.000Z',
+          timestamp: EVENT_TIMESTAMP,
           context: { traits: { email: sha256('user@example.com') } },
           properties: { source_url: 'https://example.com/item' },
         },
@@ -432,7 +436,80 @@ describe('OpenAIAdsIntegration', () => {
       }),
       error: 'opt_out must be a boolean',
     },
+    {
+      input: {
+        ...makeInput(1),
+        message: {
+          type: 'track',
+          event: 'Product Viewed',
+          messageId: 'msg-err',
+          timestamp: new Date(Date.now() - 8 * 24 * 60 * 60 * 1000).toISOString(),
+        },
+      },
+      error: 'timestamp must be within the last 7 days',
+    },
+    {
+      input: {
+        ...makeInput(1),
+        message: {
+          type: 'track',
+          event: 'Product Viewed',
+          messageId: 'msg-err',
+          timestamp: new Date(Date.now() + 20 * 60 * 1000).toISOString(),
+        },
+      },
+      error: 'timestamp must not be more than 600 seconds in the future',
+    },
   ])('throws deterministic validation errors', ({ input, error }) => {
     expect(() => transform(input as RouterTransformationRequestData)).toThrow(error);
+  });
+
+  // The window edges are read off Date.now() inside the transform, so they are pinned with a fake
+  // clock rather than by leaving slack in a wall-clock offset.
+  describe('ingest window edges', () => {
+    const NOW = Date.parse('2026-09-04T12:00:00.000Z');
+    const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
+    const MARGIN_MS = 60 * 1000;
+
+    beforeAll(() => {
+      jest.useFakeTimers().setSystemTime(NOW);
+    });
+    afterAll(() => {
+      jest.useRealTimers();
+    });
+
+    const transformAt = (timestampMs: number) =>
+      transform({
+        ...makeInput(1),
+        message: {
+          type: 'track',
+          event: 'Product Viewed',
+          messageId: 'msg-window',
+          timestamp: new Date(timestampMs).toISOString(),
+        },
+      } as RouterTransformationRequestData);
+
+    it.each([
+      { label: 'the oldest accepted instant', timestampMs: NOW - SEVEN_DAYS_MS + MARGIN_MS },
+      { label: 'the furthest accepted future instant', timestampMs: NOW + 600 * 1000 },
+      { label: 'now', timestampMs: NOW },
+    ])('accepts $label', ({ timestampMs }) => {
+      expect(transformAt(timestampMs).body.timestamp_ms).toBe(timestampMs);
+    });
+
+    it.each([
+      {
+        label: 'one millisecond older than the margin allows',
+        timestampMs: NOW - SEVEN_DAYS_MS + MARGIN_MS - 1,
+        error: 'timestamp must be within the last 7 days',
+      },
+      {
+        label: 'one millisecond beyond the future skew',
+        timestampMs: NOW + 600 * 1000 + 1,
+        error: 'timestamp must not be more than 600 seconds in the future',
+      },
+    ])('rejects a timestamp $label', ({ timestampMs, error }) => {
+      expect(() => transformAt(timestampMs)).toThrow(error);
+    });
   });
 });

--- a/src/v0/destinations/openai_ads/routerTransform.test.ts
+++ b/src/v0/destinations/openai_ads/routerTransform.test.ts
@@ -448,28 +448,15 @@ describe('OpenAIAdsIntegration', () => {
       },
       error: 'timestamp must be within the last 7 days',
     },
-    {
-      input: {
-        ...makeInput(1),
-        message: {
-          type: 'track',
-          event: 'Product Viewed',
-          messageId: 'msg-err',
-          timestamp: new Date(Date.now() + 20 * 60 * 1000).toISOString(),
-        },
-      },
-      error: 'timestamp must not be more than 600 seconds in the future',
-    },
   ])('throws deterministic validation errors', ({ input, error }) => {
     expect(() => transform(input as RouterTransformationRequestData)).toThrow(error);
   });
 
-  // The window edges are read off Date.now() inside the transform, so they are pinned with a fake
+  // The window edge is read off Date.now() inside the transform, so it is pinned with a fake
   // clock rather than by leaving slack in a wall-clock offset.
   describe('ingest window edges', () => {
     const NOW = Date.parse('2026-09-04T12:00:00.000Z');
     const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
-    const MARGIN_MS = 60 * 1000;
 
     beforeAll(() => {
       jest.useFakeTimers().setSystemTime(NOW);
@@ -490,26 +477,18 @@ describe('OpenAIAdsIntegration', () => {
       } as RouterTransformationRequestData);
 
     it.each([
-      { label: 'the oldest accepted instant', timestampMs: NOW - SEVEN_DAYS_MS + MARGIN_MS },
-      { label: 'the furthest accepted future instant', timestampMs: NOW + 600 * 1000 },
+      { label: 'the oldest accepted instant', timestampMs: NOW - SEVEN_DAYS_MS },
       { label: 'now', timestampMs: NOW },
+      // Only the age bound is enforced here — a future timestamp is left for OpenAI to judge.
+      { label: 'a future instant', timestampMs: NOW + 20 * 60 * 1000 },
     ])('accepts $label', ({ timestampMs }) => {
       expect(transformAt(timestampMs).body.timestamp_ms).toBe(timestampMs);
     });
 
-    it.each([
-      {
-        label: 'one millisecond older than the margin allows',
-        timestampMs: NOW - SEVEN_DAYS_MS + MARGIN_MS - 1,
-        error: 'timestamp must be within the last 7 days',
-      },
-      {
-        label: 'one millisecond beyond the future skew',
-        timestampMs: NOW + 600 * 1000 + 1,
-        error: 'timestamp must not be more than 600 seconds in the future',
-      },
-    ])('rejects a timestamp $label', ({ timestampMs, error }) => {
-      expect(() => transformAt(timestampMs)).toThrow(error);
+    it('rejects a timestamp one millisecond older than the window', () => {
+      expect(() => transformAt(NOW - SEVEN_DAYS_MS - 1)).toThrow(
+        'timestamp must be within the last 7 days',
+      );
     });
   });
 });

--- a/src/v0/destinations/openai_ads/routerTransform.test.ts
+++ b/src/v0/destinations/openai_ads/routerTransform.test.ts
@@ -457,6 +457,7 @@ describe('OpenAIAdsIntegration', () => {
   describe('ingest window edges', () => {
     const NOW = Date.parse('2026-09-04T12:00:00.000Z');
     const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
+    const TEN_MINUTES_MS = 10 * 60 * 1000;
 
     beforeAll(() => {
       jest.useFakeTimers().setSystemTime(NOW);
@@ -479,8 +480,7 @@ describe('OpenAIAdsIntegration', () => {
     it.each([
       { label: 'the oldest accepted instant', timestampMs: NOW - SEVEN_DAYS_MS },
       { label: 'now', timestampMs: NOW },
-      // Only the age bound is enforced here — a future timestamp is left for OpenAI to judge.
-      { label: 'a future instant', timestampMs: NOW + 20 * 60 * 1000 },
+      { label: 'the furthest accepted future instant', timestampMs: NOW + TEN_MINUTES_MS },
     ])('accepts $label', ({ timestampMs }) => {
       expect(transformAt(timestampMs).body.timestamp_ms).toBe(timestampMs);
     });
@@ -488,6 +488,12 @@ describe('OpenAIAdsIntegration', () => {
     it('rejects a timestamp one millisecond older than the window', () => {
       expect(() => transformAt(NOW - SEVEN_DAYS_MS - 1)).toThrow(
         'timestamp must be within the last 7 days',
+      );
+    });
+
+    it('rejects a timestamp one millisecond beyond the accepted future skew', () => {
+      expect(() => transformAt(NOW + TEN_MINUTES_MS + 1)).toThrow(
+        'timestamp must not be more than 10 minutes in the future',
       );
     });
   });

--- a/src/v0/destinations/openai_ads/utils.ts
+++ b/src/v0/destinations/openai_ads/utils.ts
@@ -19,6 +19,9 @@ import {
   CUSTOMER_ACTION_DATA_TYPE,
   CUSTOM_EVENT_SENTINEL,
   DESTINATION,
+  EVENT_AGE_SAFETY_MARGIN_MS,
+  MAX_EVENT_AGE_MS,
+  MAX_EVENT_FUTURE_SKEW_MS,
   STANDARD_EVENT_DATA_TYPES,
 } from './config';
 import mappingConfig from './data/OPENAI_ADSConfig.json';
@@ -270,6 +273,27 @@ const resolveSourceUrl = (payload: EventBasePayload, actionSource?: string): str
   return rawUrl;
 };
 
+const resolveTimestampMs = (payload: EventBasePayload): number => {
+  const timestampMs = payload.timestamp_ms;
+  // Narrowing only. `constructPayload` declares this mapping `required` and rejects a missing or
+  // unparseable timestamp before we get here, so this branch is not reachable in practice.
+  if (typeof timestampMs !== 'number' || !Number.isFinite(timestampMs)) {
+    throw new InstrumentationError('OpenAI Ads timestamp is required and must be a valid date');
+  }
+  const now = Date.now();
+  if (timestampMs > now + MAX_EVENT_FUTURE_SKEW_MS) {
+    throw new InstrumentationError(
+      `OpenAI Ads timestamp must not be more than ${MAX_EVENT_FUTURE_SKEW_MS / 1000} seconds in the future`,
+    );
+  }
+  if (timestampMs < now - MAX_EVENT_AGE_MS + EVENT_AGE_SAFETY_MARGIN_MS) {
+    throw new InstrumentationError(
+      `OpenAI Ads timestamp must be within the last ${MAX_EVENT_AGE_MS / (24 * 60 * 60 * 1000)} days`,
+    );
+  }
+  return timestampMs;
+};
+
 const resolveOptOut = (payload: EventBasePayload): boolean | undefined => {
   const value = payload.opt_out;
   if (!isPresent(value)) return undefined;
@@ -490,6 +514,9 @@ export const buildOpenAIEvent = (
     message,
     OPENAI_ADS_MAPPING_CONFIG.topLevelMappings,
   ) as EventBasePayload;
+  // Resolved before buildUser so an out-of-window event fails without first SHA-256-hashing every
+  // identifier on it — a stale backfill would otherwise pay that cost per event, batch-wide.
+  const timestampMs = resolveTimestampMs(topLevelPayload);
   const actionSource = resolveActionSource(topLevelPayload, config);
   const sourceUrl = resolveSourceUrl(topLevelPayload, actionSource);
   const user = buildUser(message);
@@ -499,7 +526,7 @@ export const buildOpenAIEvent = (
     id: resolveEventId(message, mapping),
     type: eventType,
     custom_event_name: customEventName,
-    timestamp_ms: topLevelPayload.timestamp_ms as number,
+    timestamp_ms: timestampMs,
     opt_out: optOut,
     action_source: actionSource,
     source_url: sourceUrl,

--- a/src/v0/destinations/openai_ads/utils.ts
+++ b/src/v0/destinations/openai_ads/utils.ts
@@ -20,6 +20,7 @@ import {
   CUSTOM_EVENT_SENTINEL,
   DESTINATION,
   MAX_EVENT_AGE_MS,
+  MAX_EVENT_FUTURE_SKEW_MS,
   STANDARD_EVENT_DATA_TYPES,
 } from './config';
 import mappingConfig from './data/OPENAI_ADSConfig.json';
@@ -278,9 +279,16 @@ const resolveTimestampMs = (payload: EventBasePayload): number => {
   if (typeof timestampMs !== 'number' || !Number.isFinite(timestampMs)) {
     throw new InstrumentationError('OpenAI Ads timestamp is required and must be a valid date');
   }
-  if (timestampMs < Date.now() - MAX_EVENT_AGE_MS) {
+  // One clock read for both bounds, so the accepted window cannot straddle a tick.
+  const now = Date.now();
+  if (timestampMs < now - MAX_EVENT_AGE_MS) {
     throw new InstrumentationError(
       `OpenAI Ads timestamp must be within the last ${MAX_EVENT_AGE_MS / (24 * 60 * 60 * 1000)} days`,
+    );
+  }
+  if (timestampMs > now + MAX_EVENT_FUTURE_SKEW_MS) {
+    throw new InstrumentationError(
+      `OpenAI Ads timestamp must not be more than ${MAX_EVENT_FUTURE_SKEW_MS / (60 * 1000)} minutes in the future`,
     );
   }
   return timestampMs;

--- a/src/v0/destinations/openai_ads/utils.ts
+++ b/src/v0/destinations/openai_ads/utils.ts
@@ -19,9 +19,7 @@ import {
   CUSTOMER_ACTION_DATA_TYPE,
   CUSTOM_EVENT_SENTINEL,
   DESTINATION,
-  EVENT_AGE_SAFETY_MARGIN_MS,
   MAX_EVENT_AGE_MS,
-  MAX_EVENT_FUTURE_SKEW_MS,
   STANDARD_EVENT_DATA_TYPES,
 } from './config';
 import mappingConfig from './data/OPENAI_ADSConfig.json';
@@ -280,13 +278,7 @@ const resolveTimestampMs = (payload: EventBasePayload): number => {
   if (typeof timestampMs !== 'number' || !Number.isFinite(timestampMs)) {
     throw new InstrumentationError('OpenAI Ads timestamp is required and must be a valid date');
   }
-  const now = Date.now();
-  if (timestampMs > now + MAX_EVENT_FUTURE_SKEW_MS) {
-    throw new InstrumentationError(
-      `OpenAI Ads timestamp must not be more than ${MAX_EVENT_FUTURE_SKEW_MS / 1000} seconds in the future`,
-    );
-  }
-  if (timestampMs < now - MAX_EVENT_AGE_MS + EVENT_AGE_SAFETY_MARGIN_MS) {
+  if (timestampMs < Date.now() - MAX_EVENT_AGE_MS) {
     throw new InstrumentationError(
       `OpenAI Ads timestamp must be within the last ${MAX_EVENT_AGE_MS / (24 * 60 * 60 * 1000)} days`,
     );

--- a/test/integrations/destinations/openai_ads/router/data.ts
+++ b/test/integrations/destinations/openai_ads/router/data.ts
@@ -2,6 +2,13 @@ import sha256 from 'sha256';
 import { RouterTestData } from '../../../testTypes';
 import { destination, endpoint, metadata } from '../common';
 
+// OpenAI only ingests events from the last 7 days, so these are stamped relative to now rather
+// than at a fixed date that would age out of the window.
+const EVENT_TIMESTAMP = new Date(Date.now() - 60_000).toISOString();
+const EVENT_TIMESTAMP_MS = new Date(EVENT_TIMESTAMP).getTime();
+const EVENT_TIMESTAMP_NEXT = new Date(EVENT_TIMESTAMP_MS + 1000).toISOString();
+const EVENT_TIMESTAMP_NEXT_MS = EVENT_TIMESTAMP_MS + 1000;
+
 const batchedRequest = {
   version: '1',
   type: 'REST',
@@ -16,14 +23,14 @@ const batchedRequest = {
         {
           id: 'msg-1',
           type: 'contents_viewed',
-          timestamp_ms: 1704067200000,
+          timestamp_ms: EVENT_TIMESTAMP_MS,
           action_source: 'offline',
           data: { type: 'contents' },
         },
         {
           id: 'msg-2',
           type: 'lead_created',
-          timestamp_ms: 1704067201000,
+          timestamp_ms: EVENT_TIMESTAMP_NEXT_MS,
           action_source: 'offline',
           data: { type: 'customer_action' },
         },
@@ -57,7 +64,7 @@ export const data: RouterTestData[] = [
                 type: 'track',
                 event: 'Product Viewed',
                 messageId: 'msg-1',
-                timestamp: '2024-01-01T00:00:00.000Z',
+                timestamp: EVENT_TIMESTAMP,
                 properties: {},
               },
               metadata: metadata(1),
@@ -68,7 +75,7 @@ export const data: RouterTestData[] = [
                 type: 'track',
                 event: 'Lead Created',
                 messageId: 'msg-2',
-                timestamp: '2024-01-01T00:00:01.000Z',
+                timestamp: EVENT_TIMESTAMP_NEXT,
                 properties: {},
               },
               metadata: metadata(2),
@@ -116,7 +123,7 @@ export const data: RouterTestData[] = [
                 event: 'Product Viewed',
                 messageId: 'msg-4',
                 userId: 'User-4',
-                timestamp: '2024-01-01T00:00:00.000Z',
+                timestamp: EVENT_TIMESTAMP,
                 context: {
                   ip: '203.0.113.10',
                   userAgent: 'Mozilla/5.0',
@@ -178,7 +185,7 @@ export const data: RouterTestData[] = [
                       {
                         id: 'msg-4',
                         type: 'contents_viewed',
-                        timestamp_ms: 1704067200000,
+                        timestamp_ms: EVENT_TIMESTAMP_MS,
                         opt_out: true,
                         action_source: 'web',
                         source_url: 'https://example.com/path?secret=1#hash',
@@ -250,7 +257,7 @@ export const data: RouterTestData[] = [
                 type: 'track',
                 event: 'Custom Checkout Data',
                 messageId: 'msg-5',
-                timestamp: '2024-01-01T00:00:00.000Z',
+                timestamp: EVENT_TIMESTAMP,
                 properties: {
                   id: 'custom-id',
                   name: 'Custom Name',
@@ -282,7 +289,7 @@ export const data: RouterTestData[] = [
                         id: 'msg-5',
                         type: 'custom',
                         custom_event_name: 'ccd',
-                        timestamp_ms: 1704067200000,
+                        timestamp_ms: EVENT_TIMESTAMP_MS,
                         action_source: 'offline',
                         source_url: 'https://example.com/custom',
                         data: {
@@ -325,7 +332,7 @@ export const data: RouterTestData[] = [
                 type: 'track',
                 event: 'Unknown Event',
                 messageId: 'msg-3',
-                timestamp: '2024-01-01T00:00:00.000Z',
+                timestamp: EVENT_TIMESTAMP,
                 properties: {},
               },
               metadata: metadata(3),


### PR DESCRIPTION
## What

Rejects OpenAI Ads events whose `timestamp_ms` falls outside OpenAI's documented ingest window — the last 7 days, and no more than 10 minutes in the future — instead of sending them and letting OpenAI reject the batch.

## Why

OpenAI enforces the window **per batch, atomically**. One violating event fails the entire request:

```
422 event_timestamp_too_old
{"error":{"code":"event_timestamp_too_old",
  "message":"event_timestamp_ms must be within the last 7 days."}}
```

We cannot attribute that failure to a single job. The delivery spec maps `400` and `422` alike to `retry({ dontBatch: true })` (`delivery.ts:57-63`) without reading `param`, so the batch gets split blindly, one event at a time. At `MAX_BATCH_SIZE = 1000`, a single bad event turns one request into 1001 — and the bad one is aborted at the end of that anyway.

Checking the window before the request turns that whole cycle into one `InstrumentationError` against the one event that is actually bad.

## Scope

Both halves of the window are enforced, off a single `Date.now()` read, at OpenAI's own values — `7 days` and `10 minutes` — with no safety margin on either.

The one trade-off worth naming: OpenAI re-evaluates the window when it *receives* the batch, which is later than when we build the event. For the age bound that only makes us more permissive than OpenAI (safe — an event that ages out in transit is OpenAI's call, not ours). For the future bound it runs the other way: an event between 10m00s and 10m00s + transit-delay in the future is rejected here though OpenAI might have accepted it on arrival. That band is narrow and anything in it is clock skew that is anomalous on its own; the realistic offenders are unit-confusion timestamps (µs/ns read as ms), which land thousands of years out. Adding slack to close the band would reintroduce the fudge constant this branch deliberately removed, so it is left strict.
