### PR TITLE
chore(test): clear allure-results before ts test runs

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "test:js": "NODE_OPTIONS='--no-node-snapshot' jest -c jest.default.config.js --detectOpenHandles",
     "test:js:silent": "export LOG_LEVEL=silent && npm run test:js -- --silent",
     "test:js:ci": "npm run test:js -- --coverage --expand --maxWorkers=50%",
-    "test:ts": "npm run build:sandboxes && NODE_OPTIONS='--no-node-snapshot' jest -c jest.config.typescript.js --detectOpenHandles",
+    "test:ts": "rm -rf ./allure-results && npm run build:sandboxes && NODE_OPTIONS='--no-node-snapshot' jest -c jest.config.typescript.js --detectOpenHandles",
     "test:ts:component:generateNwMocks": "npm run test:ts -- component --generate=true",
     "test:ts:component:rudder_test": "npm run test:ts -- component --destination=rudder_test",
     "test:live": "NODE_OPTIONS='--no-node-snapshot' jest -c jest.config.live.js",


### PR DESCRIPTION
## What are the changes introduced in this PR?

`test:ts` now removes `./allure-results` before running the TypeScript test suite.

## What is the related Linear task?

N/A

## Please explain the objectives of your changes below

`jest.config.typescript.js` uses the `allure-jest/node` test environment, which writes result files on every component test run. Nothing removes them locally and the directory is git-ignored, so it grows without bound on developer machines. A large enough `allure-results` makes the editor's debugger scan of the workspace never finish, which freezes the extension host and makes debug sessions appear to hang.

Clearing the directory at the start of `test:ts` keeps each run's results self-contained. CI runs `test:ts:ci` once per workflow in a fresh container and does not consume `allure-results`, so this is a no-op there.

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

Allure results from previous local runs are no longer retained across `test:ts` invocations.

### Any new dependencies introduced with this change?

N/A

### Any new generic utility introduced or modified. Please explain the changes.

N/A

### Any technical or performance related pointers to consider with the change?

`rm -rf` on a missing directory is a no-op, matching the existing `clean` script's usage.

<hr>

### Developer checklist

- [x] My code follows the style guidelines of this project
- [x] **No breaking changes are being introduced.**
- [ ] All related docs linked with the PR?
- [x] All changes manually tested?
- [ ] Any documentation changes needed with this change?
- [x] Is the PR limited to 10 file changes?
- [x] Is the PR limited to one linear task?
- [ ] Are relevant unit and component test-cases added in **new readability format**?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?
- [ ] Verified that there are no credentials or confidential data exposed with the changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)