### PR TITLE
fix(openai_ads): resolve standard event names without a mapping row

### DIFF
--- a/src/v0/destinations/openai_ads/routerTransform.test.ts
+++ b/src/v0/destinations/openai_ads/routerTransform.test.ts
@@ -9,6 +9,7 @@ import type {
 } from '../../../types/destinationTransformation';
 import type { Destination } from '../../../types';
 import type { OpenAIAdsEventPayload } from './types';
+import { STANDARD_EVENTS, STANDARD_EVENT_DATA_TYPES } from './config';
 import { Integration } from './routerTransform';
 const destination: Destination = {
   ID: 'openai-ads-dest-1',
@@ -272,19 +273,77 @@ describe('OpenAIAdsIntegration', () => {
     );
   });
 
-  it('rejects exact standard event names when mapping is empty', () => {
+  const unmappedDestination = {
+    ...destination,
+    Config: {
+      apiKey: 'test-api-key',
+      pixelId: 'pixel-123',
+      defaultActionSource: 'offline',
+    },
+  };
+
+  it.each(STANDARD_EVENTS)(
+    'resolves standard event %s with no mapping configured',
+    (standardEvent) => {
+      const body = transform(makeInput(1, standardEvent, unmappedDestination)).body;
+
+      expect(body.type).toBe(standardEvent);
+      expect(body.data.type).toBe(STANDARD_EVENT_DATA_TYPES[standardEvent]);
+      expect(body.custom_event_name).toBeUndefined();
+    },
+  );
+
+  it.each([
+    { label: 'title case', event: 'Order Created' },
+    { label: 'upper case', event: 'ORDER CREATED' },
+    { label: 'hyphenated', event: 'Order-Created' },
+    { label: 'surrounding whitespace', event: '  Order Created  ' },
+    { label: 'repeated separators', event: 'Order   Created' },
+  ])('folds $label onto the standard name', ({ event }) => {
+    expect(transform(makeInput(1, event, unmappedDestination)).body.type).toBe('order_created');
+  });
+
+  it.each([
+    'Some Bespoke Event',
+    // Names that resolve up Object.prototype if the event-type table is a plain object.
+    'constructor',
+    '__proto__',
+    'toString',
+  ])('rejects non-standard event %s when no mapping is configured', (event) => {
+    expect(() => transform(makeInput(1, event, unmappedDestination))).toThrow(
+      `OpenAI Ads event mapping not found for ${event}`,
+    );
+  });
+
+  it('does not fall back once any mapping row is configured', () => {
+    // The mapping table is the allowlist: a standard-named event absent from a non-empty table was
+    // filtered deliberately, so it must still abort rather than deliver itself.
     expect(() =>
       transform(
         makeInput(1, 'order_created', {
           ...destination,
           Config: {
-            apiKey: 'test-api-key',
-            pixelId: 'pixel-123',
-            defaultActionSource: 'offline',
+            ...unmappedDestination.Config,
+            eventMapping: [{ from: 'Something Else', to: 'lead_created' }],
           },
         }),
       ),
     ).toThrow('OpenAI Ads event mapping not found for order_created');
+  });
+
+  it('prefers an explicit mapping over the standard name', () => {
+    const body = transform(
+      makeInput(1, 'order_created', {
+        ...destination,
+        Config: {
+          ...unmappedDestination.Config,
+          eventMapping: [{ from: 'order_created', to: 'custom', customEventName: 'renamed' }],
+        },
+      }),
+    ).body;
+
+    expect(body.type).toBe('custom');
+    expect(body.custom_event_name).toBe('renamed');
   });
 
   it('uses destination.Config credentials', () => {

--- a/src/v0/destinations/openai_ads/routerTransform.test.ts
+++ b/src/v0/destinations/openai_ads/routerTransform.test.ts
@@ -304,6 +304,9 @@ describe('OpenAIAdsIntegration', () => {
     'Some Bespoke Event',
     // Not in OpenAI's naming, so it needs a mapping row like any other bespoke name.
     'Order Created',
+    // The custom sentinel is not a standard event. If the fallback ever resolved it, it would
+    // return to: 'custom' without the customEventName that only the mapped branch enforces.
+    'custom',
     // Names that resolve up Object.prototype if the event-type table is a plain object.
     'constructor',
     '__proto__',
@@ -312,6 +315,12 @@ describe('OpenAIAdsIntegration', () => {
     expect(() => transform(makeInput(1, event, unmappedDestination))).toThrow(
       `OpenAI Ads event mapping not found for ${event}`,
     );
+  });
+
+  it('keeps the custom sentinel out of the standard event list', () => {
+    // The fallback resolves any name in STANDARD_EVENTS onto itself and bypasses the
+    // customEventName guard, so 'custom' leaking into that list would emit a malformed payload.
+    expect(STANDARD_EVENTS as readonly string[]).not.toContain('custom');
   });
 
   it('resolves a standard name absent from a non-empty mapping table', () => {

--- a/src/v0/destinations/openai_ads/routerTransform.test.ts
+++ b/src/v0/destinations/openai_ads/routerTransform.test.ts
@@ -293,18 +293,17 @@ describe('OpenAIAdsIntegration', () => {
     },
   );
 
-  it.each([
-    { label: 'title case', event: 'Order Created' },
-    { label: 'upper case', event: 'ORDER CREATED' },
-    { label: 'hyphenated', event: 'Order-Created' },
-    { label: 'surrounding whitespace', event: '  Order Created  ' },
-    { label: 'repeated separators', event: 'Order   Created' },
-  ])('folds $label onto the standard name', ({ event }) => {
-    expect(transform(makeInput(1, event, unmappedDestination)).body.type).toBe('order_created');
-  });
+  it.each(['ORDER_CREATED', 'Order_Created'])(
+    'matches the standard name case-insensitively for %s',
+    (event) => {
+      expect(transform(makeInput(1, event, unmappedDestination)).body.type).toBe('order_created');
+    },
+  );
 
   it.each([
     'Some Bespoke Event',
+    // Not in OpenAI's naming, so it needs a mapping row like any other bespoke name.
+    'Order Created',
     // Names that resolve up Object.prototype if the event-type table is a plain object.
     'constructor',
     '__proto__',
@@ -315,12 +314,27 @@ describe('OpenAIAdsIntegration', () => {
     );
   });
 
-  it('does not fall back once any mapping row is configured', () => {
-    // The mapping table is the allowlist: a standard-named event absent from a non-empty table was
-    // filtered deliberately, so it must still abort rather than deliver itself.
+  it('resolves a standard name absent from a non-empty mapping table', () => {
+    // A mapping table translates the names that need translating. An event already in OpenAI's
+    // naming needs no row, so its absence from the table is not a decision to exclude it.
+    const body = transform(
+      makeInput(1, 'order_created', {
+        ...destination,
+        Config: {
+          ...unmappedDestination.Config,
+          eventMapping: [{ from: 'Something Else', to: 'lead_created' }],
+        },
+      }),
+    ).body;
+
+    expect(body.type).toBe('order_created');
+    expect(body.data.type).toBe(STANDARD_EVENT_DATA_TYPES.order_created);
+  });
+
+  it('rejects a non-standard name absent from a non-empty mapping table', () => {
     expect(() =>
       transform(
-        makeInput(1, 'order_created', {
+        makeInput(1, 'Some Bespoke Event', {
           ...destination,
           Config: {
             ...unmappedDestination.Config,
@@ -328,7 +342,7 @@ describe('OpenAIAdsIntegration', () => {
           },
         }),
       ),
-    ).toThrow('OpenAI Ads event mapping not found for order_created');
+    ).toThrow('OpenAI Ads event mapping not found for Some Bespoke Event');
   });
 
   it('prefers an explicit mapping over the standard name', () => {

--- a/src/v0/destinations/openai_ads/utils.ts
+++ b/src/v0/destinations/openai_ads/utils.ts
@@ -19,6 +19,8 @@ import {
   CUSTOMER_ACTION_DATA_TYPE,
   CUSTOM_EVENT_SENTINEL,
   DESTINATION,
+  EVENT_DATA_TYPES,
+  STANDARD_EVENTS,
   STANDARD_EVENT_DATA_TYPES,
 } from './config';
 import mappingConfig from './data/OPENAI_ADSConfig.json';
@@ -38,10 +40,12 @@ import type {
 const ACTION_SOURCE_SET = new Set<string>(ACTION_SOURCES);
 const CURRENCY_RE = /^[A-Z]{3}$/;
 const PUNCTUATION_REGEX = /[\x21-\x2F\x3A-\x40\x5B-\x60\x7B-\x7E]/g;
-const EVENT_DATA_TYPE_BY_EVENT = {
-  ...STANDARD_EVENT_DATA_TYPES,
+// Null-prototype so an event type of `constructor` or `toString` misses instead of resolving to
+// something off Object.prototype. The zod schema already rejects those before they reach the
+// lookup, but the invariant should not depend on a validation layer two files away staying put.
+const EVENT_DATA_TYPE_BY_EVENT = Object.assign(Object.create(null), STANDARD_EVENT_DATA_TYPES, {
   [CUSTOM_EVENT_SENTINEL]: CUSTOM_EVENT_SENTINEL,
-} as const;
+}) as Record<string, (typeof EVENT_DATA_TYPES)[number]>;
 
 type OpenAIAdsMappingConfig = {
   hashedUserMappings: MappingEntry[];
@@ -227,16 +231,48 @@ const getSourceKey = (message: RudderMessage): string => {
   return String(sourceName);
 };
 
+const STANDARD_EVENT_SET = new Set<string>(STANDARD_EVENTS);
+
+const isStandardEvent = (name: string): name is OpenAIAdsStandardEvent =>
+  STANDARD_EVENT_SET.has(name);
+
+/**
+ * Fold a source event name onto OpenAI's own naming. OpenAI's names are snake_case
+ * (`order_created`) while the RudderStack convention is title case (`Order Created`), so casing is
+ * dropped and runs of whitespace or hyphens collapse to the underscore they stand in for. An
+ * underscore already present is left alone. Nothing fuzzier: this bridges spelling, not meaning.
+ */
+const normalizeEventName = (name: string): string =>
+  name
+    .trim()
+    .toLowerCase()
+    .replace(/[\s-]+/g, '_');
+
 const resolveEventMapping = (
   message: RudderMessage,
   config: OpenAIAdsDestinationConfig,
 ): OpenAIAdsEventMapping => {
   const sourceKey = getSourceKey(message);
   const normalizedSourceKey = sourceKey.toLowerCase();
-  const mapping = (config.eventMapping ?? []).find(
+  const eventMapping = config.eventMapping ?? [];
+  const mapping = eventMapping.find(
     (candidate) => candidate.from.toLowerCase() === normalizedSourceKey,
   );
   if (!mapping) {
+    // Only when nothing is configured at all. Once a destination has any mapping rows, that table
+    // is its allowlist — an event missing from it was filtered on purpose, and this is the only
+    // gate that applies in cloud mode (the `eventFilteringOption` fields in the destination
+    // definition sit under `destConfig.web` and are enforced SDK-side, never on the router path).
+    // Falling back on a partially-mapped destination would silently start delivering events the
+    // customer had excluded, which for a conversions API means billing and optimising on them.
+    //
+    // With nothing configured there is no intent to contradict, and an event already named after a
+    // standard OpenAI event needs no configuration to be understood — so rather than dropping 100%
+    // of the destination's traffic, take the name at face value.
+    const standardEventName = normalizeEventName(sourceKey);
+    if (eventMapping.length === 0 && isStandardEvent(standardEventName)) {
+      return { from: sourceKey, to: standardEventName };
+    }
     throw new InstrumentationError(`OpenAI Ads event mapping not found for ${sourceKey}`);
   }
   if (mapping.to === CUSTOM_EVENT_SENTINEL && !mapping.customEventName) {

--- a/src/v0/destinations/openai_ads/utils.ts
+++ b/src/v0/destinations/openai_ads/utils.ts
@@ -236,42 +236,22 @@ const STANDARD_EVENT_SET = new Set<string>(STANDARD_EVENTS);
 const isStandardEvent = (name: string): name is OpenAIAdsStandardEvent =>
   STANDARD_EVENT_SET.has(name);
 
-/**
- * Fold a source event name onto OpenAI's own naming. OpenAI's names are snake_case
- * (`order_created`) while the RudderStack convention is title case (`Order Created`), so casing is
- * dropped and runs of whitespace or hyphens collapse to the underscore they stand in for. An
- * underscore already present is left alone. Nothing fuzzier: this bridges spelling, not meaning.
- */
-const normalizeEventName = (name: string): string =>
-  name
-    .trim()
-    .toLowerCase()
-    .replace(/[\s-]+/g, '_');
-
 const resolveEventMapping = (
   message: RudderMessage,
   config: OpenAIAdsDestinationConfig,
 ): OpenAIAdsEventMapping => {
   const sourceKey = getSourceKey(message);
   const normalizedSourceKey = sourceKey.toLowerCase();
-  const eventMapping = config.eventMapping ?? [];
-  const mapping = eventMapping.find(
+  const mapping = (config.eventMapping ?? []).find(
     (candidate) => candidate.from.toLowerCase() === normalizedSourceKey,
   );
   if (!mapping) {
-    // Only when nothing is configured at all. Once a destination has any mapping rows, that table
-    // is its allowlist — an event missing from it was filtered on purpose, and this is the only
-    // gate that applies in cloud mode (the `eventFilteringOption` fields in the destination
-    // definition sit under `destConfig.web` and are enforced SDK-side, never on the router path).
-    // Falling back on a partially-mapped destination would silently start delivering events the
-    // customer had excluded, which for a conversions API means billing and optimising on them.
-    //
-    // With nothing configured there is no intent to contradict, and an event already named after a
-    // standard OpenAI event needs no configuration to be understood — so rather than dropping 100%
-    // of the destination's traffic, take the name at face value.
-    const standardEventName = normalizeEventName(sourceKey);
-    if (eventMapping.length === 0 && isStandardEvent(standardEventName)) {
-      return { from: sourceKey, to: standardEventName };
+    // An event already named after a standard OpenAI event carries its own mapping, so take the
+    // name at face value instead of dropping the event. This holds whatever else is configured: a
+    // mapping table translates the names that need translating, and an event that is already in
+    // OpenAI's naming needs no row — its absence is not a decision to exclude it.
+    if (isStandardEvent(normalizedSourceKey)) {
+      return { from: sourceKey, to: normalizedSourceKey };
     }
     throw new InstrumentationError(`OpenAI Ads event mapping not found for ${sourceKey}`);
   }


### PR DESCRIPTION
## What

An event whose name is already a standard OpenAI event name resolves on its own name instead of aborting, whether or not the destination has `eventMapping` rows configured.

## Why

`resolveEventMapping` looked the source event name up in `config.eventMapping` and threw if it missed. `eventMapping` is optional in the destination's `schema.json` (only `rudderAccountId` is required) and the UI saves an empty table by default — so a destination in that state drops **100%** of its traffic, one `OpenAI Ads event mapping not found for <event>` per event, with nothing at save time to warn you.

But the empty table is only the extreme case of a more general one. `eventMapping` exists to *translate* names — to say "our `Purchase` is OpenAI's `order_created`". An event literally named `order_created` needs no translating, so the absence of a row for it is not a decision to exclude it; it is a row nobody had any reason to add. A partially-configured table hits exactly this: rows for the names that needed translating, and a standard-named event alongside them that silently aborted.

So the fallback is unconditional on the table's contents: if no row matches and the name is already a standard OpenAI event, take it at face value.

## Only a literal match

The name is compared case-insensitively — matching how the mapping lookup already compares `from` — and nothing else. No whitespace/hyphen folding, no synonyms, no heuristics. `order_created` and `ORDER_CREATED` resolve; `Order Created` does not, and still needs a mapping row like any other name in a house style that isn't OpenAI's.

Keeping it literal is what makes the unconditional fallback safe. `eventMapping` is the only event gate on the router path — the destination definition's `eventFilteringOption` / `whitelistedEvents` / `blacklistedEvents` sit under `destConfig.web`, the ui-config groups them as "Client-side event filtering" gated on device mode, and rudder-server has no reference to them, so that filtering is SDK-side only. Anything the fallback resolves therefore gets delivered, and this is a conversions API, so that means billing and optimising on it.

With a literal match the only events that newly flow are ones a source deliberately named in OpenAI's own snake_case. Under name folding that would not have held: `src/sources/shopify/config.js` emits events named verbatim `"Checkout Started"` and `"Order Created"`, and `shopify` is in the destination's `supportedSourceTypes` — a Shopify connection mapping only `Order Created` would have started sending `checkout_started` too. Literal matching leaves both of those needing a row, as they should.

## Notes for the reviewer

- **`page` and `screen` are not covered by this.** `getSourceKey` uses `message.name` for them, which is a page title (`"Home"`, `"Docs Page"`) and essentially never a literal OpenAI event name. So the rescue is `track`-only in practice. Defaulting `page` to `page_viewed` would be a coherent follow-up but is a bigger semantic call than this PR should make — flagging it rather than smuggling it in.
- **An explicit mapping still wins.** The table is searched first; the fallback only runs when nothing matched. A row remapping `order_created` to something else keeps working.
- **`EVENT_DATA_TYPE_BY_EVENT` moved to a null prototype.** It is a plain object literal indexed by a config-controlled key, which is a bug class this repo has been bitten by (an event named `constructor` resolving to `Object`). It is not reachable today — the zod schema rejects those values first — but the invariant shouldn't depend on a validation layer two files away staying where it is. There are regression tests pinning `constructor`, `__proto__` and `toString`.
- **The `custom` sentinel deliberately falls through to the error.** `STANDARD_EVENTS` is derived from `STANDARD_EVENT_DATA_TYPES` and `CUSTOM_EVENT_SENTINEL` is a separate const, so an event named `custom` is not a standard event and aborts. That matters because the `customEventName` guard only runs on the mapped branch — if `custom` were ever in that list the fallback would emit `type: 'custom'` with no `custom_event_name`. Nothing in the type system pins this, so there is a test for it.
- **`isStandardEvent` is a type predicate**, not an `as` cast, so the resolved name is genuinely narrowed rather than asserted.

## Testing

- `npx jest src/v0/destinations/openai_ads` — 40 passed
- `npm run test:ts -- component --destination=openai_ads` — 9 passed
- All 12 standard events are covered exhaustively by looping `STANDARD_EVENTS` and asserting the derived `data.type` against `STANDARD_EVENT_DATA_TYPES`, so a 13th event wired to the wrong data type fails the suite.
- Plus: case-insensitive matching (`ORDER_CREATED`, `Order_Created`); that `Order Created` and other non-OpenAI-format names are still rejected; that a standard name absent from a **non-empty** table resolves while a non-standard one alongside it still aborts; that an explicit row wins; and the prototype-chain names above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
