### PR TITLE
fix(openai_ads): stop rejecting values OpenAI accepts

### DIFF
--- a/src/v0/destinations/openai_ads/routerTransform.test.ts
+++ b/src/v0/destinations/openai_ads/routerTransform.test.ts
@@ -404,14 +404,6 @@ describe('OpenAIAdsIntegration', () => {
       error: 'currency is required when amount is present',
     },
     {
-      input: makeInput(1, 'Product Viewed', destination, {
-        amount: '1.234',
-        currency: 'USD',
-        source_url: 'https://example.com/item',
-      }),
-      error: 'more precision than USD supports',
-    },
-    {
       input: {
         ...makeInput(1),
         message: {
@@ -434,5 +426,121 @@ describe('OpenAIAdsIntegration', () => {
     },
   ])('throws deterministic validation errors', ({ input, error }) => {
     expect(() => transform(input as RouterTransformationRequestData)).toThrow(error);
+  });
+
+  it.each([
+    { label: 'a negative refund amount', amount: '-25.99', currency: 'USD', expected: -2599 },
+    { label: 'a negative whole amount', amount: -10, currency: 'USD', expected: -1000 },
+    { label: 'zero', amount: '0.00', currency: 'USD', expected: 0 },
+    { label: 'sub-unit precision rounded up', amount: '1.235', currency: 'USD', expected: 124 },
+    { label: 'sub-unit precision rounded down', amount: '1.234', currency: 'USD', expected: 123 },
+    {
+      label: 'a negative amount rounded away from zero',
+      amount: '-1.235',
+      currency: 'USD',
+      expected: -124,
+    },
+    { label: 'a zero-decimal currency', amount: '1500', currency: 'JPY', expected: 1500 },
+    { label: 'a zero-decimal currency rounded', amount: '1500.6', currency: 'JPY', expected: 1501 },
+    // A fraction shorter than the currency's precision exercises the padEnd side of the scaling.
+    {
+      label: 'a fraction shorter than the precision',
+      amount: '1.5',
+      currency: 'USD',
+      expected: 150,
+    },
+    // BHD has 3 decimal digits, CLF has 4 — the widest scaling currency-codes yields.
+    { label: 'a 3-decimal currency rounded up', amount: '1.2345', currency: 'BHD', expected: 1235 },
+    {
+      label: 'a 3-decimal currency rounded down',
+      amount: '1.2344',
+      currency: 'BHD',
+      expected: 1234,
+    },
+    {
+      label: 'a 3-decimal currency short fraction',
+      amount: '1.5',
+      currency: 'BHD',
+      expected: 1500,
+    },
+    { label: 'a 4-decimal currency', amount: '1.00005', currency: 'CLF', expected: 10001 },
+    // Rounding happens before the safe-integer guard, so this lands exactly on the boundary.
+    {
+      label: 'the largest safely representable amount',
+      amount: '90071992547409.905',
+      currency: 'USD',
+      expected: Number.MAX_SAFE_INTEGER,
+    },
+    {
+      label: 'the negative safe-integer floor',
+      amount: '-90071992547409.905',
+      currency: 'USD',
+      expected: -Number.MAX_SAFE_INTEGER,
+    },
+    // BigInt has no negative zero, so a negative amount that rounds to nothing stays +0.
+    { label: 'a negative amount rounding to zero', amount: '-0.001', currency: 'USD', expected: 0 },
+  ])('converts $label to minor units', ({ amount, currency, expected }) => {
+    const body = transform(
+      makeInput(1, 'Product Viewed', destination, {
+        amount,
+        currency,
+        source_url: 'https://example.com/item',
+      }),
+    ).body;
+
+    expect(body.data.amount).toBe(expected);
+  });
+
+  it.each([
+    { label: 'zero', quantity: 0 },
+    { label: 'a negative return line', quantity: -2 },
+  ])('accepts a content quantity of $label', ({ quantity }) => {
+    const body = transform(
+      makeInput(1, 'Product Viewed', destination, {
+        source_url: 'https://example.com/item',
+        products: [{ id: 'sku-1', quantity }],
+      }),
+    ).body;
+
+    expect((body.data.contents as Array<Record<string, unknown>>)[0].quantity).toBe(quantity);
+  });
+
+  it.each([
+    { label: 'a fractional value', quantity: 2.5 },
+    // Number(false) / Number([]) / Number('  ') are all 0, so without a type guard these would
+    // ship as `quantity: 0` now that the positive-only bound is gone.
+    { label: 'a boolean', quantity: false },
+    { label: 'an array', quantity: [] },
+    { label: 'a blank string', quantity: '  ' },
+  ])('rejects a content quantity that is $label', ({ quantity }) => {
+    expect(() =>
+      transform(
+        makeInput(1, 'Product Viewed', destination, {
+          source_url: 'https://example.com/item',
+          products: [{ id: 'sku-1', quantity }],
+        }),
+      ),
+    ).toThrow('content quantity must be an integer');
+  });
+
+  it.each([
+    { label: 'is not numeric', amount: 'abc', error: 'finite decimal value' },
+    { label: 'is a boolean', amount: true, error: 'number or numeric string' },
+    { label: 'is absurdly long', amount: '9'.repeat(64), error: 'finite decimal value' },
+    {
+      label: 'overflows the safe integer range after conversion',
+      amount: '90071992547409.92',
+      error: 'exceeds the maximum safe integer',
+    },
+  ])('rejects an amount that $label', ({ amount, error }) => {
+    expect(() =>
+      transform(
+        makeInput(1, 'Product Viewed', destination, {
+          amount,
+          currency: 'USD',
+          source_url: 'https://example.com/item',
+        }),
+      ),
+    ).toThrow(error);
   });
 });

--- a/src/v0/destinations/openai_ads/utils.ts
+++ b/src/v0/destinations/openai_ads/utils.ts
@@ -36,6 +36,8 @@ import type {
 } from './types';
 
 const ACTION_SOURCE_SET = new Set<string>(ACTION_SOURCES);
+// Comfortably past any real monetary value, and short enough that BigInt parsing stays free.
+const MAX_AMOUNT_LENGTH = 40;
 const CURRENCY_RE = /^[A-Z]{3}$/;
 const PUNCTUATION_REGEX = /[\x21-\x2F\x3A-\x40\x5B-\x60\x7B-\x7E]/g;
 const EVENT_DATA_TYPE_BY_EVENT = {
@@ -337,20 +339,33 @@ const toMinorUnits = (amount: unknown, currency: CurrencyMetadata): number => {
     throw new InstrumentationError('Amount must be a number or numeric string');
   }
   const raw = String(amount);
-  if (!/^\d+(?:\.\d+)?$/.test(raw)) {
+  // Bound the input before BigInt sees it: the digit string is customer-controlled, and BigInt
+  // parses an arbitrarily long one on the event loop (~50ms at a million digits) before throwing a
+  // bare SyntaxError — not an InstrumentationError — somewhere past 2^30 bits.
+  if (raw.length > MAX_AMOUNT_LENGTH || !/^-?\d+(?:\.\d+)?$/.test(raw)) {
     throw new InstrumentationError('Amount must be a finite decimal value');
   }
-  const [whole, fraction = ''] = raw.split('.');
-  if (fraction.length > currency.digits) {
-    throw new InstrumentationError(`Amount has more precision than ${currency.code} supports`);
-  }
-  const minorUnits =
-    BigInt(whole) * 10n ** BigInt(currency.digits) +
-    BigInt(fraction.padEnd(currency.digits, '0') || '0');
+  // Negatives are OpenAI-legal and carry real meaning — a refund or a return is a conversion with a
+  // negative value — so the sign is split off here and reapplied at the end rather than rejected.
+  const negative = raw.startsWith('-');
+  const [whole, fraction = ''] = (negative ? raw.slice(1) : raw).split('.');
+  // OpenAI only accepts integer minor units, so precision finer than the currency supports is
+  // rounded half-away-from-zero instead of aborting the event: dropping a conversion over a
+  // fraction of a cent loses more than the rounding does.
+  //
+  // padEnd guarantees at least `digits + 1` characters, so the slice is exactly `digits` wide and
+  // concatenating it onto the whole part is the scaling — no multiply, and no empty-string case.
+  const scaled = fraction.padEnd(currency.digits + 1, '0');
+  let minorUnits = BigInt(whole + scaled.slice(0, currency.digits));
+  if (Number(scaled[currency.digits]) >= 5) minorUnits += 1n;
+  // After the increment, so a value cannot round up across the boundary undetected. The magnitude
+  // is what is tested; MIN_SAFE_INTEGER is exactly -MAX_SAFE_INTEGER, so the negative side is
+  // representable wherever the positive side is.
   if (minorUnits > BigInt(Number.MAX_SAFE_INTEGER)) {
     throw new InstrumentationError('Amount exceeds the maximum safe integer after conversion');
   }
-  return Number(minorUnits);
+  // Negate as a BigInt: BigInt has no negative zero, so '-0.001' yields 0 rather than -0.
+  return Number(negative ? -minorUnits : minorUnits);
 };
 
 const resolveCurrency = (
@@ -390,9 +405,17 @@ const mapContentItem = (
   const quantityValue = getValueFromMessage(item, OPENAI_ADS_MAPPING_CONFIG.contentQuantityPaths);
   // isDefinedAndNotNullAndNotEmpty is unusable here: lodash isEmpty treats every number as empty.
   if (isPresent(quantityValue)) {
-    const quantity = Number(quantityValue);
-    if (!Number.isInteger(quantity) || quantity <= 0) {
-      throw new InstrumentationError('OpenAI Ads content quantity must be a positive integer');
+    // OpenAI requires an integer but places no bound on it — zero and negative quantities are
+    // accepted, and a return line is legitimately negative — so only the integer-ness is enforced.
+    // Coercion is deliberately narrow rather than a bare Number(): Number(false), Number([]) and
+    // Number('  ') are all 0, so with the positive-only bound gone they would otherwise ship as
+    // `quantity: 0` instead of failing.
+    const quantity =
+      typeof quantityValue === 'string' && /^-?\d+$/.test(quantityValue.trim())
+        ? Number(quantityValue)
+        : quantityValue;
+    if (typeof quantity !== 'number' || !Number.isInteger(quantity)) {
+      throw new InstrumentationError('OpenAI Ads content quantity must be an integer');
     }
     content.quantity = quantity;
   }


### PR DESCRIPTION
## What

Stops the OpenAI Ads transform rejecting three classes of value that OpenAI itself accepts.

## Why

Each of these was a client-side rule stricter than the API it guards, so events OpenAI would have ingested were aborted before they were ever sent. All three were confirmed against the live API — the responses below are real:

| Payload | OpenAI |
|---|---|
| `data.amount: -2599` | `200 {"accepted_events":1}` |
| `contents[].amount: -500` | `200 {"accepted_events":1}` |
| `contents[].quantity: 0` | `200 {"accepted_events":1}` |
| `contents[].quantity: -2` | `200 {"accepted_events":1}` |
| `data.amount: 25.99` | `400 events[0].data.amount must be an integer.` |
| `contents[].quantity: 2.5` | `400 events[0].data.contents[0].quantity must be an integer.` |

So integer-ness is real and stays enforced; the sign and the positive-only bound were ours alone.

### 1. Negative amounts

A refund or a return is a conversion with a negative value. `toMinorUnits`'s format check was `^\d+(?:\.\d+)?$`, so `-25.99` failed as "Amount must be a finite decimal value" — which it also isn't, `-25.99` is perfectly finite. The sign is now split off before scaling and reapplied as a BigInt at the end.

### 2. Sub-unit precision

`1.235` USD aborted with "Amount has more precision than USD supports". OpenAI only accepts integer minor units, so the alternative to rounding is dropping the conversion and its attributed revenue outright — a bounded error of at most half a cent is strictly the better trade. Rounding is half-away-from-zero, which matches the totals a customer sees on their own orders and keeps refunds symmetric with purchases (`1.235` → `124`, `-1.235` → `-124`).

### 3. Content quantity

The check required a *positive* integer. OpenAI bounds it not at all, and a return line is legitimately negative.

## Notes for the reviewer

- **Coercion for quantity is narrower than a bare `Number()`, deliberately.** `Number(false)`, `Number([])` and `Number('  ')` are all `0` and `Number.isInteger(0)` is true, so simply dropping the `<= 0` clause would have let non-numeric junk ship as `quantity: 0`. Strings must now match `/^-?\d+$/` to be coerced at all.
- **`-0` is not producible.** The negation happens on the BigInt, which has no negative zero, so `-0.001` USD yields `0` rather than `-0`. (`-0` would serialize fine but breaks `toBe(0)` in tests, which is how it would first be noticed.)
- **The safe-integer guard runs after the rounding increment**, so a value cannot round up across the boundary undetected. `Number.MIN_SAFE_INTEGER === -Number.MAX_SAFE_INTEGER` exactly, so testing the magnitude covers both signs.
- **An input length cap was added** before the regex. The digit string is customer-controlled and `BigInt` parses an arbitrarily long one on the event loop before eventually throwing a bare `SyntaxError` — not an `InstrumentationError` — which would surface as a 500. Pre-existing, but this PR is already in that function.
- **Scaling is now a string concatenation** rather than a multiply by `10n ** digits`. `padEnd(digits + 1)` guarantees the slice is exactly `digits` wide, so the two are equivalent; I fuzzed them against each other over 200k random `(digits, whole, fraction)` triples before swapping.
- **Not addressed here:** the rounding is silent. A customer sending amounts already in minor units gets quietly corrected forever, where the old precision error surfaced that loudly. A `stats.counter` when rounding fires would restore the signal — happy to add it here or follow up, say which you'd prefer.

## Testing

- `npm test -- --testPathPattern="openai_ads"` — 44 passed
- `npm run test:ts -- component --destination=openai_ads` — 9 passed
- New coverage for the paths the rewrite actually risks: 3- and 4-decimal currencies (BHD, CLF), fractions shorter than the currency's precision, both safe-integer boundaries, and the rejection branches — which previously had no coverage anywhere in `src/` or `test/integrations/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
