### PR TITLE
fix(mp): treat 409 on create deletion task as already scheduled

### DIFF
--- a/src/v0/destinations/mp/config.js
+++ b/src/v0/destinations/mp/config.js
@@ -65,6 +65,9 @@ const MAX_PAYLOAD_SIZE_BYTES = 1024 * 1024; // 1MB
 // Delete user
 const DEL_MAX_BATCH_SIZE = 1000;
 const DISTINCT_ID_MAX_BATCH_SIZE = 1999;
+// Returned by the create deletion task api when a deletion task already exists for one or more of
+// the requested distinct_ids.
+const DELETION_TASK_ALREADY_EXISTS_STATUS = 409;
 
 const DESTINATION = 'MP';
 
@@ -77,6 +80,7 @@ module.exports = {
   GEO_SOURCE_ALLOWED_VALUES,
   MP_IDENTIFY_EXCLUSION_LIST,
   DISTINCT_ID_MAX_BATCH_SIZE,
+  DELETION_TASK_ALREADY_EXISTS_STATUS,
   IMPORT_MAX_BATCH_SIZE,
   ENGAGE_MAX_BATCH_SIZE,
   GROUPS_MAX_BATCH_SIZE,

--- a/src/v0/destinations/mp/deleteUsers.js
+++ b/src/v0/destinations/mp/deleteUsers.js
@@ -2,7 +2,11 @@ const lodash = require('lodash');
 const { ConfigurationError, NetworkError } = require('@rudderstack/integrations-lib');
 const { handleHttpRequest } = require('../../../adapters/network');
 const { isHttpStatusSuccess } = require('../../util');
-const { DEL_MAX_BATCH_SIZE, DISTINCT_ID_MAX_BATCH_SIZE } = require('./config');
+const {
+  DEL_MAX_BATCH_SIZE,
+  DISTINCT_ID_MAX_BATCH_SIZE,
+  DELETION_TASK_ALREADY_EXISTS_STATUS,
+} = require('./config');
 const { executeCommonValidations } = require('../../util/regulation-api');
 const { getDynamicErrorType } = require('../../../adapters/utils/networkUtils');
 const tags = require('../../util/tags');
@@ -105,7 +109,23 @@ const createDeletionTask = async (userAttributes, config) => {
           module: 'deletion',
         },
       );
