### PR TITLE
test(mp): add deleteUsers live integration tests

### DIFF
--- a/test/integrations/component.live.test.ts
+++ b/test/integrations/component.live.test.ts
@@ -10,6 +10,7 @@ import { getEnrolledDestinations } from './live/registry';
 import { SecretResolver } from './live/secretResolver';
 import { RunContextImpl } from './live/runContext';
 import { runPipelineStep } from './live/runPipelineStep';
+import { runDeleteUsersStep } from './live/runDeleteUsersStep';
 import { retryUntilPasses } from './live/poll';
 import { OAuthTokenResolver } from './live/oauthTokenResolver';
 import { RudderAuthContainer } from './live/rudderAuthContainer';
@@ -215,7 +216,8 @@ describe('Live Integration Test Suite', () => {
           failIfSkipped(`step "${step.name}"`);
           try {
             // Steps run in declared order; dispatch by discriminant — action = direct API side
-            // effect, verify = read-back assertion, pipeline = seed -> transform -> deliver -> assert.
+            // effect, verify = read-back assertion, pipeline = seed -> transform -> deliver -> assert,
+            // deleteUsers = one regulation-worker job -> /deleteUsers -> assert successful.
             switch (step.stepType) {
               case 'action':
                 await step.run(ctx);
@@ -231,6 +233,17 @@ describe('Live Integration Test Suite', () => {
                   ctx,
                   config: scenarioConfig,
                   connection,
+                  http: {
+                    post: async (url, body) => agent().post(url).send(body),
+                  },
+                });
+                return;
+              case 'deleteUsers':
+                await runDeleteUsersStep({
+                  destination,
+                  step,
+                  ctx,
+                  config: scenarioConfig,
                   http: {
                     post: async (url, body) => agent().post(url).send(body),
                   },

--- a/test/integrations/destinations/mp/live.ts
+++ b/test/integrations/destinations/mp/live.ts
@@ -1,0 +1,108 @@
+import axios from 'axios';
+import { Agent } from 'https';
+import type { LiveSpec, LiveStep, RunContext } from '../../live/types';
+
+// Mixpanel's create deletion task API allows one request per second per project, so every call in
+// this spec, through the transformer or direct, waits past that window first.
+const RATE_LIMIT_DELAY_MS = 1100;
+
+// Keyed by the destination's dataResidency, as in src/v0/destinations/mp/config.js.
+const CREATE_DELETION_TASK_ENDPOINTS: Record<string, string> = {
+  us: 'https://mixpanel.com/api/app/data-deletions/v3.0/',
+  eu: 'https://eu.mixpanel.com/api/app/data-deletions/v3.0/',
+  in: 'https://in.mixpanel.com/api/app/data-deletions/v3.0/',
+};
+
+// keepAlive:false so read-back sockets don't linger as open handles.
+const mixpanelAgent = new Agent({ keepAlive: false });
+
+const sleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
+const deleteUsers = (name: string, userIds: (ctx: RunContext) => string[]): LiveStep => ({
+  stepType: 'deleteUsers',
+  name,
+  userAttributes: (ctx) => userIds(ctx).map((userId) => ({ userId })),
+  delayBeforeMs: RATE_LIMIT_DELAY_MS,
+});
+
+// The transformer does not return Mixpanel's task id, so the read-back asks again: a request for a
+// user who already has a deletion task running is rejected with a 409 that names them. A 2xx would
+// mean no task was running, and that request schedules one, which is harmless for a synthetic id.
+const verifyDeletionTaskRunning = (entity: string): LiveStep => ({
+  stepType: 'verify',
+  name: `verify a deletion task is running for ${entity}`,
+  check: async (ctx) => {
+    await sleep(RATE_LIMIT_DELAY_MS);
+    const {
+      token,
+      gdprApiToken,
+      dataResidency = 'us',
+    } = ctx.liveSecret.config as Record<string, string>;
+    const response = await axios.post(
+      `${CREATE_DELETION_TASK_ENDPOINTS[dataResidency]}?token=${token}`,
+      {
+        distinct_ids: [ctx.identity(entity)],
+        compliance_type: dataResidency === 'eu' ? 'GDPR' : 'CCPA',
+      },
+      {
+        headers: { Authorization: `Bearer ${gdprApiToken}` },
+        httpsAgent: mixpanelAgent,
+        timeout: 15000,
+        validateStatus: () => true,
+      },
+    );
+    expect({
+      status: response.status,
+      conflictingIds: response.data?.error?.conflicting_distinct_ids,
+    }).toEqual({ status: 409, conflictingIds: [ctx.identity(entity)] });
+  },
+});
+
+const newUser = (ctx: RunContext): string[] => [ctx.identity('user')];
+const conflictingUser = (ctx: RunContext): string[] => [ctx.identity('conflicting')];
+const conflictingAndNewUser = (ctx: RunContext): string[] => [
+  ctx.identity('conflicting'),
+  ctx.identity('user'),
+];
+
+export const live = {
+  enabled: true,
+  authType: 'apiKey',
+  // LIVE_SECRET_MP config: { token, gdprApiToken, dataResidency }.
+  resolveConfig: (s) => ({ userDeletionApi: 'task', ...s.config }),
+  scenarios: [
+    {
+      id: 'mp-delete-users-task',
+      description: 'A deletion task is created for a new user',
+      steps: [deleteUsers('delete a new user', newUser)],
+    },
+    {
+      id: 'mp-delete-users-task-already-running',
+      description: 'Deleting a user whose deletion task is still running succeeds',
+      steps: [
+        deleteUsers('delete a new user', newUser),
+        deleteUsers('delete the same user again', newUser),
+      ],
+    },
+    {
+      id: 'mp-delete-users-task-partial-conflict',
+      description: 'A batch where one user conflicts still schedules the other user',
+      steps: [
+        deleteUsers('delete the conflicting user', conflictingUser),
+        deleteUsers('delete the conflicting user and a new user', conflictingAndNewUser),
+        verifyDeletionTaskRunning('user'),
+      ],
+    },
+    {
+      id: 'mp-delete-users-profile',
+      description: 'The engage profile delete path deletes a user profile',
+      configOverride: ({ userDeletionApi, ...base }) => base,
+      steps: [deleteUsers('delete a user profile', newUser)],
+    },
+  ],
+} satisfies LiveSpec;
+
+export default live;

--- a/test/integrations/live/README.md
+++ b/test/integrations/live/README.md
@@ -97,7 +97,8 @@ Impact-based PR subsetting (running only the destinations a PR touches). Vault-b
 GitHub-OIDC → Vault auth, and the CI workflow are now implemented — see
 `.github/workflows/live-integration-tests.yml`.
 
-**Scope — transform path.** The harness drives only `/routerTransform → /proxy`. rudder-server
+**Scope — transform and user-deletion paths.** The harness drives `/routerTransform → /proxy`,
+and `/deleteUsers` through `deleteUsers` steps (see "Scenarios and steps"). rudder-server
 also runs the processor transform (`/v0/destinations/<dest>`) ahead of delivery, whose response
 shape differs; that chaining is not exercised here (INT-NNNN). **GZIP** proxy bodies are likewise
 unmapped (INT-NNNN) — see `routerProxyRequests.ts`.
@@ -214,6 +215,12 @@ scenario-level `cleanup`. There are no lifecycle hooks. Each step declares a req
   `expect(...)` prints a real diff instead of a bare timeout. This read-back is also what actually
   confirms a batch write: a batch endpoint can return `207` (which counts as delivered) even when an
   item fails, so the delivery verdict alone is not proof the write landed.
+- **deleteUsers**: `{ stepType: 'deleteUsers', name, userAttributes, delayBeforeMs? }` — the
+  regulation-worker's user-deletion call. `userAttributes(ctx)` returns the users to delete
+  (`[{ userId, ...attributes }]`); the runner posts them as one job to `/deleteUsers` with the
+  scenario's `destination.Config` and asserts the job comes back successful. Set `delayBeforeMs`
+  for a rate-limited deletion API — see `destinations/mp/live.ts`, whose read-back re-requests the
+  deletion directly and expects the vendor's conflict response.
 
 The **common trailing read-back** is better declared as a scenario-level `verify` the way
 `cleanup` is: `verify: { check: (ctx) => …, attempts?, delayMs? }`. The framework runs `check`

--- a/test/integrations/live/runDeleteUsersStep.test.ts
+++ b/test/integrations/live/runDeleteUsersStep.test.ts
@@ -1,0 +1,87 @@
+import { runDeleteUsersStep } from './runDeleteUsersStep';
+import { RunContextImpl } from './runContext';
+import type { DeleteUsersStep, LiveHttpResponse, RunContext } from './types';
+
+const ctx = (): RunContext =>
+  new RunContextImpl({ liveSecret: { authType: 'apiKey', config: {} } });
+
+const deleteUserStep: DeleteUsersStep = {
+  stepType: 'deleteUsers',
+  name: 'delete a user',
+  userAttributes: (runCtx) => [{ userId: runCtx.identity('user') }],
+};
+
+const httpReturning = (response: LiveHttpResponse) => ({
+  post: jest.fn().mockResolvedValue(response),
+});
+
+describe('runDeleteUsersStep', () => {
+  const failedResponses = [
+    {
+      name: 'a failed deletion',
+      response: {
+        status: 409,
+        body: [{ statusCode: 409, error: 'User deletion request failed' }],
+      },
+    },
+    {
+      name: 'a 200 whose job entry is not successful',
+      response: {
+        status: 200,
+        body: [{ statusCode: 500, error: 'User deletion request failed' }],
+      },
+    },
+  ];
+
+  it('posts one regulation-worker job with the step config and passes when it succeeds', async () => {
+    const runCtx = ctx();
+    const http = httpReturning({
+      status: 200,
+      body: [{ statusCode: 200, status: 'successful' }],
+    });
+
+    await runDeleteUsersStep({
+      destination: 'mp',
+      step: deleteUserStep,
+      ctx: runCtx,
+      config: { token: 'project-token' },
+      http,
+    });
+
+    expect(http.post).toHaveBeenCalledWith('/deleteUsers', [
+      {
+        jobId: expect.stringMatching(/^\d+$/),
+        destType: 'mp',
+        config: { token: 'project-token' },
+        userAttributes: [{ userId: runCtx.identity('user') }],
+      },
+    ]);
+  });
+
+  it.each(failedResponses)('fails the step on $name', async ({ response }) => {
+    await expect(
+      runDeleteUsersStep({
+        destination: 'mp',
+        step: deleteUserStep,
+        ctx: ctx(),
+        config: {},
+        http: httpReturning(response),
+      }),
+    ).rejects.toThrow(/User deletion request failed/);
+  });
+
+  it('rejects a step that names no users, before any request', async () => {
+    const http = httpReturning({ status: 200, body: [] });
+
+    await expect(
+      runDeleteUsersStep({
+        destination: 'mp',
+        step: { ...deleteUserStep, userAttributes: () => [] },
+        ctx: ctx(),
+        config: {},
+        http,
+      }),
+    ).rejects.toThrow('the step named no users to delete');
+    expect(http.post).not.toHaveBeenCalled();
+  });
+});

--- a/test/integrations/live/runDeleteUsersStep.ts
+++ b/test/integrations/live/runDeleteUsersStep.ts
@@ -1,0 +1,41 @@
+import { HttpStatusCode } from 'axios';
+import { randomInt } from 'crypto';
+import type { RunDeleteUsersStepParams } from './types';
+
+const sleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
+// Sends one user-deletion job to /deleteUsers, shaped like the regulation-worker's request
+// (rudder-server regulation-worker/internal/delete/api mapJobToPayload), and asserts the
+// transformer reports it successful.
+export const runDeleteUsersStep = async ({
+  destination,
+  step,
+  ctx,
+  config,
+  http,
+}: RunDeleteUsersStepParams): Promise<void> => {
+  if (step.delayBeforeMs) {
+    await sleep(step.delayBeforeMs);
+  }
+  const userAttributes = step.userAttributes(ctx);
+  if (userAttributes.length === 0) {
+    throw new Error(`[live:${destination}:${step.name}] the step named no users to delete`);
+  }
+  const response = await http.post('/deleteUsers', [
+    {
+      jobId: String(randomInt(1, 2_147_483_647)),
+      destType: destination,
+      config,
+      userAttributes,
+    },
+  ]);
+  // One entry per job: { statusCode, status } on success, { statusCode, error } on failure. The
+  // whole response is asserted so a failure prints the transformer's error.
+  expect({ status: response.status, body: response.body }).toEqual({
+    status: HttpStatusCode.Ok,
+    body: [{ statusCode: HttpStatusCode.Ok, status: 'successful' }],
+  });
+};

--- a/test/integrations/live/types.ts
+++ b/test/integrations/live/types.ts
@@ -157,7 +157,17 @@ interface VerifyStep extends Step {
   check: (ctx: RunContext) => Promise<void>;
 }
 
-type LiveStep = PipelineStep | ActionStep | VerifyStep;
+// A deleteUsers step: the regulation-worker's user-deletion call, POST /deleteUsers with the
+// scenario's destination config, asserting the job comes back successful.
+interface DeleteUsersStep extends Step {
+  stepType: 'deleteUsers';
+  // The users to delete, as the regulation-worker sends them: one { userId, ...attributes } each.
+  userAttributes: (ctx: RunContext) => Record<string, string>[];
+  // Sleep this long before the call, for destinations whose deletion API is rate limited.
+  delayBeforeMs?: number;
+}
+
+type LiveStep = PipelineStep | ActionStep | VerifyStep | DeleteUsersStep;
 
 // A scenario is an ordered list of steps (pipeline | action | verify) sharing one RunContext.
 // Setup, teardown and read-back are expressed as action/verify steps — no lifecycle hooks.
@@ -369,6 +379,15 @@ interface RetryUntilPassesOptions {
   delayMs?: (attempt: number) => number; // default 1000 * 2 ** attempt
 }
 
+// Arguments threaded into a single deleteUsers-step run.
+interface RunDeleteUsersStepParams {
+  destination: string;
+  step: DeleteUsersStep;
+  ctx: RunContext;
+  config: Record<string, unknown>;
+  http: LiveHttpClient;
+}
+
 export {
   AccountDefinition,
   AuthType,
@@ -386,6 +405,7 @@ export {
   PipelineStep,
   ActionStep,
   VerifyStep,
+  DeleteUsersStep,
   LiveProcessorOutputSchema,
   LiveRouterOutputSchema,
   RouterOutput,
@@ -398,6 +418,7 @@ export {
   LiveHttpClient,
   DeliveryFailure,
   RunPipelineStepParams,
+  RunDeleteUsersStepParams,
   PollCheckResult,
   PollUntilOptions,
   RetryUntilPassesOptions,


### PR DESCRIPTION
## What are the changes introduced in this PR?

Adds live (real-destination) integration tests for MP user deletion. That needs the live harness to support `/deleteUsers`, which it could not reach before; it only drove `/routerTransform → /proxy`.

- **Harness: a new `deleteUsers` step type.** `test/integrations/live/runDeleteUsersStep.ts` posts one job, shaped like the regulation-worker's request (`[{ jobId, destType, config, userAttributes }]`), to `/deleteUsers` with the scenario's `destination.Config`. It asserts the job comes back `[{ statusCode: 200, status: 'successful' }]`, and takes an optional `delayBeforeMs` for rate-limited deletion APIs. Wired into the runner's step dispatch and `types.ts`, documented in the live README, and unit-tested in `runDeleteUsersStep.test.ts`.
- **MP live spec (`test/integrations/destinations/mp/live.ts`)**, all using per-run synthetic ids:

| Scenario | What it checks |
|---|---|
| `mp-delete-users-task` | A deletion task is created for a new user |
| `mp-delete-users-task-already-running` | Deleting the same user again, while its task is still running, succeeds |
| `mp-delete-users-task-partial-conflict` | A batch of a conflicting user plus a new user succeeds. A direct Mixpanel call then gets a 409 naming the new user, which proves it was scheduled |
| `mp-delete-users-profile` | The `/engage` profile-delete path deletes a user profile |

Every call in the spec waits 1.1s first, because Mixpanel's create-deletion-task API allows 1 request per second per project.

## What is the related Linear task?

Refs INT-7111

## Please explain the objectives of your changes below

**Depends on #5578** (the INT-7111 fix), which makes a 409 for an already-running deletion task succeed. The `already-running` and `partial-conflict` scenarios assert that behaviour. Merge #5578 first.

These scenarios guard that fix against real Mixpanel, which the mocked component tests can't do. Checked both ways against the Mixpanel test project:

| `deleteUsers.js` | Result |
|---|---|
| With the #5578 fix | 7/7 steps pass |
| `develop` (no fix) | 3/7 fail. "delete the same user again" and "delete the conflicting user and a new user" get **409**; the verify step does not run |

**Before merging, add the Vault secret.** This workflow runs on PRs to `develop`, so the MP job fails until `LIVE_SECRET_MP` exists. It goes under `engineering_shared/data/integrations_team/e2e_test/rudder-transformer`, as **single-line** JSON:

```
{"authType":"apiKey","config":{"token":"<project-token>","gdprApiToken":"<gdpr-api-token>","dataResidency":"us"}}
```

**Sandbox:** the Mixpanel test project used by rudder-mini. Each run creates deletion tasks for a handful of synthetic `ci-<runId>-*` ids and deletes one synthetic profile. No real users are touched and there is nothing to clean up.

### Any changes to existing capabilities/behaviour, mention the reason & what are the changes ?

The live harness gains a `deleteUsers` step type. Existing step types and specs are unchanged.

### Any new dependencies introduced with this change?

N/A

### Any new generic utility introduced or modified. Please explain the changes.

`runDeleteUsersStep` in the live harness, described above.

### Any technical or performance related pointers to consider with the change?

The MP live job takes about 21s, mostly the 1.1s rate-limit waits.

<hr>

### Developer checklist

- [x] My code follows the style guidelines of this project

- [x] **No breaking changes are being introduced.**

- [x] All related docs linked with the PR?

- [x] All changes manually tested?

- [x] Any documentation changes needed with this change?

- [x] Is the PR limited to 10 file changes?

- [x] Is the PR limited to one linear task?

- [x] Are relevant unit and component test-cases added in **new readability format**?

### Reviewer checklist

- [ ] Is the type of change in the PR title appropriate as per the changes?

- [ ] Verified that there are no credentials or confidential data exposed with the changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TtFmebUFukLMqURdNQW2vX
