### PR TITLE
fix(slack): tolerate absent or malformed optional array config

### DIFF
--- a/src/v0/destinations/slack/transform.js
+++ b/src/v0/destinations/slack/transform.js
@@ -7,6 +7,7 @@ const {
   getName,
   getWhiteListedTraits,
   buildDefaultTraitTemplate,
+  toArray,
 } = require('./util');
 const logger = require('../../../logger');
 
@@ -106,7 +107,7 @@ const processIdentify = (message, destination) => {
 const isEventNameMatchesRegex = (eventName, regex) => eventName.match(regex)?.length > 0;
 
 const getChannelForEventName = (eventChannelSettings, eventName) => {
-  for (const channelConfig of eventChannelSettings) {
+  for (const channelConfig of toArray(eventChannelSettings)) {
     const configEventName =
       channelConfig?.eventName?.trim()?.length > 0 ? channelConfig.eventName : null;
     const channelWebhook =
@@ -132,7 +133,7 @@ const getChannelForEventName = (eventChannelSettings, eventName) => {
   return null;
 };
 const getChannelNameForEvent = (eventChannelSettings, eventName) => {
-  for (const channelConfig of eventChannelSettings) {
+  for (const channelConfig of toArray(eventChannelSettings)) {
     const configEventName =
       channelConfig?.eventName?.trim()?.length > 0 ? channelConfig.eventName : null;
     const configEventChannel =
@@ -158,10 +159,10 @@ const getChannelNameForEvent = (eventChannelSettings, eventName) => {
 };
 
 const buildtemplateList = (templateListForThisEvent, eventTemplateSettings, eventName) => {
-  eventTemplateSettings.forEach((templateConfig) => {
+  toArray(eventTemplateSettings).forEach((templateConfig) => {
     const configEventName =
       templateConfig?.eventName?.trim()?.length > 0 ? templateConfig.eventName : undefined;
-    const configEventTemplate = templateConfig.eventTemplate
+    const configEventTemplate = templateConfig?.eventTemplate
       ? templateConfig.eventTemplate.trim()?.length > 0
         ? templateConfig.eventTemplate
         : undefined
@@ -188,11 +189,9 @@ const processTrack = (message, destination) => {
   if (!eventName) {
     throw new InstrumentationError('Event name is required');
   }
-  if (denyListOfEvents?.length > 0) {
-    const denyListofEvents = denyListOfEvents.map((item) => item.eventName);
-    if (denyListofEvents.includes(eventName)) {
-      throw new ConfigurationError('Event is denied. Please check configuration.');
-    }
+  const denyListofEvents = toArray(denyListOfEvents).map((item) => item?.eventName);
+  if (denyListofEvents.includes(eventName)) {
+    throw new ConfigurationError('Event is denied. Please check configuration.');
   }
 
   const templateListForThisEvent = new Set();

--- a/src/v0/destinations/slack/util.js
+++ b/src/v0/destinations/slack/util.js
@@ -32,22 +32,29 @@ const getName = (message) => {
 };
 
 /**
+ * Every array-shaped setting in the Slack config is optional (the config schema only
+ * requires `webhookUrl`), so it can reach us absent, null or otherwise malformed.
+ * Normalise to an array so callers can iterate unconditionally.
+ * @param {*} value value read from destination.Config
+ * @returns the value when it is an array, an empty array otherwise
+ */
+const toArray = (value) => (Array.isArray(value) ? value : []);
+
+/**
  * To get whitelisted traits from config
  * @param {*} destination
  * @param {*} traitsList map the whitelisted traits to this list
  */
 const getWhiteListedTraits = (destination) => {
   const traitsList = [];
-  if (destination?.Config?.whitelistedTraitsSettings) {
-    destination.Config.whitelistedTraitsSettings.forEach((whiteListTrait) => {
-      if (whiteListTrait.trait) {
-        const tmpWhitelistTrait = whiteListTrait.trait.trim();
-        if (tmpWhitelistTrait.trim().length > 0) {
-          traitsList.push(tmpWhitelistTrait);
-        }
+  toArray(destination?.Config?.whitelistedTraitsSettings).forEach((whiteListTrait) => {
+    if (whiteListTrait?.trait) {
+      const tmpWhitelistTrait = whiteListTrait.trait.trim();
+      if (tmpWhitelistTrait.trim().length > 0) {
+        traitsList.push(tmpWhitelistTrait);
       }
-    });
-  }
+    }
+  });
   return traitsList;
 };
 
@@ -96,4 +103,5 @@ module.exports = {
   getName,
   getWhiteListedTraits,
   buildDefaultTraitTemplate,
+  toArray,
 };

--- a/test/integrations/destinations/slack/processor/data.ts
+++ b/test/integrations/destinations/slack/processor/data.ts
@@ -110,6 +110,20 @@ const buildOptionalArrayConfigTestCases = (): ProcessorTestData[] => [
     'Track call on the modern incoming-webhooks path where eventChannelSettings is absent',
     { incomingWebhooksType: 'modern', eventChannelSettings: undefined },
   ),
+  // Mirrors the exact config of the destination that produced the reported 500:
+  // only `webhookUrl` and `eventTemplateSettings` are set. `incomingWebhooksType`
+  // is absent too, so the legacy branch runs and `getChannelNameForEvent` is the
+  // function that throws — matching the reported stack trace.
+  buildOptionalArrayConfigTestCase(
+    'slack-track-production-config-shape',
+    'Track call with only webhookUrl and eventTemplateSettings set, as in the reported incident',
+    {
+      eventChannelSettings: undefined,
+      whitelistedTraitsSettings: undefined,
+      denyListOfEvents: undefined,
+      incomingWebhooksType: undefined,
+    },
+  ),
 ];
 
 export const data: ProcessorTestData[] = [

--- a/test/integrations/destinations/slack/processor/data.ts
+++ b/test/integrations/destinations/slack/processor/data.ts
@@ -6,6 +6,112 @@ import {
   generateCommonMetadata,
 } from '../common';
 
+/**
+ * The Slack config schema marks only `webhookUrl` as required, so every array-shaped
+ * setting (`eventChannelSettings`, `eventTemplateSettings`, `whitelistedTraitsSettings`,
+ * `denyListOfEvents`) may legitimately arrive absent, null or malformed. The transform
+ * must fall back to the default behaviour instead of throwing a 500.
+ */
+const buildOptionalArrayConfigTestCase = (
+  id: string,
+  scenario: string,
+  configOverrides: Record<string, any>,
+): ProcessorTestData => ({
+  id,
+  name: 'slack',
+  description: scenario,
+  feature: 'processor',
+  module: 'destination',
+  version: 'v0',
+  scenario,
+  successCriteria:
+    'The track call falls back to the default template and the base webhook URL instead of throwing',
+  input: {
+    request: {
+      method: 'POST',
+      body: [
+        {
+          destination: overrideDestination(baseDestination, configOverrides),
+          message: generateCommonMessage(
+            'track',
+            '12345',
+            '4de817fb-7f8e-4e23-b9be-f6736dbda20f',
+            '9ecc0183-89ed-48bd-87eb-b2d8e1ca6780',
+            { event: 'so.wtf' },
+          ),
+          metadata: generateCommonMetadata(901, '12345', '9ecc0183-89ed-48bd-87eb-b2d8e1ca6780'),
+        },
+      ],
+    },
+  },
+  output: {
+    response: {
+      status: 200,
+      body: [
+        {
+          output: {
+            version: '1',
+            type: 'REST',
+            method: 'POST',
+            endpoint: 'https://hooks.slack.com/services/THZM86VSS/BV9HZ2UN6/demo',
+            headers: {
+              'Content-Type': 'application/x-www-form-urlencoded',
+            },
+            params: {},
+            body: {
+              JSON: {},
+              JSON_ARRAY: {},
+              XML: {},
+              FORM: {
+                payload: JSON.stringify({
+                  text: 'my-name did so.wtf',
+                  username: 'RudderStack',
+                  icon_url: 'https://cdn.rudderlabs.com/rudderstack.png',
+                }),
+              },
+            },
+            files: {},
+            userId: '12345',
+          },
+          metadata: generateCommonMetadata(901, '12345', '9ecc0183-89ed-48bd-87eb-b2d8e1ca6780'),
+          statusCode: 200,
+        },
+      ],
+    },
+  },
+  mockFns: () => {
+    return {};
+  },
+});
+
+const buildOptionalArrayConfigTestCases = (): ProcessorTestData[] => [
+  buildOptionalArrayConfigTestCase(
+    'slack-track-missing-event-channel-settings',
+    'Track call where eventChannelSettings is absent from the destination config',
+    { eventChannelSettings: undefined },
+  ),
+  buildOptionalArrayConfigTestCase(
+    'slack-track-null-event-channel-settings',
+    'Track call where eventChannelSettings is null',
+    { eventChannelSettings: null },
+  ),
+  buildOptionalArrayConfigTestCase(
+    'slack-track-non-array-optional-settings',
+    'Track call where the optional array settings are non-array objects',
+    {
+      eventChannelSettings: {},
+      eventTemplateSettings: {},
+      whitelistedTraitsSettings: {},
+      denyListOfEvents: {},
+    },
+  ),
+  buildOptionalArrayConfigTestCase(
+    'slack-track-modern-webhooks-missing-event-channel-settings',
+    'Track call on the modern incoming-webhooks path where eventChannelSettings is absent',
+    { incomingWebhooksType: 'modern', eventChannelSettings: undefined },
+  ),
+];
+
 export const data: ProcessorTestData[] = [
   {
     id: 'slack-identify-default-template',
@@ -240,4 +346,5 @@ export const data: ProcessorTestData[] = [
       return {};
     },
   },
+  ...buildOptionalArrayConfigTestCases(),
 ];


### PR DESCRIPTION
## What

Fixes `eventChannelSettings is not iterable` thrown from the Slack destination's processor transform.

## Root cause

The Slack config schema marks **only `webhookUrl`** as required ([`schema.json`](https://github.com/rudderlabs/rudder-integrations-config/blob/develop/src/configurations/destinations/slack/schema.json)), so every array-shaped setting may legitimately arrive absent. But `processTrack` destructured them straight out of `Config` and iterated unconditionally:

```js
const getChannelNameForEvent = (eventChannelSettings, eventName) => {
  for (const channelConfig of eventChannelSettings) {   // throws when not an array
```

A destination whose config omits `eventChannelSettings` therefore threw a raw `TypeError`. Because it is an untyped throw it is tagged `errorCategory=transformation` and surfaces as a **500**, failing the event rather than degrading gracefully.

**Confirmed config of the affected destination:** only `webhookUrl` (string) and `eventTemplateSettings` (array) are set. `eventChannelSettings` is absent, and so is `incomingWebhooksType` — which is falsy, so the `else` branch runs and `getChannelNameForEvent` is what throws, matching the reported stack trace exactly.

This is a latent bug, not a regression — `transform.js` has not changed since #4357.

## Why guard all of them, not just the reported field

To be straight about scope: for **this** destination, `const { eventChannelSettings = [] } = Config` would have been enough. `eventTemplateSettings` is populated, so nothing downstream would have thrown. This section is not claiming otherwise.

The reason to fix the siblings anyway is that the schema permits exactly the same omission for each of them, so the one-field fix leaves the next config shape to rediscover the same bug:

**Absent is schema-legal, and nothing fills it in.** These fields are not in the schema's `required` list *and carry no `default`*. Config-backend validates destination writes with AJV `useDefaults: true`, so a schema `default` would have been injected and persisted at save time — but Slack's schema declares none, so an omitted field stays omitted and reaches the transformer as `undefined`.

**Demonstrated:** with `eventTemplateSettings` also omitted — equally schema-legal — applying only `eventChannelSettings = []` still fails, now with `Cannot read properties of undefined (reading 'forEach')` from `buildtemplateList`, which runs unconditionally for every track event. Across the schema-legal space there are three reachable crash sites over two settings: both webhook paths of `eventChannelSettings`, plus `eventTemplateSettings`.

**On non-array values (`null`, `{}`):** these are rejected with a 400 on the validated write paths — AJV 8 with `coerceTypes` off will not accept `null` for `"type": "array"`, and `VALIDATION_ENABLED` is `"true"` in `values.common.yaml`. So guarding them is defence-in-depth, not a fix for a reachable bug. It is cheap insurance rather than theoretical, because several internal paths bypass validation entirely (the raw `updateDestination` persist, `addConnectionModeToDestination`, and ~45 direct-write call sites in the admin scripts service). `Array.isArray` costs the same as `= []`.

Under the absent case `whitelistedTraitsSettings` (truthiness guard) and `denyListOfEvents` (`?.length > 0` guard) are already safe; those two guards are hardening only.

### Suggested follow-up (separate repo)

Adding `"default": []` to these four properties in `rudder-integrations-config`'s Slack `schema.json` would let AJV's `useDefaults` populate them at write time, closing the hole for newly saved configs. It would not backfill existing rows, so it complements this change rather than replacing it.

## Change

Adds a `toArray` helper and routes every optional array setting through it, so a missing / null / non-array value falls back to the documented default behaviour:

| Site | Setting |
|---|---|
| `getChannelForEventName` | `eventChannelSettings` (modern webhooks) |
| `getChannelNameForEvent` | `eventChannelSettings` (legacy webhooks — the reported crash) |
| `buildtemplateList` | `eventTemplateSettings` |
| `getWhiteListedTraits` | `whitelistedTraitsSettings` |
| `processTrack` | `denyListOfEvents` |

`getWhiteListedTraits` lives in `slack/util.js` and is **also imported by the discord destination**, which gets the same hardening.

Deny-list semantics are unchanged: for any valid config the behaviour is identical (non-empty array → same result; empty/absent → no-op, as before). `item?.eventName` cannot produce a false match because `eventName` is already proven truthy immediately above.

## Tests

5 new processor cases, all of which fail on `develop` and pass here:

- **the exact config shape of the affected destination** (only `webhookUrl` + `eventTemplateSettings`) — reproduces the reported error on the legacy branch

- `eventChannelSettings` absent → reproduces the exact production payload: `error: "eventChannelSettings is not iterable"`, `errorCategory: transformation`, `statusCode: 500`
- `eventChannelSettings: null`
- all optional array settings as non-array objects → this one surfaced the `whitelistedTraitsSettings.forEach` site
- the `modern` incoming-webhooks path

```
Slack processor:  13 passed (8 pre-existing + 5 new)
Slack router:      2 passed
Discord:           8 passed
```

## Blast radius

Low: a single occurrence over a 30-day window, and the only Slack v0 transform crash of any kind in that period. Each affected event fails individually rather than poisoning a batch.

So this is a low-urgency latent bug rather than an active incident — but the crash is a raw `TypeError` on a config shape the schema explicitly permits, so it is worth closing off rather than leaving to re-fire whenever a destination is saved without these optional arrays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017UQtPZLMoBNaM2ybmXwaZc