-      if (!isHttpStatusSuccess(handledDelResponse.status)) {
+      // Mixpanel answers 409 Conflict when a deletion task already exists for a requested
+      // distinct_id. For a single-id request that is unambiguous: this user is already scheduled
+      // for deletion on their side, so the request has achieved what it was for. Retrying can only
+      // ever return 409 again, so treating it as a failure burns every regulation-worker attempt
+      // and aborts the job — the deletion is recorded as failed even though Mixpanel is deleting
+      // the user. This mirrors the 404 ("nothing left to delete") handling in the
+      // custify/intercom/iterable handlers.
+      //
+      // We deliberately do NOT extend this to multi-id requests. Mixpanel does not document 409,
+      // so we cannot tell whether a conflict rejects the whole request or only the conflicting id.
+      // If it rejects the whole request, swallowing it would mark every other user in the batch as
+      // deleted when none of them were — a silent compliance gap. Failing the batch is the safe
+      // side of that unknown.
+      const alreadyDeletionScheduled =
+        handledDelResponse.status === DELETION_TASK_ALREADY_EXISTS_STATUS &&
+        batchEvent.length === 1;
+      if (!isHttpStatusSuccess(handledDelResponse.status) && !alreadyDeletionScheduled) {
         throw new NetworkError(
           'User deletion request failed for `create deletion task` api',
           handledDelResponse.status,

--- a/test/integrations/destinations/mp/deleteUsers/data.ts
+++ b/test/integrations/destinations/mp/deleteUsers/data.ts
@@ -3245,6 +3245,89 @@ export const data = [
   },
   {
     name: 'mp',
+    description:
+      'Test 6.1: a 409 from the create deletion task api means Mixpanel already has a deletion task for these distinct_ids, so the job is treated as successful rather than retried',
+    feature: 'userDeletion',
+    module: 'destination',
+    version: 'v0',
+    input: {
+      request: {
+        body: [
+          {
+            destType: 'MP',
+            userAttributes: [
+              {
+                userId: 'rudderAlreadyDeleted',
+              },
+            ],
+            config: {
+              token: secret4,
+              prefixProperties: true,
+              useNativeSDK: false,
+              userDeletionApi: 'task',
+              gdprApiToken: secret4,
+            },
+          },
+        ],
+      },
+    },
+    output: {
+      response: {
+        status: 200,
+        body: [
+          {
+            statusCode: 200,
+            status: 'successful',
+          },
+        ],
+      },
+    },
+  },
+  {
+    name: 'mp',
+    description:
+      'Test 6.2: a 409 on a multi distinct_id create deletion task request still fails, because a conflict on one id does not prove the others were scheduled for deletion',
+    feature: 'userDeletion',
+    module: 'destination',
+    version: 'v0',
+    input: {
+      request: {
+        body: [
+          {
+            destType: 'MP',
+            userAttributes: [
+              {
+                userId: 'rudderAlreadyDeleted',
+              },
+              {
+                userId: 'rudderNotDeleted',
+              },
+            ],
+            config: {
+              token: secret4,
+              prefixProperties: true,
+              useNativeSDK: false,
+              userDeletionApi: 'task',
+              gdprApiToken: secret4,
+            },
+          },
+        ],
+      },
+    },
+    output: {
+      response: {
+        status: 409,
+        body: [
+          {
+            statusCode: 409,
+            error: 'User deletion request failed for `create deletion task` api',
+          },
+        ],
+      },
+    },
+  },
+  {
+    name: 'mp',
     description: 'Test 6',
     feature: 'userDeletion',
     module: 'destination',

--- a/test/integrations/destinations/mp/network.ts
+++ b/test/integrations/destinations/mp/network.ts
@@ -1100,6 +1100,50 @@ const deleteNwData = [
   {
     httpReq: {
       method: 'post',
+      url: `https://mixpanel.com/api/app/data-deletions/v3.0/?token=${secret4}`,
+      data: {
+        distinct_ids: ['rudderAlreadyDeleted'],
+        compliance_type: 'CCPA',
+      },
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: authHeader4,
+      },
+    },
+    httpRes: {
+      status: 409,
+      statusText: 'Conflict',
+      data: {
+        status: 'error',
+        error: 'a deletion task for this distinct_id already exists',
+      },
+    },
+  },
+  {
+    httpReq: {
+      method: 'post',
+      url: `https://mixpanel.com/api/app/data-deletions/v3.0/?token=${secret4}`,
+      data: {
+        distinct_ids: ['rudderAlreadyDeleted', 'rudderNotDeleted'],
+        compliance_type: 'CCPA',
+      },
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: authHeader4,
+      },
+    },
+    httpRes: {
+      status: 409,
+      statusText: 'Conflict',
+      data: {
+        status: 'error',
+        error: 'a deletion task for this distinct_id already exists',
+      },
+    },
+  },
+  {
+    httpReq: {
+      method: 'post',
 
       url: `https://mixpanel.com/api/app/data-deletions/v3.0/?token=${secret4}`,
       data: {


### PR DESCRIPTION
## What

Mixpanel's create-deletion-task API (`POST /api/app/data-deletions/v3.0/`) answers **409 Conflict** when a deletion task already exists for a requested `distinct_id`. `createDeletionTask` treated any non-2xx as a `NetworkError`, so the regulation-worker recorded the job as `failed` and retried it.

Retries send the identical request, so they get the same 409. The job burns every attempt and is then **aborted** — recording a failed deletion for a user Mixpanel is already deleting.

This change treats 409 as success for **single-`distinct_id`** requests, matching the 404 ("nothing left to delete") handling already present in the `custify`, `intercom` and `iterable` deletion handlers.

## Why it matters

A duplicate deletion request — the same user covered by an earlier request — is enough to trigger it. Once it happens the outcome is deterministic: every attempt 409s, the job aborts, and the deletion is recorded as failed even though the vendor is deleting the user.

It also fires the P0 `regulations-error-spike` alert for MP. MP has a single active workspace, so the alert's documented single-customer waiver applies and one aborted job reads as "100% of active MP destinations failing all deletions".

Observed in production: one destination type, one deletion job covering a single user, 5 consecutive attempts, all 409, then abort. The immediately preceding deletions for the same destination succeeded (201), so this was not a credential or connectivity problem.

## Scope — deliberately narrow

The 409 is **not** swallowed for multi-id requests.

Mixpanel does not document 409 for this endpoint, so we cannot tell whether a conflict rejects the whole request or only the conflicting id. If it rejects the whole request, swallowing it would mark every other user in the batch as deleted when none of them were — a silent compliance gap. Failing the batch is the safe side of that unknown.

Worth confirming the exact semantics with Mixpanel support; if a conflict only skips the conflicting id, this can be widened to the whole batch.

## Tests

Two component cases added:

- single `distinct_id` + 409 → job succeeds
- two `distinct_ids` + 409 → job still fails (locks in the narrow scope)

`mp` component suite: 109 passed, 0 failed.

Note: `custom_audience` component tests fail on a clean `develop` checkout, unrelated to this change.