### PR TITLE
fix(mp): handle 409 from create deletion task in deleteUsers

### DIFF
--- a/src/v0/destinations/mp/deleteUsers.js
+++ b/src/v0/destinations/mp/deleteUsers.js
@@ -1,14 +1,19 @@
 const lodash = require('lodash');
 const { ConfigurationError, NetworkError } = require('@rudderstack/integrations-lib');
 const { handleHttpRequest } = require('../../../adapters/network');
+const logger = require('../../../logger');
 const { isHttpStatusSuccess } = require('../../util');
 const { DEL_MAX_BATCH_SIZE, DISTINCT_ID_MAX_BATCH_SIZE } = require('./config');
 const { executeCommonValidations } = require('../../util/regulation-api');
 const { getDynamicErrorType } = require('../../../adapters/utils/networkUtils');
 const tags = require('../../util/tags');
-const { JSON_MIME_TYPE } = require('../../util/constant');
+const { HTTP_STATUS_CODES, JSON_MIME_TYPE } = require('../../util/constant');
 const { getUserIdBatches } = require('../../util/deleteUserUtils');
 const { getBaseEndpoint, getCreateDeletionTaskEndpoint } = require('./util');
+
+// The create deletion task API allows one request per second; a faster request gets
+// 429 "Too Many Requests, this API is limited to 1 req/s".
+const DELETION_TASK_REQUEST_INTERVAL_MS = 1000;
 
 const deleteProfile = async (userAttributes, config) => {
   const endpoint = `${getBaseEndpoint(config)}/engage`;
@@ -86,16 +91,23 @@ const createDeletionTask = async (userAttributes, config) => {
   // batchEvents = [[e1,e2,e3,..batchSize],[e1,e2,e3,..batchSize]..]
   // ref : https://developer.mixpanel.com/docs/privacy-security#create-a-deletion-task
   const batchEvents = getUserIdBatches(userAttributes, DISTINCT_ID_MAX_BATCH_SIZE);
-  await Promise.all(
-    batchEvents.map(async (batchEvent) => {
-      const request = {
-        distinct_ids: batchEvent,
-        compliance_type: complianceType,
-      };
+  let requestCount = 0;
+  // Requests are sent one at a time to stay within the API's rate limit.
+  for (const batchEvent of batchEvents) {
+    let distinctIds = batchEvent;
+    while (distinctIds.length > 0) {
+      if (requestCount > 0) {
+        // eslint-disable-next-line no-await-in-loop
+        await new Promise((resolve) => {
+          setTimeout(resolve, DELETION_TASK_REQUEST_INTERVAL_MS);
+        });
+      }
+      requestCount += 1;
+      // eslint-disable-next-line no-await-in-loop
       const { processedResponse: handledDelResponse } = await handleHttpRequest(
         'post',
         endpoint,
-        request,
+        { distinct_ids: distinctIds, compliance_type: complianceType },
         { headers },
         {
           destType: 'mp',
@@ -105,7 +117,20 @@ const createDeletionTask = async (userAttributes, config) => {
           module: 'deletion',
         },
       );
-      if (!isHttpStatusSuccess(handledDelResponse.status)) {
+      if (isHttpStatusSuccess(handledDelResponse.status)) {
+        break;
+      }
+
+      // A 409 rejects the whole request and names the ids that already have a deletion task running:
+      // { status: 'error', error: { conflicting_distinct_ids: ['u1'], conflicting_task_ids: ['<task id>'], error: '...' } }
+      // Those users are already being deleted, so only the rest are resubmitted.
+      const conflictingIds = handledDelResponse.response?.error?.conflicting_distinct_ids;
+      const remainingIds =
+        handledDelResponse.status === HTTP_STATUS_CODES.CONFLICT && Array.isArray(conflictingIds)
+          ? lodash.difference(distinctIds, conflictingIds)
+          : distinctIds;
+      // Any other failure, including a 409 that names none of these ids, fails the request.
+      if (remainingIds.length === distinctIds.length) {
         throw new NetworkError(
           'User deletion request failed for `create deletion task` api',
           handledDelResponse.status,
@@ -115,8 +140,17 @@ const createDeletionTask = async (userAttributes, config) => {
           handledDelResponse,
         );
       }
-    }),
-  );
+      logger.info(
+        '[MP] Deletion task already running for some distinct ids, resubmitting the rest',
+        {
+          conflictingCount: distinctIds.length - remainingIds.length,
+          remainingCount: remainingIds.length,
+          conflictingTaskIds: handledDelResponse.response.error.conflicting_task_ids,
+        },
+      );
+      distinctIds = remainingIds;
+    }
+  }
 
   return {
     statusCode: 200,

--- a/test/integrations/destinations/mp/deleteUsers/data.ts
+++ b/test/integrations/destinations/mp/deleteUsers/data.ts
@@ -1,5 +1,6 @@
 import { defaultApiKey } from '../../../common/secrets';
 import { secret4 } from '../maskedSecrets';
+import { useRealTimers } from '../mocks';
 
 export const data = [
   {
@@ -3276,6 +3277,128 @@ export const data = [
           {
             statusCode: 200,
             status: 'successful',
+          },
+        ],
+      },
+    },
+  },
+  {
+    name: 'mp',
+    description:
+      'Create deletion task: a 409 for an id that already has a running deletion task is treated as success',
+    feature: 'userDeletion',
+    module: 'destination',
+    version: 'v0',
+    input: {
+      request: {
+        body: [
+          {
+            destType: 'MP',
+            userAttributes: [
+              {
+                userId: 'mp-conflicting-user',
+              },
+            ],
+            config: {
+              token: secret4,
+              userDeletionApi: 'task',
+              gdprApiToken: secret4,
+            },
+          },
+        ],
+      },
+    },
+    output: {
+      response: {
+        status: 200,
+        body: [
+          {
+            statusCode: 200,
+            status: 'successful',
+          },
+        ],
+      },
+    },
+  },
+  {
+    name: 'mp',
+    description:
+      'Create deletion task: a 409 rejects the whole batch, so the ids it does not name are resubmitted',
+    feature: 'userDeletion',
+    mockFns: useRealTimers,
+    module: 'destination',
+    version: 'v0',
+    input: {
+      request: {
+        body: [
+          {
+            destType: 'MP',
+            userAttributes: [
+              {
+                userId: 'mp-conflicting-user',
+              },
+              {
+                userId: 'mp-new-user',
+              },
+            ],
+            config: {
+              token: secret4,
+              userDeletionApi: 'task',
+              gdprApiToken: secret4,
+            },
+          },
+        ],
+      },
+    },
+    output: {
+      response: {
+        status: 200,
+        body: [
+          {
+            statusCode: 200,
+            status: 'successful',
+          },
+        ],
+      },
+    },
+  },
+  {
+    name: 'mp',
+    description:
+      'Create deletion task: a failed resubmit after a 409 fails the request with the resubmit status',
+    feature: 'userDeletion',
+    mockFns: useRealTimers,
+    module: 'destination',
+    version: 'v0',
+    input: {
+      request: {
+        body: [
+          {
+            destType: 'MP',
+            userAttributes: [
+              {
+                userId: 'mp-conflicting-user',
+              },
+              {
+                userId: 'mp-rate-limited-user',
+              },
+            ],
+            config: {
+              token: secret4,
+              userDeletionApi: 'task',
+              gdprApiToken: secret4,
+            },
+          },
+        ],
+      },
+    },
+    output: {
+      response: {
+        status: 429,
+        body: [
+          {
+            statusCode: 429,
+            error: 'User deletion request failed for `create deletion task` api',
           },
         ],
       },

--- a/test/integrations/destinations/mp/mocks.ts
+++ b/test/integrations/destinations/mp/mocks.ts
@@ -1,0 +1,7 @@
+// The create deletion task handler waits on a real 1s timer between requests. Destinations that run
+// earlier in the shared component suite switch Jest to fake timers (to pin the system time) and
+// never switch back, and a fake timer does not fire on its own, so cases that exercise that wait
+// switch real timers back on.
+export const useRealTimers = () => {
+  jest.useRealTimers();
+};

--- a/test/integrations/destinations/mp/network.ts
+++ b/test/integrations/destinations/mp/network.ts
@@ -1123,6 +1123,135 @@ const deleteNwData = [
   {
     httpReq: {
       method: 'post',
+      url: `https://mixpanel.com/api/app/data-deletions/v3.0/?token=${secret4}`,
+      data: {
+        distinct_ids: ['mp-conflicting-user'],
+        compliance_type: 'CCPA',
+      },
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: authHeader4,
+      },
+    },
+    httpRes: {
+      status: 409,
+      statusText: 'Conflict',
+      data: {
+        error: {
+          conflicting_distinct_id_count: 1,
+          conflicting_distinct_ids: ['mp-conflicting-user'],
+          conflicting_task_ids: ['50d6ff45-0989-4dac-bcb9-0244a9baf1a5'],
+          error:
+            '1 of these distinct IDs are already being deleted by a request that is still running. Wait for 50d6ff45-0989-4dac-bcb9-0244a9baf1a5 to finish, then submit them again.',
+        },
+        status: 'error',
+      },
+    },
+  },
+  {
+    httpReq: {
+      method: 'post',
+      url: `https://mixpanel.com/api/app/data-deletions/v3.0/?token=${secret4}`,
+      data: {
+        distinct_ids: ['mp-conflicting-user', 'mp-new-user'],
+        compliance_type: 'CCPA',
+      },
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: authHeader4,
+      },
+    },
+    httpRes: {
+      status: 409,
+      statusText: 'Conflict',
+      data: {
+        error: {
+          conflicting_distinct_id_count: 1,
+          conflicting_distinct_ids: ['mp-conflicting-user'],
+          conflicting_task_ids: ['50d6ff45-0989-4dac-bcb9-0244a9baf1a5'],
+          error:
+            '1 of these distinct IDs are already being deleted by a request that is still running. Wait for 50d6ff45-0989-4dac-bcb9-0244a9baf1a5 to finish, then submit them again.',
+        },
+        status: 'error',
+      },
+    },
+  },
+  {
+    httpReq: {
+      method: 'post',
+      url: `https://mixpanel.com/api/app/data-deletions/v3.0/?token=${secret4}`,
+      data: {
+        distinct_ids: ['mp-new-user'],
+        compliance_type: 'CCPA',
+      },
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: authHeader4,
+      },
+    },
+    httpRes: {
+      status: 200,
+      statusText: 'OK',
+      data: {
+        ' message': '1',
+      },
+    },
+  },
+  {
+    httpReq: {
+      method: 'post',
+      url: `https://mixpanel.com/api/app/data-deletions/v3.0/?token=${secret4}`,
+      data: {
+        distinct_ids: ['mp-conflicting-user', 'mp-rate-limited-user'],
+        compliance_type: 'CCPA',
+      },
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: authHeader4,
+      },
+    },
+    httpRes: {
+      status: 409,
+      statusText: 'Conflict',
+      data: {
+        error: {
+          conflicting_distinct_id_count: 1,
+          conflicting_distinct_ids: ['mp-conflicting-user'],
+          conflicting_task_ids: ['50d6ff45-0989-4dac-bcb9-0244a9baf1a5'],
+          error:
+            '1 of these distinct IDs are already being deleted by a request that is still running. Wait for 50d6ff45-0989-4dac-bcb9-0244a9baf1a5 to finish, then submit them again.',
+        },
+        status: 'error',
+      },
+    },
+  },
+  {
+    httpReq: {
+      method: 'post',
+      url: `https://mixpanel.com/api/app/data-deletions/v3.0/?token=${secret4}`,
+      data: {
+        distinct_ids: ['mp-rate-limited-user'],
+        compliance_type: 'CCPA',
+      },
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: authHeader4,
+      },
+    },
+    httpRes: {
+      status: 429,
+      statusText: 'Too Many Requests',
+      data: {
+        error: {
+          error: 'Too Many Requests, this API is limited to 1 req/s',
+        },
+        status: 'error',
+      },
+    },
+  },
+  {
+    httpReq: {
+      method: 'post',
 
       url: 'https://api-eu.mixpanel.com/engage',
       data: [


### PR DESCRIPTION
## What are the changes introduced in this PR?

Fixes MP `deleteUsers` for the create-deletion-task path (`userDeletionApi: 'task'`) when Mixpanel answers **409 Conflict**.

- **409 with `conflicting_distinct_ids`:** those ids already have a deletion task running at Mixpanel, so they are dropped and the rest of the batch is resubmitted. The request succeeds once no ids are left. Any other failure fails the request as before, including a 409 that names none of the requested ids.
- **Rate limit:** requests to the create-deletion-task API are now sent one at a time, at least 1s apart. Mixpanel limits this API to 1 request per second (`429 Too Many Requests, this API is limited to 1 req/s`), and the previous `Promise.all` sent all batches at once.
- **Logging:** when conflicts are dropped, an info log records the conflicting and remaining counts and Mixpanel's task ids. It never logs user ids.

The `/engage` delete-profile path is unchanged.

## What is the related Linear task?

Resolves INT-7111

## Please explain the objectives of your changes below

Every non-2xx from create-deletion-task was a `NetworkError`, so the regulation-worker marked the job `failed` and retried a byte-identical request. That request got the same 409 every time, and the job was aborted after `REGULATION_DELETION_MAX_FAILED_ATTEMPTS`. It was recorded as a failed deletion for a user Mixpanel was already deleting, and it fired the `regulations-error-spike` P0.

The ticket's open question was whether a 409 rejects the whole request or only the conflicting id. Tested against a real Mixpanel project:

| Request | Mixpanel |
|---|---|
| `[A]` | 200, task created |
| `[A]` again | 409, `conflicting_distinct_ids: [A]` |
| `[A, C]` (C new) | 409, `conflicting_distinct_ids: [A]` only |
| `[C]` straight after | 200, so C was **not** scheduled by the previous request |

**A 409 rejects the whole request.** Treating it as success would silently skip every other user in the batch, which is why only the ids Mixpanel names are dropped. Mixpanel's 409 body is:

```json
{"status":"error","error":{"conflicting_distinct_id_count":1,"conflicting_distinct_ids":["A"],"conflicting_task_ids":["<task id>"],"error":"1 of these distinct IDs are already being deleted by a request that is still running. Wait for <task id> to finish, then submit them again."}}
```

End-to-end reproduction (local stack: data-regulation-service → regulation-worker → transformer → Mixpanel): a second deletion regulation for a user with a running task got 409 on all 5 attempts and was aborted. That matches the production incident.

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

- A 409 that names conflicting ids no longer fails the job; those users count as deleted, since Mixpanel is deleting them. This matches the guarantee a 200 gives today: task creation, not completion.
- Create-deletion-task batches are sent sequentially, at least 1s apart, instead of all at once.

### Any new dependencies introduced with this change?

N/A

### Any new generic utility introduced or modified. Please explain the changes.

N/A

### Any technical or performance related pointers to consider with the change?

- Each extra request (a further batch of more than 1999 ids, or a resubmit after a 409) waits 1s. A typical job (at most 1000 users per regulation job) is one request, plus one when a conflict is resubmitted.
- The loop always terminates: every resubmit strictly shrinks the id list, and a 409 that names none of the ids fails immediately.
- Tests: the two component cases that resubmit wait on the real 1s timer, so they switch Jest back to real timers through `mp/mocks.ts`. Destinations earlier in the shared component suite turn on fake timers to pin the system time and never switch them off.

<hr>

### Developer checklist

- [x] My code follows the style guidelines of this project

- [x] **No breaking changes are being introduced.**

- [x] All related docs linked with the PR?

- [x] All changes manually tested?

- [ ] Any documentation changes needed with this change?

- [x] Is the PR limited to 10 file changes?

- [x] Is the PR limited to one linear task?

- [x] Are relevant unit and component test-cases added in **new readability format**?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TtFmebUFukLMqURdNQW2vX
