### PR TITLE
fix(google_adwords): treat NOT_ADS_USER 401 as terminal, not refreshable

### DIFF
--- a/src/v0/util/googleUtils/index.js
+++ b/src/v0/util/googleUtils/index.js
@@ -126,7 +126,13 @@ const getAuthErrCategory = ({ response, status }) => {
       // https://developers.google.com/google-ads/api/docs/oauth/2sv
       authenticationError.includes('TWO_STEP_VERIFICATION_NOT_ENROLLED') ||
       // https://developers.google.com/google-ads/api/docs/common-errors#:~:text=this%20for%20you.-,CUSTOMER_NOT_FOUND,-Summary
-      authenticationError.includes('CUSTOMER_NOT_FOUND')
+      authenticationError.includes('CUSTOMER_NOT_FOUND') ||
+      // The authorising Google account is not associated with ANY Ads account, so no token minted
+      // for that identity can ever be accepted. Classifying it as REFRESH_TOKEN made rudder-server
+      // refresh and retry indefinitely (the refresh itself succeeds), which minted a new access
+      // token per delivery attempt and tripped the OAuth success circuit breaker. INT-7101.
+      // https://developers.google.com/google-ads/api/reference/rpc/v23/AuthenticationErrorEnum.AuthenticationError#not_ads_user
+      authenticationError.includes('NOT_ADS_USER')
     ) {
       return AUTH_STATUS_INACTIVE;
     }

--- a/src/v0/util/googleUtils/index.js
+++ b/src/v0/util/googleUtils/index.js
@@ -113,6 +113,23 @@ const finaliseAnalyticsConsents = (consentConfigMap, eventLevelConsent = {}) => 
   return consentObj;
 };
 
+// Google AuthenticationError codes that no amount of token refreshing can clear: the grant or the
+// authorising identity itself is the problem, so a fresh token gets rejected exactly like the last
+// one. Anything not listed here stays REFRESH_TOKEN, which is the genuinely recoverable case (an
+// expired or invalidated access token).
+// Ref - https://developers.google.com/google-ads/api/reference/rpc/v23/AuthenticationErrorEnum.AuthenticationError
+const TERMINAL_AUTHENTICATION_ERRORS = [
+  // https://developers.google.com/google-ads/api/docs/oauth/2sv
+  'TWO_STEP_VERIFICATION_NOT_ENROLLED',
+  // https://developers.google.com/google-ads/api/docs/common-errors#:~:text=this%20for%20you.-,CUSTOMER_NOT_FOUND,-Summary
+  'CUSTOMER_NOT_FOUND',
+  // The authorising Google account is not associated with ANY Ads account. Treating this as
+  // REFRESH_TOKEN made rudder-server refresh and retry indefinitely (the refresh itself succeeds),
+  // minting a new access token per delivery attempt until the OAuth success circuit breaker
+  // tripped. INT-7101.
+  'NOT_ADS_USER',
+];
+
 const getAuthErrCategory = ({ response, status }) => {
   if (status === 401) {
     let respArr = response;
@@ -122,18 +139,7 @@ const getAuthErrCategory = ({ response, status }) => {
     const authenticationError = respArr.map((resp) =>
       get(resp, 'error.details.0.errors.0.errorCode.authenticationError'),
     );
-    if (
-      // https://developers.google.com/google-ads/api/docs/oauth/2sv
-      authenticationError.includes('TWO_STEP_VERIFICATION_NOT_ENROLLED') ||
-      // https://developers.google.com/google-ads/api/docs/common-errors#:~:text=this%20for%20you.-,CUSTOMER_NOT_FOUND,-Summary
-      authenticationError.includes('CUSTOMER_NOT_FOUND') ||
-      // The authorising Google account is not associated with ANY Ads account, so no token minted
-      // for that identity can ever be accepted. Classifying it as REFRESH_TOKEN made rudder-server
-      // refresh and retry indefinitely (the refresh itself succeeds), which minted a new access
-      // token per delivery attempt and tripped the OAuth success circuit breaker. INT-7101.
-      // https://developers.google.com/google-ads/api/reference/rpc/v23/AuthenticationErrorEnum.AuthenticationError#not_ads_user
-      authenticationError.includes('NOT_ADS_USER')
-    ) {
+    if (authenticationError.some((errCode) => TERMINAL_AUTHENTICATION_ERRORS.includes(errCode))) {
       return AUTH_STATUS_INACTIVE;
     }
     return REFRESH_TOKEN;

--- a/src/v0/util/googleUtils/index.test.js
+++ b/src/v0/util/googleUtils/index.test.js
@@ -2,7 +2,12 @@ const {
   finaliseConsent,
   populateConsentFromConfig,
   finaliseAnalyticsConsents,
+  getAuthErrCategory,
 } = require('./index');
+const {
+  AUTH_STATUS_INACTIVE,
+  REFRESH_TOKEN,
+} = require('../../../adapters/networkhandler/authConstants');
 
 describe('unit test for populateConsentFromConfig', () => {
   const consentConfigMap = {
@@ -291,5 +296,68 @@ describe('unit test for finaliseAnalyticsConsents', () => {
       personalizationConsent: 'RANDOM',
     });
     expect(result).toEqual({});
+  });
+});
+
+describe('unit test for getAuthErrCategory', () => {
+  // Google states the machine-readable cause in details[].errors[].errorCode.authenticationError.
+  // error.message is a generic string Google reuses across unrelated 401s (a valid token against a
+  // customer it cannot see produces the same "Request is missing required authentication
+  // credential" text as a request with no Authorization header at all), so it is never the thing to
+  // branch on. Bodies below mirror what Google Ads v23 actually returns.
+  const buildGoogleAuthError = (authenticationError) => ({
+    error: {
+      code: 401,
+      message:
+        'Request is missing required authentication credential. Expected OAuth 2 access token, login cookie or other valid authentication credential.',
+      status: 'UNAUTHENTICATED',
+      ...(authenticationError && {
+        details: [
+          {
+            '@type': 'type.googleapis.com/google.ads.googleads.v23.errors.GoogleAdsFailure',
+            errors: [{ errorCode: { authenticationError }, message: 'some message' }],
+            requestId: 'some-request-id',
+          },
+        ],
+      }),
+    },
+  });
+
+  it.each([
+    // Refreshing cannot fix an identity that is not an Ads user at all, so this must abort rather
+    // than drive the refresh loop. Regression guard for INT-7101.
+    ['NOT_ADS_USER', AUTH_STATUS_INACTIVE],
+    ['CUSTOMER_NOT_FOUND', AUTH_STATUS_INACTIVE],
+    ['TWO_STEP_VERIFICATION_NOT_ENROLLED', AUTH_STATUS_INACTIVE],
+    // A genuinely expired token is what the refresh path exists for - keep it refreshable.
+    ['OAUTH_TOKEN_EXPIRED', REFRESH_TOKEN],
+  ])('should map a 401 with authenticationError %s to %s', (authenticationError, expected) => {
+    expect(
+      getAuthErrCategory({ response: buildGoogleAuthError(authenticationError), status: 401 }),
+    ).toEqual(expected);
+  });
+
+  it('should map a terminal 401 to AUTH_STATUS_INACTIVE when the response is an array', () => {
+    // googleAds:searchStream answers with a top-level array; uploadClickConversions with an object.
+    expect(
+      getAuthErrCategory({ response: [buildGoogleAuthError('NOT_ADS_USER')], status: 401 }),
+    ).toEqual(AUTH_STATUS_INACTIVE);
+  });
+
+  it('should map an expired or invalid token 401 to REFRESH_TOKEN', () => {
+    // No details[] at all - this is the genuinely refreshable case.
+    expect(getAuthErrCategory({ response: buildGoogleAuthError(null), status: 401 })).toEqual(
+      REFRESH_TOKEN,
+    );
+  });
+
+  it('should map a 403 to AUTH_STATUS_INACTIVE', () => {
+    expect(getAuthErrCategory({ response: { error: { code: 403 } }, status: 403 })).toEqual(
+      AUTH_STATUS_INACTIVE,
+    );
+  });
+
+  it('should return an empty category for non-auth statuses', () => {
+    expect(getAuthErrCategory({ response: { error: { code: 400 } }, status: 400 })).toEqual('');
   });
 });


### PR DESCRIPTION
## What

Google Ads returns `401` with `authenticationError: NOT_ADS_USER` when the authorising Google account is not associated with **any** Ads account. `getAuthErrCategory` allowlisted only `TWO_STEP_VERIFICATION_NOT_ENROLLED` and `CUSTOMER_NOT_FOUND` as `AUTH_STATUS_INACTIVE`, so `NOT_ADS_USER` fell through to `REFRESH_TOKEN`.

Refreshing can never fix it — the identity has no Ads access, and the refresh itself *succeeds*. So rudder-server refreshes, rewrites the status to `500`, retries, and refreshes again on the next attempt, forever.

This classifies `NOT_ADS_USER` alongside `CUSTOMER_NOT_FOUND`: `AUTH_STATUS_INACTIVE` → `400` → the job aborts on the first attempt.

## Why (INT-7101)

A P0 OAuth circuit-breaker alert fired on `GOOGLE_ADWORDS_OFFLINE_CONVERSIONS`. Aggregate impact from a single misconfigured destination carrying ~75 events:

| | |
|---|---|
| Google access tokens minted | ~4,000 in under 25h |
| Mint rate | ~160/hour, against ~1/hour for a healthy account |
| Delivery attempts | ~10,800 |
| Events delivered | 0 |
| Events lost | ~46, to the 24h router retention drain |

The circuit breaker was the messenger, not the bug: the error breaker never tripped for this account, i.e. every control-plane call succeeded. The *success* breaker trips on 5+ genuinely different tokens minted within a minute, which is exactly what the retry loop produced.

## Verification

Reproduced against the real transformer proxy API (`/v1/destinations/google_adwords_offline_conversions/proxy`) before the fix, driving a real Google Ads token minted via rudder-auth:

| Case | `authenticationError` | `authErrorCategory` | |
|---|---|---|---|
| **LIVE** unknown customerId | `CUSTOMER_NOT_FOUND` | `AUTH_STATUS_INACTIVE` | abort ✅ |
| **LIVE** invalid token | *(none)* | `REFRESH_TOKEN` | refresh ✅ correct |
| MOCK `CUSTOMER_NOT_FOUND` | `CUSTOMER_NOT_FOUND` | `AUTH_STATUS_INACTIVE` | abort ✅ |
| MOCK `TWO_STEP…NOT_ENROLLED` | `TWO_STEP_VERIFICATION_NOT_ENROLLED` | `AUTH_STATUS_INACTIVE` | abort ✅ |
| **MOCK `NOT_ADS_USER`** | `NOT_ADS_USER` | **`REFRESH_TOKEN`** | **loops ❌** |

The live `CUSTOMER_NOT_FOUND` row classifies identically to its mock twin, which is what validates the mock bodies as faithful — they are built from the documented [`AuthenticationError`](https://developers.google.com/google-ads/api/reference/rpc/v23/AuthenticationErrorEnum.AuthenticationError) shape, not from a captured production response. A `NOT_ADS_USER` row cannot be produced live from a test account that *is* an Ads user, hence the mock for that one case.

Test results:

- The new unit tests fail on `NOT_ADS_USER` before the change (2 failed / 6 passed) and pass after. `getAuthErrCategory` had **no** coverage previously.
- `npm run test:ts -- component --destination=google_adwords_offline_conversions,google_adwords_enhanced_conversions,google_adwords_remarketing_lists,campaign_manager` → **202 passed**.
- `npx jest src/v0/util/googleUtils/` → **83 passed**.
- Prettier + eslint clean.

## Blast radius

`getAuthErrCategory` is shared by GAOC, GAEC, GARL and Campaign Manager. All four now abort on `NOT_ADS_USER` instead of retrying. `AUTH_STATUS_INACTIVE` currently only sets a `400` in rudder-server (`services/oauth/v2/http/transport.go`) → `isJobTerminated` → abort; no code toggles the destination's `authStatus` on current master, so there is no destination-disabling side effect.

The second commit is a pure refactor: the `||` chain of `includes(...)` calls becomes a named `TERMINAL_AUTHENTICATION_ERRORS` list with a single `some` membership check. Behaviour is identical; adding a code is now a one-line edit.

## Follow-ups (not in this PR)

1. **The default is backwards.** Any 401 whose `authenticationError` we don't recognise — including a 401 with no `details[]` — still falls through to `REFRESH_TOKEN` and retries forever. A default-terminal policy with an explicit *refreshable* list (`OAUTH_TOKEN_EXPIRED`, `OAUTH_TOKEN_INVALID`) would be the durable fix; extending the allowlist one code at a time is not. The new list makes that swap cheap.
2. `getAuthErrCategory` only inspects `details[0].errors[0]`, so a terminal code in a later position is missed. Pre-existing, unchanged here.
3. Nothing counts consecutive refresh-then-still-401 cycles, so a permanently broken grant retries until the retention drain rather than aborting on a bounded count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
